### PR TITLE
Ensure Docker user UID:GID matches host user UID:GID

### DIFF
--- a/changes/403.bugfix.rst
+++ b/changes/403.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure Dockerfile user matches uid/gid of host user

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -151,6 +151,8 @@ class Docker:
                     "--build-arg", "SYSTEM_REQUIRES={system_requires}".format(
                         system_requires=system_requires
                     ),
+                    "--build-arg", "HOST_UID={uid}".format(uid=self.command.os.getuid()),
+                    "--build-arg", "HOST_GID={gid}".format(gid=self.command.os.getgid()),
                     Path(str(self.command.base_path), *self.app.sources[0].split('/')[:-1])
                 ],
                 check=True,
@@ -173,7 +175,7 @@ class Docker:
             "--volume", "{self.command.platform_path}:/app".format(
                 self=self
             ),
-            "--volume", "{self.command.dot_briefcase_path}:/root/.briefcase".format(
+            "--volume", "{self.command.dot_briefcase_path}:/home/brutus/.briefcase".format(
                 self=self
             ),
         ]
@@ -205,7 +207,7 @@ class Docker:
             elif str(self.command.dot_briefcase_path) in arg:
                 docker_args.append(
                     arg.replace(
-                        str(self.command.dot_briefcase_path), '/root/.briefcase'
+                        str(self.command.dot_briefcase_path), '/home/brutus/.briefcase'
                     )
                 )
             else:

--- a/tests/integrations/docker/conftest.py
+++ b/tests/integrations/docker/conftest.py
@@ -16,6 +16,8 @@ def mock_docker(tmp_path):
     command.dot_briefcase_path = tmp_path / '.briefcase'
     command.docker_image_tag.return_value = 'briefcase/com.example.myapp:py3.X'
     command.python_version_tag = "3.X"
+    command.os.getuid.return_value = "37"
+    command.os.getgid.return_value = "42"
 
     command.subprocess = Subprocess(command)
     command.subprocess._subprocess = MagicMock()

--- a/tests/integrations/docker/test_Docker__prepare.py
+++ b/tests/integrations/docker/test_Docker__prepare.py
@@ -18,6 +18,8 @@ def test_prepare(mock_docker, tmp_path):
             '--file', str(tmp_path / 'bundle' / 'Dockerfile'),
             '--build-arg', "PY_VERSION=3.X",
             '--build-arg', "SYSTEM_REQUIRES=things==1.2 stuff>=3.4",
+            '--build-arg', "HOST_UID=1",
+            '--build-arg', "HOST_GID=1",
             str(tmp_path / "base" / "path" / "to" / "src")
         ],
         check=True,
@@ -42,6 +44,8 @@ def test_prepare_failure(mock_docker, tmp_path):
             '--file', str(tmp_path / 'bundle' / 'Dockerfile'),
             '--build-arg', "PY_VERSION=3.X",
             '--build-arg', "SYSTEM_REQUIRES=things==1.2 stuff>=3.4",
+            '--build-arg', "HOST_UID=1",
+            '--build-arg', "HOST_GID=1",
             str(tmp_path / "base" / "path" / "to" / "src")
         ],
         check=True,

--- a/tests/integrations/docker/test_Docker__prepare.py
+++ b/tests/integrations/docker/test_Docker__prepare.py
@@ -18,8 +18,8 @@ def test_prepare(mock_docker, tmp_path):
             '--file', str(tmp_path / 'bundle' / 'Dockerfile'),
             '--build-arg', "PY_VERSION=3.X",
             '--build-arg', "SYSTEM_REQUIRES=things==1.2 stuff>=3.4",
-            '--build-arg', "HOST_UID=1",
-            '--build-arg', "HOST_GID=1",
+            '--build-arg', "HOST_UID=37",
+            '--build-arg', "HOST_GID=42",
             str(tmp_path / "base" / "path" / "to" / "src")
         ],
         check=True,
@@ -44,8 +44,8 @@ def test_prepare_failure(mock_docker, tmp_path):
             '--file', str(tmp_path / 'bundle' / 'Dockerfile'),
             '--build-arg', "PY_VERSION=3.X",
             '--build-arg', "SYSTEM_REQUIRES=things==1.2 stuff>=3.4",
-            '--build-arg', "HOST_UID=1",
-            '--build-arg', "HOST_GID=1",
+            '--build-arg', "HOST_UID=37",
+            '--build-arg', "HOST_GID=42",
             str(tmp_path / "base" / "path" / "to" / "src")
         ],
         check=True,

