### PR TITLE
Add support for single element source paths.

### DIFF
--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -222,7 +222,7 @@ class BaseCommand(ABC):
         app_home = [
             path.split('/')
             for path in app.sources
-            if path.rsplit('/', 1)[1] == app.module_name
+            if path.rsplit('/', 1)[-1] == app.module_name
         ]
         try:
             if len(app_home) == 1:

--- a/tests/commands/base/test_app_module_path.py
+++ b/tests/commands/base/test_app_module_path.py
@@ -17,6 +17,13 @@ def test_no_prefix(base_command, myapp):
     assert str(base_command.app_module_path(myapp)) == str(base_command.base_path / 'my_app')
 
 
+def test_long_prefix(base_command, myapp):
+    "If an app provides a source location with a long prefix and it matches, it is selected as the dist-info location"
+    myapp.sources = ['path/to/src/my_app']
+
+    assert str(base_command.app_module_path(myapp)) == str(base_command.base_path / 'path' / 'to' / 'src' / 'my_app')
+
+
 def test_matching_source(base_command, myapp):
     "If an app provides a single matching source location, it is selected as the dist-info location"
     myapp.sources = ['src/other', 'src/my_app', 'src/extra']
@@ -25,7 +32,7 @@ def test_matching_source(base_command, myapp):
 
 
 def test_multiple_match(base_command, myapp):
-    "If an app provides multiple matching source location, it is selected as the dist-info location"
+    "If an app provides multiple matching source location, an error is raised"
     myapp.sources = ['src/my_app', 'extra/my_app']
 
     with pytest.raises(BriefcaseCommandError):
@@ -33,7 +40,8 @@ def test_multiple_match(base_command, myapp):
 
 
 def test_hyphen_source(base_command, myapp):
-    "If an app provides a single matching source location, it is selected as the dist-info location"
+    "If an app provides a single source location with a hypye, an error is raised."
+    # The source directory must be a valid module, so hyphens aren't legal.
     myapp.sources = ['src/my-app']
 
     with pytest.raises(BriefcaseCommandError):
@@ -41,8 +49,16 @@ def test_hyphen_source(base_command, myapp):
 
 
 def test_no_match(base_command, myapp):
-    "If an app provides a single matching source location, it is selected as the dist-info location"
+    "If an app provides a multiple locations, none of which match, an error is raised"
     myapp.sources = ['src/pork', 'src/spam']
+
+    with pytest.raises(BriefcaseCommandError):
+        base_command.app_module_path(myapp)
+
+
+def test_no_source(base_command, myapp):
+    "If an app provides no source locations, an error is raised"
+    myapp.sources = []
 
     with pytest.raises(BriefcaseCommandError):
         base_command.app_module_path(myapp)

--- a/tests/commands/base/test_app_module_path.py
+++ b/tests/commands/base/test_app_module_path.py
@@ -10,6 +10,13 @@ def test_single_source(base_command, myapp):
     assert str(base_command.app_module_path(myapp)) == str(base_command.base_path / 'src' / 'my_app')
 
 
+def test_no_prefix(base_command, myapp):
+    "If an app provides a source location without a prefix and it matches, it is selected as the dist-info location"
+    myapp.sources = ['my_app']
+
+    assert str(base_command.app_module_path(myapp)) == str(base_command.base_path / 'my_app')
+
+
 def test_matching_source(base_command, myapp):
     "If an app provides a single matching source location, it is selected as the dist-info location"
     myapp.sources = ['src/other', 'src/my_app', 'src/extra']


### PR DESCRIPTION
Allows for source paths that have no prefix, or have a long prefix.