### PR TITLE
Suggesting next possible step when the iOS setup/build exits

### DIFF
--- a/src/briefcase/ios.py
+++ b/src/briefcase/ios.py
@@ -132,7 +132,7 @@ class ios(app):
             if self.os_version is None:
                 os_list = [label for label in data['devices'] if label.startswith('iOS')]
                 if len(os_list) == 0:
-                    print('No iOS device simulators found', file=sys.stderr)
+                    print('No iOS device simulators found. Build your xcodeproj file manually using XCode.', file=sys.stderr)
                     sys.exit(1)
                 elif len(os_list) == 1:
                     print('Building for {}...'.format(os_list[0]))


### PR DESCRIPTION
This PR suggests a minor improvement to the ''No iOS device simulators found" exit message of the iOS build.

It proposes the next possible step for the build when simulator is not found (might simply be due to permission settings in macOS Mojave 10.14.4) so the first time users, especially when doing the tutorials get this error, they know how to proceed.