### PR TITLE
Allow support packages to be pinned at a revision

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -270,6 +270,20 @@ A file path or URL pointing at a tarball containing a Python support package.
 If this setting is not provided, Briefcase will use the default support
 package for the platform.
 
+``support_revision``
+~~~~~~~~~~~~~~~~~~~~
+
+The specific revision of a support package that should be used. By default,
+Briefcase will always use the most recently released support package; if you
+specify a support revision, the support package will be pinned to that version
+for your app.
+
+If the support package is a URL, a query argument of
+``revision=<support_revision>`` will be added to the support package URL when
+it is downloaded.
+
+If the support package is a file path, this argument is ignored.
+
 ``template``
 ~~~~~~~~~~~~
 

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -114,7 +114,6 @@ class CreateCommand(BaseCommand):
         super().__init__(*args, **kwargs)
         self._path_index = {}
         self._s3 = None
-        self._support_package_url = None
 
     @property
     def app_template_url(self):

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -383,9 +383,14 @@ class CreateCommand(BaseCommand):
                     ))
                     # If a revision has been specified, add the revision
                     # as an query argument in the support package URL.
+                    # This is a lot more painful than "add arg to query" should
+                    # be because (a) url splits aren't appendable, and
+                    # (b) Python 3.5 doesn't guarantee dictionary order.
                     url_parts = list(urlsplit(support_package_url))
