### PR TITLE
macOS | Include project version in output DMG volume name

### DIFF
--- a/src/briefcase/macos.py
+++ b/src/briefcase/macos.py
@@ -108,7 +108,7 @@ class macos(app):
 
         dmgbuild.build_dmg(
             filename=dmg_path,
-            volume_name=self.formal_name,
+            volume_name=self.formal_name + ' ' + self.version,
             settings={
                 'files': [self.app_location],
                 'symlinks': {'Applications': '/Applications'},


### PR DESCRIPTION
This should have been included in #271, but I missed it:

* #271 ensures that the output DMG filename includes the project version.
* This PR ensures that the DMG volume name includes the project version (the name used when the DMG is mounted and, possibly, visible as a "disk icon" on the desktop).

Tested and working on my dev system.

PS: Went for "name-version.dmg" for the filename because no spaces in filenames minimize some human driven mistakes, but opted for "name version" in the volume name for readability. Willing to review and discuss. :)