### PR TITLE
Allow for icon/splash screen variants

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -250,8 +250,16 @@ example, iOS requires multiple splash screens, (including 1024x768px,
 ``resources/splash-2048x1536.png``, and so on. The sizes that are required are
 determined by the platform template.
 
+Some platforms also require different *variants* (e.g., both portrait and
+landscape splash screens). These variants can be specified by qualifying the
+splash specification:
+
+    splash.portrait = "resource/portrait-splash"
+    splash.landscape = "resource/landscape-splash"
+
 If the platform output format does not use a splash screen, the ``splash``
-setting is ignored.
+setting is ignored. If the platform requires both variants *and* sizes, the
+handling will be combined.
 
 ``support_package``
 ~~~~~~~~~~~~~~~~~~~
@@ -316,11 +324,23 @@ specification of::
 will use ``resources/icon.icns`` on macOS, and ``resources/icon.ico`` on
 Windows.
 
+Some platforms also require different *variants* (e.g., both square and round
+icons). These variants can be specified by qualifying the icon specification:
+
+    icon.round = "resource/round-icon"
+    icon.square = "resource/square-icon"
+
 Some platforms require multiple icons, at different sizes; these will be
 handled by appending the required size to the provided icon name. For example,
 iOS requires multiple icon sizes (ranging from 20px to 1024px); Briefcase will
 look for ``resources/icon-20.png``, ``resources/icon-1024.png``, and so on. The
 sizes that are required are determined by the platform template.
+
+If a platform requires both different sizes *and* variants, the variant
+handling and size handling will be combined. For example, Android requires
+round and square icons, in sizes ranging from 48px to 192px; Briefcase will
+look for ``resource/round-icon-42.png``, ``resource/square-icon-42.png``,
+``resource/round-icon-192.png``, and so on.
 
 ``url``
 -------

--- a/docs/reference/platforms/android.rst
+++ b/docs/reference/platforms/android.rst
@@ -2,11 +2,52 @@
 Android
 =======
 
-.. note::
-
-    The BeeWare project *has* tooling for Android. Unfortunately, due to some
-    recent changes in the Android ecosystem, combined with some changes in Toga
-    itself, means that our Android tooling is currently broken. We're working
-    on it, and hope to have a solution in the very near future.
-
 When generating an Android project, Briefcase produces a Gradle project.
+
+Icon format
+===========
+
+Android projects use ``.png`` format icons, in round and square variants. An
+application must provide the following icons:
+
+  * round
+    * 48px
+    * 72px
+    * 96px
+    * 144px
+    * 192px
+  * square
+    * 48px
+    * 72px
+    * 96px
+    * 144px
+    * 192px
+
+Image format
+============
+
+Android projects use ``.png`` format splash screen iamges. An application must
+provide splash images of the following sizes:
+
+  * TBD
+
+Android projects do not support installer images.
+
+Additional options
+==================
+
+The following options can be provided at the command line when producing
+Android projects
+
+build
+-----
+
+``-d <device>`` / ``--device <device>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The device simulator to target. Can be either a device ID, or a device name.
+
+run
+---
+
+The device simulator to target. Can be either a device ID, or a device name.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -534,17 +534,28 @@ class CreateCommand(BaseCommand):
                         )
 
                 else:
-                    source_filename = '{source}-{size}{target.suffix}'.format(
-                        source=source[variant],
-                        variant=variant,
-                        size=size,
-                        target=target,
-                    )
-                    full_role = '{size}px {variant} {role}'.format(
-                        size=size,
-                        variant=variant,
-                        role=role,
-                    )
+                    try:
+                        source_filename = '{source}-{size}{target.suffix}'.format(
+                            source=source[variant],
+                            variant=variant,
+                            size=size,
+                            target=target,
+                        )
+                        full_role = '{size}px {variant} {role}'.format(
+                            size=size,
+                            variant=variant,
+                            role=role,
+                        )
+                    except (TypeError, KeyError):
+                        print(
+                            "Unable to find {size}px {variant} variant for {role}; "
+                            "using default".format(
+                                size=size,
+                                variant=variant,
+                                role=role,
+                            )
+                        )
+                        return
 
             full_source = self.base_path / source_filename
             if full_source.exists():

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -460,35 +460,91 @@ class CreateCommand(BaseCommand):
             )
         )
 
