### PR TITLE
allow ad-hoc code signing

### DIFF
--- a/changes/409.feature.rst
+++ b/changes/409.feature.rst
@@ -1,1 +1,1 @@
-Allow ad-hoc code signing on macOS with ``briefcase package -i '-'``
+Allow ad-hoc code signing on macOS with ``briefcase package --adhoc-sign``

--- a/changes/409.feature.rst
+++ b/changes/409.feature.rst
@@ -1,0 +1,1 @@
+Allow ad-hoc code signing on macOS with ``briefcase package -i '-'``

--- a/docs/reference/platforms/macOS/app.rst
+++ b/docs/reference/platforms/macOS/app.rst
@@ -34,7 +34,7 @@ publish
 Don't perform code signing on the ``.app`` bundles.
 
 ``--adhoc-sign``
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 Sign ``.app`` bundles with adhoc identity.
 

--- a/docs/reference/platforms/macOS/app.rst
+++ b/docs/reference/platforms/macOS/app.rst
@@ -33,6 +33,11 @@ publish
 
 Don't perform code signing on the ``.app`` bundles.
 
+``--adhoc-sign``
+~~~~~~~~~~~~~
+
+Sign ``.app`` bundles with adhoc identity.
+
 ``-i <identity>`` / ``--identity <identity>``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/reference/platforms/macOS/dmg.rst
+++ b/docs/reference/platforms/macOS/dmg.rst
@@ -41,7 +41,7 @@ publish
 Don't perform code signing on the ``.app`` bundles in the DMG.
 
 ``--adhoc-sign``
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 Sign ``.app`` bundles with adhoc identity.
 

--- a/docs/reference/platforms/macOS/dmg.rst
+++ b/docs/reference/platforms/macOS/dmg.rst
@@ -40,6 +40,11 @@ publish
 
 Don't perform code signing on the ``.app`` bundles in the DMG.
 
+``--adhoc-sign``
+~~~~~~~~~~~~~
+
+Sign ``.app`` bundles with adhoc identity.
+
 ``-i <identity>`` / ``--identity <identity>``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -108,7 +108,7 @@ class macOSAppPackageCommand(macOSAppMixin, PackageCommand):
         # ad-hoc code signing
         if identity == "-":
             return "-"
-        
+
         # Obtain the valid codesigning identities.
         identities = self.get_identities(self, 'codesigning')
 

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -105,6 +105,10 @@ class macOSAppPackageCommand(macOSAppMixin, PackageCommand):
             confirm that it is a valid codesigning identity.
         :returns: The final identity to use
         """
+        # ad-hoc code signing
+        if identity == "-":
+            return "-"
+        
         # Obtain the valid codesigning identities.
         identities = self.get_identities(self, 'codesigning')
 

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -87,17 +87,17 @@ class macOSAppPackageCommand(macOSAppMixin, PackageCommand):
             action='store_false',
         )
         parser.add_argument(
+            '--adhoc-sign',
+            help='Sign .app bundles with adhoc identity.',
+            action='store_true',
+        )
+        parser.add_argument(
             '-i',
             '--identity',
             dest='identity',
             help='The code signing identity to use; either the 40-digit hex '
                  'checksum, or the full name of the identity.',
             required=False,
-        )
-        parser.add_argument(
-            '--adhoc-sign',
-            help='Sign .app bundles with adhoc identity',
-            action='store_true',
         )
 
     def select_identity(self, identity=None):
@@ -173,8 +173,8 @@ class macOSAppPackageCommand(macOSAppMixin, PackageCommand):
             )
 
     def package_app(
-            self, app: BaseConfig, sign_app=True, identity=None, adhoc_sign=False, **kwargs
-        ):
+        self, app: BaseConfig, sign_app=True, identity=None, adhoc_sign=False, **kwargs
+    ):
         """
         Prepare the .app bundle for distribution.
 

--- a/tests/platforms/macOS/app/test_package.py
+++ b/tests/platforms/macOS/app/test_package.py
@@ -81,3 +81,19 @@ def test_package_app_no_sign(first_app_with_binaries, tmp_path):
     # No code signing has been performed.
     assert command.select_identity.call_count == 0
     assert command.subprocess.run.call_count == 0
+
+
+def test_package_app_adhoc_sign(first_app_with_binaries, tmp_path):
+    "A macOS App can be packaged and signed with adhoc identity"
+
+    command = macOSAppPackageCommand(base_path=tmp_path)
+    command.subprocess = mock.MagicMock()
+
+    command.select_identity = mock.MagicMock(return_value="Sekrit identity (DEADBEEF)")
+
+    command.package_app(first_app_with_binaries, adhoc_sign=True)
+
+    # the select_identity method has not been used
+    assert command.select_identity.call_count == 0
+    # but code signing has been performed with "--sign -"
+    assert command.subprocess.run.call_args[0][0][1:3] == ["--sign", "-"]


### PR DESCRIPTION
Curious whether you would allow this?  I know that ad-hoc signing has significant limitations, but it can be slightly more useful than no code-signing during app development.