### PR TITLE
Tell Android users how to have enough storage

### DIFF
--- a/src/briefcase/integrations/adb.py
+++ b/src/briefcase/integrations/adb.py
@@ -146,6 +146,8 @@ If you do not see any devices, you can create and start an emulator by running:
 --name robotfriend --abi x86 \
 --package 'system-images;android-28;default;x86' --device pixel
 
+    $ echo 'disk.dataPartition.size=4096M' >> $HOME/.android/avd/robotfriend.avd/config.ini
+
     $ {emulator_path} -avd robotfriend &
 
 """.format(


### PR DESCRIPTION
Close #331

## How the change was tested

I ensured the message gets printed:

![Screenshot from 2020-03-26 07-26-06](https://user-images.githubusercontent.com/25457/77658499-0587f480-6f34-11ea-9d78-24e5a801f297.png)

I then created a new emulator that way, and looked at its storage settings. Less than half used.

![Screenshot from 2020-03-26 07-26-09](https://user-images.githubusercontent.com/25457/77658553-15073d80-6f34-11ea-90ab-a419004cd901.png)

I then installed an enormous briefcase-generated app twice. The app launched properly both times (although I was using a broken app, so it also immediately quit). Here's storage after that.

![Screenshot from 2020-03-26 07-27-30](https://user-images.githubusercontent.com/25457/77658579-205a6900-6f34-11ea-8da3-efb1598f46b4.png)
