### PR TITLE
Updates to packaging metadata following usage in Toga

### DIFF
--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -235,11 +235,11 @@ class BaseCommand(ABC):
                 path = Path(str(self.base_path), *app_home[0])
             else:
                 raise BriefcaseCommandError(
-                    "Multiple paths in sources found for application '{app.name}'".format(app=app)
+                    "Multiple paths in sources found for application '{app.app_name}'".format(app=app)
                 )
         except IndexError:
             raise BriefcaseCommandError(
-                "Unable to find code for application '{app.name}'".format(app=app)
+                "Unable to find code for application '{app.app_name}'".format(app=app)
             )
 
         return path

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -44,7 +44,7 @@ class BuildCommand(BaseCommand):
         state = self.build_app(app, **full_kwargs(state, kwargs))
 
         print()
-        print("[{app.name}] Built {filename}".format(
+        print("[{app.app_name}] Built {filename}".format(
             app=app,
             filename=self.binary_path(app).relative_to(self.base_path),
         ))

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -97,7 +97,7 @@ def write_dist_info(app: BaseConfig, dist_info_path: Path):
         f.write('Metadata-Version: 2.1\n')
         f.write('Name: {app.name}\n'.format(app=app))
         f.write('Formal-Name: {app.formal_name}\n'.format(app=app))
-        f.write('Bundle: {app.bundle}\n'.format(app=app))
+        f.write('App-ID: {app.bundle}.{app.name}\n'.format(app=app))
         f.write('Version: {app.version}\n'.format(app=app))
         if app.url:
             f.write('Home-page: {app.url}\n'.format(app=app))

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -95,9 +95,9 @@ def write_dist_info(app: BaseConfig, dist_info_path: Path):
         f.write('briefcase\n')
     with (dist_info_path / 'METADATA').open('w') as f:
         f.write('Metadata-Version: 2.1\n')
-        f.write('Name: {app.name}\n'.format(app=app))
+        f.write('App-Name: {app.app_name}\n'.format(app=app))
         f.write('Formal-Name: {app.formal_name}\n'.format(app=app))
-        f.write('App-ID: {app.bundle}.{app.name}\n'.format(app=app))
+        f.write('App-ID: {app.bundle}.{app.app_name}\n'.format(app=app))
         f.write('Version: {app.version}\n'.format(app=app))
         if app.url:
             f.write('Home-page: {app.url}\n'.format(app=app))
@@ -488,7 +488,7 @@ class CreateCommand(BaseCommand):
                 else:
                     self.shutil.copy(str(original), str(target))
         else:
-            print("No sources defined for {app.name}.".format(app=app))
+            print("No sources defined for {app.app_name}.".format(app=app))
 
         # Write the dist-info folder for the application.
         write_dist_info(
@@ -588,52 +588,52 @@ class CreateCommand(BaseCommand):
         bundle_path = self.bundle_path(app)
         if bundle_path.exists():
             print()
-            confirm = self.input('Application {app.name} already exists; overwrite (y/N)? '.format(
+            confirm = self.input('Application {app.app_name} already exists; overwrite (y/N)? '.format(
                 app=app
             ))
             if confirm.lower() != 'y':
-                print("Aborting creation of app {app.name}".format(
+                print("Aborting creation of app {app.app_name}".format(
                     app=app
                 ))
                 return
             print()
-            print("[{app.name}] Removing old application bundle...".format(
+            print("[{app.app_name}] Removing old application bundle...".format(
                 app=app
             ))
             self.shutil.rmtree(str(bundle_path))
 
         print()
-        print('[{app.name}] Generating application template...'.format(
+        print('[{app.app_name}] Generating application template...'.format(
             app=app
         ))
         self.generate_app_template(app=app)
 
         print()
-        print('[{app.name}] Installing support package...'.format(
+        print('[{app.app_name}] Installing support package...'.format(
             app=app
         ))
         self.install_app_support_package(app=app)
 
         print()
-        print('[{app.name}] Installing dependencies...'.format(
+        print('[{app.app_name}] Installing dependencies...'.format(
             app=app
         ))
         self.install_app_dependencies(app=app)
 
         print()
-        print('[{app.name}] Installing application code...'.format(
+        print('[{app.app_name}] Installing application code...'.format(
             app=app
         ))
         self.install_app_code(app=app)
 
         print()
-        print('[{app.name}] Installing application resources...'.format(
+        print('[{app.app_name}] Installing application resources...'.format(
             app=app
         ))
         self.install_app_resources(app=app)
         print()
 
-        print("[{app.name}] Created {filename}".format(
+        print("[{app.app_name}] Created {filename}".format(
             app=app,
             filename=self.bundle_path(app).relative_to(self.base_path),
         ))

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -95,7 +95,7 @@ def write_dist_info(app: BaseConfig, dist_info_path: Path):
         f.write('briefcase\n')
     with (dist_info_path / 'METADATA').open('w') as f:
         f.write('Metadata-Version: 2.1\n')
-        f.write('App-Name: {app.app_name}\n'.format(app=app))
+        f.write('Name: {app.app_name}\n'.format(app=app))
         f.write('Formal-Name: {app.formal_name}\n'.format(app=app))
         f.write('App-ID: {app.bundle}.{app.app_name}\n'.format(app=app))
         f.write('Version: {app.version}\n'.format(app=app))

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -96,7 +96,7 @@ class DevCommand(BaseCommand):
         except subprocess.CalledProcessError:
             print()
             raise BriefcaseCommandError(
-                "Unable to start application '{app.name}'".format(
+                "Unable to start application '{app.app_name}'".format(
                     app=app
                 ))
 
@@ -132,14 +132,14 @@ class DevCommand(BaseCommand):
         dist_info_path = self.app_module_path(app).parent / '{app.module_name}.dist-info'.format(app=app)
         if update_dependencies or not dist_info_path.exists():
             print()
-            print('[{app.name}] Installing dependencies...'.format(
+            print('[{app.app_name}] Installing dependencies...'.format(
                 app=app
             ))
             self.install_dev_dependencies(app, **kwargs)
             write_dist_info(app, dist_info_path)
 
         print()
-        print('[{app.name}] Starting in dev mode...'.format(
+        print('[{app.app_name}] Starting in dev mode...'.format(
             app=app
         ))
         state = self.run_dev_app(app, **kwargs)

--- a/src/briefcase/commands/update.py
+++ b/src/briefcase/commands/update.py
@@ -34,33 +34,33 @@ class UpdateCommand(CreateCommand):
         bundle_path = self.bundle_path(app)
         if not bundle_path.exists():
             print()
-            print("[{app.name}] Application does not exist; call create first!".format(
+            print("[{app.app_name}] Application does not exist; call create first!".format(
                 app=app
             ))
             return
 
         if update_dependencies:
             print()
-            print('[{app.name}] Updating dependencies...'.format(
+            print('[{app.app_name}] Updating dependencies...'.format(
                 app=app
             ))
             self.install_app_dependencies(app=app)
 
         print()
-        print('[{app.name}] Updating application code...'.format(
+        print('[{app.app_name}] Updating application code...'.format(
             app=app
         ))
         self.install_app_code(app=app)
 
         if update_resources:
             print()
-            print('[{app.name}] Updating extra application resources...'.format(
+            print('[{app.app_name}] Updating extra application resources...'.format(
                 app=app
             ))
             self.install_app_resources(app=app)
 
         print()
-        print('[{app.name}] Application updated.'.format(
+        print('[{app.app_name}] Application updated.'.format(
             app=app
         ))
 

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -74,7 +74,7 @@ class GlobalConfig(BaseConfig):
 class AppConfig(BaseConfig):
     def __init__(
         self,
-        name,
+        app_name,
         version,
         bundle,
         description,
@@ -92,12 +92,12 @@ class AppConfig(BaseConfig):
     ):
         super().__init__(**kwargs)
 
-        self.name = name
+        self.app_name = app_name
         self.version = version
         self.bundle = bundle
         self.description = description
         self.sources = sources
-        self.formal_name = name if formal_name is None else formal_name
+        self.formal_name = app_name if formal_name is None else formal_name
         self.url = url
         self.author = author
         self.author_email = author_email
@@ -108,9 +108,9 @@ class AppConfig(BaseConfig):
         self.template = template
 
         # Validate that the app name is valid.
-        if not PEP508_NAME_RE.match(self.name):
+        if not PEP508_NAME_RE.match(self.app_name):
             raise BriefcaseConfigError(
-                "{self.name!r} is not a valid app name.\n\n"
+                "{self.app_name!r} is not a valid app name.\n\n"
                 "App names must be PEP508 compliant (i.e., they can only "
                 "include letters, numbers, '-' and '_'; must start with a "
                 "letter; and cannot end with '-' or '_'.".format(self=self)
@@ -119,7 +119,7 @@ class AppConfig(BaseConfig):
         # Version number is PEP440 compliant:
         if not is_pep440_canonical_version(self.version):
             raise BriefcaseConfigError(
-                "Version number for {self.name} ({self.version}) is not valid.\n\n"
+                "Version number for {self.app_name} ({self.version}) is not valid.\n\n"
                 "Version numbers must be PEP440 compliant; "
                 "see https://www.python.org/dev/peps/pep-0440/ for details.".format(
                     self=self
@@ -130,19 +130,19 @@ class AppConfig(BaseConfig):
         source_modules = {source.rsplit('/', 1)[-1] for source in self.sources}
         if len(self.sources) != len(source_modules):
             raise BriefcaseConfigError(
-                "The `sources` list for {self.name} contains duplicated "
+                "The `sources` list for {self.app_name} contains duplicated "
                 "package names.".format(self=self)
             )
 
         # There is, at least, a source for the app module
         if self.module_name not in source_modules:
             raise BriefcaseConfigError(
-                "The `sources` list for {self.name} does not include a "
+                "The `sources` list for {self.app_name} does not include a "
                 "package named '{self.module_name}'.".format(self=self)
             )
 
     def __repr__(self):
-        return "<{self.bundle}.{self.name} v{self.version} AppConfig>".format(
+        return "<{self.bundle}.{self.app_name} v{self.version} AppConfig>".format(
             self=self,
         )
 
@@ -154,7 +154,7 @@ class AppConfig(BaseConfig):
         This is derived from the name, but:
         * all `-` have been replaced with `_`.
         """
-        return self.name.replace('-', '_')
+        return self.app_name.replace('-', '_')
 
 
 def merge_config(config, data):
@@ -278,7 +278,7 @@ def parse_config(config_file, platform, output_format):
         config = copy.deepcopy(global_config)
 
         # The app name is both the key, and a property of the configuration
-        config['name'] = app_name
+        config['app_name'] = app_name
 
         # Merge the app-specific requirements
         merge_config(config, app_data)

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -226,7 +226,7 @@ class iOSXcodeBuildCommand(iOSXcodeMixin, BuildCommand):
         ))
 
         print()
-        print('[{app.name}] Building XCode project...'.format(
+        print('[{app.app_name}] Building XCode project...'.format(
             app=app
         ))
 
@@ -262,7 +262,7 @@ class iOSXcodeBuildCommand(iOSXcodeMixin, BuildCommand):
         except subprocess.CalledProcessError:
             print()
             raise BriefcaseCommandError(
-                "Unable to build app {app.name}.".format(app=app)
+                "Unable to build app {app.app_name}.".format(app=app)
             )
 
         # Preserve the device selection as state.
@@ -352,8 +352,8 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
 
         # Try to uninstall the app first. If the app hasn't been installed
         # before, this will still succeed.
-        app_identifier = '.'.join([app.bundle, app.name])
-        print('[{app.name}] Uninstalling old app version...'.format(
+        app_identifier = '.'.join([app.bundle, app.app_name])
+        print('[{app.app_name}] Uninstalling old app version...'.format(
             app=app
         ))
         try:
@@ -363,13 +363,13 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
             )
         except subprocess.CalledProcessError:
             raise BriefcaseCommandError(
-                "Unable to uninstall old version of app {app.name}.".format(
+                "Unable to uninstall old version of app {app.app_name}.".format(
                     app=app
                 )
             )
 
         # Install the app.
-        print('[{app.name}] Installing new app version...'.format(
+        print('[{app.app_name}] Installing new app version...'.format(
             app=app
         ))
         try:
@@ -379,12 +379,12 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
             )
         except subprocess.CalledProcessError:
             raise BriefcaseCommandError(
-                "Unable to install new version of app {app.name}.".format(
+                "Unable to install new version of app {app.app_name}.".format(
                     app=app
                 )
             )
 
-        print('[{app.name}] Starting app...'.format(
+        print('[{app.app_name}] Starting app...'.format(
             app=app
         ))
         try:
@@ -394,7 +394,7 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
             )
         except subprocess.CalledProcessError:
             raise BriefcaseCommandError(
-                "Unable to launch app {app.name}.".format(
+                "Unable to launch app {app.app_name}.".format(
                     app=app
                 )
             )

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -87,7 +87,7 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
         :param app: The application to build
         """
         print()
-        print("[{app.name}] Building AppImage...".format(app=app))
+        print("[{app.app_name}] Building AppImage...".format(app=app))
 
         try:
             print()
@@ -104,7 +104,7 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
                     str(self.linuxdeploy_appimage),
                     "--appdir={appdir_path}".format(appdir_path=appdir_path),
                     "-d", str(
-                        appdir_path / "{app.bundle}.{app.name}.desktop".format(
+                        appdir_path / "{app.bundle}.{app.app_name}.desktop".format(
                             app=app,
                         )
                     ),
@@ -120,7 +120,7 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
         except subprocess.CalledProcessError:
             print()
             raise BriefcaseCommandError(
-                "Error while building app {app.name}.".format(app=app)
+                "Error while building app {app.app_name}.".format(app=app)
             )
 
 
@@ -135,7 +135,7 @@ class LinuxAppImageRunCommand(LinuxAppImageMixin, RunCommand):
         :param base_path: The path to the project directory.
         """
         print()
-        print('[{app.name}] Starting app...'.format(
+        print('[{app.app_name}] Starting app...'.format(
             app=app
         ))
         try:
@@ -149,7 +149,7 @@ class LinuxAppImageRunCommand(LinuxAppImageMixin, RunCommand):
         except subprocess.CalledProcessError:
             print()
             raise BriefcaseCommandError(
-                "Unable to start app {app.name}.".format(app=app)
+                "Unable to start app {app.app_name}.".format(app=app)
             )
 
 

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -49,7 +49,7 @@ class macOSAppRunCommand(macOSAppMixin, RunCommand):
         :param base_path: The path to the project directory.
         """
         print()
-        print('[{app.name}] Starting app...'.format(
+        print('[{app.app_name}] Starting app...'.format(
             app=app
         ))
         try:
@@ -64,7 +64,7 @@ class macOSAppRunCommand(macOSAppMixin, RunCommand):
         except subprocess.CalledProcessError:
             print()
             raise BriefcaseCommandError(
-                "Unable to start app {app.name}.".format(app=app)
+                "Unable to start app {app.app_name}.".format(app=app)
             )
 
 
@@ -184,7 +184,7 @@ class macOSAppPackageCommand(macOSAppMixin, PackageCommand):
             identity = self.select_identity(identity=identity)
 
             print()
-            print("[{app.name}] Signing app with identity {identity}...".format(
+            print("[{app.app_name}] Signing app with identity {identity}...".format(
                 app=app,
                 identity=identity
             ))

--- a/src/briefcase/platforms/macOS/dmg.py
+++ b/src/briefcase/platforms/macOS/dmg.py
@@ -72,7 +72,7 @@ class macOSDmgPackageCommand(macOSDmgMixin, macOSAppPackageCommand):
         super().package_app(app, **kwargs)
 
         print()
-        print("[{app.name}] Building DMG...".format(app=app))
+        print("[{app.app_name}] Building DMG...".format(app=app))
 
         dmg_settings = {
             'files': [str(self.binary_path(app))],

--- a/src/briefcase/platforms/windows/msi.py
+++ b/src/briefcase/platforms/windows/msi.py
@@ -121,9 +121,9 @@ class WindowsMSICreateCommand(WindowsMSIMixin, CreateCommand):
             guid = app.guid
         except AttributeError:
             # Create a DNS domain by reversing the bundle identifier
-            domain = '.'.join([app.name] + app.bundle.split('.')[::-1])
+            domain = '.'.join([app.app_name] + app.bundle.split('.')[::-1])
             guid = uuid.uuid5(uuid.NAMESPACE_DNS, domain)
-            print("Assigning {app.name} an application GUID of {guid}".format(
+            print("Assigning {app.app_name} an application GUID of {guid}".format(
                 app=app,
                 guid=guid,
             ))
@@ -175,7 +175,7 @@ class WindowsMSIRunCommand(WindowsMSIMixin, RunCommand):
         :param base_path: The path to the project directory.
         """
         print()
-        print('[{app.name}] Starting app...'.format(
+        print('[{app.app_name}] Starting app...'.format(
             app=app
         ))
         try:
@@ -190,7 +190,7 @@ class WindowsMSIRunCommand(WindowsMSIMixin, RunCommand):
         except subprocess.CalledProcessError:
             print()
             raise BriefcaseCommandError(
-                "Unable to start app {app.name}.".format(app=app)
+                "Unable to start app {app.app_name}.".format(app=app)
             )
 
 
@@ -204,7 +204,7 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
         :param app: The application to build
         """
         print()
-        print("[{app.name}] Building MSI...".format(app=app))
+        print("[{app.app_name}] Building MSI...".format(app=app))
 
         try:
             print()
@@ -223,14 +223,14 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
                     "-dr", "{app.module_name}_ROOTDIR".format(app=app),  # Root directory reference name
                     "-cg", "{app.module_name}_COMPONENTS".format(app=app),  # Root component group name
                     "-var", "var.SourceDir",  # variable to use as the source dir
-                    "-out", "{app.name}-manifest.wxs".format(app=app),
+                    "-out", "{app.app_name}-manifest.wxs".format(app=app),
                 ],
                 check=True,
                 cwd=str(self.bundle_path(app))
             )
         except subprocess.CalledProcessError:
             raise BriefcaseCommandError(
-                "Unable to generate manifest for app {app.name}.".format(app=app)
+                "Unable to generate manifest for app {app.app_name}.".format(app=app)
             )
 
         try:
@@ -243,15 +243,15 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
                     "-ext", "WixUtilExtension",
                     "-ext", "WixUIExtension",
                     "-dSourceDir=src",
-                    "{app.name}.wxs".format(app=app),
-                    "{app.name}-manifest.wxs".format(app=app),
+                    "{app.app_name}.wxs".format(app=app),
+                    "{app.app_name}-manifest.wxs".format(app=app),
                 ],
                 check=True,
                 cwd=str(self.bundle_path(app))
             )
         except subprocess.CalledProcessError:
             raise BriefcaseCommandError(
-                "Unable to compile app {app.name}.".format(app=app)
+                "Unable to compile app {app.app_name}.".format(app=app)
             )
 
         try:
@@ -264,8 +264,8 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
                     "-ext", "WixUtilExtension",
                     "-ext", "WixUIExtension",
                     "-o", str(self.distribution_path(app)),
-                    "{app.name}.wixobj".format(app=app),
-                    "{app.name}-manifest.wixobj".format(app=app),
+                    "{app.app_name}.wixobj".format(app=app),
+                    "{app.app_name}-manifest.wixobj".format(app=app),
                 ],
                 check=True,
                 cwd=str(self.bundle_path(app))
@@ -273,7 +273,7 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
         except subprocess.CalledProcessError:
             print()
             raise BriefcaseCommandError(
-                "Unable to link app {app.name}.".format(app=app)
+                "Unable to link app {app.app_name}.".format(app=app)
             )
 
 

--- a/tests/commands/base/conftest.py
+++ b/tests/commands/base/conftest.py
@@ -84,7 +84,7 @@ class CustomGlobalConfig(BaseConfig):
 class CustomAppConfig(AppConfig):
     def __init__(self, foo, bar, **kwargs):
         super().__init__(
-            name='custom',
+            app_name='custom',
             bundle='com.example',
             description='Custom app',
             version="37.42",
@@ -127,7 +127,7 @@ def other_command(tmp_path):
 @pytest.fixture
 def my_app():
     return AppConfig(
-        name='my-app',
+        app_name='my-app',
         formal_name='My App',
         bundle='com.example',
         version='1.2.3',

--- a/tests/commands/base/test_parse_config.py
+++ b/tests/commands/base/test_parse_config.py
@@ -87,7 +87,7 @@ def test_parse_config(base_command):
     # defined in the config file.
     assert repr(base_command.apps['firstapp']) == '<org.beeware.firstapp v1.2.3 AppConfig>'
     assert base_command.apps['firstapp'].project_name == 'Sample project'
-    assert base_command.apps['firstapp'].name == 'firstapp'
+    assert base_command.apps['firstapp'].app_name == 'firstapp'
     assert base_command.apps['firstapp'].bundle == 'org.beeware'
     assert base_command.apps['firstapp'].mystery == 'default'
     assert not hasattr(base_command.apps['firstapp'], 'extra')
@@ -96,7 +96,7 @@ def test_parse_config(base_command):
     # value for `mystery`, and an `extra` value.
     assert repr(base_command.apps['secondapp']) == '<org.beeware.secondapp v1.2.3 AppConfig>'
     assert base_command.apps['secondapp'].project_name == 'Sample project'
-    assert base_command.apps['secondapp'].name == 'secondapp'
+    assert base_command.apps['secondapp'].app_name == 'secondapp'
     assert base_command.apps['secondapp'].bundle == 'org.beeware'
     assert base_command.apps['secondapp'].mystery == 'sekrits'
     assert base_command.apps['secondapp'].extra == 'something'
@@ -173,6 +173,6 @@ def test_parse_config_custom_config_classes(other_command):
     assert other_command.apps['firstapp'].bar == 'ham'
 
     # The custom class sets the underlying attributes of the AppConfig
-    assert other_command.apps['firstapp'].name == 'custom'
+    assert other_command.apps['firstapp'].app_name == 'custom'
     assert other_command.apps['firstapp'].bundle == 'com.example'
     assert other_command.apps['firstapp'].version == "37.42"

--- a/tests/commands/build/conftest.py
+++ b/tests/commands/build/conftest.py
@@ -20,33 +20,33 @@ class DummyBuildCommand(BuildCommand):
         self.actions = []
 
     def bundle_path(self, app):
-        return self.platform_path / '{app.name}.dummy'.format(app=app)
+        return self.platform_path / '{app.app_name}.dummy'.format(app=app)
 
     def binary_path(self, app):
-        return self.platform_path / '{app.name}.dummy.bin'.format(app=app)
+        return self.platform_path / '{app.app_name}.dummy.bin'.format(app=app)
 
     def distribution_path(self, app):
-        return self.platform_path / '{app.name}.dummy.dist'.format(app=app)
+        return self.platform_path / '{app.app_name}.dummy.dist'.format(app=app)
 
     def build_app(self, app, **kwargs):
-        self.actions.append(('build', app.name, kwargs))
+        self.actions.append(('build', app.app_name, kwargs))
         return full_kwargs({
-            'build_state': app.name
+            'build_state': app.app_name
         }, kwargs)
 
     # These commands override the default behavior, simply tracking that
     # they were invoked, rather than instantiating a Create/Update command.
     # This is for testing purposes.
     def create_command(self, app, **kwargs):
-        self.actions.append(('create', app.name, kwargs))
+        self.actions.append(('create', app.app_name, kwargs))
         return full_kwargs({
-            'create_state': app.name
+            'create_state': app.app_name
         }, kwargs)
 
     def update_command(self, app, **kwargs):
-        self.actions.append(('update', app.name, kwargs))
+        self.actions.append(('update', app.app_name, kwargs))
         return full_kwargs({
-            'update_state': app.name
+            'update_state': app.app_name
         }, kwargs)
 
 
@@ -58,7 +58,7 @@ def build_command(tmp_path):
 @pytest.fixture
 def first_app_config():
     return AppConfig(
-        name='first',
+        app_name='first',
         bundle='com.example',
         version='0.0.1',
         description='The first simple app',
@@ -90,7 +90,7 @@ def first_app(first_app_unbuilt, tmp_path):
 @pytest.fixture
 def second_app_config():
     return AppConfig(
-        name='second',
+        app_name='second',
         bundle='com.example',
         version='0.0.2',
         description='The second simple app',

--- a/tests/commands/create/conftest.py
+++ b/tests/commands/create/conftest.py
@@ -30,13 +30,13 @@ class DummyCreateCommand(CreateCommand):
         self.support_file = support_file
 
     def bundle_path(self, app):
-        return self.platform_path / '{app.name}.bundle'.format(app=app)
+        return self.platform_path / '{app.app_name}.bundle'.format(app=app)
 
     def binary_path(self, app):
-        return self.platform_path / '{app.name}.binary'.format(app=app)
+        return self.platform_path / '{app.app_name}.binary'.format(app=app)
 
     def distribution_path(self, app):
-        return self.platform_path / '{app.name}.dist'.format(app=app)
+        return self.platform_path / '{app.app_name}.dist'.format(app=app)
 
     # Hard code the python version to make testing easier.
     @property
@@ -97,14 +97,14 @@ def tracking_create_command(tmp_path):
         base_path=tmp_path,
         apps={
             'first': AppConfig(
-                name='first',
+                app_name='first',
                 bundle='com.example',
                 version='0.0.1',
                 description='The first simple app',
                 sources=['src/first'],
             ),
             'second': AppConfig(
-                name='second',
+                app_name='second',
                 bundle='com.example',
                 version='0.0.2',
                 description='The second simple app',
@@ -117,7 +117,7 @@ def tracking_create_command(tmp_path):
 @pytest.fixture
 def myapp():
     return AppConfig(
-        name='my-app',
+        app_name='my-app',
         formal_name='My App',
         bundle='com.example',
         version='1.2.3',
@@ -131,7 +131,7 @@ def bundle_path(myapp, tmp_path):
     # Return the bundle path for the app; however, as a side effect,
     # ensure that the app, app_packages and support target directories
     # exist, and the briefcase index file has been created.
-    bundle_path = tmp_path / 'tester' / '{myapp.name}.bundle'.format(myapp=myapp)
+    bundle_path = tmp_path / 'tester' / '{myapp.app_name}.bundle'.format(myapp=myapp)
     (bundle_path / 'path' / 'to' / 'app').mkdir(parents=True, exist_ok=True)
     (bundle_path / 'path' / 'to' / 'app_packages').mkdir(parents=True, exist_ok=True)
     (bundle_path / 'path' / 'to' / 'support').mkdir(parents=True, exist_ok=True)

--- a/tests/commands/create/test_generate_app_template.py
+++ b/tests/commands/create/test_generate_app_template.py
@@ -15,7 +15,7 @@ from briefcase.exceptions import NetworkFailure
 def full_context(extra):
     "The full context associated with myapp"
     context = {
-        'name': 'my-app',
+        'app_name': 'my-app',
         'formal_name': 'My App',
         'bundle': 'com.example',
         'version': '1.2.3',

--- a/tests/commands/create/test_install_app_code.py
+++ b/tests/commands/create/test_install_app_code.py
@@ -17,7 +17,7 @@ def assert_dist_info(app_path):
 
     with (dist_info_path / 'METADATA').open() as f:
         assert f.read() == """Metadata-Version: 2.1
-Name: my-app
+App-Name: my-app
 Formal-Name: My App
 App-ID: com.example.my-app
 Version: 1.2.3

--- a/tests/commands/create/test_install_app_code.py
+++ b/tests/commands/create/test_install_app_code.py
@@ -19,7 +19,7 @@ def assert_dist_info(app_path):
         assert f.read() == """Metadata-Version: 2.1
 Name: my-app
 Formal-Name: My App
-Bundle: com.example
+App-ID: com.example.my-app
 Version: 1.2.3
 Summary: This is a simple app
 """

--- a/tests/commands/create/test_install_app_code.py
+++ b/tests/commands/create/test_install_app_code.py
@@ -17,7 +17,7 @@ def assert_dist_info(app_path):
 
     with (dist_info_path / 'METADATA').open() as f:
         assert f.read() == """Metadata-Version: 2.1
-App-Name: my-app
+Name: my-app
 Formal-Name: My App
 App-ID: com.example.my-app
 Version: 1.2.3

--- a/tests/commands/create/test_install_app_resources.py
+++ b/tests/commands/create/test_install_app_resources.py
@@ -6,7 +6,7 @@ from briefcase.config import AppConfig
 def test_no_resources(create_command):
     "If the template defines no extra targets, none are installed"
     myapp = AppConfig(
-        name='my-app',
+        app_name='my-app',
         formal_name='My App',
         bundle='com.example',
         version='1.2.3',
@@ -30,7 +30,7 @@ def test_no_resources(create_command):
 def test_icon_target(create_command, tmp_path):
     "If the template defines an icon target, it will be installed"
     myapp = AppConfig(
-        name='my-app',
+        app_name='my-app',
         formal_name='My App',
         bundle='com.example',
         version='1.2.3',
@@ -75,7 +75,7 @@ def test_icon_target(create_command, tmp_path):
 def test_splash_target(create_command, tmp_path):
     "If the template defines an splash target, it will be installed"
     myapp = AppConfig(
-        name='my-app',
+        app_name='my-app',
         formal_name='My App',
         bundle='com.example',
         version='1.2.3',
@@ -120,7 +120,7 @@ def test_splash_target(create_command, tmp_path):
 def test_doctype_icon_target(create_command, tmp_path):
     "If the template defines document types, their icons will be installed"
     myapp = AppConfig(
-        name='my-app',
+        app_name='my-app',
         formal_name='My App',
         bundle='com.example',
         version='1.2.3',

--- a/tests/commands/dev/conftest.py
+++ b/tests/commands/dev/conftest.py
@@ -20,12 +20,12 @@ class DummyDevCommand(DevCommand):
         self.actions = []
 
     def install_dev_dependencies(self, app, **kwargs):
-        self.actions.append(('dev_dependencies', app.name, kwargs))
+        self.actions.append(('dev_dependencies', app.app_name, kwargs))
 
     def run_dev_app(self, app, **kwargs):
-        self.actions.append(('run_dev', app.name, kwargs))
+        self.actions.append(('run_dev', app.app_name, kwargs))
         return full_kwargs({
-            'run_dev_state': app.name
+            'run_dev_state': app.app_name
         }, kwargs)
 
 
@@ -42,7 +42,7 @@ def first_app_uninstalled(tmp_path):
         f.write('print("Hello world")')
 
     return AppConfig(
-        name='first',
+        app_name='first',
         bundle='com.example',
         version='0.0.1',
         description='The first simple app',
@@ -69,7 +69,7 @@ def second_app(tmp_path):
     (tmp_path / 'src' / 'second.dist-info').mkdir(exist_ok=True)
 
     return AppConfig(
-        name='second',
+        app_name='second',
         bundle='com.example',
         version='0.0.2',
         description='The second simple app',

--- a/tests/commands/publish/conftest.py
+++ b/tests/commands/publish/conftest.py
@@ -20,13 +20,13 @@ class DummyPublishCommand(PublishCommand):
         self.actions = []
 
     def bundle_path(self, app):
-        return self.platform_path / '{app.name}.dummy'.format(app=app)
+        return self.platform_path / '{app.app_name}.dummy'.format(app=app)
 
     def binary_path(self, app):
-        return self.platform_path / '{app.name}.dummy.bin'.format(app=app)
+        return self.platform_path / '{app.app_name}.dummy.bin'.format(app=app)
 
     def distribution_path(self, app):
-        return self.platform_path / '{app.name}.dummy.dist'.format(app=app)
+        return self.platform_path / '{app.app_name}.dummy.dist'.format(app=app)
 
     @property
     def publication_channels(self):
@@ -37,30 +37,30 @@ class DummyPublishCommand(PublishCommand):
         return 's3'
 
     def publish_app(self, app, channel, **kwargs):
-        self.actions.append(('publish', app.name, channel, kwargs))
+        self.actions.append(('publish', app.app_name, channel, kwargs))
         return full_kwargs({
-            'publish_state': app.name
+            'publish_state': app.app_name
         }, kwargs)
 
     # These commands override the default behavior, simply tracking that
     # they were invoked, rather than instantiating a Create/Update/Build command.
     # This is for testing purposes.
     def create_command(self, app, **kwargs):
-        self.actions.append(('create', app.name, kwargs))
+        self.actions.append(('create', app.app_name, kwargs))
         return full_kwargs({
-            'create_state': app.name
+            'create_state': app.app_name
         }, kwargs)
 
     def update_command(self, app, **kwargs):
-        self.actions.append(('update', app.name, kwargs))
+        self.actions.append(('update', app.app_name, kwargs))
         return full_kwargs({
-            'update_state': app.name
+            'update_state': app.app_name
         }, kwargs)
 
     def build_command(self, app, **kwargs):
-        self.actions.append(('build', app.name, kwargs))
+        self.actions.append(('build', app.app_name, kwargs))
         return full_kwargs({
-            'build_state': app.name
+            'build_state': app.app_name
         }, kwargs)
 
 
@@ -72,7 +72,7 @@ def publish_command(tmp_path):
 @pytest.fixture
 def first_app_config():
     return AppConfig(
-        name='first',
+        app_name='first',
         bundle='com.example',
         version='0.0.1',
         description='The first simple app',
@@ -104,7 +104,7 @@ def first_app(first_app_unbuilt, tmp_path):
 @pytest.fixture
 def second_app_config():
     return AppConfig(
-        name='second',
+        app_name='second',
         bundle='com.example',
         version='0.0.2',
         description='The second simple app',

--- a/tests/commands/run/conftest.py
+++ b/tests/commands/run/conftest.py
@@ -20,39 +20,39 @@ class DummyRunCommand(RunCommand):
         self.actions = []
 
     def bundle_path(self, app):
-        return self.platform_path / app.name
+        return self.platform_path / app.app_name
 
     def binary_path(self, app):
-        return self.platform_path / app.name / '{app.name}.bin'.format(app=app)
+        return self.platform_path / app.app_name / '{app.app_name}.bin'.format(app=app)
 
     def distribution_path(self, app):
-        return self.platform_path / app.name / '{app.name}.dist'.format(app=app)
+        return self.platform_path / app.app_name / '{app.app_name}.dist'.format(app=app)
 
     def run_app(self, app, **kwargs):
-        self.actions.append(('run', app.name, kwargs))
+        self.actions.append(('run', app.app_name, kwargs))
         return full_kwargs({
-            'run_state': app.name
+            'run_state': app.app_name
         }, kwargs)
 
     # These commands override the default behavior, simply tracking that
     # they were invoked, rather than instantiating a Create/Update/Build command.
     # This is for testing purposes.
     def create_command(self, app, **kwargs):
-        self.actions.append(('create', app.name, kwargs))
+        self.actions.append(('create', app.app_name, kwargs))
         return full_kwargs({
-            'create_state': app.name
+            'create_state': app.app_name
         }, kwargs)
 
     def update_command(self, app, **kwargs):
-        self.actions.append(('update', app.name, kwargs))
+        self.actions.append(('update', app.app_name, kwargs))
         return full_kwargs({
-            'update_state': app.name
+            'update_state': app.app_name
         }, kwargs)
 
     def build_command(self, app, **kwargs):
-        self.actions.append(('build', app.name, kwargs))
+        self.actions.append(('build', app.app_name, kwargs))
         return full_kwargs({
-            'build_state': app.name
+            'build_state': app.app_name
         }, kwargs)
 
 
@@ -64,7 +64,7 @@ def run_command(tmp_path):
 @pytest.fixture
 def first_app_config():
     return AppConfig(
-        name='first',
+        app_name='first',
         bundle='com.example',
         version='0.0.1',
         description='The first simple app',
@@ -96,7 +96,7 @@ def first_app(first_app_uncompiled, tmp_path):
 @pytest.fixture
 def second_app_config():
     return AppConfig(
-        name='second',
+        app_name='second',
         bundle='com.example',
         version='0.0.2',
         description='The second simple app',

--- a/tests/commands/update/conftest.py
+++ b/tests/commands/update/conftest.py
@@ -19,13 +19,13 @@ class DummyUpdateCommand(UpdateCommand):
         self.actions = []
 
     def bundle_path(self, app):
-        return self.platform_path / '{app.name}.dummy'.format(app=app)
+        return self.platform_path / '{app.app_name}.dummy'.format(app=app)
 
     def binary_path(self, app):
-        return self.platform_path / '{app.name}.dummy.bin'.format(app=app)
+        return self.platform_path / '{app.app_name}.dummy.bin'.format(app=app)
 
     def distribution_path(self, app):
-        return self.platform_path / '{app.name}.dummy.dist'.format(app=app)
+        return self.platform_path / '{app.app_name}.dummy.dist'.format(app=app)
 
     def verify_tools(self):
         self.actions.append(('verify'))
@@ -54,14 +54,14 @@ def update_command(tmp_path):
         base_path=tmp_path,
         apps={
             'first': AppConfig(
-                name='first',
+                app_name='first',
                 bundle='com.example',
                 version='0.0.1',
                 description='The first simple app',
                 sources=['src/first'],
             ),
             'second': AppConfig(
-                name='second',
+                app_name='second',
                 bundle='com.example',
                 version='0.0.2',
                 description='The second simple app',

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -7,7 +7,7 @@ from briefcase.exceptions import BriefcaseConfigError
 def test_minimal_AppConfig():
     "A simple config can be defined"
     config = AppConfig(
-        name="myapp",
+        app_name="myapp",
         version="1.2.3",
         bundle="org.beeware",
         description="A simple app",
@@ -15,7 +15,7 @@ def test_minimal_AppConfig():
     )
 
     # The basic properties have been set.
-    assert config.name == "myapp"
+    assert config.app_name == "myapp"
     assert config.version == '1.2.3'
     assert config.bundle == 'org.beeware'
     assert config.description == 'A simple app'
@@ -35,7 +35,7 @@ def test_minimal_AppConfig():
 def test_extra_attrs():
     "A config can contain attributes in addition to those required"
     config = AppConfig(
-        name="myapp",
+        app_name="myapp",
         formal_name="My App",
         version="1.2.3",
         bundle="org.beeware",
@@ -54,7 +54,7 @@ def test_extra_attrs():
     )
 
     # The basic properties have been set.
-    assert config.name == "myapp"
+    assert config.app_name == "myapp"
     assert config.version == '1.2.3'
     assert config.bundle == 'org.beeware'
     assert config.description == 'A simple app'
@@ -95,7 +95,7 @@ def test_extra_attrs():
 def test_valid_app_name(name):
     try:
         AppConfig(
-            name=name,
+            app_name=name,
             version="1.2.3",
             bundle="org.beeware",
             description="A simple app",
@@ -121,7 +121,7 @@ def test_valid_app_name(name):
 def test_invalid_app_name(name):
     with pytest.raises(BriefcaseConfigError, match=r"is not a valid app name\."):
         AppConfig(
-            name=name,
+            app_name=name,
             version="1.2.3",
             bundle="org.beeware",
             description="A simple app",
@@ -132,7 +132,7 @@ def test_invalid_app_name(name):
 def test_valid_app_version():
     try:
         AppConfig(
-            name="myapp",
+            app_name="myapp",
             version="1.2.3",
             bundle="org.beeware",
             description="A simple app",
@@ -145,7 +145,7 @@ def test_valid_app_version():
 def test_invalid_app_version():
     with pytest.raises(BriefcaseConfigError, match=r"Version number for myapp.*is not valid\."):
         AppConfig(
-            name="myapp",
+            app_name="myapp",
             version="foobar",
             bundle="org.beeware",
             description="A simple app",
@@ -162,7 +162,7 @@ def test_invalid_app_version():
 )
 def test_module_name(name, module_name):
     config = AppConfig(
-        name=name,
+        app_name=name,
         version="1.2.3",
         bundle="org.beeware",
         description="A simple app",
@@ -184,7 +184,7 @@ def test_module_name(name, module_name):
 def test_duplicated_source(sources):
     with pytest.raises(BriefcaseConfigError, match=r"contains duplicated package names\."):
         AppConfig(
-            name='dupe',
+            app_name='dupe',
             version="1.2.3",
             bundle="org.beeware",
             description="A simple app",
@@ -195,7 +195,7 @@ def test_duplicated_source(sources):
 def test_no_source_for_app():
     with pytest.raises(BriefcaseConfigError, match=r" does not include a package named 'my_app'\."):
         AppConfig(
-            name='my-app',
+            app_name='my-app',
             version="1.2.3",
             bundle="org.beeware",
             description="A simple app",

--- a/tests/config/test_parse_config.py
+++ b/tests/config/test_parse_config.py
@@ -73,7 +73,7 @@ def test_single_minimal_app():
     # It inherits the value from the base definition.
     assert apps == {
         'my_app': {
-            "name": "my_app",
+            "app_name": "my_app",
             "value": 42
         }
     }
@@ -90,7 +90,7 @@ def test_multiple_minimal_apps():
         number=37
 
         [tool.briefcase.app.second]
-        name="my_app"
+        app_name="my_app"
         number=42
         """
     )
@@ -104,11 +104,11 @@ def test_multiple_minimal_apps():
     # The second tool overrides it's app name
     assert apps == {
         'first': {
-            "name": "first",
+            "app_name": "first",
             "number": 37,
         },
         'second': {
-            "name": "my_app",
+            "app_name": "my_app",
             "number": 42,
         },
     }
@@ -159,14 +159,14 @@ def test_platform_override():
     # will be processed before macos.
     assert apps == {
         'my_app': {
-            "name": "my_app",
+            "app_name": "my_app",
             "value": 2,
             "basevalue": "the base",
             "appvalue": "the app",
             "platformvalue": "macos platform",
         },
         'other_app': {
-            "name": "other_app",
+            "app_name": "other_app",
             "value": 4,
             "basevalue": "the base",
             "platformvalue": "other macos platform",
@@ -219,14 +219,14 @@ def test_platform_override_ordering():
     # will be processed after macos.
     assert apps == {
         'my_app': {
-            "name": "my_app",
+            "app_name": "my_app",
             "value": 2,
             "basevalue": "the base",
             "appvalue": "the app",
             "platformvalue": "macos platform",
         },
         'other_app': {
-            "name": "other_app",
+            "app_name": "other_app",
             "value": 4,
             "basevalue": "the base",
             "platformvalue": "other macos platform",
@@ -299,7 +299,7 @@ def test_format_override():
     # will be processed before dmg and homebrew.
     assert apps == {
         'my_app': {
-            "name": "my_app",
+            "app_name": "my_app",
             "value": 21,
             "basevalue": "the base",
             "appvalue": "the app",
@@ -307,7 +307,7 @@ def test_format_override():
             "formatvalue": "app format",
         },
         'other_app': {
-            "name": "other_app",
+            "app_name": "other_app",
             "value": 41,
             "basevalue": "the base",
             "formatvalue": "other macos app format",
@@ -380,7 +380,7 @@ def test_format_override_ordering():
     # will be processed after app, but before homebrew.
     assert apps == {
         'my_app': {
-            "name": "my_app",
+            "app_name": "my_app",
             "value": 22,
             "basevalue": "the base",
             "appvalue": "the app",
@@ -388,7 +388,7 @@ def test_format_override_ordering():
             "formatvalue": "dmg format",
         },
         'other_app': {
-            "name": "other_app",
+            "app_name": "other_app",
             "value": 0,
             "basevalue": "the base",
         }
@@ -441,7 +441,7 @@ def test_requires():
     # The other_app app doesn't specify any options.
     assert apps == {
         'my_app': {
-            "name": "my_app",
+            "app_name": "my_app",
             "requires": [
                 "base value",
                 "my_app value",
@@ -451,7 +451,7 @@ def test_requires():
             "value": 0,
         },
         'other_app': {
-            "name": "other_app",
+            "app_name": "other_app",
             "requires": [
                 "base value",
             ],
@@ -473,7 +473,7 @@ def test_requires():
     # The other_app dmg doesn't specify any options.
     assert apps == {
         'my_app': {
-            "name": "my_app",
+            "app_name": "my_app",
             "requires": [
                 "base value",
                 "my_app value",
@@ -483,7 +483,7 @@ def test_requires():
             "value": 0,
         },
         'other_app': {
-            "name": "other_app",
+            "app_name": "other_app",
             "requires": [
                 "base value",
             ],
@@ -503,7 +503,7 @@ def test_requires():
     # The linux my_app appimage overrides the *base* value, but extends for linux.
     assert apps == {
         'my_app': {
-            "name": "my_app",
+            "app_name": "my_app",
             "requires": [
                 "base value",
                 "my_app value",
@@ -513,7 +513,7 @@ def test_requires():
             "value": 0,
         },
         'other_app': {
-            "name": "other_app",
+            "app_name": "other_app",
             "requires": [
                 "base value",
             ],
@@ -556,7 +556,7 @@ def test_document_types():
     # The other_app app doesn't specify any options.
     assert apps == {
         'my_app': {
-            "name": "my_app",
+            "app_name": "my_app",
             "document_type": {
                 'document': {
                     'extension': 'doc',
@@ -570,7 +570,7 @@ def test_document_types():
             "value": 0,
         },
         'other_app': {
-            "name": "other_app",
+            "app_name": "other_app",
             "value": 0,
         }
     }

--- a/tests/platforms/conftest.py
+++ b/tests/platforms/conftest.py
@@ -6,7 +6,7 @@ from briefcase.config import AppConfig
 @pytest.fixture
 def first_app_config():
     return AppConfig(
-        name='first-app',
+        app_name='first-app',
         project_name='First Project',
         formal_name='First App',
         bundle='com.example',


### PR DESCRIPTION
Actually using the app metadata in Toga revealed some minor tweaks in order to maintain consistency, and expose useful properties.

* `name` has been renamed `app_name` (except where required by PEP566)
* The distinfo file contains App-ID, not Bundle-ID.