### PR TITLE
Rely on Android device model, in device list

### DIFF
--- a/changes/433.feature.rst
+++ b/changes/433.feature.rst
@@ -1,0 +1,1 @@
+Use Android device model name and unique ID in ``briefcase run android`` list so that e.g. a Pixel 3A shows up as "Pixel_3a (adbDeviceId)".

--- a/changes/433.feature.rst
+++ b/changes/433.feature.rst
@@ -1,1 +1,3 @@
 Use Android device model name and unique ID in ``briefcase run android`` list so that e.g. a Pixel 3A shows up as "Pixel_3a (adbDeviceId)".
+
+For virtual devices, always give them a name starting with "emulator", followed by the AVD name and optionally device model in parentheses.

--- a/changes/433.feature.rst
+++ b/changes/433.feature.rst
@@ -1,3 +1,3 @@
-Use Android device model name and unique ID in ``briefcase run android`` list so that e.g. a Pixel 3A shows up as "Pixel_3a (adbDeviceId)".
-
-For virtual devices, always give them a name starting with the emulator AVD name prefixed by "@", followed the device model (if available) and the word "emulator" in parentheses.
+The device list returned by ``briefcase run android`` now uses the Android
+device model name and unique ID e.g. a Pixel 3a shows up as ``Pixel 3a
+(adbDeviceId)``.

--- a/changes/433.feature.rst
+++ b/changes/433.feature.rst
@@ -1,3 +1,3 @@
 Use Android device model name and unique ID in ``briefcase run android`` list so that e.g. a Pixel 3A shows up as "Pixel_3a (adbDeviceId)".
 
-For virtual devices, always give them a name starting with "emulator", followed by the AVD name and optionally device model in parentheses.
+For virtual devices, always give them a name starting with the emulator AVD name prefixed by "@", followed the device model (if available) and the word "emulator" in parentheses.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -377,8 +377,8 @@ class AndroidSDK:
             if avd:
                 # It's a running emulator
                 running_avds[avd] = d
