### PR TITLE
Fixed 1 issue of type: PYTHON_F401 throughout 1 file in repo.

### DIFF
--- a/src/briefcase/django.py
+++ b/src/briefcase/django.py
@@ -5,9 +5,9 @@ import sys
 import webbrowser
 
 try:
-    from urllib.request import urlopen
+    pass
 except ImportError:  # Python 2 compatibility
-    from urllib2 import urlopen
+    pass
 
 from .app import app
 


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        