-                    query = dict(parse_qsl(url_parts[3]))
-                    query['revision'] = app.support_revision
+                    query = []
+                    for key, value in parse_qsl(url_parts[3]):
+                        query.append((key, value))
+                    query.append(('revision', app.support_revision))
                     url_parts[3] = urlencode(query)
                     support_package_url = urlunsplit(url_parts)
 

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -35,9 +35,6 @@ def test_install_app_support_package(create_command, myapp, tmp_path, support_pa
 
 def test_install_custom_app_support_package_file(create_command, myapp, tmp_path, support_path):
     "A custom support package can be specified as a local file"
-    # Hardcode the support package URL for test purposes
-    create_command._support_package_url = 'https://example.com/path/to/support.zip'
-
     # Provide an app-specific override of the package URL
     myapp.support_package = str(tmp_path / 'custom' / 'support.zip')
 
@@ -64,9 +61,6 @@ def test_install_custom_app_support_package_file(create_command, myapp, tmp_path
 
 def test_install_custom_app_support_package_url(create_command, myapp, tmp_path, support_path):
     "A custom support package can be specified as URL"
-    # Hardcode the support package URL for test purposes
-    create_command._support_package_url = 'https://example.com/path/to/support.zip'
-
     # Provide an app-specific override of the package URL
     myapp.support_package = 'https://example.com/custom/support.zip'
 
@@ -94,9 +88,6 @@ def test_install_custom_app_support_package_url(create_command, myapp, tmp_path,
 
 def test_offline_install(create_command, myapp, support_path):
     "If the computer is offline, an error is raised"
-    # Hardcode the support package URL for test purposes
-    create_command._support_package_url = 'https://example.com/path/to/support.zip'
-
     create_command.download_url = mock.MagicMock(
         side_effect=requests_exceptions.ConnectionError
     )
@@ -108,9 +99,6 @@ def test_offline_install(create_command, myapp, support_path):
 
 def test_invalid_support_package(create_command, myapp, tmp_path, support_path):
     "If the support package isn't a valid zipfile, an error is raised"
-    # Hardcode the support package URL for test purposes
-    create_command._support_package_url = 'https://example.com/path/to/support.zip'
-
     # Create a support package that isn't a zipfile
     support_file = tmp_path / 'out.zip'
     with open(str(support_file), 'w') as bad_support_zip:

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -10,7 +10,7 @@ from briefcase.exceptions import NetworkFailure
 
 
 def test_install_app_support_package(create_command, myapp, tmp_path, support_path):
-    "A support package can be unpacked where it is needed"
+    "A support package can be downloaded and unpacked where it is needed"
     # Write a temporary support zip file
     support_file = tmp_path / 'out.zip'
     with zipfile.ZipFile(str(support_file), 'w') as support_zip:
@@ -26,6 +26,33 @@ def test_install_app_support_package(create_command, myapp, tmp_path, support_pa
     create_command.download_url.assert_called_with(
         download_path=create_command.dot_briefcase_path / 'support',
         url='https://briefcase-support.org/python?platform=tester&version=3.X',
+    )
+
+    # Confirm that the full path to the support file
+    # has been unpacked.
+    assert (support_path / 'internal' / 'file.txt').exists()
+
+
+def test_install_pinned_app_support_package(create_command, myapp, tmp_path, support_path):
+    "A pinned support package can be downloaded and unpacked where it is needed"
+    # Pin the support revision
+    myapp.support_revision = '42'
+
+    # Write a temporary support zip file
+    support_file = tmp_path / 'out.zip'
+    with zipfile.ZipFile(str(support_file), 'w') as support_zip:
+        support_zip.writestr('internal/file.txt', data='hello world')
+
+    # Modify download_url to return the temp zipfile
+    create_command.download_url = mock.MagicMock(return_value=support_file)
+
+    # Install the support package
+    create_command.install_app_support_package(myapp)
+
+    # Confirm the right URL was used
+    create_command.download_url.assert_called_with(
+        download_path=create_command.dot_briefcase_path / 'support',
+        url='https://briefcase-support.org/python?platform=tester&version=3.X&revision=42',
     )
 
     # Confirm that the full path to the support file
@@ -79,6 +106,66 @@ def test_install_custom_app_support_package_url(create_command, myapp, tmp_path,
     create_command.download_url.assert_called_with(
         download_path=create_command.dot_briefcase_path / 'support',
         url='https://example.com/custom/support.zip',
+    )
+
+    # Confirm that the full path to the support file
+    # has been unpacked.
+    assert (support_path / 'internal' / 'file.txt').exists()
+
+
+def test_install_pinned_custom_app_support_package_url(create_command, myapp, tmp_path, support_path):
+    "A custom support package can be specified as URL, and pinned to a revision"
+    # Pin the support revision
+    myapp.support_revision = '42'
+
+    # Provide an app-specific override of the package URL
+    myapp.support_package = 'https://example.com/custom/support.zip'
+
+    # Write a temporary support zip file
+    support_file = tmp_path / 'out.zip'
+    with zipfile.ZipFile(str(support_file), 'w') as support_zip:
+        support_zip.writestr('internal/file.txt', data='hello world')
+
+    # Modify download_url to return the temp zipfile
+    create_command.download_url = mock.MagicMock(return_value=support_file)
+
+    # Install the support package
+    create_command.install_app_support_package(myapp)
+
+    # Confirm the right URL was used
+    create_command.download_url.assert_called_with(
+        download_path=create_command.dot_briefcase_path / 'support',
+        url='https://example.com/custom/support.zip?revision=42',
+    )
+
+    # Confirm that the full path to the support file
+    # has been unpacked.
+    assert (support_path / 'internal' / 'file.txt').exists()
+
+
+def test_install_pinned_custom_app_support_package_url_with_args(create_command, myapp, tmp_path, support_path):
+    "A custom support package can be specified as URL with args, and pinned to a revision"
+    # Pin the support revision
+    myapp.support_revision = '42'
+
+    # Provide an app-specific override of the package URL
+    myapp.support_package = 'https://example.com/custom/support.zip?cool=Yes'
+
+    # Write a temporary support zip file
+    support_file = tmp_path / 'out.zip'
+    with zipfile.ZipFile(str(support_file), 'w') as support_zip:
+        support_zip.writestr('internal/file.txt', data='hello world')
+
+    # Modify download_url to return the temp zipfile
+    create_command.download_url = mock.MagicMock(return_value=support_file)
+
+    # Install the support package
+    create_command.install_app_support_package(myapp)
+
+    # Confirm the right URL was used
+    create_command.download_url.assert_called_with(
+        download_path=create_command.dot_briefcase_path / 'support',
+        url='https://example.com/custom/support.zip?cool=Yes&revision=42',
     )
 
     # Confirm that the full path to the support file


### PR DESCRIPTION
When building apps for production, developers may not wish to upgrade the support package version; or, they may discover that an updated version has a production stopping bug (e.g., the 3.7.7 release for windows)

This PR allows developers to pin an application to a specific support revision; e.g.,:
```
support_revision = 'b4'
```
would force an app to use the `b4` support revision.