-                full_name = "@{avd} ({name} emulator)".format(
-                    avd=avd, name=name,
+                full_name = "@{avd} (running emulator)".format(
+                    avd=avd,
                 )
                 choices.append((d, full_name))
 
@@ -689,8 +689,8 @@ find this page helpful in diagnosing emulator problems.
                             # Found an active device that matches
                             # the AVD we are starting.
                             name = details["name"]
-                            full_name = "@{avd} ({name} emulator)".format(
-                                avd=avd, name=name,
+                            full_name = "@{avd} (running emulator)".format(
+                                avd=avd,
                             )
                             break
                         else:

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -688,7 +688,6 @@ find this page helpful in diagnosing emulator problems.
                         if device_avd == avd:
                             # Found an active device that matches
                             # the AVD we are starting.
-                            name = details["name"]
                             full_name = "@{avd} (running emulator)".format(
                                 avd=avd,
                             )

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -320,7 +320,7 @@ class AndroidSDK:
                         details[key] = value
 
                     if parts[1] == "device":
-                        name = details["model"]
+                        name = details["model"].replace("_", " ")
                         authorized = True
                     elif parts[1] == "offline":
                         name = "Unknown device (offline)"

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -377,7 +377,7 @@ class AndroidSDK:
             if avd:
                 # It's a running emulator
                 running_avds[avd] = d
-                full_name = "@{avd} ({name} emulator)".format(
+                full_name = "emulator (@{avd} {name})".format(
                     avd=avd, name=name,
                 )
                 choices.append((d, full_name))

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -377,7 +377,7 @@ class AndroidSDK:
             if avd:
                 # It's a running emulator
                 running_avds[avd] = d
-                full_name = "emulator (@{avd} {name})".format(
+                full_name = "@{avd} ({name} emulator)".format(
                     avd=avd, name=name,
                 )
                 choices.append((d, full_name))
@@ -397,7 +397,7 @@ class AndroidSDK:
         # Add any non-running emulator AVDs to the list of candidate devices
         for avd in self.emulators():
             if avd not in running_avds:
-                name = "emulator (@{avd})".format(avd=avd)
+                name = "@{avd} (emulator)".format(avd=avd)
                 choices.append(("@" + avd, name))
                 device_choices["@" + avd] = name
 

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -320,7 +320,7 @@ class AndroidSDK:
                         details[key] = value
 
                     if parts[1] == "device":
-                        name = details["device"]
+                        name = details["model"]
                         authorized = True
                     elif parts[1] == "offline":
                         name = "Unknown device (offline)"
@@ -390,13 +390,14 @@ class AndroidSDK:
                 device_choices["@" + avd] = full_name
             else:
                 # It's a physical device (might be disabled)
-                choices.append((d, name))
-                device_choices[d] = name
+                full_name = "{name} ({d})".format(name=name, d=d)
+                choices.append((d, full_name))
+                device_choices[d] = full_name
 
         # Add any non-running emulator AVDs to the list of candidate devices
         for avd in self.emulators():
             if avd not in running_avds:
-                name = "@{avd} (emulator)".format(avd=avd)
+                name = "emulator (@{avd})".format(avd=avd)
                 choices.append(("@" + avd, name))
                 device_choices["@" + avd] = name
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_devices.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_devices.py
@@ -26,7 +26,7 @@ def test_one_emulator(mock_sdk):
 
     assert mock_sdk.devices() == {
         'emulator-5554': {
-            'name': 'generic_x86',
+            'name': 'Android_SDK_built_for_x86',
             'authorized': True,
         },
     }
@@ -46,7 +46,7 @@ def test_multiple_devices(mock_sdk):
             'authorized': True,
         },
         'emulator-5554': {
-            'name': 'generic_x86',
+            'name': 'Android_SDK_built_for_x86',
             'authorized': True,
         },
         'emulator-5556': {

--- a/tests/integrations/android_sdk/AndroidSDK/test_devices.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_devices.py
@@ -26,7 +26,7 @@ def test_one_emulator(mock_sdk):
 
     assert mock_sdk.devices() == {
         'emulator-5554': {
-            'name': 'Android_SDK_built_for_x86',
+            'name': 'Android SDK built for x86',
             'authorized': True,
         },
     }
@@ -42,11 +42,11 @@ def test_multiple_devices(mock_sdk):
             'authorized': False,
         },
         'KABCDABCDA1513': {
-            'name': 'Kogan_Agora_9',
+            'name': 'Kogan Agora 9',
             'authorized': True,
         },
         'emulator-5554': {
-            'name': 'Android_SDK_built_for_x86',
+            'name': 'Android SDK built for x86',
             'authorized': True,
         },
         'emulator-5556': {

--- a/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
@@ -23,11 +23,11 @@ def mock_sdk(tmp_path):
             'authorized': False,
         },
         'KABCDABCDA1513': {
-            'name': 'Kogan_Agora_9',
+            'name': 'Kogan Agora 9',
             'authorized': True,
         },
         'emulator-5554': {
-            'name': 'generic_x86',
+            'name': 'Android SDK built for x86',
             'authorized': True,
         },
     })
@@ -59,7 +59,7 @@ def test_explicit_device(mock_sdk):
 
     # Physical running device, so no AVD
     assert device == 'KABCDABCDA1513'
-    assert name == 'Kogan_Agora_9 (KABCDABCDA1513)'
+    assert name == 'Kogan Agora 9 (KABCDABCDA1513)'
     assert avd is None
 
     # No input was requested
@@ -85,7 +85,7 @@ def test_explicit_running_emulator_by_id(mock_sdk):
 
     # Emulator is running, so there is a device ID
     assert device == 'emulator-5554'
-    assert name == '@runningEmulator (generic_x86 emulator)'
+    assert name == '@runningEmulator (running emulator)'
     assert avd == "runningEmulator"
 
     # No input was requested
@@ -100,7 +100,7 @@ def test_explicit_running_emulator_by_avd(mock_sdk):
 
     # Emulator is running, so there is a device ID
     assert device == 'emulator-5554'
-    assert name == '@runningEmulator (generic_x86 emulator)'
+    assert name == '@runningEmulator (running emulator)'
     assert avd == "runningEmulator"
 
     # No input was requested
@@ -147,14 +147,14 @@ def test_explicit_invalid_avd(mock_sdk):
 def test_select_device(mock_sdk, capsys):
     "If the user manually selects a physical device, details are returned"
     # Mock the user input
-    mock_sdk.command.input.values = ["1"]
+    mock_sdk.command.input.values = ["2"]
 
     # Run the selection with no pre-existing choice
     device, name, avd = mock_sdk.select_target_device(None)
 
     # Physical running device, so no AVD
     assert device == 'KABCDABCDA1513'
-    assert name == 'Kogan_Agora_9 (KABCDABCDA1513)'
+    assert name == 'Kogan Agora 9 (KABCDABCDA1513)'
     assert avd is None
 
     # The user was asked to select a device
@@ -168,7 +168,7 @@ def test_select_device(mock_sdk, capsys):
 def test_select_unauthorized_device(mock_sdk):
     "If the user manually selects an unauthorized running device, an error is raised"
     # Mock the user input
-    mock_sdk.command.input.values = ['2']
+    mock_sdk.command.input.values = ['3']
 
     # Run the selection with no pre-existing choice
     with pytest.raises(AndroidDeviceNotAuthorized):
@@ -178,14 +178,14 @@ def test_select_unauthorized_device(mock_sdk):
 def test_select_running_emulator(mock_sdk, capsys):
     "If the user manually selects a running emulator, details are returned"
     # Mock the user input
-    mock_sdk.command.input.values = ['3']
+    mock_sdk.command.input.values = ['1']
 
     # Run the selection with no pre-existing choice
     device, name, avd = mock_sdk.select_target_device(None)
 
     # Emulator is running, so there is a device ID
     assert device == 'emulator-5554'
-    assert name == '@runningEmulator (generic_x86 emulator)'
+    assert name == '@runningEmulator (running emulator)'
     assert avd == "runningEmulator"
 
     # A re-run prompt has been provided
@@ -268,7 +268,7 @@ def test_input_disabled_one_device(mock_sdk):
     # Set up a single device.
     mock_sdk.devices = MagicMock(return_value={
         'KABCDABCDA1513': {
-            'name': 'Kogan_Agora_9',
+            'name': 'Kogan Agora 9',
             'authorized': True,
         },
     })
@@ -279,7 +279,7 @@ def test_input_disabled_one_device(mock_sdk):
 
     # The only device is returned
     assert device == 'KABCDABCDA1513'
-    assert name == "Kogan_Agora_9 (KABCDABCDA1513)"
+    assert name == "Kogan Agora 9 (KABCDABCDA1513)"
     assert avd is None
 
     # No input was requested

--- a/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
@@ -85,7 +85,7 @@ def test_explicit_running_emulator_by_id(mock_sdk):
 
     # Emulator is running, so there is a device ID
     assert device == 'emulator-5554'
-    assert name == '@runningEmulator (generic_x86 emulator)'
+    assert name == 'emulator (@runningEmulator generic_x86)'
     assert avd == "runningEmulator"
 
     # No input was requested
@@ -100,7 +100,7 @@ def test_explicit_running_emulator_by_avd(mock_sdk):
 
     # Emulator is running, so there is a device ID
     assert device == 'emulator-5554'
-    assert name == '@runningEmulator (generic_x86 emulator)'
+    assert name == 'emulator (@runningEmulator generic_x86)'
     assert avd == "runningEmulator"
 
     # No input was requested
@@ -185,7 +185,7 @@ def test_select_running_emulator(mock_sdk, capsys):
 
     # Emulator is running, so there is a device ID
     assert device == 'emulator-5554'
-    assert name == '@runningEmulator (generic_x86 emulator)'
+    assert name == 'emulator (@runningEmulator generic_x86)'
     assert avd == "runningEmulator"
 
     # A re-run prompt has been provided

--- a/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
@@ -85,7 +85,7 @@ def test_explicit_running_emulator_by_id(mock_sdk):
 
     # Emulator is running, so there is a device ID
     assert device == 'emulator-5554'
-    assert name == 'emulator (@runningEmulator generic_x86)'
+    assert name == '@runningEmulator (generic_x86 emulator)'
     assert avd == "runningEmulator"
 
     # No input was requested
@@ -100,7 +100,7 @@ def test_explicit_running_emulator_by_avd(mock_sdk):
 
     # Emulator is running, so there is a device ID
     assert device == 'emulator-5554'
-    assert name == 'emulator (@runningEmulator generic_x86)'
+    assert name == '@runningEmulator (generic_x86 emulator)'
     assert avd == "runningEmulator"
 
     # No input was requested
@@ -115,7 +115,7 @@ def test_explicit_idle_emulator(mock_sdk):
 
     # Emulator is not running, so no device ID
     assert device is None
-    assert name == 'emulator (@idleEmulator)'
+    assert name == '@idleEmulator (emulator)'
     assert avd == 'idleEmulator'
 
     # No input was requested
@@ -185,7 +185,7 @@ def test_select_running_emulator(mock_sdk, capsys):
 
     # Emulator is running, so there is a device ID
     assert device == 'emulator-5554'
-    assert name == 'emulator (@runningEmulator generic_x86)'
+    assert name == '@runningEmulator (generic_x86 emulator)'
     assert avd == "runningEmulator"
 
     # A re-run prompt has been provided
@@ -203,7 +203,7 @@ def test_select_idle_emulator(mock_sdk, capsys):
 
     # Emulator is not running, so no device ID
     assert device is None
-    assert name == 'emulator (@idleEmulator)'
+    assert name == '@idleEmulator (emulator)'
     assert avd == 'idleEmulator'
 
     # A re-run prompt has been provided

--- a/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
@@ -59,7 +59,7 @@ def test_explicit_device(mock_sdk):
 
     # Physical running device, so no AVD
     assert device == 'KABCDABCDA1513'
-    assert name == 'Kogan_Agora_9'
+    assert name == 'Kogan_Agora_9 (KABCDABCDA1513)'
     assert avd is None
 
     # No input was requested
@@ -115,7 +115,7 @@ def test_explicit_idle_emulator(mock_sdk):
 
     # Emulator is not running, so no device ID
     assert device is None
-    assert name == '@idleEmulator (emulator)'
+    assert name == 'emulator (@idleEmulator)'
     assert avd == 'idleEmulator'
 
     # No input was requested
@@ -154,7 +154,7 @@ def test_select_device(mock_sdk, capsys):
 
     # Physical running device, so no AVD
     assert device == 'KABCDABCDA1513'
-    assert name == 'Kogan_Agora_9'
+    assert name == 'Kogan_Agora_9 (KABCDABCDA1513)'
     assert avd is None
 
     # The user was asked to select a device
@@ -203,7 +203,7 @@ def test_select_idle_emulator(mock_sdk, capsys):
 
     # Emulator is not running, so no device ID
     assert device is None
-    assert name == '@idleEmulator (emulator)'
+    assert name == 'emulator (@idleEmulator)'
     assert avd == 'idleEmulator'
 
     # A re-run prompt has been provided
@@ -279,7 +279,7 @@ def test_input_disabled_one_device(mock_sdk):
 
     # The only device is returned
     assert device == 'KABCDABCDA1513'
-    assert name == "Kogan_Agora_9"
+    assert name == "Kogan_Agora_9 (KABCDABCDA1513)"
     assert avd is None
 
     # No input was requested

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -52,11 +52,11 @@ def test_start_emulator(mock_sdk):
             'authorized': False,
         },
         'KABCDABCDA1513': {
-            'name': 'Kogan_Agora_9',
+            'name': 'Kogan Agora 9',
             'authorized': True,
         },
         'emulator-5554': {
-            'name': 'generic_x86',
+            'name': 'Android SDK built for x86',
             'authorized': True,
         },
     }
