### PR TITLE
Check for Xcode and Command Line Tools before building MacOS Application

### DIFF
--- a/src/briefcase/macos.py
+++ b/src/briefcase/macos.py
@@ -11,7 +11,9 @@ from .app import app
 class macos(app):
     description = "Create a macOS app to wrap this project"
 
-    def confirm_prerequistes(self):
+    def confirm_prerequisites(self):
+        print()
+        print(" * Confirming prerequisites...")
         # Before we start, exit if xcode is not installed
         print()
         print(" * Looking for Xcode...")
@@ -42,8 +44,6 @@ class macos(app):
             sys.exit(1)
 
     def finalize_options(self):
-        print()
-        print(" * Confirming prerequistes...")
         self.confirm_prerequistes()
 
         # Copy over all the options from the base 'app' command

--- a/src/briefcase/macos.py
+++ b/src/briefcase/macos.py
@@ -20,11 +20,10 @@ class macos(app):
                 '/usr/bin/xcodebuild', '-version'
             ]
         ).wait() == 1:
-            # raise error
-            print("Xcode is required.  Couldn't find Xcode.")
-            print("Please install the latest stable release from:")
+            print("Briefcase requires Xcode, but it does not appear to be installed.")
+            print("Please install the latest version of Xcode using the Mac App Store:")
             print()
-            print("    https://developer.apple.com/xcode/")
+            print("    https://itunes.apple.com/us/app/xcode/id497799835")
             sys.exit(1)
 
         # Before we start, exit if Command Line Tools is not installed
@@ -36,8 +35,8 @@ class macos(app):
                 'gcc', '--version'
             ]
         ).wait() == 1:
-            print("Command Line Tools are required. Couldn't find Command Line Tools.")
-            print("Please install the latest stable release by running the following in your terminal:")
+            print("Briefcase requires the Xcode Command Line Tools, but they do not appear to be installed.")
+            print("Please install the command line tools by running:")
             print()
             print("    xcode-select --install")
             sys.exit(1)

--- a/src/briefcase/macos.py
+++ b/src/briefcase/macos.py
@@ -12,6 +12,37 @@ class macos(app):
     description = "Create a macOS app to wrap this project"
 
     def finalize_options(self):
+        # Before we start, exit if xcode is not installed
+        print()
+        print(" * Looking for Xcode...")
+        if subprocess.Popen(
+            [
+                '/usr/bin/xcodebuild', '-version'
+            ]
+            ).wait() == 1:
+            # raise error
+            print("Xcode is required.  Couldn't find Xcode.")
+            print("Please install the latest stable release from:")
+            print()
+            print("    https://developer.apple.com/xcode/")
+            sys.exit(1)
+
+        # Before we start, exit if Command Line Tools is not installed
+        # This check if gcc is installed properly, which will ensure Command Line Tools are there
+
+        print()
+        print(" * Looking for Command Line Tools...")
+        if subprocess.Popen(
+            [
+                'gcc', '--version'
+            ]
+            ).wait() == 1:
+            print("Command Line Tools are required. Couldn't find Command Line Tools.")
+            print("Please install the latest stable release by running the following in your terminal:")
+            print()
+            print("    xcode-select --install")
+            sys.exit(1)
+
         # Copy over all the options from the base 'app' command
         finalized = self.get_finalized_command('app')
         options = ('formal_name', 'organization_name',

--- a/src/briefcase/macos.py
+++ b/src/briefcase/macos.py
@@ -19,7 +19,7 @@ class macos(app):
             [
                 '/usr/bin/xcodebuild', '-version'
             ]
-            ).wait() == 1:
+        ).wait() == 1:
             # raise error
             print("Xcode is required.  Couldn't find Xcode.")
             print("Please install the latest stable release from:")
@@ -36,7 +36,7 @@ class macos(app):
             [
                 'gcc', '--version'
             ]
-            ).wait() == 1:
+        ).wait() == 1:
             print("Command Line Tools are required. Couldn't find Command Line Tools.")
             print("Please install the latest stable release by running the following in your terminal:")
             print()

--- a/src/briefcase/macos.py
+++ b/src/briefcase/macos.py
@@ -11,7 +11,7 @@ from .app import app
 class macos(app):
     description = "Create a macOS app to wrap this project"
 
-    def finalize_options(self):
+    def confirm_prerequistes(self):
         # Before we start, exit if xcode is not installed
         print()
         print(" * Looking for Xcode...")
@@ -29,7 +29,6 @@ class macos(app):
 
         # Before we start, exit if Command Line Tools is not installed
         # This check if gcc is installed properly, which will ensure Command Line Tools are there
-
         print()
         print(" * Looking for Command Line Tools...")
         if subprocess.Popen(
@@ -42,6 +41,11 @@ class macos(app):
             print()
             print("    xcode-select --install")
             sys.exit(1)
+
+    def finalize_options(self):
+        print()
+        print(" * Confirming prerequistes...")
+        self.confirm_prerequistes()
 
         # Copy over all the options from the base 'app' command
         finalized = self.get_finalized_command('app')


### PR DESCRIPTION
If Xcode and Command Line Tools are not installed on the mac, an `DMGError` would triggered when building MacOS Application.

To prevent the error being raised, and to give more information about what the problem is.  We should check if Xcode and Command Line Tools are installed first before proceeding.

This will check for both and exit if they are not found.