### PR TITLE
New app wizard should use template to generate questions for user input

### DIFF
--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 import requests
 from cookiecutter.main import cookiecutter
 from cookiecutter.repository import is_repo_url
+from cookiecutter.vcs import clone
 
 from briefcase import __version__, integrations
 from briefcase.config import AppConfig, GlobalConfig, parse_config
@@ -482,6 +483,10 @@ class BaseCommand(ABC):
             # fall back to using the specified template directly.
             try:
                 cached_template = cookiecutter_cache_path(template)
+                if not cached_template.exists():
+                    print('Fetching the template...')
+                    clone(template, checkout=branch,
+                          clone_to_dir=cached_template.parent)
                 repo = self.git.Repo(cached_template)
                 try:
                     # Attempt to update the repository

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -11,7 +11,7 @@ import json
 from briefcase.config import PEP508_NAME_RE
 from briefcase.exceptions import NetworkFailure
 
-from .base import BaseCommand, BriefcaseCommandError
+from .base import BaseCommand, BriefcaseCommandError, cookiecutter_cache_path
 from .create import InvalidTemplateRepository
 
 VALID_BUNDLE_RE = re.compile(r'[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+$')
@@ -365,8 +365,9 @@ Select one of the following:
 
         :returns:
             Default dictionary of keys/values for cookiecutter,
-            Optional dictionary 
+            plus dictionary of extra explanation for cookiecutter parameters.
         """
+        cached_template = cookiecutter_cache_path(cached_template)
         # Make a dictionary of default cookicutter values
         with open(Path(cached_template) / "cookiecutter.json") as f:
             defaults = json.loads(f.read())

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -452,6 +452,11 @@ What GUI toolkit do you want to use for this project?""",
         if template is None:
             template = 'https://github.com/beeware/briefcase-template'
 
+        cached_template = self.update_cookiecutter_cache(
+            template=template,
+            branch='v0.3'
+        )
+
         if self.input.enabled:
             print()
             print("Let's build a new Briefcase app!")
