### PR TITLE
added instructions to pip install Toga

### DIFF
--- a/docs/background/getting-started.rst
+++ b/docs/background/getting-started.rst
@@ -32,6 +32,28 @@ recommend), don't forget to activate it.
   On some versions the activate script may be in the venv/Scripts/ folder in which
   case swap: ``$ . venv/bin/activate`` for ``$ . venv/Scripts/activate``
 
+Install Toga
+-------------
+
+Next, install Toga into your virtual environment:
+
+macOS or Linux
+~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    (venv) $ pip install --pre toga
+
+Windows
+~~~~~~~
+
+.. code-block:: bash
+
+    (venv) C:\...>pip install --pre toga
+
+(note: a pre-release version of Toga is currently in use.)
+
+
 Install platform dependencies
 -----------------------------
 


### PR DESCRIPTION
Working through the tutorial in the "getting started" page, a step is missing to "pip install Toga". I updated the "getting started" page with this step. 