### PR TITLE
Windows MSI reference docs: MSIs now install per-user.

### DIFF
--- a/changes/382.doc.rst
+++ b/changes/382.doc.rst
@@ -1,3 +1,1 @@
-Windows MSI reference:
-updated templates produce per-user installable MSI installers,
-while still supporting per-maching installs, via the CLI.
+Documented that Windows MSI builds produce per-user installable MSI installers, while still supporting per-maching installs via the CLI.

--- a/changes/382.doc.rst
+++ b/changes/382.doc.rst
@@ -1,0 +1,3 @@
+Windows MSI reference:
+updated templates produce per-user installable MSI installers,
+while still supporting per-maching installs, via the CLI.

--- a/docs/reference/platforms/windows/msi.rst
+++ b/docs/reference/platforms/windows/msi.rst
@@ -26,3 +26,16 @@ Image format
 ============
 
 MSI installers do not support splash screens or installer images.
+
+
+Features
+========
+
+Briefcase produced MSI installers do not require elevated privileges for installation:
+they default to *per-user* installs.
+*Per-machine* installs can still be obtained, via the CLI, with:
+
+.. code-block::
+
+    > msiexec.exe /i <msi-filename> MSIINSTALLPERUSER=""
+

--- a/docs/reference/platforms/windows/msi.rst
+++ b/docs/reference/platforms/windows/msi.rst
@@ -31,11 +31,10 @@ MSI installers do not support splash screens or installer images.
 Features
 ========
 
-Briefcase produced MSI installers do not require elevated privileges for installation:
-they default to *per-user* installs.
-*Per-machine* installs can still be obtained, via the CLI, with:
+Briefcase produced MSI installers do not require elevated privileges for 
+installation; they default to *per-user* installs. The installer can be
+installed for all users using the CLI, with:
 
 .. code-block::
 
     > msiexec.exe /i <msi-filename> MSIINSTALLPERUSER=""
-


### PR DESCRIPTION
Addressing #382.

Doubts:
* Not sure about the wording "Features".
* Also not sure if it should be the last section.
* Created a `towncrier` change fragment. Went with `docs`. Should it be `feature`? `misc`?
* `tox` is failing the `towncrier-check`. Did not investigate.

Thanks in advance for reviewing. Happy to address suggested improvements.