-    def install_image(self, role, size, source, target):
+    def install_image(self, role, variant, size, source, target):
         """
         Install an icon/image of the requested size at a target location, using
         the source images defined by the app config.
 
         :param role: A string describing the role the of the image.
+        :param variant: The image variant. A variant of ``None`` means the image
+            has no variants
         :param size: The requested size for the image. A size of
             ``None`` means the largest available size should be used.
-        :param source: The image source. This will *not* include any extension
-            or size modifier; these will be added based on the requested target.
+        :param source: The image source; or a dictionary of sources for each
+            variant. The sources will *not* include any extension or size
+            modifier; these will be added based on the requested target and
+            variant.
         :param target: The full path where the image should be installed.
         """
         if source is not None:
             if size is None:
-                source_filename = '{source}{ext}'.format(
-                    source=source,
-                    ext=target.suffix
-                )
-                full_role = role
+                if variant is None:
+                    source_filename = '{source}{target.suffix}'.format(
+                        source=source,
+                        target=target,
+                    )
+                    full_role = role
+                else:
+                    try:
+                        source_filename = '{source}{target.suffix}'.format(
+                            source=source[variant],
+                            variant=variant,
+                            target=target,
+                        )
+                        full_role = '{variant} {role}'.format(
+                            variant=variant,
+                            role=role,
+                        )
+                    except (TypeError, KeyError):
+                        print(
+                            "Unable to find {variant} variant for {role}; "
+                            "using default".format(
+                                variant=variant,
+                                role=role,
+                            )
+                        )
+                        return
             else:
-                source_filename = '{source}-{size}{ext}'.format(
-                    source=source,
-                    size=size,
-                    ext=target.suffix
-                )
-                full_role = '{size}px {role}'.format(
-                    size=size,
-                    role=role,
-                )
+                if variant is None:
+                    # An annoying edge case is the case of an unsized variant.
+                    # In that case, `size` is actually the variant, and the
+                    # source is a dictionary keyed by variant. Try that
+                    # lookup; if it fails, we have a sized image with no
+                    # variant.
+                    try:
+                        source_filename = '{source}{target.suffix}'.format(
+                            source=source[size],
+                            target=target,
+                        )
+                        full_role = '{size} {role}'.format(
+                            size=size,
+                            role=role,
+                        )
+                    except TypeError:
+                        # The lookup on the source failed; that means we
+                        # have an sized image without variants.
+                        source_filename = '{source}-{size}{target.suffix}'.format(
+                            source=source,
+                            size=size,
+                            target=target,
+                        )
+                        full_role = '{size}px {role}'.format(
+                            size=size,
+                            role=role,
+                        )
+
+                else:
+                    source_filename = '{source}-{size}{target.suffix}'.format(
+                        source=source[variant],
+                        variant=variant,
+                        size=size,
+                        target=target,
+                    )
+                    full_role = '{size}px {variant} {role}'.format(
+                        size=size,
+                        variant=variant,
+                        role=role,
+                    )
 
             full_source = self.base_path / source_filename
             if full_source.exists():
