### PR TITLE
Add BaseCommand.dot_briefcase_path

### DIFF
--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -116,7 +116,7 @@ class BaseCommand(ABC):
             base_path,
             dot_briefcase_path=Path.home() / ".briefcase",
             apps=None,
-        ):
+            ):
         self.base_path = base_path
         self.dot_briefcase_path = dot_briefcase_path
 

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -111,8 +111,14 @@ class BaseCommand(ABC):
     GLOBAL_CONFIG_CLASS = GlobalConfig
     APP_CONFIG_CLASS = AppConfig
 
-    def __init__(self, base_path, apps=None):
+    def __init__(
+            self,
+            base_path,
+            dot_briefcase_path=Path.home() / ".briefcase",
+            apps=None,
+        ):
         self.base_path = base_path
+        self.dot_briefcase_path = dot_briefcase_path
 
         self.global_config = None
         self.apps = {} if apps is None else apps

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -382,7 +382,7 @@ class CreateCommand(BaseCommand):
                 # in the user's briefcase support cache directory.
                 support_filename = self.download_url(
                     url=support_package_url,
-                    download_path=Path.home() / '.briefcase' / 'support'
+                    download_path=self.dot_briefcase_path / 'support'
                 )
             else:
                 support_filename = support_package_url

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -80,7 +80,7 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
             print("Ensure we have the linuxdeploy AppImage...")
             self.linuxdeploy_appimage = self.download_url(
                 url=self.linuxdeploy_download_url,
-                download_path=Path.home() / '.briefcase' / 'tools'
+                download_path=self.dot_briefcase_path / 'tools'
             )
             self.os.chmod(str(self.linuxdeploy_appimage), 0o755)
         except requests_exceptions.ConnectionError:

--- a/tests/commands/create/conftest.py
+++ b/tests/commands/create/conftest.py
@@ -89,7 +89,10 @@ class TrackingCreateCommand(DummyCreateCommand):
 
 @pytest.fixture
 def create_command(tmp_path):
-    return DummyCreateCommand(base_path=tmp_path)
+    return DummyCreateCommand(
+        base_path=tmp_path,
+        dot_briefcase_path=tmp_path / "dot-briefcase",
+    )
 
 
 @pytest.fixture

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -24,7 +24,7 @@ def test_install_app_support_package(create_command, myapp, tmp_path, support_pa
 
     # Confirm the right URL was used
     create_command.download_url.assert_called_with(
-        download_path=Path.home() / '.briefcase' / 'support',
+        download_path=create_command.dot_briefcase_path / 'support',
         url='https://briefcase-support.org/python?platform=tester&version=3.X',
     )
 
@@ -83,7 +83,7 @@ def test_install_custom_app_support_package_url(create_command, myapp, tmp_path,
 
     # Confirm the right URL was used
     create_command.download_url.assert_called_with(
-        download_path=Path.home() / '.briefcase' / 'support',
+        download_path=create_command.dot_briefcase_path / 'support',
         url='https://example.com/custom/support.zip',
     )
 

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -13,6 +13,9 @@ from briefcase.platforms.linux.appimage import LinuxAppImageBuildCommand
 def build_command(tmp_path, first_app_config):
     command = LinuxAppImageBuildCommand(
         base_path=tmp_path,
+        # `dot-briefcase` below makes it easy to find references to literal
+        # `.briefcase` when grepping the source.
+        dot_briefcase_path=tmp_path / "dot-briefcase",
         apps={'first': first_app_config}
     )
     command.host_os = 'Linux'
@@ -96,7 +99,7 @@ def test_verify_tools_download_failure(build_command):
     # The download was attempted
     build_command.download_url.assert_called_with(
         url='https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-wonky.AppImage',
-        download_path=Path.home() / '.briefcase' / 'tools'
+        download_path=build_command.dot_briefcase_path / 'tools'
     )
 
     # But it failed, so the file won't be made executable...


### PR DESCRIPTION
This adds a customizable `dot_briefcase_path` to the `BaseCommand`.

The main reason to add this, for now, is to ensure the tests (1) don't interfere with other tests and (2) don't create invalid state for my laptop's real `~/.briefcase`. (2) is something that actually happened to me -- a testing `.zip` file ended up in `~/.briefcase`, resulting in weird behavior from real briefcase.

One day, we could use something like [user-config](https://pypi.org/project/user-config/) or [config-path](https://pypi.org/project/config-path/) or [appdirs](https://pypi.org/project/appdirs/) or [codi](https://pypi.org/project/codi/) to be more flexible about the location of Briefcase configuration data. That's a task for another pull request IMHO.
