### PR TITLE
Isolate git checks 

### DIFF
--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -261,7 +261,7 @@ class BaseCommand(ABC):
 
         Raises MissingToolException if a required system tool is missing.
         """
-        self.git = self.integrations.git.verify_git_is_installed()
+        pass
 
     def parse_options(self, extra):
         parser = argparse.ArgumentParser(

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -716,6 +716,14 @@ class CreateCommand(BaseCommand):
             filename=self.bundle_path(app).relative_to(self.base_path),
         ))
 
+    def verify_tools(self):
+        """
+        Verify that the tools needed to run this command exist
+
+        Raises MissingToolException if a required system tool is missing.
+        """
+        self.git = self.integrations.git.verify_git_is_installed()
+
     def __call__(self, app: Optional[BaseConfig] = None, **kwargs):
         # Confirm all required tools are available
         self.verify_tools()

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -502,6 +502,14 @@ Application '{formal_name}' has been generated. To run your application, type:
     briefcase dev
 """.format(**context))
 
+    def verify_tools(self):
+        """
+        Verify that the tools needed to run this command exist
+
+        Raises MissingToolException if a required system tool is missing.
+        """
+        self.git = self.integrations.git.verify_git_is_installed()
+
     def __call__(
         self,
         template: Optional[str] = None,

--- a/src/briefcase/integrations/__init__.py
+++ b/src/briefcase/integrations/__init__.py
@@ -1,5 +1,3 @@
-from . import adb
-from . import git
-from . import xcode
+from . import adb, git, xcode
 
 __all__ = ['adb', 'git', 'xcode']

--- a/src/briefcase/integrations/__init__.py
+++ b/src/briefcase/integrations/__init__.py
@@ -1,0 +1,5 @@
+from . import adb
+from . import git
+from . import xcode
+
+__all__ = ['adb', 'git', 'xcode']

--- a/src/briefcase/integrations/git.py
+++ b/src/briefcase/integrations/git.py
@@ -1,0 +1,33 @@
+from briefcase.exceptions import BriefcaseCommandError
+
+
+def verify_git_is_installed():
+    """
+    Verify if git is installed.
+
+    Unfortunately, `import git` triggers a call on the operating system
+    to run the git executable. On some platforms (notably macOS), the git
+    binary has been instrumented such that if git *isnt'* installed,
+    running git triggers a prompt to install Xcode. However, that messes
+    with the UX workflow.
+
+    So - we defer importing git until we actually know we need it. This
+    enables Briefcase to start us to do other Xcode checks as part of
+    macOS workflows, and ensures that "briefcase --help" works on other
+    platforms without raising an error.
+
+    :returns: The git module, if `git` is installed and available.
+    """
+    # Check whether the git executable could be imported.
+    try:
+        import git
+        return git
+    except ImportError:
+        raise BriefcaseCommandError("""
+Briefcase requires git, but it is not installed (or is not on your PATH). Visit:
+
+    https://git-scm.com/
+
+to download and install git. If you have installed git recently and are still
+getting this error, you may need to restart your terminal session.
+""")

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -1,5 +1,4 @@
 import subprocess
-from pathlib import Path
 
 from requests import exceptions as requests_exceptions
 

--- a/tests/commands/base/test_update_cookiecutter_cache.py
+++ b/tests/commands/base/test_update_cookiecutter_cache.py
@@ -9,9 +9,9 @@ from briefcase.commands.base import (
 )
 
 
-def test_non_url(base_command):
+def test_non_url(base_command, mock_git):
     "If the provided template isn't a URL, don't try to update."
-    base_command.git = mock.MagicMock()
+    base_command.git = mock_git
 
     cached_template = base_command.update_cookiecutter_cache(
         template='/path/to/template',
@@ -23,9 +23,9 @@ def test_non_url(base_command):
     assert base_command.git.Repo.call_count == 0
 
 
-def test_explicit_new_repo_template(base_command):
+def test_explicit_new_repo_template(base_command, mock_git):
     "If a previously unknown URL template is specified it is used"
-    base_command.git = mock.MagicMock()
+    base_command.git = mock_git
 
     # There won't be a cookiecutter cache, so there won't be
     # a repo path (yet).
@@ -46,9 +46,9 @@ def test_explicit_new_repo_template(base_command):
     base_command.git.Repo.assert_called_once_with(cached_path)
 
 
-def test_explicit_cached_repo_template(base_command):
+def test_explicit_cached_repo_template(base_command, mock_git):
     "If a previously known URL template is specified it is used"
-    base_command.git = mock.MagicMock()
+    base_command.git = mock_git
 
     mock_repo = mock.MagicMock()
     mock_remote = mock.MagicMock()
@@ -85,9 +85,9 @@ def test_explicit_cached_repo_template(base_command):
     assert cached_template == cached_path
 
 
-def test_offline_repo_template(base_command):
+def test_offline_repo_template(base_command, mock_git):
     "If the user is offline the first time a repo template is requested, an error is raised"
-    base_command.git = mock.MagicMock()
+    base_command.git = mock_git
 
     mock_repo = mock.MagicMock()
     mock_remote = mock.MagicMock()
@@ -126,9 +126,9 @@ def test_offline_repo_template(base_command):
     assert cached_template == cached_path
 
 
-def test_cached_missing_branch_template(base_command):
+def test_cached_missing_branch_template(base_command, mock_git):
     "If the cached repo doesn't have the requested branch, an error is raised"
-    base_command.git = mock.MagicMock()
+    base_command.git = mock_git
 
     mock_repo = mock.MagicMock()
     mock_remote = mock.MagicMock()

--- a/tests/commands/base/test_verify_tools.py
+++ b/tests/commands/base/test_verify_tools.py
@@ -1,30 +1,5 @@
-from unittest import mock
-
-import pytest
-
-from briefcase.exceptions import BriefcaseCommandError
-
-
-def test_no_git(base_command):
-    "If Git is not installed, an error is raised"
-    # Mock a non-existent git
-    integrations = mock.MagicMock()
-    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
-        "Briefcase requires git, but it is not installed"
-    )
-    base_command.integrations = integrations
-
-    # The command will fail tool verification.
-    with pytest.raises(
-        BriefcaseCommandError,
-        match=r"Briefcase requires git, but it is not installed"
-    ):
-        base_command.verify_tools()
 
 
 def test_base_tools_exist(base_command):
-    "If all the required base tools exist, verification passes"
-
-    # This assumes git is actually in the test environment. If it isn't,
-    # this test will fail.
+    "No verification required for base command."
     base_command.verify_tools()

--- a/tests/commands/base/test_verify_tools.py
+++ b/tests/commands/base/test_verify_tools.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
@@ -6,7 +8,11 @@ from briefcase.exceptions import BriefcaseCommandError
 def test_no_git(base_command):
     "If Git is not installed, an error is raised"
     # Mock a non-existent git
-    base_command.git = None
+    integrations = mock.MagicMock()
+    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
+        "Briefcase requires git, but it is not installed"
+    )
+    base_command.integrations = integrations
 
     # The command will fail tool verification.
     with pytest.raises(

--- a/tests/commands/build/test_call.py
+++ b/tests/commands/build/test_call.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
@@ -6,7 +8,11 @@ from briefcase.exceptions import BriefcaseCommandError
 def test_no_git(build_command):
     "If Git is not installed, an error is raised"
     # Mock a non-existent git
-    build_command.git = None
+    integrations = mock.MagicMock()
+    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
+        "Briefcase requires git, but it is not installed"
+    )
+    build_command.integrations = integrations
 
     # The command will fail tool verification.
     with pytest.raises(

--- a/tests/commands/build/test_call.py
+++ b/tests/commands/build/test_call.py
@@ -1,27 +1,3 @@
-from unittest import mock
-
-import pytest
-
-from briefcase.exceptions import BriefcaseCommandError
-
-
-def test_no_git(build_command):
-    "If Git is not installed, an error is raised"
-    # Mock a non-existent git
-    integrations = mock.MagicMock()
-    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
-        "Briefcase requires git, but it is not installed"
-    )
-    build_command.integrations = integrations
-
-    # The command will fail tool verification.
-    with pytest.raises(
-        BriefcaseCommandError,
-        match=r"Briefcase requires git, but it is not installed"
-    ):
-        build_command()
-
-
 def test_specific_app(build_command, first_app, second_app):
     "If a specific app is requested, build it"
     # Add two apps

