### PR TITLE
remove --interactive from docker run

### DIFF
--- a/changes/439.bugfix.rst
+++ b/changes/439.bugfix.rst
@@ -1,1 +1,1 @@
-Removed `--interactive` from docker run to prevent failure on CI
+Linux Docker builds no longer use interactive mode, allowing builds to run on CI (or other TTY-less devices).

--- a/changes/439.bugfix.rst
+++ b/changes/439.bugfix.rst
@@ -1,0 +1,1 @@
+Removed `--interactive` from docker run to prevent failure on CI

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -170,7 +170,6 @@ class Docker:
         # with volume mounts for the platform and .briefcase directories.
         docker_args = [
             "docker", "run",
-            # "--interactive",
             "--tty",
             "--volume", "{self.command.platform_path}:/app".format(
                 self=self

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -170,7 +170,7 @@ class Docker:
         # with volume mounts for the platform and .briefcase directories.
         docker_args = [
             "docker", "run",
-            "--interactive",
+            # "--interactive",
             "--tty",
             "--volume", "{self.command.platform_path}:/app".format(
                 self=self

--- a/tests/integrations/docker/test_Docker__run.py
+++ b/tests/integrations/docker/test_Docker__run.py
@@ -12,7 +12,6 @@ def test_simple_call(mock_docker, tmp_path, capsys):
         [
             'docker',
             'run', '--tty',
-            # 'run', '--interactive', '--tty',
             '--volume', '{platform_path}:/app'.format(
                 platform_path=tmp_path / 'platform'
             ),
@@ -36,7 +35,6 @@ def test_simple_call_with_arg(mock_docker, tmp_path, capsys):
         [
             'docker',
             'run', '--tty',
-            # 'run', '--interactive', '--tty',
             '--volume', '{platform_path}:/app'.format(
                 platform_path=tmp_path / 'platform'
             ),
@@ -60,7 +58,6 @@ def test_simple_call_with_path_arg(mock_docker, tmp_path, capsys):
     mock_docker._subprocess._subprocess.run.assert_called_with(
         [
             'docker',
-            # 'run', '--interactive', '--tty',
             'run',  '--tty',
             '--volume', '{platform_path}:/app'.format(
                 platform_path=tmp_path / 'platform'
@@ -91,7 +88,6 @@ def test_simple_verbose_call(mock_docker, tmp_path, capsys):
         [
             'docker',
             'run', '--tty',
-            # 'run', '--interactive', '--tty',
             '--volume', '{platform_path}:/app'.format(
                 platform_path=tmp_path / 'platform'
             ),
@@ -104,7 +100,6 @@ def test_simple_verbose_call(mock_docker, tmp_path, capsys):
         ]
     )
     assert capsys.readouterr().out == (
-        # ">>> docker run --interactive --tty "
         ">>> docker run --tty "
         "--volume {platform_path}:/app "
         "--volume {dot_briefcase_path}:/home/brutus/.briefcase "

--- a/tests/integrations/docker/test_Docker__run.py
+++ b/tests/integrations/docker/test_Docker__run.py
@@ -11,7 +11,8 @@ def test_simple_call(mock_docker, tmp_path, capsys):
     mock_docker._subprocess._subprocess.run.assert_called_with(
         [
             'docker',
-            'run', '--interactive', '--tty',
+            'run', '--tty',
+            # 'run', '--interactive', '--tty',
             '--volume', '{platform_path}:/app'.format(
                 platform_path=tmp_path / 'platform'
             ),
@@ -34,7 +35,8 @@ def test_simple_call_with_arg(mock_docker, tmp_path, capsys):
     mock_docker._subprocess._subprocess.run.assert_called_with(
         [
             'docker',
-            'run', '--interactive', '--tty',
+            'run', '--tty',
+            # 'run', '--interactive', '--tty',
             '--volume', '{platform_path}:/app'.format(
                 platform_path=tmp_path / 'platform'
             ),
@@ -58,7 +60,8 @@ def test_simple_call_with_path_arg(mock_docker, tmp_path, capsys):
     mock_docker._subprocess._subprocess.run.assert_called_with(
         [
             'docker',
-            'run', '--interactive', '--tty',
+            # 'run', '--interactive', '--tty',
+            'run',  '--tty',
             '--volume', '{platform_path}:/app'.format(
                 platform_path=tmp_path / 'platform'
             ),
@@ -87,7 +90,8 @@ def test_simple_verbose_call(mock_docker, tmp_path, capsys):
     mock_docker._subprocess._subprocess.run.assert_called_with(
         [
             'docker',
-            'run', '--interactive', '--tty',
+            'run', '--tty',
+            # 'run', '--interactive', '--tty',
             '--volume', '{platform_path}:/app'.format(
                 platform_path=tmp_path / 'platform'
             ),
@@ -100,7 +104,8 @@ def test_simple_verbose_call(mock_docker, tmp_path, capsys):
         ]
     )
     assert capsys.readouterr().out == (
-        ">>> docker run --interactive --tty "
+        # ">>> docker run --interactive --tty "
+        ">>> docker run --tty "
         "--volume {platform_path}:/app "
         "--volume {dot_briefcase_path}:/home/brutus/.briefcase "
         "briefcase/com.example.myapp:py3.X "

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -202,7 +202,6 @@ def test_build_appimage_with_docker(build_command, first_app_config, tmp_path):
         [
             "docker",
             "run", "--tty",
-            # "run", "--interactive", "--tty",
             '--volume', '{platform_path}:/app'.format(
                 platform_path=build_command.platform_path
             ),

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -201,7 +201,8 @@ def test_build_appimage_with_docker(build_command, first_app_config, tmp_path):
     build_command._subprocess.run.assert_called_with(
         [
             "docker",
-            "run", "--interactive", "--tty",
+            "run", "--tty",
+            # "run", "--interactive", "--tty",
             '--volume', '{platform_path}:/app'.format(
                 platform_path=build_command.platform_path
             ),


### PR DESCRIPTION
As talk in #400, removing --interactive allows build on CI with docker.
this https://github.com/jgirardet/MyCartable/runs/821248582?check_suite_focus=true was built with this patch.