### PR TITLE
Use sensible dot_briefcase_path in tests

### DIFF
--- a/tests/platforms/android/gradle/test_build.py
+++ b/tests/platforms/android/gradle/test_build.py
@@ -10,7 +10,7 @@ from briefcase.platforms.android.gradle import GradleBuildCommand
 @pytest.fixture
 def build_command(tmp_path, first_app_config):
     command = GradleBuildCommand(base_path=tmp_path / "base_path")
-    command.dot_briefcase_path = tmp_path / ".briefcase" / "tools"
+    command.dot_briefcase_path = tmp_path / ".briefcase"
     command.os = MagicMock()
     command.os.environ = {}
     command.sys = MagicMock()

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -10,7 +10,7 @@ from briefcase.platforms.android.gradle import GradleRunCommand
 @pytest.fixture
 def run_command(tmp_path, first_app_config):
     command = GradleRunCommand(base_path=tmp_path / "base_path")
-    command.dot_briefcase_path = tmp_path / ".briefcase" / "tools"
+    command.dot_briefcase_path = tmp_path / ".briefcase"
 
     command.mock_adb = MagicMock()
     command.ADB = MagicMock(return_value=command.mock_adb)

--- a/tests/platforms/android/gradle/test_verify_tools.py
+++ b/tests/platforms/android/gradle/test_verify_tools.py
@@ -21,7 +21,7 @@ def build_command(tmp_path, first_app_config):
     command.sys = mock.MagicMock()
     # Use the `tmp_path` in `dot_briefcase_path` to ensure tests don't interfere
     # with each other.
-    command.dot_briefcase_path = tmp_path / ".briefcase" / "tools"
+    command.dot_briefcase_path = tmp_path / ".briefcase"
     # Override the `os` module so the app has an empty environment.
     command.os = mock.MagicMock(environ={})
     # Override the requests` and `subprocess` modules so we can test side-effects.


### PR DESCRIPTION
This is a purely cosmetic change. The tests do not actually care what the value
of `dot_briefcase_path` is; they read it out of the command object, and so does
the command itself.