--- a/tests/commands/create/conftest.py
+++ b/tests/commands/create/conftest.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 import toml
-from git import exc as git_exceptions
 
 from briefcase.commands import CreateCommand
 from briefcase.config import AppConfig
@@ -17,7 +16,7 @@ class DummyCreateCommand(CreateCommand):
     output_format = 'dummy'
     description = 'Dummy create command'
 
-    def __init__(self, *args, support_file=None, **kwargs):
+    def __init__(self, *args, support_file=None, git=None, **kwargs):
         super().__init__(*args, **kwargs)
 
         # If a test sets this property, the tool verification step will
@@ -25,8 +24,7 @@ class DummyCreateCommand(CreateCommand):
         self._missing_tool = None
 
         # Mock the external services
-        self.git = mock.MagicMock()
-        self.git.exc = git_exceptions
+        self.git = git
         self.cookiecutter = mock.MagicMock()
         self.subprocess = mock.MagicMock()
         self.support_file = support_file
@@ -90,16 +88,18 @@ class TrackingCreateCommand(DummyCreateCommand):
 
 
 @pytest.fixture
-def create_command(tmp_path):
+def create_command(tmp_path, mock_git):
     return DummyCreateCommand(
         base_path=tmp_path,
         dot_briefcase_path=tmp_path / "dot-briefcase",
+        git=mock_git,
     )
 
 
 @pytest.fixture
