### PR TITLE
Use setuptools_scm for version number

### DIFF
--- a/briefcase/__init__.py
+++ b/briefcase/__init__.py
@@ -1,15 +1,1 @@
 from __future__ import print_function, unicode_literals, absolute_import, division
-
-__all__ = [
-    '__version__',
-]
-
-# Examples of valid version strings
-# __version__ = '1.2.3.dev1'  # Development release 1
-# __version__ = '1.2.3a1'     # Alpha Release 1
-# __version__ = '1.2.3b1'     # Beta Release 1
-# __version__ = '1.2.3rc1'    # RC Release 1
-# __version__ = '1.2.3'       # Final Release
-# __version__ = '1.2.3.post1' # Post Release 1
-
-__version__ = '0.2.1'

--- a/setup.py
+++ b/setup.py
@@ -8,21 +8,13 @@ if sys.version_info[:3] < (3, 4):
     raise SystemExit("Briefcase requires Python 3.4+.")
 
 
-with io.open('./briefcase/__init__.py', encoding='utf8') as version_file:
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
-    if version_match:
-        version = version_match.group(1)
-    else:
-        raise RuntimeError("Unable to find version string.")
-
-
 with io.open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 
 setup(
     name='briefcase',
-    version=version,
+    use_scm_version=True,  # Generate version number from git commit/tags
     description='Tools to support converting a Python project into a standalone native application.',
     long_description=long_description,
     author='Russell Keith-Magee',
@@ -43,6 +35,10 @@ setup(
             'windows = briefcase.windows:windows',
         ]
     },
+    setup_requires=[
+        'setuptools_scm',
+        'setuptools_git'
+    ],
     install_requires=[
         'pip >= 8.1',
         'cookiecutter >= 1.0',
@@ -50,6 +46,8 @@ setup(
         'setuptools >= 27.0',
         'requests < 3.0',
         'boto3 >= 1.4.4',
+        'setuptools_scm',
+        'setuptools_git'
     ],
     license='New BSD',
     classifiers=[


### PR DESCRIPTION
**setuptools_scm** : the blessed (by pypa team) package to manage your versions by scm tags.

This is my by-far favorite means of managing project versioning, which in turn makes it dramatically easier to reliably release software.

Rather than having version numbers baked into source somewhere this module manages version numbers based on git tags. 

Having the single-source-of-truth being the git tag means you can always find exactly which commit was released; I've notice the current briefcase 0.2.1 doesn't have a tag, meaning it's hard to know which commit here is actually on pypi.

setuptools_scm also generates .dev version numbers on demand if you build/install the package in between tags which gives a decent amount of information about where the source came from. This makes it easy to share beta builds etc.

In terms of making releasing easier:
I don't know if beekeeper allows storing private variables for a repo, nor whether you can run scripts/tasks only on tagged commits?  

I ask this because with setuptools_scm in use on my other personal projects, hosted and ci'd with gitlab, releasing updates to packages is a one-step operation - make a git tag with the new version number. 

gitlab ci goes and runs all my defined tests in a clean docker, then (if they passed) handles the deploy to pypi with the new version number (again, in a clean docker). 
This guarantees the upload only happens if tests pass, and that it's a clean copy of the code being uploaded.

This way the update is all done in a couple of minutes without the possibility to forget a step. 
See this CI script for an example: https://gitlab.com/alelec/structured_config/blob/master/.gitlab-ci.yml

There is only one real negative to this module: the package no longer works from a raw zip downloaded from github as the zip doesn't contain any information about the current version. 
The alternatives are to either:
* make and use a python sdist/bdist of the package
* use `pip install [-e] /path/to/clone/of/repo`
* do a `pip install git+https://github.com/pybee/briefcase` if you want to install directly from a github url

More info:
https://pypi.python.org/pypi/setuptools_scm