### PR TITLE
Use consistent venv creation in docs

### DIFF
--- a/docs/background/getting-started.rst
+++ b/docs/background/getting-started.rst
@@ -15,8 +15,9 @@ this `guide <https://docs.python.org/3/using/index.html>`__ will help you get st
 Install Briefcase
 -----------------
 
-The first step is to install Briefcase. If you're using a virtual environment
-for your project, don't forget to activate it.
+The first step is to install Briefcase. If you're using a `virtual environment
+<https://docs.python.org/3/library/venv.html>` for your project, don't forget
+to activate it.
 
 .. code-block:: bash
 

--- a/docs/how-to/contribute.rst
+++ b/docs/how-to/contribute.rst
@@ -12,14 +12,16 @@ If you experience problems with Briefcase, `log them on GitHub`_. If you want to
 Setting up your development environment
 ---------------------------------------
 
-The recommended way of setting up your development envrionment for Briefcase
-is to install a virtual environment, install the required dependencies and
-start coding. Assuming that you are using ``virtualenvwrapper``, you only have
-to run::
+The recommended way of setting up your development envrionment for Briefcase is
+to install a `virtual environment
+<https://docs.python.org/3/library/venv.html>`, install the required
+dependencies and start coding. Assuming that you are using
+``virtualenvwrapper``, you only have to run::
 
     $ git clone git@github.com:beeware/briefcase.git
     $ cd briefcase
-    $ mkvirtualenv briefcase
+    $ python3 -m venv venv
+    $ . venv/bin/activate
 
 Briefcase uses ``unittest`` (or ``unittest2`` for Python < 2.7) for its own test
 suite as well as additional helper modules for testing. To install all the


### PR DESCRIPTION
Let's not assume people have virtualenvwrapper installed (I mean, chances are good, but `python -m venv` is actually referenced in other parts of the docs).