-def tracking_create_command(tmp_path):
+def tracking_create_command(tmp_path, mock_git):
     return TrackingCreateCommand(
+        git=mock_git,
         base_path=tmp_path,
         apps={
             'first': AppConfig(

--- a/tests/commands/create/conftest.py
+++ b/tests/commands/create/conftest.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 import toml
+from git import exc as git_exceptions
 
 from briefcase.commands import CreateCommand
 from briefcase.config import AppConfig
@@ -25,6 +26,7 @@ class DummyCreateCommand(CreateCommand):
 
         # Mock the external services
         self.git = mock.MagicMock()
+        self.git.exc = git_exceptions
         self.cookiecutter = mock.MagicMock()
         self.subprocess = mock.MagicMock()
         self.support_file = support_file

--- a/tests/commands/create/test_call.py
+++ b/tests/commands/create/test_call.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
@@ -6,7 +8,11 @@ from briefcase.exceptions import BriefcaseCommandError
 def test_no_git(tracking_create_command):
     "If Git is not installed, an error is raised"
     # Mock a non-existent git
-    tracking_create_command.git = None
+    integrations = mock.MagicMock()
+    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
+        "Briefcase requires git, but it is not installed"
+    )
+    tracking_create_command.integrations = integrations
 
     # The command will fail tool verification.
     with pytest.raises(

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -1,5 +1,4 @@
 import zipfile
-from pathlib import Path
 from unittest import mock
 
 import pytest

--- a/tests/commands/dev/test_call.py
+++ b/tests/commands/dev/test_call.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from briefcase.commands import DevCommand
@@ -40,7 +42,11 @@ def dev_command(tmp_path):
 def test_no_git(dev_command, first_app):
     "If Git is not installed, an error is raised"
     # Mock a non-existent git
-    dev_command.git = None
+    integrations = mock.MagicMock()
+    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
+        "Briefcase requires git, but it is not installed"
+    )
+    dev_command.integrations = integrations
 
     # The command will fail tool verification.
     with pytest.raises(

--- a/tests/commands/dev/test_call.py
+++ b/tests/commands/dev/test_call.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 from briefcase.commands import DevCommand
@@ -37,25 +35,6 @@ class DummyDevCommand(DevCommand):
 @pytest.fixture
 def dev_command(tmp_path):
     return DummyDevCommand(base_path=tmp_path)
-
-
-def test_no_git(dev_command, first_app):
-    "If Git is not installed, an error is raised"
-    # Mock a non-existent git
-    integrations = mock.MagicMock()
-    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
-        "Briefcase requires git, but it is not installed"
-    )
-    dev_command.integrations = integrations
-
-    # The command will fail tool verification.
-    with pytest.raises(
-        BriefcaseCommandError, match=r"Briefcase requires git, but it is not installed"
-    ):
-        dev_command()
-
-    # No apps will be launched
-    assert dev_command.actions == []
 
 
 def test_no_args_one_app(dev_command, first_app):

--- a/tests/commands/new/test_call.py
+++ b/tests/commands/new/test_call.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
@@ -6,7 +8,11 @@ from briefcase.exceptions import BriefcaseCommandError
 def test_no_git(new_command):
     "If Git is not installed, an error is raised"
     # Mock a non-existent git
-    new_command.git = None
+    integrations = mock.MagicMock()
+    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
+        "Briefcase requires git, but it is not installed"
+    )
+    new_command.integrations = integrations
 
     # The command will fail tool verification.
     with pytest.raises(

--- a/tests/commands/publish/test_call.py
+++ b/tests/commands/publish/test_call.py
@@ -1,25 +1,6 @@
-from unittest import mock
-
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
-
-
-def test_no_git(publish_command):
-    "If Git is not installed, an error is raised"
-    # Mock a non-existent git
-    integrations = mock.MagicMock()
-    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
-        "Briefcase requires git, but it is not installed"
-    )
-    publish_command.integrations = integrations
-
-    # The command will fail tool verification.
-    with pytest.raises(
-        BriefcaseCommandError,
-        match=r"Briefcase requires git, but it is not installed"
-    ):
-        publish_command()
 
 
 def test_publish(publish_command, first_app, second_app):

--- a/tests/commands/publish/test_call.py
+++ b/tests/commands/publish/test_call.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
@@ -6,7 +8,11 @@ from briefcase.exceptions import BriefcaseCommandError
 def test_no_git(publish_command):
     "If Git is not installed, an error is raised"
     # Mock a non-existent git
-    publish_command.git = None
+    integrations = mock.MagicMock()
+    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
+        "Briefcase requires git, but it is not installed"
+    )
+    publish_command.integrations = integrations
 
     # The command will fail tool verification.
     with pytest.raises(

--- a/tests/commands/run/test_call.py
+++ b/tests/commands/run/test_call.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
@@ -6,7 +8,11 @@ from briefcase.exceptions import BriefcaseCommandError
 def test_no_git(run_command):
     "If Git is not installed, an error is raised"
     # Mock a non-existent git
-    run_command.git = None
+    integrations = mock.MagicMock()
+    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
+        "Briefcase requires git, but it is not installed"
+    )
+    run_command.integrations = integrations
 
     # The command will fail tool verification.
     with pytest.raises(

--- a/tests/commands/run/test_call.py
+++ b/tests/commands/run/test_call.py
@@ -5,23 +5,6 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError
 
 
-def test_no_git(run_command):
-    "If Git is not installed, an error is raised"
-    # Mock a non-existent git
-    integrations = mock.MagicMock()
-    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
-        "Briefcase requires git, but it is not installed"
-    )
-    run_command.integrations = integrations
-
-    # The command will fail tool verification.
-    with pytest.raises(
-        BriefcaseCommandError,
-        match=r"Briefcase requires git, but it is not installed"
-    ):
-        run_command()
-
-
 def test_no_args_one_app(run_command, first_app):
     "If there is one app, run starts that app by default"
     # Add a single app

