### PR TITLE
Fixes #341 - Add ability to create new Android devices

### DIFF
--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -103,14 +103,10 @@ class BaseCommand(ABC):
     GLOBAL_CONFIG_CLASS = GlobalConfig
     APP_CONFIG_CLASS = AppConfig
 
-    def __init__(
-            self,
-            base_path,
-            dot_briefcase_path=Path.home() / ".briefcase",
-            apps=None,
-            ):
+    def __init__(self, base_path, home_path=Path.home(), apps=None):
         self.base_path = base_path
-        self.dot_briefcase_path = dot_briefcase_path
+        self.home_path = home_path
+        self.dot_briefcase_path = home_path / ".briefcase"
 
         self.global_config = None
         self.apps = {} if apps is None else apps

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1,6 +1,7 @@
 import re
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 from requests import exceptions as requests_exceptions
@@ -489,17 +490,31 @@ In future, you can specify this device by running:")
         # Get the list of existing emulators
         emulators = set(self.emulators())
 
+        default_avd = 'beePhone'
+        i = 1
+        # Make sure the default name is unique
+        while default_avd in emulators:
+            i += 1
+            default_avd = 'beePhone{i}'.format(i=i)
+
         # Prompt for a device avd until a valid one is provided.
         print("""
 You need to select a name for your new emulator. This is an identifier that
 can be used to start the emulator in future. It should follow the same naming
 conventions as a Python package (i.e., it may only contain letters, numbers,
-hyphens and underscores).
+hyphens and underscores). If you don't provide a name, Briefcase will use the
+a default name '{default_avd}'.
 
-""")
+""".format(default_avd=default_avd))
         avd_is_invalid = True
         while avd_is_invalid:
-            avd = self.command.input("Emulator name: ")
+            avd = self.command.input("Emulator name [{default_avd}]: ".format(
+                default_avd=default_avd
+            ))
+            # If the user doesn't provide a name, use the default.
+            if avd == '':
+                avd = default_avd
+
             if not PEP508_NAME_RE.match(avd):
                 print("""
 '{avd}' is not a valid emulator name. An emulator name may only contain

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1,7 +1,6 @@
 import re
 import shutil
 import subprocess
-import time
 from pathlib import Path
 
 from requests import exceptions as requests_exceptions

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1,6 +1,7 @@
 import re
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 from requests import exceptions as requests_exceptions
@@ -130,6 +131,9 @@ class AndroidSDK:
         self.command = command
         self.root_path = root_path
         self.dot_android_path = self.command.home_path / ".android"
+
+        # A wrapper for testing purposes
+        self.sleep = time.sleep
 
     @property
     def sdkmanager_path(self):
@@ -303,8 +307,11 @@ class AndroidSDK:
             # The first line is header information.
             # Each subsequent line is a single device descriptor.
             devices = {}
-            for line in output.split("\n")[1:]:
-                if line:
+            header_found = False
+            for line in output.split("\n"):
+                if line == 'List of devices attached':
+                    header_found = True
+                elif header_found and line:
                     parts = re.sub(r"\s+", " ", line).split(" ")
 
                     details = {}
@@ -315,6 +322,9 @@ class AndroidSDK:
                     if parts[1] == "device":
                         name = details["device"]
                         authorized = True
+                    elif parts[1] == "offline":
+                        name = "Unknown device (offline)"
+                        authorized = False
                     else:
                         name = "Unknown device (not authorized for development)"
                         authorized = False