@@ -463,11 +468,6 @@ What GUI toolkit do you want to use for this project?""",
         print("Generating a new application '{formal_name}'".format(
             **context
         ))
-
-        cached_template = self.update_cookiecutter_cache(
-            template=template,
-            branch='v0.3'
-        )
 
         # Make extra sure we won't clobber an existing application.
         if (self.base_path / context['app_name']).exists():

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -313,12 +313,15 @@ Select one of the following:
             content = f.read()
         defaults = json.loads(content)
 
-        with open(template/'cookiecutter_context.json') as f:
-            content = f.read()
-        explanation = json.loads(content)
-        # Join JSON multiline arrays into single strings
-        for key in explanation:
-            explanation[key] = "".join(explanation[key])
+        if (template/'cookiecutter_context.json').is_file():
+            with open(template/'cookiecutter_context.json') as f:
+                content = f.read()
+            explanation = json.loads(content)
+            # Join JSON multiline arrays into single strings
+            for key in explanation:
+                explanation[key] = "".join(explanation[key])
+        else:
+            explanation = {}
 
         validators = {
             'bundle': self.validate_bundle,

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -117,14 +117,13 @@ class NewCommand(BaseCommand):
 
         return True
 
-    def make_module_name(self, formal_name):
+    def make_module_name(self, app_name):
         """
         Construct a valid module name from an app name.
 
         :param formal_name: The app name
         :returns: The app's module name.
         """
-        app_name = self.make_app_name(formal_name)
         module_name = app_name.replace('-', '_')
         return module_name
 

--- a/tests/commands/new/test_build_app_context.py
+++ b/tests/commands/new/test_build_app_context.py
@@ -1,54 +1,87 @@
+import pytest
 
-def test_question_sequence(new_command):
+
+@pytest.fixture
+def defaults():
+    """Default dictionary reflecting briefcase-template cookiecutter.json"""
+    defaults = {
+        "formal_name": "Hello World",
+        "app_name": "helloworld",
+        "class_name": "HelloWorld",
+        "module_name": "helloworld",
+        "project_name": "Project Awesome",
+        "description": "An app that does lots of stuff",
+        "author": "Jane Developer",
+        "author_email": "jane@example.com",
+        "bundle": "com.example",
+        "url": "https://example.com",
+        "license": [
+            "BSD license",
+            "MIT license",
+            "Apache Software License",
+            "GNU General Public License v2 (GPLv2)",
+            "GNU General Public License v2 or later (GPLv2+)",
+            "GNU General Public License v3 (GPLv3)",
+            "GNU General Public License v3 or later (GPLv3+)",
+            "Proprietary",
+            "Other",
+        ],
+        "gui_framework": ["Toga", "PySide2", "PursuedPyBear", "None"],
+    }
+    return defaults
+
+
+def test_question_sequence(new_command, defaults):
     "Questions are asked, a context is constructed."
 
     # Prime answers for all the questions.
     new_command.input.values = [
         'My Application',  # formal name
         '',  # app name - accept the default
-        'org.beeware',  # bundle ID
+        '',  # class name - accept the default
+        '',  # module name - accept the default
         'My Project',  # project name
         'Cool stuff',  # description
         'Grace Hopper',  # author
         'grace@navy.mil',  # author email
+        'org.beeware',  # bundle ID
         'https://navy.mil/myapplication',  # URL
         '4',  # license
         '1',  # GUI toolkit
     ]
 
-    assert new_command.build_app_context() == {
+    assert new_command.build_app_context(defaults) == {
         'formal_name': 'My Application',
-        'class_name': 'MyApplication',
         'app_name': 'myapplication',
-        'module_name': 'myapplication',
-        'bundle': 'org.beeware',
         'class_name': 'MyApplication',
+        'module_name': 'myapplication',
         'project_name': 'My Project',
         'description': 'Cool stuff',
         'author': 'Grace Hopper',
         'author_email': 'grace@navy.mil',
+        'bundle': 'org.beeware',
         'url': 'https://navy.mil/myapplication',
         'license': 'GNU General Public License v2 (GPLv2)',
         'gui_framework': 'Toga',
     }
 
 
-def test_question_sequence_with_no_user_input(new_command):
+def test_question_sequence_with_no_user_input(new_command, defaults):
     "If no user input is provided, all user inputs are taken as default"
 
     new_command.input.enabled = False
 
-    assert new_command.build_app_context() == {
+    assert new_command.build_app_context(defaults) == {
+        'formal_name': 'Hello World',
         'app_name': 'helloworld',
+        'class_name': 'HelloWorld',
+        'module_name': 'helloworld',
+        'project_name': 'Project Awesome',
+        'description': 'An app that does lots of stuff',
         'author': 'Jane Developer',
         'author_email': 'jane@example.com',
         'bundle': 'com.example',
-        'class_name': 'HelloWorld',
-        'description': 'My first application',
-        'formal_name': 'Hello World',
-        'gui_framework': 'Toga',
+        'url': 'https://example.com',
         'license': 'BSD license',
-        'module_name': 'helloworld',
-        'project_name': 'Hello World',
-        'url': 'https://example.com/helloworld'
+        'gui_framework': 'Toga',
     }

--- a/tests/commands/new/test_new_app.py
+++ b/tests/commands/new/test_new_app.py
@@ -11,7 +11,37 @@ def new_command(tmp_path):
     return NewCommand(base_path=tmp_path)
 
 
-def test_new_app(new_command, tmp_path):
+@pytest.fixture
+def defaults():
+    """Default dictionary reflecting briefcase-template cookiecutter.json"""
+    defaults = {
+        "formal_name": "Hello World",
+        "app_name": "helloworld",
+        "class_name": "HelloWorld",
+        "module_name": "helloworld",
+        "project_name": "Project Awesome",
+        "description": "An app that does lots of stuff",
+        "author": "Jane Developer",
+        "author_email": "jane@example.com",
+        "bundle": "com.example",
+        "url": "https://example.com",
+        "license": [
+            "BSD license",
+            "MIT license",
+            "Apache Software License",
+            "GNU General Public License v2 (GPLv2)",
+            "GNU General Public License v2 or later (GPLv2+)",
+            "GNU General Public License v3 (GPLv3)",
+            "GNU General Public License v3 or later (GPLv3+)",
+            "Proprietary",
+            "Other",
+        ],
+        "gui_framework": ["Toga", "PySide2", "PursuedPyBear", "None"],
+    }
+    return defaults
+
+
+def test_new_app(new_command, tmp_path, defaults):
     "A new app can be created with the default template"
     app_context = {
         'formal_name': 'My Application',
@@ -22,18 +52,19 @@ def test_new_app(new_command, tmp_path):
     new_command.update_cookiecutter_cache = mock.MagicMock(
         return_value='~/.cookiecutters/briefcase-template'
     )
+    new_command.default_dictionary = mock.MagicMock(return_value=(defaults, {}))
     new_command.cookiecutter = mock.MagicMock()
 
     # Create the new app, using the default template.
     new_command.new_app()
 
-    # App context is constructed
-    new_command.build_app_context.assert_called_with()
     # Template is updated
     new_command.update_cookiecutter_cache.assert_called_with(
         template='https://github.com/beeware/briefcase-template',
         branch='v0.3',
     )
+    # App context is constructed
+    new_command.build_app_context.assert_called_with(defaults=defaults, explanation={})
     # Cookiecutter is invoked
     new_command.cookiecutter.assert_called_with(
         '~/.cookiecutters/briefcase-template',
@@ -44,7 +75,7 @@ def test_new_app(new_command, tmp_path):
     )
 
 
-def test_new_app_with_template(new_command, tmp_path):
+def test_new_app_with_template(new_command, tmp_path, defaults):
     "A specific template can be requested"
     app_context = {
         'formal_name': 'My Application',
@@ -55,18 +86,19 @@ def test_new_app_with_template(new_command, tmp_path):
     new_command.update_cookiecutter_cache = mock.MagicMock(
         return_value='https://example.com/other.git'
     )
+    new_command.default_dictionary = mock.MagicMock(return_value=(defaults, {}))
     new_command.cookiecutter = mock.MagicMock()
 
     # Create a new app, with a specific template.
     new_command.new_app(template='https://example.com/other.git')
 
-    # App context is constructed
-    new_command.build_app_context.assert_called_with()
     # Template is updated
     new_command.update_cookiecutter_cache.assert_called_with(
         template='https://example.com/other.git',
         branch='v0.3',
     )
+    # App context is constructed
+    new_command.build_app_context.assert_called_with(defaults=defaults, explanation={})
     # Cookiecutter is invoked
     new_command.cookiecutter.assert_called_with(
         'https://example.com/other.git',
@@ -77,7 +109,7 @@ def test_new_app_with_template(new_command, tmp_path):
     )
 
 
-def test_abort_if_directory_exists(new_command, tmp_path):
+def test_abort_if_directory_exists(new_command, tmp_path, defaults):
     "If the application name directory exists, the create aborts"
     # Create a colliding app name.
     (tmp_path / 'myapplication').mkdir()
@@ -91,6 +123,7 @@ def test_abort_if_directory_exists(new_command, tmp_path):
     new_command.update_cookiecutter_cache = mock.MagicMock(
         return_value='~/.cookiecutters/briefcase-template'
     )
+    new_command.default_dictionary = mock.MagicMock(return_value=(defaults, {}))
     new_command.cookiecutter = mock.MagicMock()
 
     # Create the new app, using the default template.
@@ -98,12 +131,12 @@ def test_abort_if_directory_exists(new_command, tmp_path):
     with pytest.raises(BriefcaseCommandError):
         new_command.new_app()
 
-    # App context is constructed
-    new_command.build_app_context.assert_called_with()
     # Template is updated
     new_command.update_cookiecutter_cache.assert_called_with(
         template='https://github.com/beeware/briefcase-template',
         branch='v0.3',
     )
+    # App context is constructed
+    new_command.build_app_context.assert_called_with(defaults=defaults, explanation={})
     # Cookiecutter was *not* invoked
     new_command.cookiecutter.call_count == 0


### PR DESCRIPTION
Closes https://github.com/beeware/briefcase/issues/392

This PR attempts to derive the questions & answer options for the `briefcase new` app wizard from the cookiecutter template, instead of hard coding these.

It does this by reading the `cookiecutter.json` file that is cached to disk into a python dictionary, then iterating through all the keys in order to build the app context. Validation functions and other special handling functions are also stored in dictionaries, and used if there is a match between keys.
