### PR TITLE
Parse Content-Disposition header if provided

### DIFF
--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -1,5 +1,6 @@
 
 import argparse
+from cgi import parse_header
 import importlib
 import inspect
 import os
@@ -374,9 +375,18 @@ getting this error, you may need to restart your terminal session.
             )
 
         # The initial URL might (read: will) go through URL redirects, so
-        # we need the *final* URL name, from which we can extract the cache
-        # filename.
-        cache_name = urlparse(response.url).path.split('/')[-1]
+        # we need the *final* response. We look at either the `Content-Disposition`
+        # header, or the final URL, to extract the cache filename.
+        cache_full_name = urlparse(response.url).path
+        if 'Content-Disposition' in response.headers:
+            # See also https://tools.ietf.org/html/rfc6266
+            header_value = response.headers['Content-Disposition']
+            value, parameters = parse_header(header_value)
+            if value.split(':', 1)[-1].strip().lower() == 'attachment':
+                # We only the `filename=` parameter. RFC 6266 defines a more complicated
+                # `filename*=` parameter, which we don't support for now.
+                cache_full_name = parameters.get('filename')
+        cache_name = cache_full_name.split('/')[-1]
         filename = download_path / cache_name
         if not filename.exists():
             # We have meaningful content, and it hasn't been cached previously,

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -378,14 +378,12 @@ getting this error, you may need to restart your terminal session.
         # we need the *final* response. We look at either the `Content-Disposition`
         # header, or the final URL, to extract the cache filename.
         cache_full_name = urlparse(response.url).path
-        if 'Content-Disposition' in response.headers:
+        header_value = response.headers.get('Content-Disposition')
+        if header_value:
             # See also https://tools.ietf.org/html/rfc6266
-            header_value = response.headers['Content-Disposition']
             value, parameters = parse_header(header_value)
-            if value.split(':', 1)[-1].strip().lower() == 'attachment':
-                # We only the `filename=` parameter. RFC 6266 defines a more complicated
-                # `filename*=` parameter, which we don't support for now.
-                cache_full_name = parameters.get('filename')
+            if (value.split(':', 1)[-1].strip().lower() == 'attachment' and parameters.get('filename')):
+                cache_full_name = parameters['filename']
         cache_name = cache_full_name.split('/')[-1]
         filename = download_path / cache_name
         if not filename.exists():

--- a/tests/commands/base/test_download_url.py
+++ b/tests/commands/base/test_download_url.py
@@ -132,8 +132,7 @@ def test_already_downloaded(base_command):
     # The request's Content-Disposition header is consumed to
     # examine the filename; the request is abandoned before
     # any other headers are read.
-    response.headers.get.assert_called_with('Content-Disposition')
-    response.headers.get.assert_called_once()
+    response.headers.get.assert_called_once_with('Content-Disposition')
 
     # but the file existed, so the method returns
     assert filename == existing_file


### PR DESCRIPTION
GitHub assets redirect to strange URLs in Amazon S3, and those URLs
provide Content-Disposition headers to indicate the appropriate filename
to use. This commit adjusts filename calculation to use
Content-Disposition accordingly.