@@ -619,16 +629,93 @@ In future, you can specify this device by running:
         :param avd: The AVD of the device.
         """
         if avd in set(self.emulators()):
-            raise BriefcaseCommandError(
-                """
-You can start the emulator by running:
-
-    $ {emulator_path} @{avd} -dns-server 8.8.8.8 &
-
-""".format(
-                    emulator_path=self.emulator_path, avd=avd
-                )
+            print("Starting emulator {avd}...".format(avd=avd))
+            emulator_popen = self.command.subprocess.Popen(
+                [
+                    str(self.emulator_path),
+                    '@' + avd,
+                    '-dns-server', '8.8.8.8'
+                ],
+                env=self.env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
             )
+
+            # The boot process happens in 2 phases.
+            # First, the emulator appears in the device list. However, it's
+            # not ready until the boot process has finished. To determine
+            # the boot status, we need the device ID, and an ADB connection.
+
+            # Step 1: Wait for the device to appear so we can get an
+            # ADB instance for the new device.
+            print()
+            print('Waiting for emulator to start...', flush=True, end='')
+            adb = None
+            known_devices = set()
+            while adb is None:
+                print('.', flush=True, end='')
+                if emulator_popen.poll() is not None:
+                    raise BriefcaseCommandError("""
+Android emulator was unable to start!
+
+Try starting the emulator manually by running:
+
+    {cmdline}
+
+Resolve any problems you discover, then try running your app again. You may
+find this page helpful in diagnosing emulator problems.
+
+    https://developer.android.com/studio/run/emulator-acceleration#accel-vm
+""".format(cmdline=' '.join(str(arg) for arg in emulator_popen.args)))
+
+                for device, details in sorted(self.devices().items()):
+                    # Only process authorized devices that we haven't seen.
+                    if details['authorized'] and device not in known_devices:
+                        adb = self.adb(device)
+                        device_avd = adb.avd_name()
+
+                        if device_avd == avd:
+                            # Found an active device that matches
+                            # the AVD we are starting.
+                            name = details["name"]
+                            full_name = "@{avd} ({name} emulator)".format(
+                                avd=avd, name=name,
+                            )
+                            break
+                        else:
+                            # Not the one. Zathras knows.
+                            adb = None
+                            known_devices.add(device)
+
+                # Try again in 2 seconds...
+                self.sleep(2)
+
+            # Print a marker so we can see the phase change
+            print('@', flush=True, end='')
+
+            # Phase 2: Wait for the boot process to complete
+            while not adb.has_booted():
+                if emulator_popen.poll() is not None:
+                    raise BriefcaseCommandError("""
+Android emulator was unable to boot!
+
+Try starting the emulator manually by running:
+
+    {cmdline}
+
+Resolve any problems you discover, then try running your app again. You may
+find this page helpful in diagnosing emulator problems.
+
+    https://developer.android.com/studio/run/emulator-acceleration#accel-vm
+""".format(cmdline=' '.join(str(arg) for arg in emulator_popen.args)))
+
+                # Try again in 2 seconds...
+                self.sleep(2)
+                print('.', flush=True, end='')
+
+            print()
+            # Return the device ID and full name.
+            return device, full_name
         else:
             raise InvalidDeviceError("emulator AVD", avd)
 
@@ -665,6 +752,24 @@ class ADB:
                         device=self.device
                     )
                 )
+
+    def has_booted(self):
+        """Determine if the device has completed booting.
+
+        :returns True if it has booted; False otherwise.
+        """
+        try:
+            # When the sys.boot_completed property of the device
+            # returns '1', the boot is complete. Any other response indicates
+            # booting is underway.
+            output = self.run('shell', 'getprop', 'sys.boot_completed')
+            return output.strip() == '1'
+        except subprocess.CalledProcessError:
+            raise BriefcaseCommandError(
+                "Unable to determine if emulator {device} has booted.".format(
+                    device=self.device
+                )
+            )
 
     def run(self, *arguments):
         """

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -10,7 +10,7 @@ from briefcase.console import select_option
 from briefcase.exceptions import (
     BriefcaseCommandError,
     InvalidDeviceError,
-    NetworkFailure,
+    NetworkFailure
 )
 
 DEVICE_NOT_FOUND = re.compile(r"^error: device '[^']*' not found")

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -482,9 +482,6 @@ class AndroidSDK:
             """
 You can create an emulator by running:
 
-    $ {sdkmanager_path} "platforms;android-28" \
-"system-images;android-28;default;x86" "emulator" "platform-tools"
-
     $ {avdmanager_path} --verbose create avd \
 --name {name} --abi x86 \
 --package 'system-images;android-28;default;x86' --device pixel
@@ -492,7 +489,6 @@ You can create an emulator by running:
     $ echo 'disk.dataPartition.size=4096M' >> $HOME/.android/avd/{name}.avd/config.ini
 
 """.format(
-                sdkmanager_path=self.sdkmanager_path,
                 avdmanager_path=self.avdmanager_path,
                 name=name,
             )

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -129,7 +129,7 @@ class AndroidSDK:
     def __init__(self, command, root_path):
         self.command = command
         self.root_path = root_path
-        self.dot_android_path = Path.home() / ".android"
+        self.dot_android_path = self.command.home_path / ".android"
 
     @property
     def sdkmanager_path(self):

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -148,21 +148,24 @@ class GradleRunCommand(GradleMixin, RunCommand):
         # Create an ADB wrapper for the selected device
         adb = self.android_sdk.adb(device=device)
 
-        # Install the latest APK file onto the device.
-        print("[{app.app_name}] Installing app...".format(
-            app=app,
-        ))
-        adb.install_apk(self.binary_path(app))
-
         # Compute Android package name based on beeware `bundle` and `app_name`
         # app properties, similar to iOS.
         package = "{app.bundle}.{app.app_name}".format(app=app)
 
         # We force-stop the app to ensure the activity launches freshly.
-        print("[{app.app_name}] Stopping app...".format(app=app))
+        print()
+        print("[{app.app_name}] Stopping old versions of the app...".format(app=app))
         adb.force_stop_app(package)
 
+        # Install the latest APK file onto the device.
+        print()
+        print("[{app.app_name}] Installing app...".format(
+            app=app,
+        ))
+        adb.install_apk(self.binary_path(app))
+
         # To start the app, we launch `org.beeware.android.MainActivity`.
+        print()
         print("[{app.app_name}] Launching app...".format(app=app))
         adb.start_app(package, "org.beeware.android.MainActivity")
 

--- a/tests/commands/create/conftest.py
+++ b/tests/commands/create/conftest.py
@@ -91,7 +91,7 @@ class TrackingCreateCommand(DummyCreateCommand):
 def create_command(tmp_path, mock_git):
     return DummyCreateCommand(
         base_path=tmp_path,
-        dot_briefcase_path=tmp_path / "dot-briefcase",
+        home_path=tmp_path,
         git=mock_git,
     )
 

--- a/tests/integrations/android_sdk/ADB/test_command.py
+++ b/tests/integrations/android_sdk/ADB/test_command.py
@@ -44,7 +44,7 @@ def test_error_handling(mock_sdk, tmp_path, name, exception):
     # Set up a mock command with a subprocess module that has with sample data loaded.
     adb_samples = Path(__file__).parent / "adb_errors"
     with (adb_samples / (name + ".txt")).open("r") as adb_output_file:
-        with (adb_samples / (name + ".returncode")).open() as returncode_file:
+        with (adb_samples / (name + ".returncode")).open(encoding='utf-8') as returncode_file:
             mock_sdk.command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
                 returncode=int(returncode_file.read().strip()),
                 cmd=["ignored"],

