### PR TITLE
Fixes #287 - Correct capitalization in new project wizard.

### DIFF
--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -233,7 +233,7 @@ class NewCommand(BaseCommand):
         while True:
             print()
             answer = self.input("{variable} [{default}]: ".format(
-                variable=variable.capitalize(),
+                variable=titlecase(variable),
                 default=default,
             ))
 

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -15,6 +15,30 @@ from .create import InvalidTemplateRepository
 VALID_BUNDLE_RE = re.compile(r'[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+$')
 
 
+def titlecase(s):
+    """
+    Convert a string to titlecase.
+
+    Follow Chicago Manual of Style rules for capitalization (roughly).
+
+    * Capitalize *only* the first letter of each word
+    * ... unless the word is an acronym (e.g., URL)
+    * ... or the word is on the exclude list ('of', 'and', 'the)
+    :param s: The input string
+    :returns: A capitalized string.
+    """
+    return ' '.join(
+        word if (
+            word.isupper()
+            or word in {
+                'a', 'an', 'and', 'as', 'at', 'but', 'by', 'en', 'for',
+                'if', 'in', 'of', 'on', 'or', 'the', 'to', 'via', 'vs'
+            }
+        ) else word.capitalize()
+        for word in s.split(' ')
+    )
+
+
 class NewCommand(BaseCommand):
     cmd_line = 'briefcase new'
     command = 'new'
@@ -260,7 +284,7 @@ Select one of the following:
 
 {variable} [1]: """.format(
                     display_options=display_options,
-                    variable=variable.title()
+                    variable=titlecase(variable)
                 )
             )
 

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -209,7 +209,7 @@ class NewCommand(BaseCommand):
         while True:
             print()
             answer = self.input("{variable} [{default}]: ".format(
-                variable=variable.title(),
+                variable=variable.capitalize(),
                 default=default,
             ))
 

--- a/tests/commands/new/test_input_select.py
+++ b/tests/commands/new/test_input_select.py
@@ -77,3 +77,27 @@ Select one of the following:
 
 My Variable [1]: """)
     assert value == "first"
+
+
+def test_prompt_capitalization(new_command):
+    "The prompt is correctly capitalized"
+    new_command.input = mock.MagicMock(return_value='2')
+
+    new_command.input_select(
+        intro="Some introduction",
+        variable="user's URL",
+        options=[
+            'first',
+            'second',
+            'third',
+        ]
+    )
+
+    new_command.input.assert_called_with("""
+Select one of the following:
+
+    [1] first
+    [2] second
+    [3] third
+
+User's URL [1]: """)

--- a/tests/commands/new/test_input_text.py
+++ b/tests/commands/new/test_input_text.py
@@ -45,3 +45,16 @@ def test_input_with_default(new_command):
     assert new_command.input.call_count == 1
     new_command.input.assert_called_with("My Variable [goodbye]: ")
     assert value == "goodbye"
+
+
+def test_prompt_capitalization(new_command):
+    "The prompt is capitalized appropriately"
+    new_command.input = mock.MagicMock(return_value='hello')
+
+    new_command.input_text(
+        intro="Some introduction",
+        variable="user's URL",
+        default="goodbye"
+    )
+
+    new_command.input.assert_called_with("User's URL [goodbye]: ")

--- a/tests/commands/new/test_titlecase.py
+++ b/tests/commands/new/test_titlecase.py
@@ -1,0 +1,24 @@
+import pytest
+
+from briefcase.commands.new import titlecase
+
+
+@pytest.mark.parametrize(
+    'raw, converted',
+    [
+        ('Hello', 'Hello'),
+        ('hello', 'Hello'),
+        ('hello world', 'Hello World'),
+        ("hello world's fair", "Hello World's Fair"),
+        ("world of wonder", "World of Wonder"),
+        ("hunt the wumpus", "Hunt the Wumpus"),
+        ("scott pilgrim vs the world", "Scott Pilgrim vs the World"),
+
+        # Specific examples that we know are problematic
+        ("author's email", "Author's Email"),
+        ("project URL", "Project URL"),
+    ]
+)
+def test_titlecase(raw, converted):
+    "Test that a string can be capitalized"
+    assert titlecase(raw) == converted


### PR DESCRIPTION
str.title() behavior is weird... use str.capitalize() instead. Thanks to @beckernick for the report.