### PR TITLE
Add initial adb `get_devices()` integration

### DIFF
--- a/src/briefcase/integrations/adb.py
+++ b/src/briefcase/integrations/adb.py
@@ -1,0 +1,27 @@
+import subprocess
+import os
+
+from briefcase.exceptions import BriefcaseCommandError
+
+
+def get_devices(sdk_path, sub=subprocess):
+    # Add our `adb` to start of the path.
+    env = dict(os.environ)
+    env['PATH'] = str(sdk_path / 'platform-tools') + ':' + env.get('PATH', '')
+    try:
+        output = sub.check_output(['adb', 'devices'], env=env)
+    except subprocess.CalledProcessError:
+        raise BriefcaseCommandError("Unable to run `adb devices`")
+
+    results = []
+    for line in output.split('\n'):
+        line = line.strip()
+        if not line:
+            continue
+        if line == 'List of devices attached':
+            continue
+        if '\t' in line:
+            first, rest = line.split('\t', 1)
+            if rest.strip() == 'device':
+                results.append(first)
+    return results

--- a/tests/integrations/adb/devices/no-devices.txt
+++ b/tests/integrations/adb/devices/no-devices.txt
@@ -1,0 +1,2 @@
+List of devices attached
+

--- a/tests/integrations/adb/devices/one-device.txt
+++ b/tests/integrations/adb/devices/one-device.txt
@@ -1,0 +1,3 @@
+List of devices attached
+emulator-5554	device
+

--- a/tests/integrations/adb/test_get_devices.py
+++ b/tests/integrations/adb/test_get_devices.py
@@ -1,0 +1,47 @@
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError
+from briefcase.integrations.adb import get_devices
+
+DUMMY_SDK_PATH = Path('.')
+
+
+def devices_result(name):
+    """Load `adb devices` output file from the sample directory, and return the content"""
+    filename = Path(__file__).parent / 'devices' / '{name}.txt'.format(name=name)
+    with filename.open() as f:
+        return f.read()
+
+
+def test_adb_missing():
+    "If adb is missing or fails to start, an exception is raised."
+    sub = mock.MagicMock()
+    sub.check_output.side_effect = subprocess.CalledProcessError(
+        cmd=['adb', 'devices'],
+        returncode=1
+    )
+
+    with pytest.raises(BriefcaseCommandError):
+        get_devices(sub=sub, sdk_path=DUMMY_SDK_PATH)
+
+
+def test_no_devices():
+    "If there are no devices available, expect the empty list"
+    sub = mock.MagicMock()
+    sub.check_output.return_value = devices_result('no-devices')
+    devices = get_devices(sub=sub, sdk_path=DUMMY_SDK_PATH)
+
+    assert devices == []
+
+
+def test_one_device():
+    "If there are no devices available, expect the empty list"
+    sub = mock.MagicMock()
+    sub.check_output.return_value = devices_result('one-device')
+    devices = get_devices(sub=sub, sdk_path=DUMMY_SDK_PATH)
+
+    assert devices == ['emulator-5554']


### PR DESCRIPTION
Hi @freakboy3742 !

I wrote this initial `adb devices` output parser as part of my Android briefcase integration work. The Android briefcase integration work isn't done yet, but I wanted to get your review on this to make sure I'm following the right direction.

If it passes review, please merge!