### PR TITLE
Use `sdkmanager.bat` and `gradlew.bat` on Windows

### DIFF
--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -190,6 +190,9 @@ class GradleBuildCommand(GradleMixin, BuildCommand):
         try:
             env = {**self.os.environ, "ANDROID_SDK_ROOT": str(self.sdk_path)}
             self.subprocess.run(
+                # Windows needs the full path to `gradlew`; macOS & Linux can find it
+                # via `./gradlew`. For simplicity of implementation, we always provide
+                # the full path.
                 [str(self.gradlew_path(app)), "assembleDebug"],
                 env=env,
                 # Set working directory so gradle can use the app bundle path as its

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -192,6 +192,8 @@ class GradleBuildCommand(GradleMixin, BuildCommand):
             self.subprocess.run(
                 [str(self.gradlew_path(app)), "assembleDebug"],
                 env=env,
+                # Set working directory so gradle can use the app bundle path as its
+                # project root, i.e., to avoid 'Task assembleDebug not found'.
                 cwd=str(self.bundle_path(app)),
                 check=True
             )

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -38,7 +38,7 @@ def test_verify_emulator_installs_android_emulator(run_command):
     run_command.verify_emulator()
     run_command.subprocess.run.assert_called_once_with(
         [
-            str(run_command.sdk_path / "tools" / "bin" / "sdkmanager"),
+            str(run_command.sdkmanager_path),
             "platforms;android-28",
             "system-images;android-28;default;x86",
             "emulator",

--- a/tests/platforms/android/gradle/test_verify_tools.py
+++ b/tests/platforms/android/gradle/test_verify_tools.py
@@ -21,7 +21,7 @@ def build_command(tmp_path, first_app_config):
     command.sys = mock.MagicMock()
     # Use the `tmp_path` in `dot_briefcase_path` to ensure tests don't interfere
     # with each other.
-    command.dot_briefcase_path = tmp_path / ".briefcase"
+    command.dot_briefcase_path = tmp_path / ".briefcase" / "tools"
     # Override the `os` module so the app has an empty environment.
     command.os = mock.MagicMock(environ={})
     # Override the requests` and `subprocess` modules so we can test side-effects.


### PR DESCRIPTION
This fixes `briefcase create android` and `briefcase build android` on Windows.

I intend to submit a follow-up once I've tested `briefcase run android` on Windows.

See also: https://github.com/beeware/briefcase/issues/330

## Implementation notes

This code assumes `JAVA_HOME` is set to a Java 8 JVM. Per conversation with @freakboy3742 , this is OK for now.

In case you're curious, I used https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u242b08.zip as my Windows JDK.

I worked hard to make the `git diff` here as minimal as possible. :)

## Validation

Copied contents of `click-button-receive-log` app [https://github.com/paulproteus/click-button-receive-log] onto a Windows 10 VM.

Ran `briefcase create android` and `briefcase build android` and got the following happy screenshots.

![Screen Shot 2020-03-30 at 8 52 55 PM](https://user-images.githubusercontent.com/25457/77985429-5186c080-72c9-11ea-9c5a-36fecdf7e3c9.png)

![Screen Shot 2020-03-30 at 8 53 07 PM](https://user-images.githubusercontent.com/25457/77985430-52b7ed80-72c9-11ea-98c4-7ec715a56b47.png)

![Screen Shot 2020-03-30 at 8 54 05 PM](https://user-images.githubusercontent.com/25457/77985432-52b7ed80-72c9-11ea-80eb-f87b30885b9a.png)

![Screen Shot 2020-03-30 at 8 56 42 PM](https://user-images.githubusercontent.com/25457/77985434-53508400-72c9-11ea-9c03-07eb10cb31f3.png)
