### PR TITLE
Add mechanism to download java if a suitable JDK isn't available.

### DIFF
--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -417,7 +417,7 @@ class CreateCommand(BaseCommand):
                 str(support_filename),
                 extract_dir=str(support_path)
             )
-        except shutil.ReadError:
+        except (shutil.ReadError, EOFError):
             print()
             raise InvalidSupportPackage(support_package_url)
 

--- a/src/briefcase/integrations/__init__.py
+++ b/src/briefcase/integrations/__init__.py
@@ -1,3 +1,3 @@
-from . import adb, git, xcode
+from . import adb, git, java, xcode
 
-__all__ = ['adb', 'git', 'xcode']
+__all__ = ['adb', 'git', 'java', 'xcode']

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -1,0 +1,201 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+from requests import exceptions as requests_exceptions
+
+from briefcase.exceptions import BriefcaseCommandError, NetworkFailure
+
+
+def verify_jdk(cmd):
+    """
+    Verify that a Java 8 JDK exists.
+
+    If ``JAVA_HOME`` is set, try that version. If it is a JRE, or it's *not*
+    a Java 8 JDK, download one.
+
+    On macOS, also try invoking /usr/libexec/java_home. If that location points
+    to a Java 8 JDK, use it.
+
+    Otherwise, download a JDK from AdoptOpenJDK and unpack it into the
+    ``~.briefcase`` path.
+
+    :param cmd: The cmd that needs to perform the verification check.
+    :returns: The value for ``JAVA_HOME``
+    """
+    java_home = cmd.os.getenv('JAVA_HOME', '')
+
+    # macOS has a helpful system utility to determine JAVA_HOME. Try it.
+    if not java_home and cmd.host_os == 'Darwin':
+        try:
+            # If no JRE/JDK is installed, /usr/libexec/java_home
+            # raises an error.
+            java_home = cmd.subprocess.check_output(
+                ['/usr/libexec/java_home'],
+                universal_newlines=True,
+                stderr=subprocess.STDOUT,
+            ).strip('\n')
+        except subprocess.CalledProcessError:
+            # No java on this machine.
+            pass
+
+    if java_home:
+        try:
+            # If JAVA_HOME is defined, try to invoke javac.
+            # This verifies that we have a JDK, not a just a JRE.
+            output = cmd.subprocess.check_output(
+                [
+                    str(Path(java_home) / 'bin' / 'javac'),
+                    '-version',
+                ],
+                universal_newlines=True,
+                stderr=subprocess.STDOUT,
+            )
+            # This should be a string of the form "javac 1.8.0_144\n"
+            version_str = output.strip('\n').split(' ')[1]
+            vparts = version_str.split('.')
+            if len(vparts) == 3 and vparts[:2] == ['1', '8']:
+                # It appears to be a Java 8 JDK.
+                # print("Using JAVA_HOME={java_home}".format(java_home=java_home))
+                return Path(java_home)
+            else:
+                # It's not a Java 8 JDK.
+                print("""
+Android requires a Java 8 JDK, but the location pointed to by JAVA_HOME
+isn't a Java 8 JDK (it appears to be Java {version_str}).
+
+Briefcase will use it's own JDK instance.
+""".format(version_str=version_str))
+
+        except FileNotFoundError:
+            print("""
+The location pointed to by JAVA HOME does not appear to be a JDK.
+It may be a Java Runtime Environment (JRE).
+
+Briefcase will use it's own JDK instance.
+""")
+
+        except subprocess.CalledProcessError:
+            print("""
+*************************************************************************
+** WARNING: Unable to invoke the Java compiler                         **
+*************************************************************************
+
+   Briefcase received an unexpected error when trying to invoke javac,
+   the Java compiler, at the location indicated by JAVA_HOME.
+
+   Briefcase will continue by downloading and using it's own JDK.
+
+   Please report this as a bug at:
+
+     https://github.com/beeware/briefcase/issues/
+
+
+   In your report, please including the output from running:
+
+     {java_home}/bin/javac -version
+
+   from the command prompt.
+
+*************************************************************************
+
+""".format(java_home=java_home))
+
+        except IndexError:
+            print("""
+*************************************************************************
+** WARNING: Unable to determine the version of Java that is installed  **
+*************************************************************************
+
+   Briefcase was unable to interpret the version information returned
+   by the Java compiler at the location indicated by JAVA_HOME.
+
+   Briefcase will continue by downloading and using it's own JDK.
+
+   Please report this as a bug at:
+
+     https://github.com/beeware/briefcase/issues/
+
+
+   In your report, please including the output from running:
+
+     {java_home}/bin/javac -version
+
+   from the command prompt.
+
+*************************************************************************
+
+""".format(java_home=java_home))
+
+    java_home = cmd.dot_briefcase_path / 'tools' / 'java'
+
+    # The macOS download has a weird layout (inherited from the official Oracle
+    # release). The actual JAVA_HOME is deeper inside the directory structure.
+    if cmd.host_os == 'Darwin':
+        java_home = java_home / 'Contents' / 'Home'
+
+    if (java_home / 'bin').exists():
+        # Using briefcase cached Java version
+        # print("Using a Java 8 JDK cached by Briefcase...")
+        return java_home
+
+    print("Obtaining a Java 8 JDK...")
+
+    # As of April 10 2020, 8u242this is the current AdoptOpenJDK
+    # https://adoptopenjdk.net/releases.html
+    jdk_release = '8u242'
+    jdk_build = 'b08'
+    jdk_platform = {
+        'Darwin': 'mac',
+        'Windows': 'windows',
+        'Linux': 'linux',
+    }.get(cmd.host_os)
+    extension = {
+        'Windows': 'zip',
+    }.get(cmd.host_os, 'tar.gz')
+
+    jdk_url = (
+        'https://github.com/AdoptOpenJDK/openjdk8-binaries/'
+        'releases/download/jdk{jdk_release}-{jdk_build}/'
+        'OpenJDK8U-jdk_x64_{jdk_platform}_hotspot_{jdk_release}{jdk_build}.{extension}'
+    ).format(
+        jdk_release=jdk_release,
+        jdk_build=jdk_build,
+        jdk_platform=jdk_platform,
+        extension=extension,
+    )
+
+    try:
+        jdk_zip_path = cmd.download_url(
+            url=jdk_url,
+            download_path=cmd.dot_briefcase_path / "tools",
+        )
+    except requests_exceptions.ConnectionError:
+        raise NetworkFailure("download Java 8 JDK")
+    try:
+        cmd.shutil.unpack_archive(
+            str(jdk_zip_path),
+            extract_dir=str(cmd.dot_briefcase_path / "tools")
+        )
+    except (shutil.ReadError, EOFError):
+        raise BriefcaseCommandError(
+            """\
+Unable to unpack AdoptOpenJDK ZIP file. The download may have been interrupted
+or corrupted.
+
+Delete {jdk_zip_path} and run briefcase again.""".format(
+                jdk_zip_path=jdk_zip_path
+            )
+        )
+    jdk_zip_path.unlink()  # Zip file no longer needed once unpacked.
+
+    # The tarball will unpack into ~.briefcase/tools/jdk8u242-b08
+    # (or whatever name matches the current release).
+    # We turn this into ~.briefcase/tools/java so we have a consistent name.
+    java_unpack_path = cmd.dot_briefcase_path / "tools" / "jdk{jdk_release}-{jdk_build}".format(
+        jdk_release=jdk_release,
+        jdk_build=jdk_build,
+    )
+    java_unpack_path.rename(cmd.dot_briefcase_path / "tools" / "java")
+
+    return java_home