--- a/tests/integrations/android_sdk/ADB/test_has_booted.py
+++ b/tests/integrations/android_sdk/ADB/test_has_booted.py
@@ -1,0 +1,63 @@
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
+from briefcase.integrations.android_sdk import ADB
+
+
+def test_booted(mock_sdk, capsys):
+    "A booted device returns true"
+    # Mock out the adb response for an emulator
+    adb = ADB(mock_sdk, "deafbeefcafe")
+    adb.run = MagicMock(return_value="1\n")
+
+    # Invoke avd_name
+    assert adb.has_booted()
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("shell", "getprop", "sys.boot_completed")
+
+
+def test_not_booted(mock_sdk, capsys):
+    "A non-booted device returns False"
+    # Mock out the adb response for an emulator
+    adb = ADB(mock_sdk, "deafbeefcafe")
+    adb.run = MagicMock(return_value="\n")
+
+    # Invoke avd_name
+    assert not adb.has_booted()
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("shell", "getprop", "sys.boot_completed")
+
+
+def test_adb_failure(mock_sdk, capsys):
+    "If ADB fails, an error is raised"
+    # Mock out the adb response for an emulator
+    adb = ADB(mock_sdk, "deafbeefcafe")
+    adb.run = MagicMock(side_effect=subprocess.CalledProcessError(
+        returncode=69, cmd='emu avd name'
+    ))
+
+    # Invoke avd_name
+    with pytest.raises(BriefcaseCommandError):
+        adb.has_booted()
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("shell", "getprop", "sys.boot_completed")
+
+
+def test_invalid_device(mock_sdk, capsys):
+    "If the device ID is invalid, an error is raised"
+    # Mock out the adb response for an emulator
+    adb = ADB(mock_sdk, "not-a-device")
+    adb.run = MagicMock(side_effect=InvalidDeviceError('device', 'exampleDevice'))
+
+    # Invoke avd_name
+    with pytest.raises(BriefcaseCommandError):
+        adb.has_booted()
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("shell", "getprop", "sys.boot_completed")

--- a/tests/integrations/android_sdk/AndroidSDK/devices/daemon_start
+++ b/tests/integrations/android_sdk/AndroidSDK/devices/daemon_start
@@ -1,0 +1,5 @@
+* daemon not running; starting now at tcp:5037
+* daemon started successfully
+List of devices attached
+
+

--- a/tests/integrations/android_sdk/AndroidSDK/devices/multiple_devices
+++ b/tests/integrations/android_sdk/AndroidSDK/devices/multiple_devices
@@ -3,3 +3,4 @@ List of devices attached
 KABCDABCDA1513         device usb:336675584X product:Kogan_Agora_9 model:Kogan_Agora_9 device:Kogan_Agora_9 transport_id:1
 emulator-5554          device product:sdk_phone_x86 model:Android_SDK_built_for_x86 device:generic_x86 transport_id:4
 
+

--- a/tests/integrations/android_sdk/AndroidSDK/devices/multiple_devices
+++ b/tests/integrations/android_sdk/AndroidSDK/devices/multiple_devices
@@ -2,5 +2,5 @@ List of devices attached
 041234567892009a       unauthorized usb:336675328X transport_id:2
 KABCDABCDA1513         device usb:336675584X product:Kogan_Agora_9 model:Kogan_Agora_9 device:Kogan_Agora_9 transport_id:1
 emulator-5554          device product:sdk_phone_x86 model:Android_SDK_built_for_x86 device:generic_x86 transport_id:4
-
+emulator-5556          offline transport_id:32
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
@@ -11,12 +11,10 @@ from briefcase.integrations.android_sdk import AndroidSDK
 @pytest.fixture
 def mock_sdk(tmp_path):
     command = MagicMock()
+    command.home_path = tmp_path
     command.host_platform = 'unknown'
 
     sdk = AndroidSDK(command, root_path=tmp_path)
