### PR TITLE
Fixed #317 -- Corrected briefcase publish implementation.

### DIFF
--- a/src/briefcase/platforms/macOS/dmg.py
+++ b/src/briefcase/platforms/macOS/dmg.py
@@ -133,16 +133,6 @@ class macOSDmgPackageCommand(macOSDmgMixin, macOSAppPackageCommand):
 class macOSDmgPublishCommand(macOSDmgMixin, macOSAppPublishCommand):
     description = "Publish a macOS DMG."
 
-    def add_options(self):
-        self.parser.add_argument(
-            '-c',
-            '--channel',
-            choices=['s3', 'github', 'appstore'],
-            default='s3',
-            metavar='channel',
-            help='The channel to publish to'
-        )
-
 
 # Declare the briefcase command bindings
 create = macOSDmgCreateCommand  # noqa


### PR DESCRIPTION
Remove a stale `add_options` method that caused an error when running `publish` on macOS.