--- a/src/briefcase/integrations/xcode.py
+++ b/src/briefcase/integrations/xcode.py
@@ -107,7 +107,7 @@ Re-run Briefcase once that installation is complete.
 
    Please report this as a bug at:
 
-     https://github.com/beeware/briefcase/issues/
+     https://github.com/beeware/briefcase/issues/new
 
    In your report, please including the output from running:
 
@@ -193,7 +193,7 @@ Re-run Briefcase once that installation is complete.
 
    Please report this as a bug at:
 
-     https://github.com/beeware/briefcase/issues/
+     https://github.com/beeware/briefcase/issues/new
 
    In your report, please including the output from running:
 
@@ -277,7 +277,7 @@ You need to accept the Xcode license before Briefcase can package your app.
 
    Please report this as a bug at:
 
-     https://github.com/beeware/briefcase/issues/
+     https://github.com/beeware/briefcase/issues/new
 
    In your report, please including the output from running:
 
@@ -300,7 +300,7 @@ You need to accept the Xcode license before Briefcase can package your app.
 
    Please report this as a bug at:
 
-     https://github.com/beeware/briefcase/issues/
+     https://github.com/beeware/briefcase/issues/new
 
    In your report, please including the output from running:
 

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -123,6 +123,13 @@ Delete {sdk_zip_path} and run briefcase again.""".format(
                 )
             )
         sdk_zip_path.unlink()  # Zip file no longer needed once unpacked.
+        # Python zip unpacking ignores permission metadata.
+        # On non-Windows, we manually fix permissions.
+        if self.host_os == "Windows":
+            return
+        for binpath in (self.sdk_path / "tools" / "bin").glob("*"):
+            if not self.os.access(str(binpath), self.os.X_OK):
+                binpath.chmod(0o755)
 
     def verify_license(self):
         license_path = self.sdk_path / "licenses" / "android-sdk-license"

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -1,5 +1,5 @@
+import shutil
 import subprocess
-from zipfile import BadZipFile, ZipFile
 
 from requests import exceptions as requests_exceptions
 
@@ -14,6 +14,7 @@ from briefcase.commands import (
 from briefcase.config import BaseConfig
 from briefcase.exceptions import BriefcaseCommandError, NetworkFailure
 from briefcase.integrations.adb import ADB, no_or_wrong_device_message
+from briefcase.integrations.java import verify_jdk
 
 
 class GradleMixin:
@@ -47,6 +48,14 @@ class GradleMixin:
     def sdkmanager_path(self):
         sdkmanager = "sdkmanager.bat" if self.host_os == "Windows" else "sdkmanager"
         return self.sdk_path / "tools" / "bin" / sdkmanager
+
+    @property
+    def android_env(self):
+        return {
+            **self.os.environ,
+            "ANDROID_SDK_ROOT": str(self.sdk_path),
+            "JAVA_HOME": str(self.java_home_path),
+        }
 
     def gradlew_path(self, app):
         gradlew = "gradlew.bat" if self.host_os == "Windows" else "gradlew"
@@ -99,9 +108,11 @@ requires Python 3.7.""".format(
         except requests_exceptions.ConnectionError:
             raise NetworkFailure("download Android SDK")
         try:
-            with ZipFile(str(sdk_zip_path)) as sdk_zip:
-                sdk_zip.extractall(path=str(self.sdk_path))
-        except BadZipFile:
+            self.shutil.unpack_archive(
+                str(sdk_zip_path),
+                extract_dir=str(self.sdk_path)
+            )
+        except (shutil.ReadError, EOFError):
             raise BriefcaseCommandError(
                 """\
 Unable to unpack Android SDK ZIP file. The download may have been interrupted
@@ -112,13 +123,6 @@ Delete {sdk_zip_path} and run briefcase again.""".format(
                 )
             )
         sdk_zip_path.unlink()  # Zip file no longer needed once unpacked.
-        # `ZipFile` ignores the permission metadata in the Android SDK ZIP
-        # file, so on non-Windows, we manually fix permissions.
-        if self.host_os == "Windows":
-            return
-        for binpath in (self.sdk_path / "tools" / "bin").glob("*"):
-            if not self.os.access(str(binpath), self.os.X_OK):
-                binpath.chmod(0o755)
 
     def verify_license(self):
         license_path = self.sdk_path / "licenses" / "android-sdk-license"
@@ -137,6 +141,7 @@ before you may use those tools.
             # the full output and can send input.
             self.subprocess.run(
                 [str(self.sdkmanager_path), "--licenses"],
+                env=self.android_env,
                 check=True,
             )
         except subprocess.CalledProcessError:
@@ -165,6 +170,7 @@ connection."""
         """
         super().verify_tools()
         self.verify_python_version()
+        self.java_home_path = verify_jdk(self)
         self.verify_sdk()
         self.verify_license()
 
@@ -188,13 +194,12 @@ class GradleBuildCommand(GradleMixin, BuildCommand):
         """
         print("[{app.app_name}] Building Android APK...".format(app=app))
         try:
-            env = {**self.os.environ, "ANDROID_SDK_ROOT": str(self.sdk_path)}
             self.subprocess.run(
                 # Windows needs the full path to `gradlew`; macOS & Linux can find it
                 # via `./gradlew`. For simplicity of implementation, we always provide
                 # the full path.
                 [str(self.gradlew_path(app)), "assembleDebug"],
-                env=env,
+                env=self.android_env,
                 # Set working directory so gradle can use the app bundle path as its
                 # project root, i.e., to avoid 'Task assembleDebug not found'.
                 cwd=str(self.bundle_path(app)),
@@ -228,6 +233,7 @@ class GradleRunCommand(GradleMixin, RunCommand):
                     "emulator",
                     "platform-tools",
                 ],
+                env=self.android_env,
                 check=True
             )
         except subprocess.CalledProcessError:

--- a/tests/integrations/java/test_verify_jdk.py
+++ b/tests/integrations/java/test_verify_jdk.py
@@ -47,7 +47,7 @@ def test_macos_tool_java_home(test_command):
         ),
         # Second is a call to verify a valid Java version
         mock.call(
-            ['/path/to/java/bin/javac', '-version'],
+            [str(Path('/path/to/java/bin/javac')), '-version'],
             universal_newlines=True,
             stderr=subprocess.STDOUT,
         ),
@@ -105,7 +105,7 @@ def test_macos_provided_overrides_tool_java_home(test_command):
 
     # A single call to check output
     test_command.subprocess.check_output.assert_called_once_with(
-        ['/path/to/java/bin/javac', '-version'],
+        [str(Path('/path/to/java/bin/javac')), '-version'],
         universal_newlines=True,
         stderr=subprocess.STDOUT,
     ),
@@ -127,7 +127,7 @@ def test_valid_provided_java_home(test_command):
 
     # A single call to check output
     test_command.subprocess.check_output.assert_called_once_with(
-        ['/path/to/java/bin/javac', '-version'],
+        [str(Path('/path/to/java/bin/javac')), '-version'],
         universal_newlines=True,
         stderr=subprocess.STDOUT,
     ),
@@ -152,7 +152,7 @@ def test_invalid_jdk_version(test_command, tmp_path):
 
     # A single call was made to check javac
     test_command.subprocess.check_output.assert_called_once_with(
-        ['/path/to/java/bin/javac', '-version'],
+        [str(Path('/path/to/java/bin/javac')), '-version'],
         universal_newlines=True,
         stderr=subprocess.STDOUT,
     ),
@@ -177,7 +177,7 @@ def test_no_javac(test_command, tmp_path):
 
     # A single call was made to check javac
     test_command.subprocess.check_output.assert_called_once_with(
-        ['/path/to/nowhere/bin/javac', '-version'],
+        [str(Path('/path/to/nowhere/bin/javac')), '-version'],
         universal_newlines=True,
         stderr=subprocess.STDOUT,
     ),
@@ -204,7 +204,7 @@ def test_javac_error(test_command, tmp_path):
 
     # A single call was made to check javac
     test_command.subprocess.check_output.assert_called_once_with(
-        ['/path/to/java/bin/javac', '-version'],
+        [str(Path('/path/to/java/bin/javac')), '-version'],
         universal_newlines=True,
         stderr=subprocess.STDOUT,
     ),
@@ -229,7 +229,7 @@ def test_unparseable_javac_version(test_command, tmp_path):
 
     # A single call was made to check javac
     test_command.subprocess.check_output.assert_called_once_with(
-        ['/path/to/java/bin/javac', '-version'],
+        [str(Path('/path/to/java/bin/javac')), '-version'],
         universal_newlines=True,
         stderr=subprocess.STDOUT,
     ),

--- a/tests/integrations/java/test_verify_jdk.py
+++ b/tests/integrations/java/test_verify_jdk.py
@@ -290,7 +290,7 @@ def test_successful_jdk_download(test_command, tmp_path, host_os, jdk_url, jhome
         extract_dir=str(tmp_path / "tools")
     )
     # The original archive was deleted
-    archive.unlink.assert_called_once()
+    archive.unlink.assert_called_once_with()
 
 
 def test_jdk_download_failure(test_command, tmp_path):

--- a/tests/integrations/java/test_verify_jdk.py
+++ b/tests/integrations/java/test_verify_jdk.py
@@ -1,0 +1,346 @@
+import shutil
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from requests import exceptions as requests_exceptions
+
+from briefcase.exceptions import BriefcaseCommandError, NetworkFailure
+from briefcase.integrations.java import verify_jdk
+
+
+@pytest.fixture
+def test_command(tmp_path):
+    cmd = mock.MagicMock()
+    cmd.dot_briefcase_path = tmp_path
+
+    # Mock getenv returning no explicit JAVA_HOME
+    cmd.os.getenv = mock.MagicMock(return_value='')
+
+    return cmd
+
+
+def test_macos_tool_java_home(test_command):
+    "On macOS, the /usr/libexec/java_home utility is checked"
+    # Mock being on macOS
+    test_command.host_os = 'Darwin'
+
+    # Mock 2 calls to check_output.
+    test_command.subprocess.check_output.side_effect = [
+        '/path/to/java',
+        'javac 1.8.0_144\n'
+    ]
+
+    # Invoke verify_jdk
+    java_home = verify_jdk(cmd=test_command)
+
+    # The JDK should have the path returned by the tool
+    assert java_home == Path('/path/to/java')
+
+    test_command.subprocess.check_output.assert_has_calls([
+        # First call is to /usr/lib/java_home
+        mock.call(
+            ['/usr/libexec/java_home'],
+            universal_newlines=True,
+            stderr=subprocess.STDOUT,
+        ),
+        # Second is a call to verify a valid Java version
+        mock.call(
+            ['/path/to/java/bin/javac', '-version'],
+            universal_newlines=True,
+            stderr=subprocess.STDOUT,
+        ),
+    ])
+
+
+def test_macos_tool_failure(test_command, tmp_path):
+    "On macOS, if the libexec tool fails, the Briefcase JDK is used"
+    # Mock being on macOS
+    test_command.host_os = 'Darwin'
+
+    # Mock getenv returning no explicit JAVA_HOME
+    test_command.os.getenv = mock.MagicMock(return_value='')
+
+    # Mock a failed call on the libexec tool
+    test_command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
+        returncode=1, cmd='/usr/libexec/java_home'
+    )
+
+    # Create a directory to make it look like the Briefcase Java already exists.
+    (tmp_path / 'tools' / 'java' / 'Contents' / 'Home' / 'bin').mkdir(parents=True)
+
+    # Invoke verify_jdk
+    java_home = verify_jdk(cmd=test_command)
+
+    # The JDK should have the briefcase JAVA_HOME
+    assert java_home == tmp_path / 'tools' / 'java' / 'Contents' / 'Home'
+
+    test_command.subprocess.check_output.assert_has_calls([
+        # First call is to /usr/lib/java_home
+        mock.call(
+            ['/usr/libexec/java_home'],
+            universal_newlines=True,
+            stderr=subprocess.STDOUT,
+        ),
+    ])
+
+
+def test_macos_provided_overrides_tool_java_home(test_command):
+    "On macOS, an explicit JAVA_HOME overrides /usr/libexec/java_home"
+    # Mock being on macOS
+    test_command.host_os = 'Darwin'
+
+    # Mock getenv returning an explicit JAVA_HOME
+    test_command.os.getenv = mock.MagicMock(return_value='/path/to/java')
+
+    # Mock return value from javac. libexec won't be invoked.
+    test_command.subprocess.check_output.return_value = 'javac 1.8.0_144\n'
+
+    # Invoke verify_jdk
+    java_home = verify_jdk(cmd=test_command)
+
+    # The JDK should have the path returned by the tool
+    assert java_home == Path('/path/to/java')
+
+    # A single call to check output
+    test_command.subprocess.check_output.assert_called_once_with(
+        ['/path/to/java/bin/javac', '-version'],
+        universal_newlines=True,
+        stderr=subprocess.STDOUT,
+    ),
+
+
+def test_valid_provided_java_home(test_command):
+    "If a valid JAVA_HOME is provided, it is used."
+    # Mock getenv returning an explicit JAVA_HOME
+    test_command.os.getenv = mock.MagicMock(return_value='/path/to/java')
+
+    # Mock return value from javac.
+    test_command.subprocess.check_output.return_value = 'javac 1.8.0_144\n'
+
+    # Invoke verify_jdk
+    java_home = verify_jdk(cmd=test_command)
+
+    # The JDK should have the path returned by the tool
+    assert java_home == Path('/path/to/java')
+
+    # A single call to check output
+    test_command.subprocess.check_output.assert_called_once_with(
+        ['/path/to/java/bin/javac', '-version'],
+        universal_newlines=True,
+        stderr=subprocess.STDOUT,
+    ),
+
+
+def test_invalid_jdk_version(test_command, tmp_path):
+    "If the JDK pointed to by JAVA_HOME isn't a Java 8 JDK, the briefcase JDK is used"
+    # Mock getenv returning an explicit JAVA_HOME
+    test_command.os.getenv = mock.MagicMock(return_value='/path/to/java')
+
+    # Mock return value from javac.
+    test_command.subprocess.check_output.return_value = 'javac 14\n'
+
+    # Create a directory to make it look like the Briefcase Java already exists.
+    (tmp_path / 'tools' / 'java' / 'bin').mkdir(parents=True)
+
+    # Invoke verify_jdk
+    java_home = verify_jdk(cmd=test_command)
+
+    # The JDK should have the briefcase JAVA_HOME
+    assert java_home == tmp_path / 'tools' / 'java'
+
+    # A single call was made to check javac
+    test_command.subprocess.check_output.assert_called_once_with(
+        ['/path/to/java/bin/javac', '-version'],
+        universal_newlines=True,
+        stderr=subprocess.STDOUT,
+    ),
+
+
+def test_no_javac(test_command, tmp_path):
+    "If the JAVA_HOME doesn't point to a location with a bin/javac, the briefcase JDK is used"
+    # Mock getenv returning an explicit JAVA_HOME
+    test_command.os.getenv = mock.MagicMock(return_value='/path/to/nowhere')
+
+    # Mock return value from javac failing because executable doesn't exist
+    test_command.subprocess.check_output.side_effect = FileNotFoundError
+
+    # Create a directory to make it look like the Briefcase Java already exists.
+    (tmp_path / 'tools' / 'java' / 'bin').mkdir(parents=True)
+
+    # Invoke verify_jdk
+    java_home = verify_jdk(cmd=test_command)
+
+    # The JDK should have the briefcase JAVA_HOME
+    assert java_home == tmp_path / 'tools' / 'java'
+
+    # A single call was made to check javac
+    test_command.subprocess.check_output.assert_called_once_with(
+        ['/path/to/nowhere/bin/javac', '-version'],
+        universal_newlines=True,
+        stderr=subprocess.STDOUT,
+    ),
+
+
+def test_javac_error(test_command, tmp_path):
+    "If javac can't be executed, the briefcase JDK is used"
+    # Mock getenv returning an explicit JAVA_HOME
+    test_command.os.getenv = mock.MagicMock(return_value='/path/to/java')
+
+    # Mock return value from javac failing because executable doesn't exist
+    test_command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
+        returncode=1, cmd='/path/to/java/bin/javac'
+    )
+
+    # Create a directory to make it look like the Briefcase Java already exists.
+    (tmp_path / 'tools' / 'java' / 'bin').mkdir(parents=True)
+
+    # Invoke verify_jdk
+    java_home = verify_jdk(cmd=test_command)
+
+    # The JDK should have the briefcase JAVA_HOME
+    assert java_home == tmp_path / 'tools' / 'java'
+
+    # A single call was made to check javac
+    test_command.subprocess.check_output.assert_called_once_with(
+        ['/path/to/java/bin/javac', '-version'],
+        universal_newlines=True,
+        stderr=subprocess.STDOUT,
+    ),
+
+
+def test_unparseable_javac_version(test_command, tmp_path):
+    "If the javac version can't be parsed, the briefcase JDK is used"
+    # Mock getenv returning an explicit JAVA_HOME
+    test_command.os.getenv = mock.MagicMock(return_value='/path/to/java')
+
+    # Mock return value from javac.
+    test_command.subprocess.check_output.return_value = 'NONSENSE\n'
+
+    # Create a directory to make it look like the Briefcase Java already exists.
+    (tmp_path / 'tools' / 'java' / 'bin').mkdir(parents=True)
+
+    # Invoke verify_jdk
+    java_home = verify_jdk(cmd=test_command)
+
+    # The JDK should have the briefcase JAVA_HOME
+    assert java_home == tmp_path / 'tools' / 'java'
+
+    # A single call was made to check javac
+    test_command.subprocess.check_output.assert_called_once_with(
+        ['/path/to/java/bin/javac', '-version'],
+        universal_newlines=True,
+        stderr=subprocess.STDOUT,
+    ),
+
+
+@pytest.mark.parametrize(
+    ("host_os, jdk_url, jhome"), [
+        (
+            "Darwin",
+            "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
+            "jdk8u242-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u242b08.tar.gz",
+            'java/Contents/Home'
+        ),
+        (
+            "Linux",
+            "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
+            "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
+            'java'
+        ),
+        (
+            "Windows",
+            "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
+            "jdk8u242-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u242b08.zip",
+            'java'
+        ),
+    ]
+)
+def test_successful_jdk_download(test_command, tmp_path, host_os, jdk_url, jhome):
+    "If needed, a JDK can be downloaded."
+    # Mock host OS
+    test_command.host_os = host_os
+
+    # Mock a JAVA_HOME that won't exist
+    # This is only needed to make macOS *not* run /usr/libexec/java_home
+    test_command.os.getenv = mock.MagicMock(return_value='/does/not/exist')
+
+    # Mock the cached download path
+    archive = mock.MagicMock()
+    archive.__str__.return_value = '/path/to/download.zip'
+    test_command.download_url.return_value = archive
+
+    # Create a directory to make it look like Java was downloaded and unpacked.
+    (tmp_path / 'tools' / 'jdk8u242-b08').mkdir(parents=True)
+
+    # Invoke the verify call
+    java_home = verify_jdk(cmd=test_command)
+
+    assert java_home == tmp_path / 'tools' / jhome
+
+    # Download was invoked
+    test_command.download_url.assert_called_with(
+        url=jdk_url,
+        download_path=tmp_path / "tools",
+    )
+    # The archive was unpacked
+    test_command.shutil.unpack_archive.assert_called_with(
+        '/path/to/download.zip',
+        extract_dir=str(tmp_path / "tools")
+    )
+    # The original archive was deleted
+    archive.unlink.assert_called_once()
+
+
+def test_jdk_download_failure(test_command, tmp_path):
+    "If an error occurs downloading the JDK, an error is raised"
+    # Mock Linux as the host
+    test_command.host_os = 'Linux'
+
+    # Mock a failure on download
+    test_command.download_url.side_effect = requests_exceptions.ConnectionError
+
+    # Invoking verify_jdk causes a network failure.
+    with pytest.raises(NetworkFailure):
+        verify_jdk(cmd=test_command)
+
+    # That download was attempted
+    test_command.download_url.assert_called_with(
+        url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
+            "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
+        download_path=tmp_path / "tools",
+    )
+    # No attempt was made to unpack the archive
+    assert test_command.shutil.unpack_archive.call_count == 0
+
+
+def test_invalid_jdk_archive(test_command, tmp_path):
+    "If the JDK download isn't a valid archive, raise an error"
+    # Mock Linux as the host
+    test_command.host_os = 'Linux'
+
+    # Mock the cached download path
+    archive = mock.MagicMock()
+    archive.__str__.return_value = '/path/to/download.zip'
+    test_command.download_url.return_value = archive
+
+    # Mock an unpack failure due to an invalid archive
+    test_command.shutil.unpack_archive.side_effect = shutil.ReadError
+
+    with pytest.raises(BriefcaseCommandError):
+        verify_jdk(cmd=test_command)
+
+    # The download occurred
+    test_command.download_url.assert_called_with(
+        url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
+            "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
+        download_path=tmp_path / "tools",
+    )
+    # An attempt was made to unpack the archive
+    test_command.shutil.unpack_archive.assert_called_with(
+        '/path/to/download.zip',
+        extract_dir=str(tmp_path / "tools")
+    )
+    # The original archive was not deleted
+    assert archive.unlink.call_count == 0

--- a/tests/platforms/android/gradle/test_build.py
+++ b/tests/platforms/android/gradle/test_build.py
@@ -11,6 +11,7 @@ from briefcase.platforms.android.gradle import GradleBuildCommand
 def build_command(tmp_path, first_app_config):
     command = GradleBuildCommand(base_path=tmp_path / "base_path")
     command.dot_briefcase_path = tmp_path / ".briefcase"
+    command.java_home_path = tmp_path / "java"
     command.os = MagicMock()
     command.os.environ = {}
     command.sys = MagicMock()
@@ -38,7 +39,11 @@ def test_execute_gradle(build_command, first_app_config, host_os, gradlew_name):
             "assembleDebug",
         ],
         cwd=str(build_command.bundle_path(first_app_config)),
-        env={"ANDROID_SDK_ROOT": str(build_command.sdk_path), "key": "value"},
+        env={
+            "ANDROID_SDK_ROOT": str(build_command.sdk_path),
+            "JAVA_HOME": str(build_command.java_home_path),
+            "key": "value",
+        },
         check=True,
     )
 

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -11,6 +11,7 @@ from briefcase.platforms.android.gradle import GradleRunCommand
 def run_command(tmp_path, first_app_config):
     command = GradleRunCommand(base_path=tmp_path / "base_path")
     command.dot_briefcase_path = tmp_path / ".briefcase"
+    command.java_home_path = tmp_path / "java"
 
     command.mock_adb = MagicMock()
     command.ADB = MagicMock(return_value=command.mock_adb)
@@ -44,6 +45,7 @@ def test_verify_emulator_installs_android_emulator(run_command):
             "emulator",
             "platform-tools",
         ],
+        env=run_command.android_env,
         check=True,
     )
 

--- a/tests/platforms/android/gradle/test_verify_tools.py
+++ b/tests/platforms/android/gradle/test_verify_tools.py
@@ -25,7 +25,7 @@ def build_command(tmp_path, first_app_config):
     # Use a dummy JAVA HOME
     command.java_home_path = tmp_path / "java"
     # Override the `os` module so the app has an empty environment.
-    getenv = mock.MagicMock(return_value=command.java_home_path)
+    getenv = mock.MagicMock(return_value=str(command.java_home_path))
     command.os = mock.MagicMock(environ={}, getenv=getenv)
     # Override the requests` and `subprocess` modules so we can test side-effects.
     command.requests = mock.MagicMock()

--- a/tests/platforms/android/gradle/test_verify_tools.py
+++ b/tests/platforms/android/gradle/test_verify_tools.py
@@ -28,9 +28,10 @@ def build_command(tmp_path, first_app_config):
     # Use a dummy JAVA HOME
     command.java_home_path = tmp_path / "java"
 
-    # Override the `os` module so the app has an empty environment.
-    getenv = mock.MagicMock(return_value=str(command.java_home_path))
-    command.os = mock.MagicMock(environ={}, getenv=getenv)
+    # Override the `os` module so the app has an environment with JAVA_HOME
+    command.os = mock.MagicMock(environ={
+        'JAVA_HOME': str(command.java_home_path)
+    })
     # Enable the command to use `os.access()` and `os.X_OK`.
     command.os.access = os.access
     command.os.X_OK = os.X_OK

--- a/tests/platforms/android/gradle/test_verify_tools.py
+++ b/tests/platforms/android/gradle/test_verify_tools.py
@@ -22,8 +22,11 @@ def build_command(tmp_path, first_app_config):
     # Use the `tmp_path` in `dot_briefcase_path` to ensure tests don't interfere
     # with each other.
     command.dot_briefcase_path = tmp_path / ".briefcase"
+    # Use a dummy JAVA HOME
+    command.java_home_path = tmp_path / "java"
     # Override the `os` module so the app has an empty environment.
-    command.os = mock.MagicMock(environ={})
+    getenv = mock.MagicMock(return_value=command.java_home_path)
+    command.os = mock.MagicMock(environ={}, getenv=getenv)
     # Override the requests` and `subprocess` modules so we can test side-effects.
     command.requests = mock.MagicMock()
     command.subprocess = mock.MagicMock()
@@ -59,7 +62,7 @@ def test_require_python_37(build_command, major, minor):
 
 
 @pytest.mark.parametrize("host_os", ("ArbitraryNotWindows", "Windows"))
-def test_verify_tools_succeeds_immediately_in_happy_path(build_command, host_os):
+def test_verify_tools_succeeds_immediately_in_happy_path(build_command, host_os, tmp_path):
     """Validate that verify_tools() successfully does nothing in its happy
     path.
 
@@ -88,11 +91,20 @@ def test_verify_tools_succeeds_immediately_in_happy_path(build_command, host_os)
     # Configure `build_command` to assume the `host_os` we parameterized with.
     build_command.host_os = host_os
 
+    # Configure subprocess to return a good Java version
+    build_command.subprocess.check_output = mock.MagicMock(
+        return_value='javac 1.8.0_144\n'
+    )
+
     # Expect verify_tools() to succeed and not call requests or subprocess.
     build_command.verify_tools()
     build_command.requests.get.assert_not_called()
     build_command.subprocess.run.assert_not_called()
-    build_command.subprocess.check_output.assert_not_called()
+    build_command.subprocess.check_output.assert_called_once_with(
+        [str(tmp_path / 'java' / 'bin' / 'javac'), '-version'],
+        universal_newlines=True,
+        stderr=subprocess.STDOUT
+    )
 
 
 def sdk_response(content):
@@ -127,20 +139,15 @@ def test_verify_sdk_downloads_sdk(build_command, tmp_path, host_os):
     build_command.requests.get.return_value = sdk_response(
         create_zip("tools/bin/exampletool")
     )
-    if host_os != 'Windows':
-        # Enable the command to use `os.access()` and `os.X_OK`.
-        build_command.os.access = os.access
-        build_command.os.X_OK = os.X_OK
+
     # Call `verify_sdk()` and validate that it made one HTTP request, which created
     # `exampletool` and marked it executable.
     build_command.verify_sdk()
     build_command.requests.get.assert_called_once_with(
         build_command.sdk_url, stream=True
     )
-    # Validate that it exists and is executable.
+    # Validate that it exists.
     assert example_tool.exists()
-    if host_os != 'Windows':
-        assert os.access(str(example_tool), os.X_OK)
 
 
 @pytest.mark.skipif(
@@ -244,6 +251,7 @@ def test_verify_license_prompts_for_licenses_and_exits_if_you_agree(build_comman
     build_command.verify_license()
     build_command.subprocess.run.assert_called_once_with(
         [str(build_command.sdkmanager_path), "--licenses"],
+        env=build_command.android_env,
         check=True,
     )
 


### PR DESCRIPTION
Android builds require a working Java 8 install. The existing code assumes Java is available.

This patch:
* Looks for a JAVA_HOME in the environment, and if it is defined, tries to run javac to determine the version. If it is a valid Java 8 JDK, it is used.
* On MacOS, tries to invoke /usr/libexec/java_home. If it returns a path, it uses the same rules as JAVA_HOME
* If no Java can be found, or the version that is found isn't a Java 8 JDK, an AdoptOpenJDK archive is downloaded and used.

Also includes a small cleanup in the way the Android SDK is unpacked, for consistency.