-
-    # Set an alternate .android location.
-    sdk.dot_android_path = tmp_path / '.android'
 
     # Mock some existing emulators
     sdk.emulators = MagicMock(return_value=[

--- a/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
@@ -1,0 +1,268 @@
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+from requests import exceptions as requests_exceptions
+
+from briefcase.exceptions import BriefcaseCommandError, NetworkFailure
+from briefcase.integrations.android_sdk import AndroidSDK
+
+
+@pytest.fixture
+def mock_sdk(tmp_path):
+    command = MagicMock()
+    command.host_platform = 'unknown'
+
+    sdk = AndroidSDK(command, root_path=tmp_path)
+
+    # Set an alternate .android location.
+    sdk.dot_android_path = tmp_path / '.android'
+
+    # Mock some existing emulators
+    sdk.emulators = MagicMock(return_value=[
+        'runningEmulator',
+        'idleEmulator',
+    ])
+
+    return sdk
+
+
+def test_create_emulator(mock_sdk, tmp_path):
+    "A new emulator can be created."
+    # This test validates everything going well on first run.
+    # This means the skin will be downloaded and unpacked.
+
+    # Mock the user providing several invalid names before getting it right.
+    mock_sdk.command.input.side_effect = [
+        'runningEmulator',
+        'invalid name',
+        'annoying!',
+        'new-emulator'
+    ]
+
+    # Mock the result of the download of a skin
+    skin_tgz_path = MagicMock()
+    skin_tgz_path.__str__.return_value = '/path/to/skin.tgz'
+    mock_sdk.command.download_url.return_value = skin_tgz_path
+
+    # Mock the initial output of an AVD config file.
+    avd_config_path = tmp_path / ".android" / "avd" / 'new-emulator.avd' / 'config.ini'
+    avd_config_path.parent.mkdir(parents=True)
+    with avd_config_path.open('w') as f:
+        f.write('hw.device.name=pixel\n')
+
+    # Create the emulator
+    avd = mock_sdk.create_emulator()
+
+    # The expected name was created.
+    assert avd == 'new-emulator'
+
+    # avdmanager was invoked
+    mock_sdk.command.subprocess.check_output.assert_called_once_with(
+        [
+            str(mock_sdk.avdmanager_path),
+            "--verbose",
+            "create", "avd",
+            "--name", "new-emulator",
+            "--abi", "x86",
+            "--package", 'system-images;android-28;default;x86',
+            "--device", "pixel",
+        ],
+        env=mock_sdk.env,
+        universal_newlines=True,
+        stderr=subprocess.STDOUT,
+    )
+
+    # Skin was downloaded
+    mock_sdk.command.download_url.assert_called_once_with(
+        url="https://android.googlesource.com/platform/tools/adt/idea/"
+            "+archive/refs/heads/mirror-goog-studio-master-dev/"
+            "artwork/resources/device-art-resources/pixel_3a.tar.gz",
+        download_path=mock_sdk.root_path,
+    )
+
+    # Skin is unpacked
+    mock_sdk.command.shutil.unpack_archive.assert_called_once_with(
+        str(skin_tgz_path),
+        extract_dir=str(mock_sdk.root_path / "skins" / "pixel_3a")
+    )
+
+    # Original file was deleted.
+    skin_tgz_path.unlink.assert_called_once_with()
+
+    # Emulator configuration file has been appended.
+    with avd_config_path.open() as f:
+        config = f.read().split('\n')
+    assert "hw.keyboard=yes" in config
+    assert "skin.name=pixel_3a" in config
+
+
+def test_create_preexisting_skins(mock_sdk, tmp_path):
+    "Test that if skins already exist, they're not re-downloaded."
+    # This test validates that if skins are already cached,
+    # they're not re-downloaded
+
+    # Mock the user getting a valid name first time
+    mock_sdk.command.input.return_value = 'new-emulator'
+
+    # Mock a pre-existing skin folder
+    (mock_sdk.root_path / "skins" / "pixel_3a").mkdir(parents=True)
+
+    # Mock the initial output of an AVD config file.
+    avd_config_path = tmp_path / ".android" / "avd" / 'new-emulator.avd' / 'config.ini'
+    avd_config_path.parent.mkdir(parents=True)
+    with avd_config_path.open('w') as f:
+        f.write('hw.device.name=pixel\n')
+
+    # Create the emulator
+    avd = mock_sdk.create_emulator()
+
+    # The expected name was created.
+    assert avd == 'new-emulator'
+
+    # avdmanager was invoked
+    mock_sdk.command.subprocess.check_output.assert_called_once_with(
+        [
+            str(mock_sdk.avdmanager_path),
+            "--verbose",
+            "create", "avd",
+            "--name", "new-emulator",
+            "--abi", "x86",
+            "--package", 'system-images;android-28;default;x86',
+            "--device", "pixel",
+        ],
+        env=mock_sdk.env,
+        universal_newlines=True,
+        stderr=subprocess.STDOUT,
+    )
+
+    # Skin was not re-downloaded
+    assert mock_sdk.command.download_url.call_count == 0
+
+    # Emulator configuration file has been appended.
+    with avd_config_path.open() as f:
+        config = f.read().split('\n')
+    assert "hw.keyboard=yes" in config
+    assert "skin.name=pixel_3a" in config
+
+
+def test_create_failure(mock_sdk):
+    "If avdmanager fails, an error is raised"
+    # Mock the user getting a valid name first time
+    mock_sdk.command.input.return_value = 'new-emulator'
+
+    # Mock an avdmanager failure.
+    mock_sdk.command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
+        returncode=1, cmd='avdmanager'
+    )
+
+    # Create the emulator
+    with pytest.raises(BriefcaseCommandError):
+        mock_sdk.create_emulator()
+
+    # but avdmanager was invoked
+    mock_sdk.command.subprocess.check_output.assert_called_once_with(
+        [
+            str(mock_sdk.avdmanager_path),
+            "--verbose",
+            "create", "avd",
+            "--name", "new-emulator",
+            "--abi", "x86",
+            "--package", 'system-images;android-28;default;x86',
+            "--device", "pixel",
+        ],
+        env=mock_sdk.env,
+        universal_newlines=True,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def test_download_failure(mock_sdk, tmp_path):
+    "If the skin download fails, an error is raised"
+    # Mock a valid user response.
+    mock_sdk.command.input.return_value = 'new-emulator'
+
+    # Mock a failure downloading the skin
+    mock_sdk.command.download_url.side_effect = requests_exceptions.ConnectionError
+
+    # Create the emulator
+    with pytest.raises(NetworkFailure):
+        mock_sdk.create_emulator()
+
+    # avdmanager was invoked
+    mock_sdk.command.subprocess.check_output.assert_called_once_with(
+        [
+            str(mock_sdk.avdmanager_path),
+            "--verbose",
+            "create", "avd",
+            "--name", "new-emulator",
+            "--abi", "x86",
+            "--package", 'system-images;android-28;default;x86',
+            "--device", "pixel",
+        ],
+        env=mock_sdk.env,
+        universal_newlines=True,
+        stderr=subprocess.STDOUT,
+    )
+
+    # An attempt was made to download the skin
+    mock_sdk.command.download_url.assert_called_once_with(
+        url="https://android.googlesource.com/platform/tools/adt/idea/"
+            "+archive/refs/heads/mirror-goog-studio-master-dev/"
+            "artwork/resources/device-art-resources/pixel_3a.tar.gz",
+        download_path=mock_sdk.root_path,
+    )
+
+    # Skin wasn't downloaded, so it wasn't unpacked
+    assert mock_sdk.command.shutil.unpack_archive.call_count == 0
+
+
+def test_unpack_failure(mock_sdk, tmp_path):
+    "If the download is corrupted and unpacking fails, an error is raised"
+    # Mock a valid user response.
+    mock_sdk.command.input.return_value = 'new-emulator'
+
+    # Mock the result of the download of a skin
+    skin_tgz_path = MagicMock()
+    skin_tgz_path.__str__.return_value = '/path/to/skin.tgz'
+    mock_sdk.command.download_url.return_value = skin_tgz_path
+
+    # Mock a failure unpacking the skin
+    mock_sdk.command.shutil.unpack_archive.side_effect = EOFError
+
+    # Create the emulator
+    with pytest.raises(BriefcaseCommandError):
+        mock_sdk.create_emulator()
+
+    # avdmanager was invoked
+    mock_sdk.command.subprocess.check_output.assert_called_once_with(
+        [
+            str(mock_sdk.avdmanager_path),
+            "--verbose",
+            "create", "avd",
+            "--name", "new-emulator",
+            "--abi", "x86",
+            "--package", 'system-images;android-28;default;x86',
+            "--device", "pixel",
+        ],
+        env=mock_sdk.env,
+        universal_newlines=True,
+        stderr=subprocess.STDOUT,
+    )
+
+    # Skin was downloaded
+    mock_sdk.command.download_url.assert_called_once_with(
+        url="https://android.googlesource.com/platform/tools/adt/idea/"
+            "+archive/refs/heads/mirror-goog-studio-master-dev/"
+            "artwork/resources/device-art-resources/pixel_3a.tar.gz",
+        download_path=mock_sdk.root_path,
+    )
+
+    # An attempt to unpack the skin was made
+    mock_sdk.command.shutil.unpack_archive.assert_called_once_with(
+        str(skin_tgz_path),
+        extract_dir=str(mock_sdk.root_path / "skins" / "pixel_3a")
+    )
+
+    # Original file wasn't deleted.
+    assert skin_tgz_path.unlink.call_count == 0

--- a/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
@@ -54,7 +54,7 @@ def test_create_emulator(mock_sdk, tmp_path):
     # Create the emulator
     avd = mock_sdk.create_emulator()
 
-    # The expected name was created.
+    # The expected device AVD was created.
     assert avd == 'new-emulator'
 
     # avdmanager was invoked
@@ -117,7 +117,7 @@ def test_create_preexisting_skins(mock_sdk, tmp_path):
     # Create the emulator
     avd = mock_sdk.create_emulator()
 
-    # The expected name was created.
+    # The expected device AVD was created.
     assert avd == 'new-emulator'
 
     # avdmanager was invoked
@@ -266,3 +266,51 @@ def test_unpack_failure(mock_sdk, tmp_path):
 
     # Original file wasn't deleted.
     assert skin_tgz_path.unlink.call_count == 0
+
+
+def test_default_name(mock_sdk, tmp_path):
+    "A new emulator can be created with the default name."
+    # This test doesn't validate most of the test process;
+    # it only checks that the emulator is created with the default name.
+
+    # User provides no input; default name will be used
+    mock_sdk.command.input.return_value = ''
+
+    # Mock the initial output of an AVD config file.
+    avd_config_path = tmp_path / ".android" / "avd" / 'beePhone.avd' / 'config.ini'
+    avd_config_path.parent.mkdir(parents=True)
+    with avd_config_path.open('w') as f:
+        f.write('hw.device.name=pixel\n')
+
+    # Create the emulator
+    avd = mock_sdk.create_emulator()
+
+    # The expected device AVD was created.
+    assert avd == 'beePhone'
+
+
+def test_default_name_with_collisions(mock_sdk, tmp_path):
+    "The default name will avoid collisions with existing emulators."
+    # This test doesn't validate most of the test process;
+    # it only checks that the emulator is created with the default name.
+
+    # Create some existing emulators that will collide with the default name.
+    mock_sdk.emulators = MagicMock(return_value=[
+        'beePhone2',
+        'runningEmulator',
+        'beePhone',
+    ])
+    # User provides no input; default name will be used
+    mock_sdk.command.input.return_value = ''
+
+    # Mock the initial output of an AVD config file.
+    avd_config_path = tmp_path / ".android" / "avd" / 'beePhone3.avd' / 'config.ini'
+    avd_config_path.parent.mkdir(parents=True)
+    with avd_config_path.open('w') as f:
+        f.write('hw.device.name=pixel\n')
+
+    # Create the emulator
+    avd = mock_sdk.create_emulator()
+
+    # The expected device AVD was created.
+    assert avd == 'beePhone3'

--- a/tests/integrations/android_sdk/AndroidSDK/test_devices.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_devices.py
@@ -6,20 +6,23 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError
 
 
+def devices_result(name):
+    "Load a adb devices result file from the sample directory, and return the content"
+    adb_samples = Path(__file__).parent / "devices"
+    with (adb_samples / (name)).open(encoding='utf-8') as adb_output_file:
+        return adb_output_file.read()
+
+
 def test_no_devices(mock_sdk):
     "If there are no devices, an empty list is returned"
-    adb_samples = Path(__file__).parent / "devices"
-    with (adb_samples / ("no_devices")).open("r") as adb_output_file:
-        mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
+    mock_sdk.command.subprocess.check_output.return_value = devices_result("no_devices")
 
     assert mock_sdk.devices() == {}
 
 
 def test_one_emulator(mock_sdk):
     "If there is a single emulator, it is returned"
-    adb_samples = Path(__file__).parent / "devices"
-    with (adb_samples / ("one_emulator")).open("r") as adb_output_file:
-        mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
+    mock_sdk.command.subprocess.check_output.return_value = devices_result("one_emulator")
 
     assert mock_sdk.devices() == {
         'emulator-5554': {
@@ -31,9 +34,7 @@ def test_one_emulator(mock_sdk):
 
 def test_multiple_devices(mock_sdk):
     "If there are multiple devices, they are all returned"
-    adb_samples = Path(__file__).parent / "devices"
-    with (adb_samples / ("multiple_devices")).open("r") as adb_output_file:
-        mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
+    mock_sdk.command.subprocess.check_output.return_value = devices_result("multiple_devices")
 
     assert mock_sdk.devices() == {
         '041234567892009a': {
@@ -48,6 +49,10 @@ def test_multiple_devices(mock_sdk):
             'name': 'generic_x86',
             'authorized': True,
         },
+        'emulator-5556': {
+            'name': 'Unknown device (offline)',
+            'authorized': False,
+        },
     }
 
 
@@ -59,3 +64,10 @@ def test_adb_error(mock_sdk):
 
     with pytest.raises(BriefcaseCommandError):
         mock_sdk.devices()
+
+
+def test_daemon_start(mock_sdk):
+    "If ADB outputs the daemon startup message, ignore those messages"
+    mock_sdk.command.subprocess.check_output.return_value = devices_result("daemon_start")
+
+    assert mock_sdk.devices() == {}

--- a/tests/integrations/android_sdk/AndroidSDK/test_properties.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_properties.py
@@ -32,6 +32,60 @@ def test_sdkmanager_path(mock_sdk, host_os, sdkmanager_name):
     )
 
 
+@pytest.mark.parametrize(
+    "host_os, adb_name",
+    [
+        ("Windows", "adb.exe"),
+        ("NonWindows", "adb")
+    ],
+)
+def test_adb_path(mock_sdk, host_os, adb_name):
+    """Validate that if the user is on Windows, we run `adb.bat`,
+    otherwise, `adb`."""
+    # Mock out `host_os` so we can test Windows when not on Windows.
+    mock_sdk.command.host_os = host_os
+
+    assert mock_sdk.adb_path == (
+        mock_sdk.root_path / "platform-tools" / adb_name
+    )
+
+
+@pytest.mark.parametrize(
+    "host_os, avdmanager_name",
+    [
+        ("Windows", "avdmanager.bat"),
+        ("NonWindows", "avdmanager")
+    ],
+)
+def test_avdmanager_path(mock_sdk, host_os, avdmanager_name):
+    """Validate that if the user is on Windows, we run `avdmanager.bat`,
+    otherwise, `avdmanager`."""
+    # Mock out `host_os` so we can test Windows when not on Windows.
+    mock_sdk.command.host_os = host_os
+
+    assert mock_sdk.avdmanager_path == (
+        mock_sdk.root_path / "tools" / "bin" / avdmanager_name
+    )
+
+
+@pytest.mark.parametrize(
+    "host_os, emulator_name",
+    [
+        ("Windows", "emulator.exe"),
+        ("NonWindows", "emulator")
+    ],
+)
+def test_emulator_path(mock_sdk, host_os, emulator_name):
+    """Validate that if the user is on Windows, we run `emulator.bat`,
+    otherwise, `emulator`."""
+    # Mock out `host_os` so we can test Windows when not on Windows.
+    mock_sdk.command.host_os = host_os
+
+    assert mock_sdk.emulator_path == (
+        mock_sdk.root_path / "emulator" / emulator_name
+    )
+
+
 def test_simple_env(mock_sdk, tmp_path):
     "The SDK Environment can be constructed"
     assert mock_sdk.env == {

--- a/tests/integrations/android_sdk/AndroidSDK/test_properties.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_properties.py
@@ -86,6 +86,10 @@ def test_emulator_path(mock_sdk, host_os, emulator_name):
     )
 
 
+def test_avd_path(mock_sdk):
+    assert mock_sdk.avd_path == Path.home() / ".android" / "avd"
+
+
 def test_simple_env(mock_sdk, tmp_path):
     "The SDK Environment can be constructed"
     assert mock_sdk.env == {

--- a/tests/integrations/android_sdk/AndroidSDK/test_properties.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_properties.py
@@ -86,8 +86,8 @@ def test_emulator_path(mock_sdk, host_os, emulator_name):
     )
 
 
-def test_avd_path(mock_sdk):
-    assert mock_sdk.avd_path == Path.home() / ".android" / "avd"
+def test_avd_path(mock_sdk, tmp_path):
+    assert mock_sdk.avd_path == tmp_path / ".android" / "avd"
 
 
 def test_simple_env(mock_sdk, tmp_path):

--- a/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
@@ -82,7 +82,7 @@ def test_explicit_running_emulator_by_id(mock_sdk):
 
     # Emulator is running, so there is a device ID
     assert device == 'emulator-5554'
-    assert name == '@runningEmulator (running generic_x86 emulator)'
+    assert name == '@runningEmulator (generic_x86 emulator)'
     assert avd == "runningEmulator"
 
     # No input was requested
@@ -97,7 +97,7 @@ def test_explicit_running_emulator_by_avd(mock_sdk):
 
     # Emulator is running, so there is a device ID
     assert device == 'emulator-5554'
-    assert name == '@runningEmulator (running generic_x86 emulator)'
+    assert name == '@runningEmulator (generic_x86 emulator)'
     assert avd == "runningEmulator"
 
     # No input was requested
@@ -179,7 +179,7 @@ def test_select_running_emulator(mock_sdk, capsys):
 
     # Emulator is running, so there is a device ID
     assert device == 'emulator-5554'
-    assert name == '@runningEmulator (running generic_x86 emulator)'
+    assert name == '@runningEmulator (generic_x86 emulator)'
     assert avd == "runningEmulator"
 
     # A re-run prompt has been provided

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -1,0 +1,297 @@
+import subprocess
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
+from briefcase.integrations.android_sdk import ADB, AndroidSDK
+
+
+@pytest.fixture
+def mock_sdk(tmp_path):
+    command = MagicMock()
+    command.host_platform = 'unknown'
+
+    sdk = AndroidSDK(command, root_path=tmp_path)
+    sdk.sleep = MagicMock()
+
+    sdk.mock_run = MagicMock()
+
+    def mock_adb(device):
+        adb = ADB(sdk, device)
+        adb.run = sdk.mock_run
+        return adb
+    sdk.adb = mock_adb
+
+    # Mock some existing emulators
+    sdk.emulators = MagicMock(return_value=[
+        'runningEmulator',
+        'idleEmulator',
+    ])
+
+    return sdk
+
+
+def test_invalid_emulator(mock_sdk):
+    "Attempting to start an invalid emulator raises an error."
+
+    with pytest.raises(InvalidDeviceError):
+        mock_sdk.start_emulator('no-such-avd')
+
+
+def test_start_emulator(mock_sdk):
+    "An emulator can be started"
+    # Mock 4 calls to devices.
+    # First call returns 3 devices, but not the new emulator.
+    # Second call returns the same thing.
+    # Third call returns the new device in an offline state.
+    # Last call returns the new device in an online state.
+    devices = {
+        '041234567892009a': {
+            'name': 'Unknown device (not authorized for development)',
+            'authorized': False,
+        },
+        'KABCDABCDA1513': {
+            'name': 'Kogan_Agora_9',
+            'authorized': True,
+        },
+        'emulator-5554': {
+            'name': 'generic_x86',
+            'authorized': True,
+        },
+    }
+    devices_3 = devices.copy()
+    devices_3['emulator-5556'] = {
+        'name': 'Unknown device (offline)',
+        'authorized': False,
+    }
+    devices_4 = devices.copy()
+    devices_4['emulator-5556'] = {
+        'name': 'generic_x86',
+        'authorized': True,
+    }
+
+    # This will result in 4 calls to get devices
+    mock_sdk.devices = MagicMock(side_effect=[
+        devices, devices, devices_3, devices_4,
+    ])
+
+    # There will be 5 calls on adb.run (3 calls to avd_name, then
+    # 2 calls to getprop)
+    mock_sdk.mock_run.side_effect = [
+        # emu avd_name
+        subprocess.CalledProcessError(
+           returncode=1, cmd='emu avd name'
+        ),
+        'runningEmulator\nOK',
+        'idleEmulator\nOK',
+        # shell getprop sys.boot_completed
+        '\n', "1\n",
+    ]
+
+    # poll() on the process continues to return None, indicating no problem.
+    emu_popen = MagicMock()
+    emu_popen.poll.return_value = None
+    mock_sdk.command.subprocess.Popen.return_value = emu_popen
+
+    # Start the emulator
+    device, name = mock_sdk.start_emulator('idleEmulator')
+
+    # The device details are as expected
+    assert device == 'emulator-5556'
+    assert name == '@idleEmulator (generic_x86 emulator)'
+
+    # The process was started.
+    mock_sdk.command.subprocess.Popen.assert_called_with(
+        [
+            str(mock_sdk.emulator_path),
+            '@idleEmulator',
+            '-dns-server', '8.8.8.8',
+        ],
+        env=mock_sdk.env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # There were 5 calls to run
+    mock_sdk.mock_run.assert_has_calls([
+        # Three calls to get avd name
+        call('emu', 'avd', 'name'),
+        call('emu', 'avd', 'name'),
+        call('emu', 'avd', 'name'),
+        # 2 calls to get boot property
+        call('shell', 'getprop', 'sys.boot_completed'),
+        call('shell', 'getprop', 'sys.boot_completed'),
+    ])
+
+    # Took a total of 5 naps.
+    assert mock_sdk.sleep.call_count == 5
+
+
+def test_emulator_fail_to_start(mock_sdk):
+    "If the emulator fails to start, and error is displayed"
+    # Mock 4 calls to devices.
+    # First call returns 3 devices, but not the new emulator.
+    # Second call returns the same thing.
+    # Third call returns the new device in an offline state.
+    # Last call returns the new device in an online state.
+    devices = {
+        '041234567892009a': {
+            'name': 'Unknown device (not authorized for development)',
+            'authorized': False,
+        },
+        'KABCDABCDA1513': {
+            'name': 'Kogan_Agora_9',
+            'authorized': True,
+        },
+        'emulator-5554': {
+            'name': 'generic_x86',
+            'authorized': True,
+        },
+    }
+    devices_3 = devices.copy()
+    devices_3['emulator-5556'] = {
+        'name': 'Unknown device (offline)',
+        'authorized': False,
+    }
+    devices_4 = devices.copy()
+    devices_4['emulator-5556'] = {
+        'name': 'generic_x86',
+        'authorized': True,
+    }
+
+    # This will result in 4 calls to get devices
+    mock_sdk.devices = MagicMock(side_effect=[
+        devices, devices, devices_3, devices_4,
+    ])
+
+    # This will result in 5 calls on adb.run (3 calls to avd_name, then
+    # 2 calls to getprop)
+    mock_sdk.mock_run.side_effect = [
+        # emu avd_name
+        subprocess.CalledProcessError(
+           returncode=1, cmd='emu avd name'
+        ),
+        'runningEmulator\nOK',
+        'idleEmulator\nOK',
+        # shell getprop sys.boot_completed
+        '\n', "1\n",
+    ]
+
+    # poll() on the process returns None for the first two attempts, but then
+    # returns 1 indicating failure.
+    emu_popen = MagicMock()
+    emu_popen.poll.side_effect = [None, None, 1]
+    emu_popen.args = [mock_sdk.emulator_path, '@idleEmulator']
+    mock_sdk.command.subprocess.Popen.return_value = emu_popen
+
+    # Start the emulator
+    with pytest.raises(BriefcaseCommandError):
+        mock_sdk.start_emulator('idleEmulator')
+
+    # The process was started.
+    mock_sdk.command.subprocess.Popen.assert_called_with(
+        [
+            str(mock_sdk.emulator_path),
+            '@idleEmulator',
+            '-dns-server', '8.8.8.8',
+        ],
+        env=mock_sdk.env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # There were 2 calls to run, both to get AVD name
+    mock_sdk.mock_run.assert_has_calls([
+        call('emu', 'avd', 'name'),
+        call('emu', 'avd', 'name'),
+    ])
+
+    # Took a total of 2 naps before failing.
+    assert mock_sdk.sleep.call_count == 2
+
+
+def test_emulator_fail_to_boot(mock_sdk):
+    "If the emulator fails to boot, and error is displayed"
+    # Mock 4 calls to devices.
+    # First call returns 3 devices, but not the new emulator.
+    # Second call returns the same thing.
+    # Third call returns the new device in an offline state.
+    # Last call returns the new device in an online state.
+    devices = {
+        '041234567892009a': {
+            'name': 'Unknown device (not authorized for development)',
+            'authorized': False,
+        },
+        'KABCDABCDA1513': {
+            'name': 'Kogan_Agora_9',
+            'authorized': True,
+        },
+        'emulator-5554': {
+            'name': 'generic_x86',
+            'authorized': True,
+        },
+    }
+    devices_3 = devices.copy()
+    devices_3['emulator-5556'] = {
+        'name': 'Unknown device (offline)',
+        'authorized': False,
+    }
+    devices_4 = devices.copy()
+    devices_4['emulator-5556'] = {
+        'name': 'generic_x86',
+        'authorized': True,
+    }
+
+    # This will result in 4 calls to get devices
+    mock_sdk.devices = MagicMock(side_effect=[
+        devices, devices, devices_3, devices_4,
+    ])
+
+    # This will result in 5 calls on adb.run (3 calls to avd_name, then
+    # 2 calls to getprop)
+    mock_sdk.mock_run.side_effect = [
+        # emu avd_name
+        subprocess.CalledProcessError(
+           returncode=1, cmd='emu avd name'
+        ),
+        'runningEmulator\nOK',
+        'idleEmulator\nOK',
+        # shell getprop sys.boot_completed
+        '\n', "1\n",
+    ]
+
+    # poll() on the process continues to return None, indicating no problem.
+    emu_popen = MagicMock()
+    emu_popen.poll.side_effect = [None, None, None, None, 1]
+    emu_popen.args = [mock_sdk.emulator_path, '@idleEmulator']
+    mock_sdk.command.subprocess.Popen.return_value = emu_popen
+
+    # Start the emulator
+    with pytest.raises(BriefcaseCommandError):
+        mock_sdk.start_emulator('idleEmulator')
+
+    # The process was started.
+    mock_sdk.command.subprocess.Popen.assert_called_with(
+        [
+            str(mock_sdk.emulator_path),
+            '@idleEmulator',
+            '-dns-server', '8.8.8.8',
+        ],
+        env=mock_sdk.env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # There were 4 calls to run before failure
+    mock_sdk.mock_run.assert_has_calls([
+        # Three calls to get avd name
+        call('emu', 'avd', 'name'),
+        call('emu', 'avd', 'name'),
+        call('emu', 'avd', 'name'),
+        # 1 calls to get boot property
+        call('shell', 'getprop', 'sys.boot_completed'),
+    ])
+
+    # Took a total of 4 naps.
+    assert mock_sdk.sleep.call_count == 4

--- a/tests/integrations/android_sdk/conftest.py
+++ b/tests/integrations/android_sdk/conftest.py
@@ -9,6 +9,7 @@ from briefcase.integrations.android_sdk import AndroidSDK
 @pytest.fixture
 def mock_sdk(tmp_path):
     command = MagicMock()
+    command.home_path = tmp_path
     command.subprocess = MagicMock()
 
     # Mock an empty environment

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -12,9 +12,7 @@ from briefcase.platforms.linux.appimage import LinuxAppImageBuildCommand
 def build_command(tmp_path, first_app_config):
     command = LinuxAppImageBuildCommand(
         base_path=tmp_path,
-        # `dot-briefcase` below makes it easy to find references to literal
-        # `.briefcase` when grepping the source.
-        dot_briefcase_path=tmp_path / "dot-briefcase",
+        home_path=tmp_path / "home",
         apps={'first': first_app_config}
     )
     command.host_os = 'Linux'


### PR DESCRIPTION
Builds on #348. 

Implements the ability to create a new Android device, if requested.

* Asks the user for a device name
* Creates a new `pixel` device
* Obtains the pixel_3a skin
* Modifies the AVD configuration to add the skin, hardware keyboard, extra disk space, etc.