### PR TITLE
Add ability to start Android emulators

### DIFF
--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -315,6 +315,9 @@ class AndroidSDK:
                     if parts[1] == "device":
                         name = details["device"]
                         authorized = True
+                    elif parts[1] == "offline":
+                        name = "Unknown device (offline)"
+                        authorized = False
                     else:
                         name = "Unknown device (not authorized for development)"
                         authorized = False

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -307,8 +307,11 @@ class AndroidSDK:
             # The first line is header information.
             # Each subsequent line is a single device descriptor.
             devices = {}
-            for line in output.split("\n")[1:]:
-                if line:
+            header_found = False
+            for line in output.split("\n"):
+                if line == 'List of devices attached':
+                    header_found = True
+                elif header_found and line:
                     parts = re.sub(r"\s+", " ", line).split(" ")
 
                     details = {}

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -632,7 +632,7 @@ In future, you can specify this device by running:
             print("Starting emulator {avd}...".format(avd=avd))
             emulator_popen = self.command.subprocess.Popen(
                 [
-                    self.emulator_path,
+                    str(self.emulator_path),
                     '@' + avd,
                     '-dns-server', '8.8.8.8'
                 ],

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -148,21 +148,24 @@ class GradleRunCommand(GradleMixin, RunCommand):
         # Create an ADB wrapper for the selected device
         adb = self.android_sdk.adb(device=device)
 
-        # Install the latest APK file onto the device.
-        print("[{app.app_name}] Installing app...".format(
-            app=app,
-        ))
-        adb.install_apk(self.binary_path(app))
-
         # Compute Android package name based on beeware `bundle` and `app_name`
         # app properties, similar to iOS.
         package = "{app.bundle}.{app.app_name}".format(app=app)
 
         # We force-stop the app to ensure the activity launches freshly.
-        print("[{app.app_name}] Stopping app...".format(app=app))
+        print()
+        print("[{app.app_name}] Stopping old versions of the app...".format(app=app))
         adb.force_stop_app(package)
 
+        # Install the latest APK file onto the device.
+        print()
+        print("[{app.app_name}] Installing app...".format(
+            app=app,
+        ))
+        adb.install_apk(self.binary_path(app))
+
         # To start the app, we launch `org.beeware.android.MainActivity`.
+        print()
         print("[{app.app_name}] Launching app...".format(app=app))
         adb.start_app(package, "org.beeware.android.MainActivity")
 

--- a/tests/integrations/android_sdk/ADB/test_command.py
+++ b/tests/integrations/android_sdk/ADB/test_command.py
@@ -44,7 +44,7 @@ def test_error_handling(mock_sdk, tmp_path, name, exception):
     # Set up a mock command with a subprocess module that has with sample data loaded.
     adb_samples = Path(__file__).parent / "adb_errors"
     with (adb_samples / (name + ".txt")).open("r") as adb_output_file:
-        with (adb_samples / (name + ".returncode")).open() as returncode_file:
+        with (adb_samples / (name + ".returncode")).open(encoding='utf-8') as returncode_file:
             mock_sdk.command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
                 returncode=int(returncode_file.read().strip()),
                 cmd=["ignored"],

--- a/tests/integrations/android_sdk/ADB/test_has_booted.py
+++ b/tests/integrations/android_sdk/ADB/test_has_booted.py
@@ -1,0 +1,63 @@
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
+from briefcase.integrations.android_sdk import ADB
+
+
+def test_booted(mock_sdk, capsys):
+    "A booted device returns true"
+    # Mock out the adb response for an emulator
+    adb = ADB(mock_sdk, "deafbeefcafe")
+    adb.run = MagicMock(return_value="1\n")
+
+    # Invoke avd_name
+    assert adb.has_booted()
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("shell", "getprop", "sys.boot_completed")
+
+
+def test_not_booted(mock_sdk, capsys):
+    "A non-booted device returns False"
+    # Mock out the adb response for an emulator
+    adb = ADB(mock_sdk, "deafbeefcafe")
+    adb.run = MagicMock(return_value="\n")
+
+    # Invoke avd_name
+    assert not adb.has_booted()
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("shell", "getprop", "sys.boot_completed")
+
+
+def test_adb_failure(mock_sdk, capsys):
+    "If ADB fails, an error is raised"
+    # Mock out the adb response for an emulator
+    adb = ADB(mock_sdk, "deafbeefcafe")
+    adb.run = MagicMock(side_effect=subprocess.CalledProcessError(
+        returncode=69, cmd='emu avd name'
+    ))
+
+    # Invoke avd_name
+    with pytest.raises(BriefcaseCommandError):
+        adb.has_booted()
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("shell", "getprop", "sys.boot_completed")
+
+
+def test_invalid_device(mock_sdk, capsys):
+    "If the device ID is invalid, an error is raised"
+    # Mock out the adb response for an emulator
+    adb = ADB(mock_sdk, "not-a-device")
+    adb.run = MagicMock(side_effect=InvalidDeviceError('device', 'exampleDevice'))
+
+    # Invoke avd_name
+    with pytest.raises(BriefcaseCommandError):
+        adb.has_booted()
+
+    # Validate call parameters.
+    adb.run.assert_called_once_with("shell", "getprop", "sys.boot_completed")

--- a/tests/integrations/android_sdk/AndroidSDK/devices/daemon_start
+++ b/tests/integrations/android_sdk/AndroidSDK/devices/daemon_start
@@ -1,0 +1,5 @@
+* daemon not running; starting now at tcp:5037
+* daemon started successfully
+List of devices attached
+
+

--- a/tests/integrations/android_sdk/AndroidSDK/devices/multiple_devices
+++ b/tests/integrations/android_sdk/AndroidSDK/devices/multiple_devices
@@ -2,5 +2,5 @@ List of devices attached
 041234567892009a       unauthorized usb:336675328X transport_id:2
 KABCDABCDA1513         device usb:336675584X product:Kogan_Agora_9 model:Kogan_Agora_9 device:Kogan_Agora_9 transport_id:1
 emulator-5554          device product:sdk_phone_x86 model:Android_SDK_built_for_x86 device:generic_x86 transport_id:4
-
+emulator-5556          offline transport_id:32
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_devices.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_devices.py
@@ -48,6 +48,10 @@ def test_multiple_devices(mock_sdk):
             'name': 'generic_x86',
             'authorized': True,
         },
