### PR TITLE
Modify GitPython dependency to fix gitdb2 bug.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     cookiecutter >= 1.0
     toml >= 0.10.0
     requests >= 2.22.0
-    GitPython==3.0.2
+    GitPython >= 3.0.8
     dmgbuild >= 1.3.3; sys_platform == "darwin"
 setup_requires=
     pytest-runner


### PR DESCRIPTION
Last week, gitdb2 published a new major version. gitdb2 is a dependency of GitPython; and GitPython is a dependency of Briefcase.

Unfortunately. GitPython doesn't specify it's version dependency in a way that protects against the major version update in gitdb2.

Making matters worse, Briefcase specifies GitPython==3.0.2 - a version that *isn't* compatible with the new version of gitdb2.

This changes the dependency on GitPython to be floating, so this will hopefully be avoided in future.