### PR TITLE
Provide a common representation of an app's sources.

### DIFF
--- a/changes/401.feature.rst
+++ b/changes/401.feature.rst
@@ -1,0 +1,1 @@
+Added a ``PYTHONPATH`` property on ``AppConfig`` that describes the ``sys.path``changes needed to run the app

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -97,13 +97,7 @@ class DevCommand(BaseCommand):
         # Create a shell environment where PYTHONPATH points to the source
         # directories described by the app config.
         env = os.environ.copy()
-        paths = []
-        for app in app.sources:
-            path = app.rsplit('/', 1)[0]
-            if path not in paths:
-                paths.append(path)
-
-        env['PYTHONPATH'] = os.pathsep.join(paths)
+        env['PYTHONPATH'] = os.pathsep.join(app.PYTHONPATH)
         return env
 
     def __call__(

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -156,6 +156,16 @@ class AppConfig(BaseConfig):
         """
         return self.app_name.replace('-', '_')
 
+    @property
+    def PYTHONPATH(self):
+        "The PYTHONPATH modifications needed to run this app."
+        paths = []
+        for source in self.sources:
+            path = source.rsplit('/', 1)[0]
+            if path not in paths:
+                paths.append(path)
+        return paths
+
 
 def merge_config(config, data):
     """

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -11,7 +11,7 @@ def test_minimal_AppConfig():
         version="1.2.3",
         bundle="org.beeware",
         description="A simple app",
-        sources=['src/myapp'],
+        sources=['src/myapp', 'somewhere/else/interesting'],
     )
 
     # The basic properties have been set.
@@ -29,6 +29,10 @@ def test_minimal_AppConfig():
     assert config.icon is None
     assert config.splash is None
 
+    # The PYTHONPATH is derived correctly
+    assert config.PYTHONPATH == ['src', 'somewhere/else']
+
+    # The object has a meaningful REPL
     assert repr(config) == "<org.beeware.myapp v1.2.3 AppConfig>"
 
 


### PR DESCRIPTION
The sources list requires some light pre-processing to be a useful PYTHONPATH, so factor that code into a property on the AppConfig.