@@ -99,7 +99,7 @@ def test_start_emulator(mock_sdk):
 
     # The device details are as expected
     assert device == 'emulator-5556'
-    assert name == '@idleEmulator (generic_x86 emulator)'
+    assert name == '@idleEmulator (running emulator)'
 
     # The process was started.
     mock_sdk.command.subprocess.Popen.assert_called_with(
@@ -141,11 +141,11 @@ def test_emulator_fail_to_start(mock_sdk):
             'authorized': False,
         },
         'KABCDABCDA1513': {
-            'name': 'Kogan_Agora_9',
+            'name': 'Kogan Agora 9',
             'authorized': True,
         },
         'emulator-5554': {
-            'name': 'generic_x86',
+            'name': 'Android SDK built for x86',
             'authorized': True,
         },
     }
@@ -224,11 +224,11 @@ def test_emulator_fail_to_boot(mock_sdk):
             'authorized': False,
         },
         'KABCDABCDA1513': {
-            'name': 'Kogan_Agora_9',
+            'name': 'Kogan Agora 9',
             'authorized': True,
         },
         'emulator-5554': {
-            'name': 'generic_x86',
+            'name': 'Android SDK built for x86',
             'authorized': True,
         },
     }
@@ -239,7 +239,7 @@ def test_emulator_fail_to_boot(mock_sdk):
     }
     devices_4 = devices.copy()
     devices_4['emulator-5556'] = {
-        'name': 'generic_x86',
+        'name': 'Android SDK built for x86',
         'authorized': True,
     }
 


### PR DESCRIPTION
Example output:

When emulator is running:

```
$ briefcase run android

Select device:

  1) @beePhone (Android SDK built for x86 emulator)
  2) Pixel 3a (94AAY0LNE1)
  3) Create a new Android emulator

> 
```

When emulator is not running:

```
Select device:

  1) Pixel 3a (94AAY0LNE1)
  2) @beePhone (emulator)
  3) Create a new Android emulator

> 
```

You had mentioned that "Android_SDK_built_for_x86" wasn't necessarily useful. IMHO it is -- it could be e.g. a x86_64 emulator instead of an x86 one.

Let's use this PR to get the output exactly right. Code refactoring can wait IMHO.