@@ -516,21 +572,49 @@ class CreateCommand(BaseCommand):
 
         :param app: The config object for the app
         """
-        for size, target in self.icon_targets(app).items():
-            self.install_image(
-                'application icon',
-                size=size,
-                source=app.icon,
-                target=self.bundle_path(app) / target
-            )
+        for variant_or_size, targets in self.icon_targets(app).items():
+            try:
+                # Treat the targets as a dictionary of sizes;
+                # if there's no `items`, then it's an icon without variants.
+                for size, target in targets.items():
+                    self.install_image(
+                        'application icon',
+                        source=app.icon,
+                        variant=variant_or_size,
+                        size=size,
+                        target=self.bundle_path(app) / target
+                    )
+            except AttributeError:
+                # Either a single variant, or a single size.
+                self.install_image(
+                    'application icon',
+                    source=app.icon,
+                    variant=None,
+                    size=variant_or_size,
+                    target=self.bundle_path(app) / targets
+                )
 
-        for size, target in self.splash_image_targets(app).items():
-            self.install_image(
-                'splash image',
-                size=size,
-                source=app.splash,
-                target=self.bundle_path(app) / target
-            )
+        for variant_or_size, targets in self.splash_image_targets(app).items():
+            try:
+                # Treat the targets as a dictionary of sizes;
+                # if there's no `items`, then it's a splash without variants
+                for size, target in targets.items():
+                    self.install_image(
+                        'splash image',
+                        source=app.splash,
+                        variant=variant_or_size,
+                        size=size,
+                        target=self.bundle_path(app) / target
+                    )
+            except AttributeError:
+                # Either a single variant, or a single size.
+                self.install_image(
+                    'splash image',
+                    source=app.splash,
+                    variant=None,
+                    size=variant_or_size,
+                    target=self.bundle_path(app) / targets
+                )
 
         for extension, doctype in self.document_type_icon_targets(app).items():
             for size, target in doctype.items():
@@ -538,6 +622,7 @@ class CreateCommand(BaseCommand):
                     'icon for .{extension} documents'.format(extension=extension),
                     size=size,
                     source=app.document_types[extension]['icon'],
+                    variant=None,
                     target=self.bundle_path(app) / target,
                 )
 

--- a/tests/commands/create/test_install_app_resources.py
+++ b/tests/commands/create/test_install_app_resources.py
@@ -59,21 +59,83 @@ def test_icon_target(create_command, tmp_path):
     install_image.assert_has_calls([
         mock.call(
             'application icon',
-            size='10',
             source='images/icon',
+            variant=None,
+            size='10',
             target=tmp_path / 'tester/my-app.bundle/path/to/icon-10.png'
         ),
         mock.call(
             'application icon',
-            size='20',
             source='images/icon',
+            variant=None,
+            size='20',
             target=tmp_path / 'tester/my-app.bundle/path/to/icon-20.png'
         ),
     ], any_order=True)
 
 
+def test_icon_variant_target(create_command, tmp_path):
+    "If the template defines an icon target with variants, they will be installed"
+    myapp = AppConfig(
+        app_name='my-app',
+        formal_name='My App',
+        bundle='com.example',
+        version='1.2.3',
+        description='This is a simple app',
+        sources=['src/my_app'],
+        icon={
+            'round': 'images/round',
+            'square': 'images/square',
+        }
+    )
+
+    # Prime the path index with 2 icon targets
+    create_command._path_index = {
+        myapp: {
+            'icon': {
+                'round': 'path/to/round.png',
+                'square': {
+                    '10': 'path/to/square-10.png',
+                    '20': 'path/to/square-20.png',
+                }
+            }
+        }
+    }
+
+    install_image = mock.MagicMock()
+    create_command.install_image = install_image
+
+    # Install app resources
+    create_command.install_app_resources(myapp)
+
+    # 3 calls to install icons will be made
+    install_image.assert_has_calls([
+        mock.call(
+            'application icon',
+            source={'round': 'images/round', 'square': 'images/square'},
+            variant=None,
+            size='round',  # This is expected for unsized variants
+            target=tmp_path / 'tester/my-app.bundle/path/to/round.png'
+        ),
+        mock.call(
+            'application icon',
+            source={'round': 'images/round', 'square': 'images/square'},
+            variant='square',
+            size='10',
+            target=tmp_path / 'tester/my-app.bundle/path/to/square-10.png'
+        ),
+        mock.call(
+            'application icon',
+            source={'round': 'images/round', 'square': 'images/square'},
+            variant='square',
+            size='20',
+            target=tmp_path / 'tester/my-app.bundle/path/to/square-20.png'
+        ),
+    ], any_order=True)
+
+
 def test_splash_target(create_command, tmp_path):
-    "If the template defines an splash target, it will be installed"
+    "If the template defines a splash target, it will be installed"
     myapp = AppConfig(
         app_name='my-app',
         formal_name='My App',
@@ -104,15 +166,77 @@ def test_splash_target(create_command, tmp_path):
     install_image.assert_has_calls([
         mock.call(
             'splash image',
-            size='10x20',
             source='images/splash',
+            variant=None,
+            size='10x20',
             target=tmp_path / 'tester/my-app.bundle/path/to/splash-10x20.png'
         ),
         mock.call(
             'splash image',
-            size='20x30',
             source='images/splash',
+            variant=None,
+            size='20x30',
             target=tmp_path / 'tester/my-app.bundle/path/to/splash-20x30.png'
+        ),
+    ], any_order=True)
+
+
+def test_splash_variant_target(create_command, tmp_path):
+    "If the template defines a splash target with variants, they will be installed"
+    myapp = AppConfig(
+        app_name='my-app',
+        formal_name='My App',
+        bundle='com.example',
+        version='1.2.3',
+        description='This is a simple app',
+        sources=['src/my_app'],
+        splash={
+            'portrait': 'images/portrait',
+            'landscape': 'images/landscape',
+        }
+    )
+
+    # Prime the path index with 2 splash targets
+    create_command._path_index = {
+        myapp: {
+            'splash': {
+                'portrait': 'path/to/portrait.png',
+                'landscape': {
+                    '10x20': 'path/to/landscape-10x20.png',
+                    '20x30': 'path/to/landscape-20x30.png',
+                }
+            }
+        }
+    }
+
+    install_image = mock.MagicMock()
+    create_command.install_image = install_image
+
+    # Install app resources
+    create_command.install_app_resources(myapp)
+
+    # 3 calls to install splashes will be made
+    install_image.assert_has_calls([
+        mock.call(
+            'splash image',
+            source={'portrait': 'images/portrait', 'landscape': 'images/landscape'},
+            variant=None,
+            size='portrait',  # This is expected for unsized variants
+            target=tmp_path / 'tester/my-app.bundle/path/to/portrait.png'
+        ),
+        mock.call(
+            'splash image',
+            source={'portrait': 'images/portrait', 'landscape': 'images/landscape'},
+            variant='landscape',
+            size='10x20',
+            target=tmp_path / 'tester/my-app.bundle/path/to/landscape-10x20.png'
+        ),
+        mock.call(
+            'splash image',
+            source={'portrait': 'images/portrait', 'landscape': 'images/landscape'},
+            variant='landscape',
+            size='20x30',
+            target=tmp_path / 'tester/my-app.bundle/path/to/landscape-20x30.png'
         ),
     ], any_order=True)
 
@@ -161,20 +285,23 @@ def test_doctype_icon_target(create_command, tmp_path):
     install_image.assert_has_calls([
         mock.call(
             'icon for .mydoc documents',
-            size=None,
             source='images/mydoc-icon',
+            variant=None,
+            size=None,
             target=tmp_path / 'tester/my-app.bundle/path/to/mydoc-icon.png'
         ),
         mock.call(
             'icon for .other documents',
-            size='10',
             source='images/other-icon',
+            variant=None,
+            size='10',
             target=tmp_path / 'tester/my-app.bundle/path/to/other-icon-10.png'
         ),
         mock.call(
             'icon for .other documents',
-            size='20',
             source='images/other-icon',
+            variant=None,
+            size='20',
             target=tmp_path / 'tester/my-app.bundle/path/to/other-icon-20.png'
         ),
     ], any_order=True)

--- a/tests/commands/create/test_install_image.py
+++ b/tests/commands/create/test_install_image.py
@@ -9,8 +9,9 @@ def test_no_source(create_command, tmp_path):
     out_path = tmp_path / 'output.png'
     create_command.install_image(
         'sample image',
-        size=None,
         source=None,
+        variant=None,
+        size=None,
         target=out_path
     )
 
@@ -26,8 +27,9 @@ def test_no_source_with_size(create_command, tmp_path):
     out_path = tmp_path / 'output.png'
     create_command.install_image(
         'sample image',
-        size='3742',
         source=None,
+        variant=None,
+        size='3742',
         target=out_path
     )
 
@@ -49,8 +51,9 @@ def test_no_requested_size(create_command, tmp_path, capsys):
     out_path = tmp_path / 'output.png'
     create_command.install_image(
         'sample image',
-        size=None,
         source='input/original',
+        variant=None,
+        size=None,
         target=out_path
     )
 
@@ -73,8 +76,9 @@ def test_no_requested_size_invalid_path(create_command, tmp_path, capsys):
     out_path = tmp_path / 'output.png'
     create_command.install_image(
         'sample image',
-        size=None,
         source='input/original',
+        variant=None,
+        size=None,
         target=out_path
     )
 
@@ -101,8 +105,9 @@ def test_requested_size(create_command, tmp_path, capsys):
     out_path = tmp_path / 'output.png'
     create_command.install_image(
         'sample image',
-        size='3742',
         source='input/original',
+        variant=None,
+        size='3742',
         target=out_path
     )
 
@@ -125,8 +130,9 @@ def test_requested_size_invalid_path(create_command, tmp_path, capsys):
     out_path = tmp_path / 'output.png'
     create_command.install_image(
         'sample image',
-        size='3742',
         source='input/original',
+        variant=None,
+        size='3742',
         target=out_path
     )
 
@@ -137,3 +143,166 @@ def test_requested_size_invalid_path(create_command, tmp_path, capsys):
 
     # The file was not copied
     assert create_command.shutil.copy.call_count == 0
+
+
+# ====
+
+
+def test_variant_with_no_requested_size(create_command, tmp_path, capsys):
+    "If the app specifies a variant with no size, the variant is used unsized."
+    create_command.shutil = mock.MagicMock()
+
+    # Create the source image
+    source_file = tmp_path / 'input' / 'original.png'
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    with source_file.open('w') as f:
+        f.write('image')
+
+    # Try to install the image
+    out_path = tmp_path / 'output.png'
+    create_command.install_image(
+        'sample image',
+        source={
+            'round': 'input/original',
+        },
+        variant='round',
+        size=None,
+        target=out_path
+    )
+
+    # The right message was written to output
+    assert capsys.readouterr().out == "Installing input/original.png as round sample image...\n"
+
+    # The file was copied into position
+    create_command.shutil.copy.assert_called_with(
+        str(create_command.base_path / 'input' / 'original.png'),
+        str(out_path),
+    )
+
+
+def test_variant_without_variant_source_and_no_requested_size(create_command, tmp_path, capsys):
+    """If the template specifies a variant with no size, but app doesn't have
+    variants, a message is reported."""
+    create_command.shutil = mock.MagicMock()
+
+    # Create the source image
+    source_file = tmp_path / 'input' / 'original.png'
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    with source_file.open('w') as f:
+        f.write('image')
+
+    # Try to install the image
+    out_path = tmp_path / 'output.png'
+    create_command.install_image(
+        'sample image',
+        source='input/original',
+        variant='round',
+        size=None,
+        target=out_path
+    )
+
+    # The right message was written to output
+    assert capsys.readouterr().out == "Unable to find round variant for sample image; using default\n"
+
+    # No file was installed.
+    create_command.shutil.copy.assert_not_called()
+
+
+def test_unknown_variant_with_no_requested_size(create_command, tmp_path, capsys):
+    "If the app specifies an unknown variant, an message is reported."
+    create_command.shutil = mock.MagicMock()
+
+    # Create the source image
+    source_file = tmp_path / 'input' / 'original.png'
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    with source_file.open('w') as f:
+        f.write('image')
+
+    # Try to install the image
+    out_path = tmp_path / 'output.png'
+    create_command.install_image(
+        'sample image',
+        source={
+            'round': 'input/original',
+        },
+        variant='unknown',
+        size=None,
+        target=out_path
+    )
+
+    # The right message was written to output
+    assert capsys.readouterr().out == "Unable to find unknown variant for sample image; using default\n"
+
+    # No file was installed.
+    create_command.shutil.copy.assert_not_called()
+
+def test_variant_with_size(create_command, tmp_path, capsys):
+    "If the app specifies a variant with a size, the sized variant is used."
+    create_command.shutil = mock.MagicMock()
+
+    # Create the source image
+    source_file = tmp_path / 'input' / 'original-3742.png'
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    with source_file.open('w') as f:
+        f.write('image')
+
+    # Try to install the image
+    out_path = tmp_path / 'output.png'
+    create_command.install_image(
+        'sample image',
+        source={
+            'round': 'input/original',
+        },
+        variant='round',
+        size='3742',
+        target=out_path
+    )
+
+    # The right message was written to output
+    assert (
+        capsys.readouterr().out
+        == "Installing input/original-3742.png as 3742px round sample image...\n"
+    )
+
+    # The file was copied into position
+    create_command.shutil.copy.assert_called_with(
+        str(create_command.base_path / 'input' / 'original-3742.png'),
+        str(out_path),
+    )
+
+
+def test_unsized_variant(create_command, tmp_path, capsys):
+    "If the app specifies an unsized variant, it is used."
+    create_command.shutil = mock.MagicMock()
+
+    # Create the source image
+    source_file = tmp_path / 'input' / 'original.png'
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    with source_file.open('w') as f:
+        f.write('image')
+
+    # Try to install the image
+    # Unsized variants are an annoying edge case; they get the *variant*
+    # as the *size*.
+    out_path = tmp_path / 'output.png'
+    create_command.install_image(
+        'sample image',
+        source={
+            'round': 'input/original',
+        },
+        variant=None,
+        size='round',
+        target=out_path
+    )
+
+    # The right message was written to output
+    assert (
+        capsys.readouterr().out
+        == "Installing input/original.png as round sample image...\n"
+    )
+
+    # The file was copied into position
+    create_command.shutil.copy.assert_called_with(
+        str(create_command.base_path / 'input' / 'original.png'),
+        str(out_path),
+    )

--- a/tests/commands/create/test_install_image.py
+++ b/tests/commands/create/test_install_image.py
@@ -145,9 +145,6 @@ def test_requested_size_invalid_path(create_command, tmp_path, capsys):
     assert create_command.shutil.copy.call_count == 0
 
 
-# ====
-
-
 def test_variant_with_no_requested_size(create_command, tmp_path, capsys):
     "If the app specifies a variant with no size, the variant is used unsized."
     create_command.shutil = mock.MagicMock()
@@ -236,6 +233,7 @@ def test_unknown_variant_with_no_requested_size(create_command, tmp_path, capsys
     # No file was installed.
     create_command.shutil.copy.assert_not_called()
 
+
 def test_variant_with_size(create_command, tmp_path, capsys):
     "If the app specifies a variant with a size, the sized variant is used."
     create_command.shutil = mock.MagicMock()
@@ -269,6 +267,37 @@ def test_variant_with_size(create_command, tmp_path, capsys):
         str(create_command.base_path / 'input' / 'original-3742.png'),
         str(out_path),
     )
+
+
+def test_variant_with_size_without_variants(create_command, tmp_path, capsys):
+    """If the app specifies a variant with a size, but no variants are specified,
+    a message is output."""
+    create_command.shutil = mock.MagicMock()
+
+    # Create the source image
+    source_file = tmp_path / 'input' / 'original-3742.png'
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    with source_file.open('w') as f:
+        f.write('image')
+
+    # Try to install the image
+    out_path = tmp_path / 'output.png'
+    create_command.install_image(
+        'sample image',
+        source='input/original',
+        variant='round',
+        size='3742',
+        target=out_path
+    )
+
+    # The right message was written to output
+    assert (
+        capsys.readouterr().out
+        == "Unable to find 3742px round variant for sample image; using default\n"
+    )
+
+    # No file was installed.
+    create_command.shutil.copy.assert_not_called()
 
 
 def test_unsized_variant(create_command, tmp_path, capsys):

--- a/tests/commands/create/test_properties.py
+++ b/tests/commands/create/test_properties.py
@@ -133,6 +133,34 @@ def test_multiple_icon(create_command, myapp):
     }
 
 
+def test_icon_variants(create_command, myapp):
+    "If there are icon variants, they are returned"
+    bundle_path = create_command.bundle_path(myapp)
+    bundle_path.mkdir(parents=True)
+    with (bundle_path / 'briefcase.toml').open('w') as f:
+        index = {
+            'paths': {
+                'app_path': 'path/to/app',
+                'icon': {
+                    'single': 'path/to/icon.png',
+                    'multi': {
+                        '10': 'path/to/icon-10.png',
+                        '20': 'path/to/icon-20.png',
+                    }
+                },
+            }
+        }
+        toml.dump(index, f)
+
+    assert create_command.icon_targets(myapp) == {
+        'single': 'path/to/icon.png',
+        'multi': {
+            '10': 'path/to/icon-10.png',
+            '20': 'path/to/icon-20.png',
+        },
+    }
+
+
 def test_no_splash(create_command, myapp):
     "If no splash target is specified, the splash list is empty"
     bundle_path = create_command.bundle_path(myapp)


### PR DESCRIPTION
Android requires square and round variants for icons. This change allows a template to specify variants that have their own sizes, and apps to specify different sources for each variant.