### PR TITLE
Use briefcase-support.org as a source of support packages.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,6 @@ install_requires =
     toml >= 0.10.0
     requests >= 2.22.0
     GitPython==3.0.2
-    boto3 >= 1.9
     dmgbuild >= 1.3.3; sys_platform == "darwin"
 setup_requires=
     pytest-runner

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -128,10 +128,10 @@ class CreateCommand(BaseCommand):
         """
         The query arguments to use in a support package query request.
         """
-        return {
-            'platform': self.platform,
-            'version': self.python_version_tag,
-        }
+        return [
+            ('platform', self.platform),
+            ('version', self.python_version_tag),
+        ]
 
     @property
     def support_package_url(self):

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -6,9 +6,7 @@ from pathlib import Path
 from typing import Optional
 from urllib.parse import urlencode
 
-import boto3
 import toml
-from botocore.handlers import disable_signing
 from cookiecutter import exceptions as cookiecutter_exceptions
 from requests import exceptions as requests_exceptions
 
@@ -124,19 +122,6 @@ class CreateCommand(BaseCommand):
         return 'https://github.com/beeware/briefcase-{self.platform}-{self.output_format}-template.git'.format(
             self=self
         )
-
-    def _anonymous_s3_client(self, region):
-        """
-        Set up an anonymous S3 client.
-
-        :param region: The AWS region name
-        :return: An S3 boto client, with request signing disabled.
-        """
-        if self._s3 is None:
-            self._s3 = boto3.client('s3', region_name=region)
-            self._s3.meta.events.register('choose-signer.s3.*', disable_signing)
-
-        return self._s3
 
     @property
     def support_package_url_query(self):

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -48,11 +48,11 @@ class LinuxAppImageCreateCommand(LinuxAppImageMixin, CreateCommand):
         """
         The query arguments to use in a support package query request.
         """
-        return {
-            'platform': self.platform,
-            'version': self.python_version_tag,
-            'arch': self.host_arch,
-        }
+        return [
+            ('platform', self.platform),
+            ('version', self.python_version_tag),
+            ('arch', self.host_arch),
+        ]
 
 
 class LinuxAppImageUpdateCommand(LinuxAppImageMixin, UpdateCommand):

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -44,10 +44,15 @@ class LinuxAppImageCreateCommand(LinuxAppImageMixin, CreateCommand):
     description = "Create and populate a Linux AppImage."
 
     @property
-    def support_package_key_prefix(self):
-        return 'python/{self.python_version_tag}/{self.platform}/{self.host_arch}/'.format(
-            self=self,
-        )
+    def support_package_url_query(self):
+        """
+        The query arguments to use in a support package query request.
+        """
+        return {
+            'platform': self.platform,
+            'version': self.python_version_tag,
+            'arch': self.host_arch,
+        }
 
 
 class LinuxAppImageUpdateCommand(LinuxAppImageMixin, UpdateCommand):

--- a/src/briefcase/platforms/windows/msi.py
+++ b/src/briefcase/platforms/windows/msi.py
@@ -77,11 +77,11 @@ class WindowsMSICreateCommand(WindowsMSIMixin, CreateCommand):
         """
         The query arguments to use in a support package query request.
         """
-        return {
-            'platform': self.platform,
-            'version': self.python_version_tag,
-            'arch': "amd64" if (struct.calcsize("P") * 8) == 64 else "win32",
-        }
+        return [
+            ('platform', self.platform),
+            ('version', self.python_version_tag),
+            ('arch', "amd64" if (struct.calcsize("P") * 8) == 64 else "win32"),
+        ]
 
     def output_format_template_context(self, app: BaseConfig):
         """

--- a/src/briefcase/platforms/windows/msi.py
+++ b/src/briefcase/platforms/windows/msi.py
@@ -73,27 +73,15 @@ class WindowsMSICreateCommand(WindowsMSIMixin, CreateCommand):
     description = "Create and populate a Windows app."
 
     @property
-    def support_package_url(self):
+    def support_package_url_query(self):
         """
