### PR TITLE
Add commands dynamically

### DIFF
--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 from briefcase import __version__
-from briefcase.commands import DevCommand, NewCommand
+from briefcase.commands import BaseCommand, DevCommand, NewCommand
 from briefcase.platforms import get_output_formats, get_platforms
 
 from .exceptions import (
@@ -42,9 +42,7 @@ def parse_cmdline(args):
     # usage string so that the instructions displayed are correct
     parser.add_argument(
         'command',
-        choices=[
-            'new', 'dev', 'create', 'update', 'build', 'run', 'package', 'publish'
-        ],
+        choices=BaseCommand.commands,
         metavar='command',
         nargs='?',
         help='the command to execute (one of: %(choices)s)',

--- a/src/briefcase/commands/__init__.py
+++ b/src/briefcase/commands/__init__.py
@@ -1,3 +1,4 @@
+from .base import BaseCommand  # noqa
 from .build import BuildCommand  # noqa
 from .create import CreateCommand  # noqa
 from .dev import DevCommand  # noqa

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -100,6 +100,7 @@ def full_kwargs(state, kwargs):
 
 
 class BaseCommand(ABC):
+    commands = []
     cmd_line = "briefcase {command} {platform} {output_format}"
     GLOBAL_CONFIG_CLASS = GlobalConfig
     APP_CONFIG_CLASS = AppConfig
@@ -493,3 +494,7 @@ class BaseCommand(ABC):
             cached_template = template
 
         return cached_template
+
+    @classmethod
+    def add_command(cls):
+        cls.commands.append(cls.command)

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -67,3 +67,6 @@ class BuildCommand(BaseCommand):
                 state = self._build_app(app, update=update, **full_kwargs(state, kwargs))
 
         return state
+
+
+BuildCommand.add_command()

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -737,3 +737,6 @@ class CreateCommand(BaseCommand):
                 state = self.create_app(app, **full_kwargs(state, kwargs))
 
         return state
+
+
+CreateCommand.add_command()

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -154,3 +154,6 @@ class DevCommand(BaseCommand):
         env = self.get_environment(app)
         state = self.run_dev_app(app, env, **kwargs)
         return state
+
+
+DevCommand.add_command()

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -521,3 +521,6 @@ Application '{formal_name}' has been generated. To run your application, type:
 
         state = self.new_app(template=template, **kwargs)
         return state
+
+
+NewCommand.add_command()

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -64,3 +64,6 @@ class PackageCommand(BaseCommand):
                 state = self._package_app(app, update=update, **full_kwargs(state, kwargs))
 
         return state
+
+
+PackageCommand.add_command()

--- a/src/briefcase/commands/publish.py
+++ b/src/briefcase/commands/publish.py
@@ -59,3 +59,6 @@ class PublishCommand(BaseCommand):
             state = self.publish_app(app, channel=channel, **full_kwargs(state, kwargs))
 
         return state
+
+
+PublishCommand.add_command()

--- a/src/briefcase/commands/run.py
+++ b/src/briefcase/commands/run.py
@@ -77,3 +77,6 @@ class RunCommand(BaseCommand):
         state = self.run_app(app, **full_kwargs(state, kwargs))
 
         return state
+
+
+RunCommand.add_command()

--- a/src/briefcase/commands/update.py
+++ b/src/briefcase/commands/update.py
@@ -92,3 +92,6 @@ class UpdateCommand(CreateCommand):
                 )
 
         return state
+
+
+UpdateCommand.add_command()

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -4,170 +4,256 @@ import pytest
 
 from briefcase import __version__
 from briefcase.cmdline import parse_cmdline
-from briefcase.commands import DevCommand, NewCommand
+from briefcase.commands import DevCommand, NewCommand, UpdateCommand
 from briefcase.exceptions import (
     InvalidFormatError,
     NoCommandError,
     ShowOutputFormats,
-    UnsupportedCommandError
+    UnsupportedCommandError,
 )
 from briefcase.platforms.linux.appimage import LinuxAppImageCreateCommand
-from briefcase.platforms.macOS.app import (
-    macOSAppCreateCommand,
-    macOSAppPublishCommand
+from briefcase.platforms.macOS.app import macOSAppCreateCommand, macOSAppPublishCommand
+from briefcase.platforms.macOS.dmg import (
+    macOSDmgCreateCommand,
+    macOSDmgUpdateCommand,
+    macOSDmgBuildCommand,
+    macOSDmgRunCommand,
+    macOSDmgPackageCommand,
+    macOSDmgPublishCommand,
 )
-from briefcase.platforms.macOS.dmg import macOSDmgCreateCommand
 from briefcase.platforms.windows.msi import WindowsMSICreateCommand
 
 
 def test_empty():
     "``briefcase`` returns basic usage"
     with pytest.raises(NoCommandError) as excinfo:
-        parse_cmdline(''.split())
+        parse_cmdline("".split())
 
     assert excinfo.value.msg.startswith(
-        'usage: briefcase [-h] <command> [<platform>] [<format>] ...\n'
-        '\n'
-        'Package Python code for distribution.\n'
-        '\n'
-        'positional arguments:\n'
+        "usage: briefcase [-h] <command> [<platform>] [<format>] ...\n"
+        "\n"
+        "Package Python code for distribution.\n"
+        "\n"
+        "positional arguments:\n"
     )
 
 
 def test_help_only():
     "``briefcase -h`` returns basic usage"
     with pytest.raises(NoCommandError) as excinfo:
-        parse_cmdline('-h'.split())
+        parse_cmdline("-h".split())
 
     assert excinfo.value.msg.startswith(
-        'usage: briefcase [-h] <command> [<platform>] [<format>] ...\n'
-        '\n'
-        'Package Python code for distribution.\n'
-        '\n'
-        'positional arguments:\n'
+        "usage: briefcase [-h] <command> [<platform>] [<format>] ...\n"
+        "\n"
+        "Package Python code for distribution.\n"
+        "\n"
+        "positional arguments:\n"
     )
 
 
 def test_version_only(capsys):
     "``briefcase -V`` returns current version"
     with pytest.raises(SystemExit) as excinfo:
-        parse_cmdline('-V'.split())
+        parse_cmdline("-V".split())
 
     # Normal exit due to displaying help
     assert excinfo.value.code == 0
     # Version is displayed.
     output = capsys.readouterr().out
-    assert output == '{__version__}\n'.format(__version__=__version__)
+    assert output == "{__version__}\n".format(__version__=__version__)
 
 
 def test_show_output_formats_only():
     "``briefcase -f`` returns basic usage as a command is needed"
     with pytest.raises(NoCommandError) as excinfo:
-        parse_cmdline('-f'.split())
+        parse_cmdline("-f".split())
 
     assert excinfo.value.msg.startswith(
-        'usage: briefcase [-h] <command> [<platform>] [<format>] ...\n'
-        '\n'
-        'Package Python code for distribution.\n'
-        '\n'
-        'positional arguments:\n'
+        "usage: briefcase [-h] <command> [<platform>] [<format>] ...\n"
+        "\n"
+        "Package Python code for distribution.\n"
+        "\n"
+        "positional arguments:\n"
     )
 
 
 def test_unknown_command():
     "``briefcase foobar`` fails as an invalid command"
     with pytest.raises(SystemExit) as excinfo:
-        parse_cmdline('foobar'.split())
+        parse_cmdline("foobar".split())
 
     assert excinfo.value.code == 2
-    assert excinfo.value.__context__.argument_name == 'command'
-    assert excinfo.value.__context__.message.startswith("invalid choice: 'foobar' (choose from")
+    assert excinfo.value.__context__.argument_name == "command"
+    assert excinfo.value.__context__.message.startswith(
+        "invalid choice: 'foobar' (choose from"
+    )
 
 
 def test_new_command():
     "``briefcase new`` returns the New command"
-    cmd, options = parse_cmdline('new'.split())
+    cmd, options = parse_cmdline("new".split())
 
     assert isinstance(cmd, NewCommand)
-    assert cmd.platform == 'all'
+    assert cmd.platform == "all"
     assert cmd.output_format is None
-    assert options == {'input_enabled': True, 'template': None, 'verbosity': 1}
+    assert options == {"input_enabled": True, "template": None, "verbosity": 1}
 
 
 def test_dev_command(monkeypatch):
     "``briefcase dev`` returns the Dev command"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
-    cmd, options = parse_cmdline('dev'.split())
+    cmd, options = parse_cmdline("dev".split())
 
     assert isinstance(cmd, DevCommand)
-    assert cmd.platform == 'macOS'
+    assert cmd.platform == "macOS"
     assert cmd.output_format is None
     assert options == {
-        'input_enabled': True,
-        'verbosity': 1,
-        'appname': None,
-        'update_dependencies': False
+        "input_enabled": True,
+        "verbosity": 1,
+        "appname": None,
+        "update_dependencies": False,
     }
 
 
-def test_bare_command(monkeypatch):
+def test_create_command(monkeypatch):
     "``briefcase create`` returns the macOS create app command"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
-    cmd, options = parse_cmdline('create'.split())
+    cmd, options = parse_cmdline("create".split())
 
     assert isinstance(cmd, macOSAppCreateCommand)
-    assert cmd.platform == 'macOS'
-    assert cmd.output_format == 'dmg'
-    assert options == {'input_enabled': True, 'verbosity': 1}
+    assert cmd.platform == "macOS"
+    assert cmd.output_format == "dmg"
+    assert options == {"input_enabled": True, "verbosity": 1}
 
 
-@pytest.mark.skipif(sys.platform != 'linux', reason="requires Linux")
+def test_update_command(monkeypatch):
+    "``briefcase update`` returns the macOS update app command"
+    # Pretend we're on macOS, regardless of where the tests run.
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    cmd, options = parse_cmdline("update".split())
+
+    assert isinstance(cmd, macOSDmgUpdateCommand)
+    assert cmd.platform == "macOS"
+    assert cmd.output_format == "dmg"
+    assert options == {
+        "input_enabled": True,
+        "update_dependencies": False,
+        "update_resources": False,
+        "verbosity": 1,
+    }
+
+
+def test_build_command(monkeypatch):
+    "``briefcase build`` returns the macOS build app command"
+    # Pretend we're on macOS, regardless of where the tests run.
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    cmd, options = parse_cmdline("build".split())
+
+    assert isinstance(cmd, macOSDmgBuildCommand)
+    assert cmd.platform == "macOS"
+    assert cmd.output_format == "dmg"
+    assert options == {"input_enabled": True, "update": False, "verbosity": 1}
+
+
+def test_run_command(monkeypatch):
+    "``briefcase run`` returns the macOS run app command"
+    # Pretend we're on macOS, regardless of where the tests run.
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    cmd, options = parse_cmdline("run".split())
+
+    assert isinstance(cmd, macOSDmgRunCommand)
+    assert cmd.platform == "macOS"
+    assert cmd.output_format == "dmg"
+    assert options == {
+        "appname": None,
+        "input_enabled": True,
+        "update": False,
+        "verbosity": 1,
+    }
+
+
+def test_package_command(monkeypatch):
+    "``briefcase package`` returns the macOS package command"
+    # Pretend we're on macOS, regardless of where the tests run.
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    cmd, options = parse_cmdline("package".split())
+
+    assert isinstance(cmd, macOSDmgPackageCommand)
+    assert cmd.platform == "macOS"
+    assert cmd.output_format == "dmg"
+    assert options == {
+        "identity": None,
+        "input_enabled": True,
+        "sign_app": True,
+        "verbosity": 1,
+    }
+
+
+def test_publish_command(monkeypatch):
+    "``briefcase publish`` returns the macOS publish command"
+    # Pretend we're on macOS, regardless of where the tests run.
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    cmd, options = parse_cmdline("publish".split())
+
+    assert isinstance(cmd, macOSDmgPublishCommand)
+    assert cmd.platform == "macOS"
+    assert cmd.output_format == "dmg"
+    assert options == {"channel": "s3", "input_enabled": True, "verbosity": 1}
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="requires Linux")
 def test_linux_default():
     "``briefcase create`` returns the linux create appimage command on Linux"
 
-    cmd, options = parse_cmdline('create'.split())
+    cmd, options = parse_cmdline("create".split())
 
     assert isinstance(cmd, LinuxAppImageCreateCommand)
-    assert cmd.platform == 'linux'
-    assert cmd.output_format == 'appimage'
-    assert options == {'input_enabled': True, 'verbosity': 1}
+    assert cmd.platform == "linux"
+    assert cmd.output_format == "appimage"
+    assert options == {"input_enabled": True, "verbosity": 1}
 
 
-@pytest.mark.skipif(sys.platform != 'darwin', reason="requires macOS")
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS")
 def test_macOS_default():
     "``briefcase create`` returns the linux create appimage command on Linux"
 
-    cmd, options = parse_cmdline('create'.split())
+    cmd, options = parse_cmdline("create".split())
 
     assert isinstance(cmd, macOSAppCreateCommand)
-    assert cmd.platform == 'macOS'
-    assert cmd.output_format == 'dmg'
-    assert options == {'input_enabled': True, 'verbosity': 1}
+    assert cmd.platform == "macOS"
+    assert cmd.output_format == "dmg"
+    assert options == {"input_enabled": True, "verbosity": 1}
 
 
-@pytest.mark.skipif(sys.platform != 'win32', reason="requires Windows")
+@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows")
 def test_windows_default():
     "``briefcase create`` returns the Windows create msi command on Windows"
 
-    cmd, options = parse_cmdline('create'.split())
+    cmd, options = parse_cmdline("create".split())
 
     assert isinstance(cmd, WindowsMSICreateCommand)
-    assert cmd.platform == 'windows'
-    assert cmd.output_format == 'msi'
-    assert options == {'input_enabled': True, 'verbosity': 1}
+    assert cmd.platform == "windows"
+    assert cmd.output_format == "msi"
+    assert options == {"input_enabled": True, "verbosity": 1}
 
 
 def test_bare_command_help(monkeypatch, capsys):
     "``briefcase create -h`` returns the macOS create app command help"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     with pytest.raises(SystemExit) as excinfo:
-        parse_cmdline('create -h'.split())
+        parse_cmdline("create -h".split())
 
     # Normal exit due to displaying help
     assert excinfo.value.code == 0
@@ -185,75 +271,77 @@ def test_bare_command_help(monkeypatch, capsys):
 def test_bare_command_version(capsys):
     "``briefcase create -V`` returns the version"
     with pytest.raises(SystemExit) as excinfo:
-        parse_cmdline('create -V'.split())
+        parse_cmdline("create -V".split())
 
     # Normal exit due to displaying help
     assert excinfo.value.code == 0
     # Version is displayed.
     output = capsys.readouterr().out
-    assert output == '{__version__}\n'.format(__version__=__version__)
+    assert output == "{__version__}\n".format(__version__=__version__)
 
 
 def test_bare_command_show_formats(monkeypatch):
     "``briefcase create -f`` returns an error indicating a platform is needed"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     with pytest.raises(ShowOutputFormats) as excinfo:
-        parse_cmdline('create -f'.split())
+        parse_cmdline("create -f".split())
 
-    assert excinfo.value.platform == 'macOS'
-    assert excinfo.value.default == 'dmg'
-    assert set(excinfo.value.choices) == {'app', 'dmg', 'homebrew'}
+    assert excinfo.value.platform == "macOS"
+    assert excinfo.value.default == "dmg"
+    assert set(excinfo.value.choices) == {"app", "dmg", "homebrew"}
 
 
 def test_command_unknown_platform(monkeypatch):
     "``briefcase create foobar`` raises an unknown platform error"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     with pytest.raises(SystemExit) as excinfo:
-        parse_cmdline('create foobar'.split())
+        parse_cmdline("create foobar".split())
 
     assert excinfo.value.code == 2
-    assert excinfo.value.__context__.argument_name == 'platform'
-    assert excinfo.value.__context__.message.startswith("invalid choice: 'foobar' (choose from")
+    assert excinfo.value.__context__.argument_name == "platform"
+    assert excinfo.value.__context__.message.startswith(
+        "invalid choice: 'foobar' (choose from"
+    )
 
 
 def test_command_explicit_platform(monkeypatch):
     "``briefcase create linux`` returns linux create app command"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
-    cmd, options = parse_cmdline('create linux'.split())
+    cmd, options = parse_cmdline("create linux".split())
 
     assert isinstance(cmd, LinuxAppImageCreateCommand)
-    assert cmd.platform == 'linux'
-    assert cmd.output_format == 'appimage'
-    assert options == {'input_enabled': True, 'verbosity': 1}
+    assert cmd.platform == "linux"
+    assert cmd.output_format == "appimage"
+    assert options == {"input_enabled": True, "verbosity": 1}
 
 
 def test_command_explicit_platform_case_handling(monkeypatch):
     "``briefcase create macOS`` returns macOS create app command"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     # This is all lower case; the command normalizes to macOS
-    cmd, options = parse_cmdline('create macOS'.split())
+    cmd, options = parse_cmdline("create macOS".split())
 
     assert isinstance(cmd, macOSAppCreateCommand)
-    assert cmd.platform == 'macOS'
-    assert cmd.output_format == 'dmg'
-    assert options == {'input_enabled': True, 'verbosity': 1}
+    assert cmd.platform == "macOS"
+    assert cmd.output_format == "dmg"
+    assert options == {"input_enabled": True, "verbosity": 1}
 
 
 def test_command_explicit_platform_help(monkeypatch, capsys):
     "``briefcase create macOS -h`` returns the macOS create app command help"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     with pytest.raises(SystemExit) as excinfo:
-        parse_cmdline('create macOS -h'.split())
+        parse_cmdline("create macOS -h".split())
 
     # Normal exit due to displaying help
     assert excinfo.value.code == 0
@@ -271,54 +359,54 @@ def test_command_explicit_platform_help(monkeypatch, capsys):
 def test_command_explicit_platform_show_formats(monkeypatch):
     "``briefcase create macOS -f`` shows formats for the platform"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     with pytest.raises(ShowOutputFormats) as excinfo:
-        parse_cmdline('create macOS -f'.split())
+        parse_cmdline("create macOS -f".split())
 
-    assert excinfo.value.platform == 'macOS'
-    assert excinfo.value.default == 'dmg'
-    assert set(excinfo.value.choices) == {'app', 'dmg', 'homebrew'}
+    assert excinfo.value.platform == "macOS"
+    assert excinfo.value.default == "dmg"
+    assert set(excinfo.value.choices) == {"app", "dmg", "homebrew"}
 
 
 def test_command_explicit_format(monkeypatch):
     "``briefcase create macOS dmg`` returns the macOS create dmg command"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
-    cmd, options = parse_cmdline('create macOS dmg'.split())
+    cmd, options = parse_cmdline("create macOS dmg".split())
 
     assert isinstance(cmd, macOSDmgCreateCommand)
-    assert cmd.platform == 'macOS'
-    assert cmd.output_format == 'dmg'
-    assert options == {'input_enabled': True, 'verbosity': 1}
+    assert cmd.platform == "macOS"
+    assert cmd.output_format == "dmg"
+    assert options == {"input_enabled": True, "verbosity": 1}
 
 
 def test_command_unknown_format(monkeypatch):
     "``briefcase create macOS foobar`` returns an invalid format error"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     with pytest.raises(InvalidFormatError):
-        parse_cmdline('create macOS foobar'.split())
+        parse_cmdline("create macOS foobar".split())
 
 
 def test_command_explicit_unsupported_format(monkeypatch):
     "``briefcase create macOS homebrew`` raises an error because the format isn't supported (yet)"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     with pytest.raises(UnsupportedCommandError):
-        parse_cmdline('create macOS homebrew'.split())
+        parse_cmdline("create macOS homebrew".split())
 
 
 def test_command_explicit_format_help(monkeypatch, capsys):
     "``briefcase create macOS dmg -h`` returns the macOS create dmg help"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     with pytest.raises(SystemExit) as excinfo:
-        parse_cmdline('create macOS dmg -h'.split())
+        parse_cmdline("create macOS dmg -h".split())
 
     # Normal exit due to displaying help
     assert excinfo.value.code == 0
@@ -336,54 +424,50 @@ def test_command_explicit_format_help(monkeypatch, capsys):
 def test_command_explicit_format_show_formats(monkeypatch):
     "``briefcase create macOS dmg -f`` shows formats for the platform"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     with pytest.raises(ShowOutputFormats) as excinfo:
-        parse_cmdline('create macOS dmg -f'.split())
+        parse_cmdline("create macOS dmg -f".split())
 
-    assert excinfo.value.platform == 'macOS'
-    assert excinfo.value.default == 'dmg'
-    assert set(excinfo.value.choices) == {'app', 'dmg', 'homebrew'}
+    assert excinfo.value.platform == "macOS"
+    assert excinfo.value.default == "dmg"
+    assert set(excinfo.value.choices) == {"app", "dmg", "homebrew"}
 
 
 def test_command_disable_input(monkeypatch):
     "``briefcase create --no-input`` disables console input"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
-    cmd, options = parse_cmdline('create --no-input'.split())
+    cmd, options = parse_cmdline("create --no-input".split())
 
     assert isinstance(cmd, macOSAppCreateCommand)
-    assert cmd.platform == 'macOS'
-    assert cmd.output_format == 'dmg'
-    assert options == {'input_enabled': False, 'verbosity': 1}
+    assert cmd.platform == "macOS"
+    assert cmd.output_format == "dmg"
+    assert options == {"input_enabled": False, "verbosity": 1}
 
 
 def test_command_options(monkeypatch, capsys):
     "Commands can provide their own arguments"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     # Invoke a command that is known to have it's own custom arguments
     # (In this case, the channel argument for publication)
-    cmd, options = parse_cmdline('publish macos app -c s3'.split())
+    cmd, options = parse_cmdline("publish macos app -c s3".split())
 
     assert isinstance(cmd, macOSAppPublishCommand)
-    assert options == {
-        'input_enabled': True,
-        'verbosity': 1,
-        'channel': 's3'
-    }
+    assert options == {"input_enabled": True, "verbosity": 1, "channel": "s3"}
 
 
 def test_unknown_command_options(monkeypatch, capsys):
     "Commands can provide their own arguments"
     # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     # Invoke a command but provide an option. that isn't defined
     with pytest.raises(SystemExit) as excinfo:
-        parse_cmdline('publish macOS app -x foobar'.split())
+        parse_cmdline("publish macOS app -x foobar".split())
 
     # Normal exit due to displaying help
     assert excinfo.value.code == 2

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -4,7 +4,7 @@ import pytest
 
 from briefcase import __version__
 from briefcase.cmdline import parse_cmdline
-from briefcase.commands import DevCommand, NewCommand, UpdateCommand
+from briefcase.commands import DevCommand, NewCommand
 from briefcase.exceptions import (
     InvalidFormatError,
     NoCommandError,


### PR DESCRIPTION
The reason for this change is that new commands won't need to be added hard-coded to *cmd.py*. Instead, we add each command to a commands list that the function `parse_cmdline` would read the commands from.