### PR TITLE
Add `line_length` so `black` operates properly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ package_dir = "src"
 filename = "docs/background/releases.rst"
 title_format = "{version} ({project_date})"
 template = "changes/template.rst"
+
+[tool.black]
+line_length = 80


### PR DESCRIPTION
`black` is a code formatter that I enjoy using. Its default configuration
meets briefcase's style needs except for the max line length. Therefore,
this commit adds the line-length configuration.

I know briefcase hasn't standardized on using `black` yet. I figure this
is OK to add if using `black` is optional.