-        Gets the URL to the embedded Python support package.
-
-        Python provides redistributable zip files containing the Windows builds,
-        making it easy to redistribute Python as part of another software
-        package.
-
-        :returns: The support package URL.
+        The query arguments to use in a support package query request.
         """
-        version = "%s.%s.%s" % sys.version_info[:3]
-        arch = "amd64" if (struct.calcsize("P") * 8) == 64 else "win32"
-
-        # Python 3.7.2 had to be repackaged for Windows,
-        # https://bugs.python.org/issue35596. Use this repackaged link for
-        # version 3.7.2, otherwise use the standard link format
-
-        if version == "3.7.2":
-            return 'https://www.python.org/ftp/python/%s/python-%s.post1-embed-%s.zip' % (version, version, arch)
-        else:
-            return 'https://www.python.org/ftp/python/%s/python-%s-embed-%s.zip' % (version, version, arch)
+        return {
+            'platform': self.platform,
+            'version': self.python_version_tag,
+            'arch': "amd64" if (struct.calcsize("P") * 8) == 64 else "win32",
+        }
 
     def output_format_template_context(self, app: BaseConfig):
         """

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -11,9 +11,6 @@ from briefcase.exceptions import NetworkFailure
 
 def test_install_app_support_package(create_command, myapp, tmp_path, support_path):
     "A support package can be unpacked where it is needed"
-    # Hardcode the support package URL for test purposes
-    create_command._support_package_url = 'https://example.com/path/to/support.zip'
-
     # Write a temporary support zip file
     support_file = tmp_path / 'out.zip'
     with zipfile.ZipFile(str(support_file), 'w') as support_zip:
