### PR TITLE
macOS | Include project version in output DMG file name

### DIFF
--- a/src/briefcase/macos.py
+++ b/src/briefcase/macos.py
@@ -103,7 +103,7 @@ class macos(app):
 
     def build_app(self):
         print("Building DMG file...")
-        dmg_name = self.formal_name + '.dmg'
+        dmg_name = self.formal_name + '-' + self.version + '.dmg'
         dmg_path = os.path.join(os.path.abspath(self.dir), dmg_name)
 
         dmgbuild.build_dmg(


### PR DESCRIPTION
In the context of [this Mu packaging issue](https://github.com/mu-editor/mu/issues/925), where I found out that `briefcase`-produced *application bundles* do not include the underlying project version, I created [this PR](https://github.com/beeware/Python-macOS-template/pull/3) in the `Python-macOS-template` project.

Along those lines, I figured that `briefcase`-produced DMG files should (could?) also include the project version in their filename. This PR implements precisely that change.

It is nearly trivial and works nicely on my dev system.

Thanks in advance for reviewing it: I'll be glad to address any improvements you may point me to.