### PR TITLE
Add an explicit Docker version check.

### DIFF
--- a/changes/402.bugfix.rst
+++ b/changes/402.bugfix.rst
@@ -1,0 +1,1 @@
+Added an explicit version check for Docker.

--- a/tests/integrations/docker/test_verify_docker.py
+++ b/tests/integrations/docker/test_verify_docker.py
@@ -82,6 +82,19 @@ def test_docker_failure(test_command, capsys):
 def test_docker_bad_version(test_command, capsys):
     "If docker exists but the version string doesn't make sense, the Docker wrapper is returned with a warning."
     # Mock a bad return value of `docker --version`
+    test_command.subprocess.check_output.return_value = "Docker version 17.2\n"
+
+    # Invoke verify_docker
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r'Briefcase requires Docker 19 or higher'
+    ):
+        verify_docker(command=test_command)
+
+
+def test_docker_unknown_version(test_command, capsys):
+    "If docker exists but the version string doesn't make sense, the Docker wrapper is returned with a warning."
+    # Mock a bad return value of `docker --version`
     test_command.subprocess.check_output.return_value = "ceci nest pas un Docker\n"
 
     # Invoke verify_docker


### PR DESCRIPTION
In testing Docker builds on Linux, we discovered that Docker 17 (which I think is the system packaged Docker version on Ubuntu 19.10) isn't sufficient for running briefcase.

This PR adds a version check to ensure Docker is at version 19 or higher.