### PR TITLE
Fixed 1 issue of type: PYTHON_E401 throughout 1 file in repo.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,8 @@ copyright = u'2013, Russell Keith-Magee'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-import io, re
+import io
+import re
 with io.open('../src/briefcase/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:


### PR DESCRIPTION
PYTHON_E401: 'multiple imports on one line'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.