--- a/tests/integrations/docker/test_Docker__run.py
+++ b/tests/integrations/docker/test_Docker__run.py
@@ -15,7 +15,7 @@ def test_simple_call(mock_docker, tmp_path, capsys):
             '--volume', '{platform_path}:/app'.format(
                 platform_path=tmp_path / 'platform'
             ),
-            '--volume', '{dot_briefcase_path}:/root/.briefcase'.format(
+            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase'.format(
                 dot_briefcase_path=tmp_path / '.briefcase'
             ),
             'briefcase/com.example.myapp:py3.X',
@@ -38,7 +38,7 @@ def test_simple_call_with_arg(mock_docker, tmp_path, capsys):
             '--volume', '{platform_path}:/app'.format(
                 platform_path=tmp_path / 'platform'
             ),
-            '--volume', '{dot_briefcase_path}:/root/.briefcase'.format(
+            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase'.format(
                 dot_briefcase_path=tmp_path / '.briefcase'
             ),
             'briefcase/com.example.myapp:py3.X',
@@ -62,7 +62,7 @@ def test_simple_call_with_path_arg(mock_docker, tmp_path, capsys):
             '--volume', '{platform_path}:/app'.format(
                 platform_path=tmp_path / 'platform'
             ),
-            '--volume', '{dot_briefcase_path}:/root/.briefcase'.format(
+            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase'.format(
                 dot_briefcase_path=tmp_path / '.briefcase'
             ),
             'briefcase/com.example.myapp:py3.X',
@@ -91,7 +91,7 @@ def test_simple_verbose_call(mock_docker, tmp_path, capsys):
             '--volume', '{platform_path}:/app'.format(
                 platform_path=tmp_path / 'platform'
             ),
-            '--volume', '{dot_briefcase_path}:/root/.briefcase'.format(
+            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase'.format(
                 dot_briefcase_path=tmp_path / '.briefcase'
             ),
             'briefcase/com.example.myapp:py3.X',
@@ -102,7 +102,7 @@ def test_simple_verbose_call(mock_docker, tmp_path, capsys):
     assert capsys.readouterr().out == (
         ">>> docker run --interactive --tty "
         "--volume {platform_path}:/app "
-        "--volume {dot_briefcase_path}:/root/.briefcase "
+        "--volume {dot_briefcase_path}:/home/brutus/.briefcase "
         "briefcase/com.example.myapp:py3.X "
         "hello world\n"
     ).format(

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -205,7 +205,7 @@ def test_build_appimage_with_docker(build_command, first_app_config, tmp_path):
             '--volume', '{platform_path}:/app'.format(
                 platform_path=build_command.platform_path
             ),
-            '--volume', '{dot_briefcase_path}:/root/.briefcase'.format(
+            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase'.format(
                 dot_briefcase_path=build_command.dot_briefcase_path
             ),
             '--env', 'VERSION=0.0.1',


### PR DESCRIPTION
This is a doozy. 

Recent changes to Briefcase included using Docker for ease of ensuring a consistent build environment for linux. Cross-operating system building (building linux on macos) works to a degree, and this Docker-based installation works fine on macos. 

However. 

Differences in implementation details of Docker for Desktop and docker-ce means that when saving computed output in mounted volumes, the owner of the created files differs between environments. 

In macOS (the most tested usecase), this is the local user and their group (for macOS, the user and the group `wheel`, GID 20)
In linux, this is root:root. 

Once the processing is done within the container and computation continues on the host system, the linux build process on linux fails, because there is an ownership issue, given the computed files are owned by root:root

The way to fix this is to ensure that the user being used matches the UID:GID of the host. How? By passing those though in the build args (this PR), and using those values to create a user and optionally group in the Dockerfile (see beeware/briefcase-linux-appimage-template#1). 

Why optionally? Ah, because of that `wheel` issue. Users in linux and macOS are guaranteed [citation needed] to have an ID larger than 500. Except wheel has an ID of 20, which can overload. So, we optionally create the group with the matching ID, but always create the user. In theory the user should always be created. The _name_ of this user/group doesn't matter, as long as the UID/GID match. In our case, we make sure the home directory is reasonable given the username we chose (brutus, group briefcase)

A note for potential future explorers: given this PR uses the current user ID, in a multi-user setup where the same linux system is used by multiple briefcase application developers and Docker image caches are shared, there could potential ownership issues should the base Docker image be used from a cache of a different user with a different UID, hence re-introducing the ownership issue this PR seeks to fix. 


(In all references, macOS is macOS Catalina, linux is Ubuntu 19.04, for the testing of this PR) 