### PR TITLE
Create `package_name` template property

### DIFF
--- a/changes/415.feature.rst
+++ b/changes/415.feature.rst
@@ -1,0 +1,1 @@
+Allow Android apps to use ``-`` in their bundle name; we now convert those to ``_`` in the resulting Android package identifier and Java package name.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -323,7 +323,7 @@ class CreateCommand(BaseCommand):
         extra_context.update({
             # Transformations of explicit properties into useful forms
             'module_name': app.module_name,
-            'bundle_as_identifier': app.bundle_as_identifier,
+            'package_name': app.package_name,
 
             # Properties that are a function of the execution
             'year': date.today().strftime('%Y'),

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -323,6 +323,7 @@ class CreateCommand(BaseCommand):
         extra_context.update({
             # Transformations of explicit properties into useful forms
             'module_name': app.module_name,
+            'bundle_as_identifier': app.bundle_as_identifier,
 
             # Properties that are a function of the execution
             'year': date.today().strftime('%Y'),

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -157,7 +157,7 @@ class AppConfig(BaseConfig):
         return self.app_name.replace('-', '_')
 
     @property
-    def bundle_as_identifier(self):
+    def package_name(self):
         """
         The bundle name of the app, with `-` replaced with `_` to create
         something that can be used a namespace identifier on Python or Java,

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -157,6 +157,15 @@ class AppConfig(BaseConfig):
         return self.app_name.replace('-', '_')
 
     @property
+    def bundle_as_identifier(self):
+        """
+        The bundle name of the app, with `-` replaced with `_` to create
+        something that can be used a namespace identifier on Python or Java,
+        similar to `module_name`.
+        """
+        return self.bundle.replace('-', '_')
+
+    @property
     def PYTHONPATH(self):
         "The PYTHONPATH modifications needed to run this app."
         paths = []

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -148,9 +148,9 @@ class GradleRunCommand(GradleMixin, RunCommand):
         # Create an ADB wrapper for the selected device
         adb = self.android_sdk.adb(device=device)
 
-        # Compute Android package name based on beeware `bundle` and `app_name`
-        # app properties, similar to iOS.
-        package = "{app.bundle}.{app.app_name}".format(app=app)
+        # Compute Android package name. The Android template uses
+        # `bundle_as_identifier` and `module_name`, so we use those here as well.
+        package = "{app.bundle_as_identifier}.{app.module_name}".format(app=app)
 
         # We force-stop the app to ensure the activity launches freshly.
         print()

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -149,8 +149,8 @@ class GradleRunCommand(GradleMixin, RunCommand):
         adb = self.android_sdk.adb(device=device)
 
         # Compute Android package name. The Android template uses
-        # `bundle_as_identifier` and `module_name`, so we use those here as well.
-        package = "{app.bundle_as_identifier}.{app.module_name}".format(app=app)
+        # `package_name` and `module_name`, so we use those here as well.
+        package = "{app.package_name}.{app.module_name}".format(app=app)
 
         # We force-stop the app to ensure the activity launches freshly.
         print()

--- a/tests/commands/create/test_generate_app_template.py
+++ b/tests/commands/create/test_generate_app_template.py
@@ -31,7 +31,7 @@ def full_context(extra):
 
         # Fields generated from other properties
         'module_name': 'my_app',
-        'bundle_as_identifier': 'com.example',
+        'package_name': 'com.example',
 
         # Date-based fields added at time of generation
         'year': date.today().strftime('%Y'),

--- a/tests/commands/create/test_generate_app_template.py
+++ b/tests/commands/create/test_generate_app_template.py
@@ -31,6 +31,7 @@ def full_context(extra):
 
         # Fields generated from other properties
         'module_name': 'my_app',
+        'bundle_as_identifier': 'com.example',
 
         # Date-based fields added at time of generation
         'year': date.today().strftime('%Y'),

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -177,6 +177,25 @@ def test_module_name(name, module_name):
 
 
 @pytest.mark.parametrize(
+    'bundle, bundle_as_identifier',
+    [
+        ('com.example', 'com.example'),
+        ('com.ex-ample', 'com.ex_ample'),
+    ]
+)
+def test_bundle_as_identifier(bundle, bundle_as_identifier):
+    config = AppConfig(
+        app_name="myapp",
+        version="1.2.3",
+        bundle=bundle,
+        description="A simple app",
+        sources=['src/myapp']
+    )
+
+    assert config.bundle_as_identifier == bundle_as_identifier
+
+
+@pytest.mark.parametrize(
     'sources',
     [
         ['src/dupe', 'src/dupe'],

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -177,13 +177,13 @@ def test_module_name(name, module_name):
 
 
 @pytest.mark.parametrize(
-    'bundle, bundle_as_identifier',
+    'bundle, package_name',
     [
         ('com.example', 'com.example'),
         ('com.ex-ample', 'com.ex_ample'),
     ]
 )
-def test_bundle_as_identifier(bundle, bundle_as_identifier):
+def test_package_name(bundle, package_name):
     config = AppConfig(
         app_name="myapp",
         version="1.2.3",
@@ -192,7 +192,7 @@ def test_bundle_as_identifier(bundle, bundle_as_identifier):
         sources=['src/myapp']
     )
 
-    assert config.bundle_as_identifier == bundle_as_identifier
+    assert config.package_name == package_name
 
 
 @pytest.mark.parametrize(

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -32,7 +32,7 @@ def test_run_existing_device(run_command, first_app_config):
         return_value=("exampleDevice", 'ExampleDevice', None)
     )
     # Set up app config to have a `-` in the `bundle`, to ensure it gets
-    # normalized into a `_` via `bundle_as_identifier`.
+    # normalized into a `_` via `package_name`.
     first_app_config.bundle = 'com.ex-ample'
 
     # Invoke run_app
@@ -51,12 +51,12 @@ def test_run_existing_device(run_command, first_app_config):
         run_command.binary_path(first_app_config)
     )
     run_command.mock_adb.force_stop_app.assert_called_once_with(
-        "{first_app_config.bundle_as_identifier}.{first_app_config.module_name}".format(
+        "{first_app_config.package_name}.{first_app_config.module_name}".format(
             first_app_config=first_app_config
         ),
     )
     run_command.mock_adb.start_app.assert_called_once_with(
-        "{first_app_config.bundle_as_identifier}.{first_app_config.module_name}".format(
+        "{first_app_config.package_name}.{first_app_config.module_name}".format(
             first_app_config=first_app_config
         ),
         "org.beeware.android.MainActivity",

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -31,6 +31,9 @@ def test_run_existing_device(run_command, first_app_config):
     run_command.android_sdk.select_target_device = MagicMock(
         return_value=("exampleDevice", 'ExampleDevice', None)
     )
+    # Set up app config to have a `-` in the `bundle`, to ensure it gets
+    # normalized into a `_` via `bundle_as_identifier`.
+    first_app_config.bundle = 'com.ex-ample'
 
     # Invoke run_app
     run_command.run_app(first_app_config, device_or_avd="exampleDevice")
@@ -48,12 +51,12 @@ def test_run_existing_device(run_command, first_app_config):
         run_command.binary_path(first_app_config)
     )
     run_command.mock_adb.force_stop_app.assert_called_once_with(
-        "{first_app_config.bundle}.{first_app_config.app_name}".format(
+        "{first_app_config.bundle_as_identifier}.{first_app_config.module_name}".format(
             first_app_config=first_app_config
         ),
     )
     run_command.mock_adb.start_app.assert_called_once_with(
-        "{first_app_config.bundle}.{first_app_config.app_name}".format(
+        "{first_app_config.bundle_as_identifier}.{first_app_config.module_name}".format(
             first_app_config=first_app_config
         ),
         "org.beeware.android.MainActivity",


### PR DESCRIPTION
This allows the Android template to rely on briefcase to convert
`-` in bundles into `_`, allowing them to be used as Android app
identifiers and Java package identifiers.

This addresses a problem where apps with `-` in their `bundle`
name, e.g., TravelTips, would not launch properly with the
briefcase Android tooling.

## Testing performed

On my own helloworld app, I changed the `bundle` in `pyproject.toml` to include a `-` character. Before this change, the app would not launch. After this change, it does.

Note that this also requires a corresponding change in the Android template.