@@ -28,7 +25,7 @@ def test_install_app_support_package(create_command, myapp, tmp_path, support_pa
     # Confirm the right URL was used
     create_command.download_url.assert_called_with(
         download_path=Path.home() / '.briefcase' / 'support',
-        url='https://example.com/path/to/support.zip',
+        url='https://briefcase-support.org/python?platform=tester&version=3.X',
     )
 
     # Confirm that the full path to the support file

--- a/tests/commands/create/test_properties.py
+++ b/tests/commands/create/test_properties.py
@@ -1,7 +1,4 @@
-import pytest
 import toml
-
-from briefcase.commands.create import NoSupportPackage
 
 
 def test_template_url(create_command):

--- a/tests/commands/create/test_properties.py
+++ b/tests/commands/create/test_properties.py
@@ -76,99 +76,10 @@ def test_support_path(create_command, myapp):
     assert create_command.support_path(myapp) == bundle_path / 'path' / 'to' / 'support'
 
 
-def test_support_package_url_single_match(create_command):
-    # Prime the s3 client, and wrap it in a stubber.
-    s3 = create_command._anonymous_s3_client('us-west-2')
-    stub_s3 = Stubber(s3)
-
-    # Add the expected request/responses from S3
-    stub_s3.add_response(
-        method='list_objects_v2',
-        expected_params={
-            'Bucket': 'briefcase-support',
-            'Prefix': 'python/3.X/tester/'
-        },
-        service_response={
-            'Contents': [
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b1.tar.gz'}
-            ],
-            'KeyCount': 1,
-        }
-    )
-
-    # We've set up all the expected S3 responses, so activate the stub
-    stub_s3.activate()
-
+def test_support_package_url(create_command):
     # Retrieve the property, retrieving the support package URL.
-    url = 'https://briefcase-support.s3-us-west-2.amazonaws.com/python/3.X/tester/Python-3.X-tester-support.b1.tar.gz'
+    url = 'https://briefcase-support.org/python?platform=tester&version=3.X'
     assert create_command.support_package_url == url
-
-    # Check the S3 calls have been exhausted
-    stub_s3.assert_no_pending_responses()
-
-
-def test_support_package_url_multiple_match(create_command):
-    "If there are multiple candidate support packages, the highest build number wins"
-    # Prime the s3 client, and wrap it in a stubber.
-    s3 = create_command._anonymous_s3_client('us-west-2')
-    stub_s3 = Stubber(s3)
-
-    # Add the expected request/responses from S3
-    stub_s3.add_response(
-        method='list_objects_v2',
-        expected_params={
-            'Bucket': 'briefcase-support',
-            'Prefix': 'python/3.X/tester/'
-        },
-        service_response={
-            'Contents': [
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b11.tar.gz'},
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b8.tar.gz'},
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b9.tar.gz'},
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b10.tar.gz'},
-            ],
-            'KeyCount': 4,
-        }
-    )
-
-    # We've set up all the expected S3 responses, so activate the stub
-    stub_s3.activate()
-
-    # Retrieve the property, retrieving the support package URL.
-    url = 'https://briefcase-support.s3-us-west-2.amazonaws.com/python/3.X/tester/Python-3.X-tester-support.b11.tar.gz'
-    assert create_command.support_package_url == url
-
-    # Check the S3 calls have been exhausted
-    stub_s3.assert_no_pending_responses()
-
-
-def test_support_package_url_no_match(create_command):
-    "If there is no plausible candidate support package, raise an error"
-    # Prime the s3 client, and wrap it in a stubber.
-    s3 = create_command._anonymous_s3_client('us-west-2')
-    stub_s3 = Stubber(s3)
-
-    # Add the expected request/responses from S3
-    stub_s3.add_response(
-        method='list_objects_v2',
-        expected_params={
-            'Bucket': 'briefcase-support',
-            'Prefix': 'python/3.X/tester/'
-        },
-        service_response={
-            'KeyCount': 0,
-        }
-    )
-
-    # We've set up all the expected S3 responses, so activate the stub
-    stub_s3.activate()
-
-    # Retrieve the property, retrieving the support package URL.
-    with pytest.raises(NoSupportPackage):
-        create_command.support_package_url
-
-    # Check the S3 calls have been exhausted
-    stub_s3.assert_no_pending_responses()
 
 
 def test_no_icon(create_command, myapp):

--- a/tests/commands/create/test_properties.py
+++ b/tests/commands/create/test_properties.py
@@ -1,6 +1,5 @@
 import pytest
 import toml
-from botocore.stub import Stubber
 
 from briefcase.commands.create import NoSupportPackage
 

--- a/tests/platforms/linux/appimage/test_create.py
+++ b/tests/platforms/linux/appimage/test_create.py
@@ -3,13 +3,15 @@ import sys
 from briefcase.platforms.linux.appimage import LinuxAppImageCreateCommand
 
 
-def test_host(first_app_config, tmp_path):
+def test_support_package_url(first_app_config, tmp_path):
     command = LinuxAppImageCreateCommand(base_path=tmp_path)
 
     # Set some properties of the host system for test purposes.
     command.host_arch = 'wonky'
     command.platform = 'tester'
 
-    assert command.support_package_key_prefix == 'python/3.{minor}/tester/wonky/'.format(
-        minor=sys.version_info.minor
-    )
+    assert command.support_package_url_query == {
+        'platform': 'tester',
+        'version': '3.{minor}'.format(minor=sys.version_info.minor),
+        'arch': 'wonky',
+    }

--- a/tests/platforms/linux/appimage/test_create.py
+++ b/tests/platforms/linux/appimage/test_create.py
@@ -10,8 +10,8 @@ def test_support_package_url(first_app_config, tmp_path):
     command.host_arch = 'wonky'
     command.platform = 'tester'
 
-    assert command.support_package_url_query == {
-        'platform': 'tester',
-        'version': '3.{minor}'.format(minor=sys.version_info.minor),
-        'arch': 'wonky',
-    }
+    assert command.support_package_url_query == [
+        ('platform', 'tester'),
+        ('version', '3.{minor}'.format(minor=sys.version_info.minor)),
+        ('arch', 'wonky'),
+    ]

--- a/tests/platforms/windows/msi/test_create.py
+++ b/tests/platforms/windows/msi/test_create.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 
 from briefcase.platforms.windows.msi import WindowsMSICreateCommand
@@ -55,3 +56,19 @@ def test_explicit_guid(first_app_config, tmp_path):
 
     # Explicitly provided GUID is used.
     assert context['guid'] == 'e822176f-b755-589f-849c-6c6600f7efb1'
+
+
+def test_support_package_url(first_app_config, tmp_path):
+    command = WindowsMSICreateCommand(base_path=tmp_path)
+
+    # Set some properties of the host system for test purposes.
+    command.host_arch = 'wonky'
+    command.platform = 'tester'
+
+    # This test result assumes we're on ARM64. However, we will be
+    # on almost every Windows box (and definite will be in CI)
+    assert command.support_package_url_query == {
+        'platform': 'tester',
+        'version': '3.{minor}'.format(minor=sys.version_info.minor),
+        'arch': 'amd64',
+    }

--- a/tests/platforms/windows/msi/test_create.py
+++ b/tests/platforms/windows/msi/test_create.py
@@ -67,8 +67,8 @@ def test_support_package_url(first_app_config, tmp_path):
 
     # This test result assumes we're on ARM64. However, we will be
     # on almost every Windows box (and definite will be in CI)
-    assert command.support_package_url_query == {
-        'platform': 'tester',
-        'version': '3.{minor}'.format(minor=sys.version_info.minor),
-        'arch': 'amd64',
-    }
+    assert command.support_package_url_query == [
+        ('platform', 'tester'),
+        ('version', '3.{minor}'.format(minor=sys.version_info.minor)),
+        ('arch', 'amd64'),
+    ]

--- a/tests/platforms/windows/msi/test_create.py
+++ b/tests/platforms/windows/msi/test_create.py
@@ -1,4 +1,5 @@
 import sys
+
 import pytest
 
 from briefcase.platforms.windows.msi import WindowsMSICreateCommand


### PR DESCRIPTION
Use a proxy for support packages, in order to provide better metrics, and a consistent URL for the "current" support package for each platform.

Has the added benefit of removing the boto3 requirement.