### PR TITLE
Roadmap page out of date, not necessary at this point.

### DIFF
--- a/docs/background/index.rst
+++ b/docs/background/index.rst
@@ -14,4 +14,3 @@ About Briefcase
    getting-started
    quickstart
    releases
-   roadmap

--- a/docs/background/roadmap.rst
+++ b/docs/background/roadmap.rst
@@ -1,9 +1,0 @@
-Briefcase Roadmap
-=================
-
-Briefcase is a new project - we have lots of things that we'd like to do. If
-you'd like to contribute, providing a patch for one of these features:
-
- * Windows support
- * Linux support (for various distros)
- * Apple watchOS support


### PR DESCRIPTION
The community page now points to the main Beeware project, no need for a separate roadmap here.