--- a/tests/commands/run/test_call.py
+++ b/tests/commands/run/test_call.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError

--- a/tests/commands/update/test_call.py
+++ b/tests/commands/update/test_call.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
@@ -6,7 +8,11 @@ from briefcase.exceptions import BriefcaseCommandError
 def test_no_git(update_command):
     "If Git is not installed, an error is raised"
     # Mock a non-existent git
-    update_command.git = None
+    integrations = mock.MagicMock()
+    integrations.git.verify_git_is_installed.side_effect = BriefcaseCommandError(
+        "Briefcase requires git, but it is not installed"
+    )
+    update_command.integrations = integrations
 
     # The command will fail tool verification.
     with pytest.raises(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+from unittest import mock
+
+import pytest
+
+from git import exc as git_exceptions
+
+
+@pytest.fixture
+def mock_git():
+    git = mock.MagicMock()
+    git.exc = git_exceptions
+
+    return git

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-
 from git import exc as git_exceptions
 
 

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -1,5 +1,4 @@
 import subprocess
-from pathlib import Path
 from unittest import mock
 
 import pytest


### PR DESCRIPTION
A system check for git is currently performed as a startup side effect, because `import git` tries to invoke git, and fails if it's not available.

This change isolates git checks until they are actually required - in the `new`, `create`, and `update` commands. (Strictly, it's not required for update, but it's annoying to avoid the check because update is an subclass of create).

It also means that we must avoid importing git *at all*, and only ever use the internal reference.