+        'emulator-5556': {
+            'name': 'Unknown device (offline)',
+            'authorized': False,
+        },
     }
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_devices.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_devices.py
@@ -6,20 +6,23 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError
 
 
+def devices_result(name):
+    "Load a adb devices result file from the sample directory, and return the content"
+    adb_samples = Path(__file__).parent / "devices"
+    with (adb_samples / (name)).open(encoding='utf-8') as adb_output_file:
+        return adb_output_file.read()
+
+
 def test_no_devices(mock_sdk):
     "If there are no devices, an empty list is returned"
-    adb_samples = Path(__file__).parent / "devices"
-    with (adb_samples / ("no_devices")).open("r") as adb_output_file:
-        mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
+    mock_sdk.command.subprocess.check_output.return_value = devices_result("no_devices")
 
     assert mock_sdk.devices() == {}
 
 
 def test_one_emulator(mock_sdk):
     "If there is a single emulator, it is returned"
-    adb_samples = Path(__file__).parent / "devices"
-    with (adb_samples / ("one_emulator")).open("r") as adb_output_file:
-        mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
+    mock_sdk.command.subprocess.check_output.return_value = devices_result("one_emulator")
 
     assert mock_sdk.devices() == {
         'emulator-5554': {
@@ -31,9 +34,7 @@ def test_one_emulator(mock_sdk):
 
 def test_multiple_devices(mock_sdk):
     "If there are multiple devices, they are all returned"
-    adb_samples = Path(__file__).parent / "devices"
-    with (adb_samples / ("multiple_devices")).open("r") as adb_output_file:
-        mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
+    mock_sdk.command.subprocess.check_output.return_value = devices_result("multiple_devices")
 
     assert mock_sdk.devices() == {
         '041234567892009a': {
@@ -67,8 +68,6 @@ def test_adb_error(mock_sdk):
 
 def test_daemon_start(mock_sdk):
     "If ADB outputs the daemon startup message, ignore those messages"
-    adb_samples = Path(__file__).parent / "devices"
-    with (adb_samples / ("daemon_start")).open("r") as adb_output_file:
-        mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
+    mock_sdk.command.subprocess.check_output.return_value = devices_result("daemon_start")
 
     assert mock_sdk.devices() == {}

--- a/tests/integrations/android_sdk/AndroidSDK/test_devices.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_devices.py
@@ -63,3 +63,12 @@ def test_adb_error(mock_sdk):
 
     with pytest.raises(BriefcaseCommandError):
         mock_sdk.devices()
+
+
+def test_daemon_start(mock_sdk):
+    "If ADB outputs the daemon startup message, ignore those messages"
+    adb_samples = Path(__file__).parent / "devices"
+    with (adb_samples / ("daemon_start")).open("r") as adb_output_file:
+        mock_sdk.command.subprocess.check_output.return_value = adb_output_file.read()
+
+    assert mock_sdk.devices() == {}

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -1,0 +1,122 @@
+import subprocess
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from briefcase.exceptions import InvalidDeviceError
+from briefcase.integrations.android_sdk import AndroidSDK, ADB
+
+
+@pytest.fixture
+def mock_sdk(tmp_path):
+    command = MagicMock()
+    command.host_platform = 'unknown'
+
+    sdk = AndroidSDK(command, root_path=tmp_path)
+    sdk.sleep = MagicMock()
+
+    sdk.mock_run = MagicMock()
+
+    def mock_adb(device):
+        adb = ADB(sdk, device)
+        adb.run = sdk.mock_run
+        return adb
+    sdk.adb = mock_adb
+
+    # Mock some existing emulators
+    sdk.emulators = MagicMock(return_value=[
+        'runningEmulator',
+        'idleEmulator',
+    ])
+
+    return sdk
+
+
+def test_invalid_emulator(mock_sdk):
+    "Attempting to start an invalid emulator raises an error."
+
+    with pytest.raises(InvalidDeviceError):
+        mock_sdk.start_emulator('no-such-avd')
+
+
+def test_start_emulator(mock_sdk):
+    "An emulator can be started"
+    # Mock 4 calls to devices.
+    # First call returns 3 devices, but not the new emulator.
+    # Second call returns the same thing.
+    # Third call returns the new device in an offline state.
+    # Last call returns the new device in an online state.
+    devices = {
+        '041234567892009a': {
+            'name': 'Unknown device (not authorized for development)',
+            'authorized': False,
+        },
+        'KABCDABCDA1513': {
+            'name': 'Kogan_Agora_9',
+            'authorized': True,
+        },
+        'emulator-5554': {
+            'name': 'generic_x86',
+            'authorized': True,
+        },
+    }
+    devices_3 = devices.copy()
+    devices_3['emulator-5556'] = {
+        'name': 'Unknown device (offline)',
+        'authorized': False,
+    }
+    devices_4 = devices.copy()
+    devices_4['emulator-5556'] = {
+        'name': 'generic_x86',
+        'authorized': True,
+    }
+
+    # This will result in
+    mock_sdk.devices = MagicMock(side_effect=[
+        devices, devices, devices_3, devices_4,
+    ])
+
+    # This will result in 5 calls on adb.run (3 calls to avd_name, then
+    # 2 calls to getprop)
+    mock_sdk.mock_run.side_effect = [
+        # emu avd_name
+        subprocess.CalledProcessError(
+           returncode=1, cmd='emu avd name'
+        ),
+        'runningEmulator\nOK',
+        'idleEmulator\nOK',
+        # shell getprop sys.boot_completed
+        '\n', "1\n",
+    ]
+
+    device, name = mock_sdk.start_emulator('idleEmulator')
+
+    # The device details are as expected
+    assert device == 'emulator-5556'
+    assert name == '@idleEmulator (generic_x86 emulator)'
+
+    # The process was started.
+    mock_sdk.command.subprocess.Popen.assert_called_with(
+        [
+            mock_sdk.emulator_path,
+            '@idleEmulator',
+            '-dns-server', '8.8.8.8',
+        ],
+        env=mock_sdk.env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # There were 5 calls to run
+    mock_sdk.mock_run.assert_has_calls([
+        # Three calls to get avd name
+        call('emu', 'avd', 'name'),
+        call('emu', 'avd', 'name'),
+        call('emu', 'avd', 'name'),
+        # 2 calls to get boot property
+        call('shell', 'getprop', 'sys.boot_completed'),
+        call('shell', 'getprop', 'sys.boot_completed'),
+    ])
+
+    # Took a total of 5 naps.
+    assert mock_sdk.sleep.call_count == 5

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -104,7 +104,7 @@ def test_start_emulator(mock_sdk):
     # The process was started.
     mock_sdk.command.subprocess.Popen.assert_called_with(
         [
-            mock_sdk.emulator_path,
+            str(mock_sdk.emulator_path),
             '@idleEmulator',
             '-dns-server', '8.8.8.8',
         ],
@@ -192,7 +192,7 @@ def test_emulator_fail_to_start(mock_sdk):
     # The process was started.
     mock_sdk.command.subprocess.Popen.assert_called_with(
         [
-            mock_sdk.emulator_path,
+            str(mock_sdk.emulator_path),
             '@idleEmulator',
             '-dns-server', '8.8.8.8',
         ],
@@ -274,7 +274,7 @@ def test_emulator_fail_to_boot(mock_sdk):
     # The process was started.
     mock_sdk.command.subprocess.Popen.assert_called_with(
         [
-            mock_sdk.emulator_path,
+            str(mock_sdk.emulator_path),
             '@idleEmulator',
             '-dns-server', '8.8.8.8',
         ],

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
-from briefcase.exceptions import InvalidDeviceError
+from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 from briefcase.integrations.android_sdk import ADB, AndroidSDK
 
 
@@ -71,12 +71,12 @@ def test_start_emulator(mock_sdk):
         'authorized': True,
     }
 
-    # This will result in
+    # This will result in 4 calls to get devices
     mock_sdk.devices = MagicMock(side_effect=[
         devices, devices, devices_3, devices_4,
     ])
 
-    # This will result in 5 calls on adb.run (3 calls to avd_name, then
+    # There will be 5 calls on adb.run (3 calls to avd_name, then
     # 2 calls to getprop)
     mock_sdk.mock_run.side_effect = [
         # emu avd_name
@@ -89,6 +89,12 @@ def test_start_emulator(mock_sdk):
         '\n', "1\n",
     ]
 
+    # poll() on the process continues to return None, indicating no problem.
+    emu_popen = MagicMock()
+    emu_popen.poll.return_value = None
+    mock_sdk.command.subprocess.Popen.return_value = emu_popen
+
+    # Start the emulator
     device, name = mock_sdk.start_emulator('idleEmulator')
 
     # The device details are as expected
@@ -120,3 +126,172 @@ def test_start_emulator(mock_sdk):
 
     # Took a total of 5 naps.
     assert mock_sdk.sleep.call_count == 5
+
+
+def test_emulator_fail_to_start(mock_sdk):
+    "If the emulator fails to start, and error is displayed"
+    # Mock 4 calls to devices.
+    # First call returns 3 devices, but not the new emulator.
+    # Second call returns the same thing.
+    # Third call returns the new device in an offline state.
+    # Last call returns the new device in an online state.
+    devices = {
+        '041234567892009a': {
+            'name': 'Unknown device (not authorized for development)',
+            'authorized': False,
+        },
+        'KABCDABCDA1513': {
+            'name': 'Kogan_Agora_9',
+            'authorized': True,
+        },
+        'emulator-5554': {
+            'name': 'generic_x86',
+            'authorized': True,
+        },
+    }
+    devices_3 = devices.copy()
+    devices_3['emulator-5556'] = {
+        'name': 'Unknown device (offline)',
+        'authorized': False,
+    }
+    devices_4 = devices.copy()
+    devices_4['emulator-5556'] = {
+        'name': 'generic_x86',
+        'authorized': True,
+    }
+
+    # This will result in 4 calls to get devices
+    mock_sdk.devices = MagicMock(side_effect=[
+        devices, devices, devices_3, devices_4,
+    ])
+
+    # This will result in 5 calls on adb.run (3 calls to avd_name, then
+    # 2 calls to getprop)
+    mock_sdk.mock_run.side_effect = [
+        # emu avd_name
+        subprocess.CalledProcessError(
+           returncode=1, cmd='emu avd name'
+        ),
+        'runningEmulator\nOK',
+        'idleEmulator\nOK',
+        # shell getprop sys.boot_completed
+        '\n', "1\n",
+    ]
+
+    # poll() on the process returns None for the first two attempts, but then
+    # returns 1 indicating failure.
+    emu_popen = MagicMock()
+    emu_popen.poll.side_effect = [None, None, 1]
+    emu_popen.args = [mock_sdk.emulator_path, '@idleEmulator']
+    mock_sdk.command.subprocess.Popen.return_value = emu_popen
+
+    # Start the emulator
+    with pytest.raises(BriefcaseCommandError):
+        mock_sdk.start_emulator('idleEmulator')
+
+    # The process was started.
+    mock_sdk.command.subprocess.Popen.assert_called_with(
+        [
+            mock_sdk.emulator_path,
+            '@idleEmulator',
+            '-dns-server', '8.8.8.8',
+        ],
+        env=mock_sdk.env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # There were 2 calls to run, both to get AVD name
+    mock_sdk.mock_run.assert_has_calls([
+        call('emu', 'avd', 'name'),
+        call('emu', 'avd', 'name'),
+    ])
+
+    # Took a total of 2 naps before failing.
+    assert mock_sdk.sleep.call_count == 2
+
+
+def test_emulator_fail_to_boot(mock_sdk):
+    "If the emulator fails to boot, and error is displayed"
+    # Mock 4 calls to devices.
+    # First call returns 3 devices, but not the new emulator.
+    # Second call returns the same thing.
+    # Third call returns the new device in an offline state.
+    # Last call returns the new device in an online state.
+    devices = {
+        '041234567892009a': {
+            'name': 'Unknown device (not authorized for development)',
+            'authorized': False,
+        },
+        'KABCDABCDA1513': {
+            'name': 'Kogan_Agora_9',
+            'authorized': True,
+        },
+        'emulator-5554': {
+            'name': 'generic_x86',
+            'authorized': True,
+        },
+    }
+    devices_3 = devices.copy()
+    devices_3['emulator-5556'] = {
+        'name': 'Unknown device (offline)',
+        'authorized': False,
+    }
+    devices_4 = devices.copy()
+    devices_4['emulator-5556'] = {
+        'name': 'generic_x86',
+        'authorized': True,
+    }
+
+    # This will result in 4 calls to get devices
+    mock_sdk.devices = MagicMock(side_effect=[
+        devices, devices, devices_3, devices_4,
+    ])
+
+    # This will result in 5 calls on adb.run (3 calls to avd_name, then
+    # 2 calls to getprop)
+    mock_sdk.mock_run.side_effect = [
+        # emu avd_name
+        subprocess.CalledProcessError(
+           returncode=1, cmd='emu avd name'
+        ),
+        'runningEmulator\nOK',
+        'idleEmulator\nOK',
+        # shell getprop sys.boot_completed
+        '\n', "1\n",
+    ]
+
+    # poll() on the process continues to return None, indicating no problem.
+    emu_popen = MagicMock()
+    emu_popen.poll.side_effect = [None, None, None, None, 1]
+    emu_popen.args = [mock_sdk.emulator_path, '@idleEmulator']
+    mock_sdk.command.subprocess.Popen.return_value = emu_popen
+
+    # Start the emulator
+    with pytest.raises(BriefcaseCommandError):
+        mock_sdk.start_emulator('idleEmulator')
+
+    # The process was started.
+    mock_sdk.command.subprocess.Popen.assert_called_with(
+        [
+            mock_sdk.emulator_path,
+            '@idleEmulator',
+            '-dns-server', '8.8.8.8',
+        ],
+        env=mock_sdk.env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # There were 4 calls to run before failure
+    mock_sdk.mock_run.assert_has_calls([
+        # Three calls to get avd name
+        call('emu', 'avd', 'name'),
+        call('emu', 'avd', 'name'),
+        call('emu', 'avd', 'name'),
+        # 1 calls to get boot property
+        call('shell', 'getprop', 'sys.boot_completed'),
+    ])
+
+    # Took a total of 4 naps.
+    assert mock_sdk.sleep.call_count == 4

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, call
 import pytest
 
 from briefcase.exceptions import InvalidDeviceError
-from briefcase.integrations.android_sdk import AndroidSDK, ADB
+from briefcase.integrations.android_sdk import ADB, AndroidSDK
 
 
 @pytest.fixture


### PR DESCRIPTION
Builds on #349.

Adds the ability to start an Android emulator. 
* Boots the emulator as a standalone process
* Monitors the device list until a device ID can be retrieved
* Uses the device ID to poll ADB and determine if the device has started.