### PR TITLE
Remove obsolete line from tutorial index.

### DIFF
--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -4,8 +4,6 @@
 Tutorials
 =========
 
-To prepare for the tutorials, first follow the instructions in :doc:`/background/getting-started`.
-
 These tutorials are step-by step guides for using Briefcase.
 
 .. toctree::


### PR DESCRIPTION
Now that tutorial files and the page have been refactored, removing no longer useful or functional duplicate link to Getting Started.