### PR TITLE
Windows shortcuts updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #/usr/bin/env python
 import io
 import re
+import platform
 
 from setuptools import setup, find_packages
 
@@ -55,7 +56,8 @@ setup(
         # this will break either requests or boto3 (or possibly both), at which point
         # the requirement can probably be dropped.
         'urllib3<1.24',
-        'dmgbuild >= 1.3.2',
+        *(['dmgbuild >= 1.3.2'] if platform.system() == 'Darwin' else
+          ['pywin32-ctypes'] if platform.system() == 'Windows' else []),
     ],
     license='New BSD',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         # the requirement can probably be dropped.
         'urllib3<1.24',
         *(['dmgbuild >= 1.3.2'] if platform.system() == 'Darwin' else
-          ['pywin32-ctypes'] if platform.system() == 'Windows' else []),
+          ['pywin32-ctypes', 'windows-entry-exe'] if platform.system() == 'Windows' else []),
     ],
     license='New BSD',
     classifiers=[
@@ -80,4 +80,8 @@ setup(
         'Tracker': 'https://github.com/pybee/briefcase/issues',
         'Source': 'https://github.com/pybee/briefcase',
     },
+    **(
+        dict(use_windows_entry_exe=True) if platform.system() == 'Windows' else {}
+    )
 )
+

--- a/src/briefcase/windows.py
+++ b/src/briefcase/windows.py
@@ -133,8 +133,8 @@ class windows(app):
                                 Name="{exe_name}"
                                 Icon="ProductIcon"
                                 Description="{description}"
-                                Target="[AppDir]\\app\\{exe_name}.exe"
-                                WorkingDirectory="[AppDir]\\app" />""".format(**locals()))
+                                Target="[WorkingDir]\\{exe_name}.exe"
+                                WorkingDirectory="WorkingDir" />""".format(**locals()))
 
         # Generate the full briefcase.wxs file
         briefcase_wxs = os.path.join(self.dir, 'briefcase.wxs')

--- a/src/briefcase/windows.py
+++ b/src/briefcase/windows.py
@@ -153,7 +153,11 @@ class windows(app):
                     lines.extend(content)
                 elif line.strip() == '<!-- CONTENTREFS -->':
                     lines.extend(contentrefs)
-                elif line.strip() == '<!-- SHORTCUTS -->':
+                elif len(shortcuts) and line.strip() == '<!-- SHORTCUTS_PROVIDED -->':
+                    # Comment out existing shortcut in template if setup provides own
+                    lines.append('                        <!--')
+                elif len(shortcuts) and line.strip() == '<!-- SHORTCUTS -->':
+                    lines.append('                        -->')
                     lines.extend(shortcuts)
                 else:
                     lines.append(line.rstrip())

--- a/src/briefcase/windows.py
+++ b/src/briefcase/windows.py
@@ -71,6 +71,7 @@ class windows(app):
         content = []
         contentrefs = []
         shortcuts = []
+        shortcuts_instance = 0
         dir_ids = []
 
         def walk_dir(path, depth=0):
@@ -125,10 +126,10 @@ class windows(app):
                 for entry in entries:
                     exe_name = entry.split('=')[0].strip()
                     description = self.distribution.get_description()
-                    shortcutid = uuid.uuid4().hex
+                    # This is used multiple times below so shortcut_id will be filled later
                     shortcuts.append("""\
                             <Shortcut
-                                Id="AppShortcut_{shortcutid}"
+                                Id="Shortcut_{{shortcut_id}}"
                                 Name="{exe_name}"
                                 Icon="ProductIcon"
                                 Description="{description}"
@@ -160,7 +161,11 @@ class windows(app):
                     lines.append('                        <!--')
                 elif len(shortcuts) and line.strip() == '<!-- SHORTCUTS -->':
                     lines.append('                        -->')
-                    lines.extend(shortcuts)
+
+                    shortcuts_instance += 1
+                    for shortcut in shortcuts:
+                        shortcut_id = uuid.uuid4().hex
+                        lines.append(shortcut.format(**locals()))
                 else:
                     lines.append(line.rstrip())
 

--- a/src/briefcase/windows.py
+++ b/src/briefcase/windows.py
@@ -134,7 +134,7 @@ class windows(app):
                                 Icon="ProductIcon"
                                 Description="{description}"
                                 Target="[AppDir]\\app\\{exe_name}.exe"
-                                WorkingDirectory="AppDir\\app" />""".format(**locals()))
+                                WorkingDirectory="[AppDir]\\app" />""".format(**locals()))
 
         # Generate the full briefcase.wxs file
         briefcase_wxs = os.path.join(self.dir, 'briefcase.wxs')

--- a/src/briefcase/windows.py
+++ b/src/briefcase/windows.py
@@ -59,7 +59,9 @@ class windows(app):
         This should return a suitable relative path which will find the
         bundled python for the relevant platform
         """
