### PR TITLE
Added Getting Started link to Tutorials page

### DIFF
--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -4,6 +4,8 @@
 Tutorials
 =========
 
+To prepare for the tutorials, first follow the instructions in :doc:`/background/getting-started`.
+
 These tutorials are step-by step guides for using Briefcase.
 
 .. toctree::


### PR DESCRIPTION
Tutorials assume Getting Started steps have been followed but there is no previous mention of Getting Started, so adding a link to the Tutorials index pointing to Getting Started.