-        return "#!.\\python\\python.exe\n"
+        # we need the specified python to be findable relative to a path entry
+        os.environ['PATH'] += os.pathsep + os.path.join(self.dir, 'content')
+        return "#!..\\python\\python.exe\n"
 
     def install_extras(self):
         print(" * Finalizing application installer script...")
@@ -131,7 +133,7 @@ class windows(app):
                                 Icon="ProductIcon"
                                 Description="{description}"
                                 Target="[AppDir]\\app\\{exe_name}.exe"
-                                WorkingDirectory="AppDir" />""".format(**locals()))
+                                WorkingDirectory="AppDir\\app" />""".format(**locals()))
 
         # Generate the full briefcase.wxs file
         briefcase_wxs = os.path.join(self.dir, 'briefcase.wxs')

--- a/src/briefcase/windows_icon.py
+++ b/src/briefcase/windows_icon.py
@@ -1,0 +1,96 @@
+import os
+from ctypes import Structure, sizeof, c_byte, c_ushort, c_int
+from win32ctypes.pywin32 import win32api
+
+
+# Structures in ico file
+class IconHeader(Structure):
+    _fields_ = [
+        ("Width", c_byte),
+        ("Height", c_byte),
+        ("Colors", c_byte),
+        ("Reserved", c_byte),
+        ("Planes", c_ushort),
+        ("BitsPerPixel", c_ushort),
+        ("ImageSize", c_int),
+        ("ImageOffset", c_int),
+    ]
+
+
+class GroupIcon(Structure):
+    _fields_ = [
+        ("Reserved", c_ushort),
+        ("ResourceType", c_ushort),
+        ("ImageCount", c_ushort),
+        # ("Enries", PIconDirResEntry),
+    ]
+
+
+# Structure for updating resource
+class IconDirResEntry(Structure):
+    _fields_ = [
+        ("Width", c_byte),
+        ("Height", c_byte),
+        ("Colors", c_byte),
+        ("Reserved", c_byte),
+        ("Planes", c_ushort),
+        ("BitsPerPixel", c_ushort),
+        ("ImageSize", c_int),
+        ("ResourceID", c_ushort),
+    ]
+
+
+RT_ICON = 3
+RT_GROUP_ICON = 14
+
+
+def apply_icon(icon, dest):
+    """
+    Use winapi UpdateResource to copy icon into exe
+
+    :param str icon: .ico file path
+    :param str dest: path of the .exe to update.
+    """
+
+    print("Applying icons from %s to %s", (icon, dest))
+    dest = os.path.abspath(dest)
+
+    with open(icon, 'rb') as iconfile:
+        # header = GroupIcon()
+        group_header_data = iconfile.read(sizeof(GroupIcon))
+        group_header = GroupIcon.from_buffer_copy(group_header_data)
+        if group_header.ResourceType != 1:
+            print("Incorrect icon ResourceType")
+
+        icon_headers = [
+            IconHeader.from_buffer_copy(iconfile.read())
+        ]
+
+        icon_data = []
+        for icon in icon_headers:
+            iconfile.seek(icon.ImageOffset)
+            icon_data.append(iconfile.read(icon.ImageSize))
+
+    h_exe = win32api.BeginUpdateResource(dest, 0)
+
+    header_data = bytes(group_header)
+
+    for i, header in enumerate(icon_headers):
+        res_icon_header = IconDirResEntry()
+        for f in ("Width", "Height", "Colors", "Reserved",
+                  "Planes", "BitsPerPixel", "ImageSize"):
+            setattr(res_icon_header, f, getattr(header, f))
+        res_icon_header.ResourceID = i+1
+        header_data += bytes(res_icon_header)
+
+    win32api.UpdateResource(h_exe, RT_GROUP_ICON, 0, header_data)
+
+    for i, data in enumerate(icon_data):
+        win32api.UpdateResource(h_exe, RT_ICON, i+1, data)
+
+    win32api.EndUpdateResource(h_exe, 0)
+
+
+if __name__ == '__main__':
+    import sys
+    apply_icon(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
While adding briefcase support to a new project at work I found my `entry_points` functionality (#75) was no longer working, eventually tracking it down to #170

Looking at that, I realised there was a significant bug in my original implementation, hence the need for those lines to be removed.

This PR re-instates the functionality properly, only removing the hardcoded shortcut if there are `entry_points` defined in `setup.py`

Further to that, I then found that gui_scripts were still using python.exe rather than pythonw.exe
Turns out the function that builds the launcher script automatically fixes that in the shebang header only if it funds the described pythonw.exe on the path. This has been fixed in the second commit.

Lastly, on a separate project where we've heavily customised the wix script, I've found it really useful to have a second copy of the app shortcuts in the program folder, in addition the the one in start menu. Generally if users navigate to a program folder in explorer, it's nice if it's obvious how to run the app. Having a shortcut there provides this. The third commit is needed for this in conjunction with an update to the template: https://github.com/pybee/Python-Windows-template/pull/3