### PR TITLE
Enhanced verification that Briefcase will be able to run docker commands

### DIFF
--- a/changes/442.doc.rst
+++ b/changes/442.doc.rst
@@ -1,1 +1,1 @@
-Added additional checks and error output around the docker commands used when running Briefcase build
+Docker-using commands now check whether the Docker daemon is running and if the user has permission to access it.

--- a/changes/442.doc.rst
+++ b/changes/442.doc.rst
@@ -1,0 +1,1 @@
+Added additional checks and error output around the docker commands used when running Briefcase build

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -97,8 +97,6 @@ to download and install git manually.
 If you have installed Docker recently and are still getting this error, you may
 need to restart your terminal session.
 '''
-
-
     try:
         # Try to get the version of docker that is installed.
         output = command.subprocess.check_output(
@@ -134,7 +132,7 @@ need to restart your terminal session.
             )
         )
 
-    _verify_docker_can_run(command) 
+    _verify_docker_can_run(command)
     # will raise BriefcaseCommandError and print help message
     # if a test docker command fails
 
@@ -190,14 +188,14 @@ docker command failed with error: {error_message}'''
             print(LACKS_PERMISSION_ERROR_MESSAGE)
             raise BriefcaseCommandError("docker lacks required permissions")
         if (
-            'Is the docker daemon running?' in failure_output or # error message on ubuntu
-            'connect: connection refused' in failure_output # error message on macos
+            'Is the docker daemon running?' in failure_output or  # error message on ubuntu
+            'connect: connection refused' in failure_output  # error message on macos
         ):
             print(DAEMON_NOT_RUNNING_ERROR_MESSAGE)
             raise BriefcaseCommandError("docker daemon not running")
 
-        print(GENERIC_ERROR_MESSAGE.format(error_message = failure_output))
-        raise BriefcaseCommandError(GENERIC_ERROR_MESSAGE.format(error_message = failure_output))
+        print(GENERIC_ERROR_MESSAGE.format(error_message=failure_output))
+        raise BriefcaseCommandError(GENERIC_ERROR_MESSAGE.format(error_message=failure_output))
 
 
 class Docker:

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -148,7 +148,7 @@ def _verify_docker_can_run(command):
 
     LACKS_PERMISSION_ERROR_MESSAGE = '''
 *************************************************************************
-** WARNING: docker command lacks relevant permissions                  **
+** ERROR: docker command lacks relevant permissions                    **
 *************************************************************************
 
 docker reported an error when Briefcase attempted to use it.  It is
@@ -161,7 +161,7 @@ option (note this may require installing additional dependencies)
 *************************************************************************'''
     DAEMON_NOT_RUNNING_ERROR_MESSAGE = '''
 *************************************************************************
-** WARNING: docker daemon not running                                  **
+** ERROR: docker daemon not running                                    **
 *************************************************************************
 
 Briefcase is unable to use docker commands because the docker daemon
@@ -173,6 +173,8 @@ running Briefcase build with the --no-docker option
 (note this may require installing addtional dependencies)
 
 *************************************************************************'''
+    GENERIC_ERROR_MESSAGE = '''
+docker command failed with error: {error_message}'''
 
     try:
         _ = command.subprocess.check_output(
@@ -193,7 +195,9 @@ running Briefcase build with the --no-docker option
         ):
             print(DAEMON_NOT_RUNNING_ERROR_MESSAGE)
             raise BriefcaseCommandError("docker daemon not running")
-        raise BriefcaseCommandError("docker command failed with error: {}".format(failure_output))
+
+        print(GENERIC_ERROR_MESSAGE.format(error_message = failure_output))
+        raise BriefcaseCommandError(GENERIC_ERROR_MESSAGE.format(error_message = failure_output))
 
 
 class Docker:

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -36,36 +36,17 @@ def verify_docker(command):
 
     :param command: The command that needs to perform the verification check.
     """
-    try:
-        # Try to get the version of docker that is installed.
-        output = command.subprocess.check_output(
-            ['docker', '--version'],
-            universal_newlines=True,
-            stderr=subprocess.STDOUT,
-        ).strip('\n')
 
-        # Do a simple check that the docker that was invoked
-        # actually looks like the real deal, and is a version that
-        # meets our requirements.
-        if output.startswith('Docker version '):
-            docker_version = output[15:]
-            version = docker_version.split('.')
-            if int(version[0]) < 19:
-                # Docker version isn't compatible.
-                raise BriefcaseCommandError("""
+    WRONG_DOCKER_VERSION_ERROR_MESSAGE = '''
 Briefcase requires Docker 19 or higher, but you are currently running
 version {docker_version}. Visit:
 
     {install_url}
 
 to download and install an updated version of Docker.
-{extra_content}""".format(
-                    docker_version=docker_version,
-                    **docker_install_details(command.host_os)
-                ))
-
-        else:
-            print("""
+{extra_content}
+'''
+    UNKNOWN_DOCKER_VERSION_WARNING = '''
 *************************************************************************
 ** WARNING: Unable to determine the version of Docker                  **
 *************************************************************************
@@ -84,9 +65,8 @@ to download and install an updated version of Docker.
    from the command prompt.
 
 *************************************************************************
-""")
-    except subprocess.CalledProcessError:
-        print("""
+'''
+    DOCKER_INSTALLATION_STATUS_UNKNOWN_WARNING = '''
 *************************************************************************
 ** WARNING: Unable to determine if Docker is installed                 **
 *************************************************************************
@@ -105,10 +85,8 @@ to download and install an updated version of Docker.
    from the command prompt.
 
 *************************************************************************
-""")
-    except FileNotFoundError:
-        # Docker executable doesn't exist.
-        raise BriefcaseCommandError("""
+'''
+    DOCKER_NOT_INSTALLED_ERROR_MESSAGE = '''
 Briefcase requires Docker, but it is not installed (or is not on your PATH).
 Visit:
 
@@ -118,10 +96,85 @@ to download and install git manually.
 {extra_content}
 If you have installed Docker recently and are still getting this error, you may
 need to restart your terminal session.
-""".format(**docker_install_details(command.host_os)))
+'''
+
+
     try:
-        # Docker is probably installed, but it still
-        # may not have the right permissions to run
+        # Try to get the version of docker that is installed.
+        output = command.subprocess.check_output(
+            ['docker', '--version'],
+            universal_newlines=True,
+            stderr=subprocess.STDOUT,
+        ).strip('\n')
+
+        # Do a simple check that the docker that was invoked
+        # actually looks like the real deal, and is a version that
+        # meets our requirements.
+        if output.startswith('Docker version '):
+            docker_version = output[15:]
+            version = docker_version.split('.')
+            if int(version[0]) < 19:
+                # Docker version isn't compatible.
+                raise BriefcaseCommandError(
+                    WRONG_DOCKER_VERSION_ERROR_MESSAGE.format(
+                        docker_version=docker_version,
+                        **docker_install_details(command.host_os),
+                    )
+                )
+
+        else:
+            print(UNKNOWN_DOCKER_VERSION_WARNING)
+    except subprocess.CalledProcessError:
+        print(DOCKER_INSTALLATION_STATUS_UNKNOWN_WARNING)
+    except FileNotFoundError:
+        # Docker executable doesn't exist.
+        raise BriefcaseCommandError(
+            DOCKER_NOT_INSTALLED_ERROR_MESSAGE.format(
+                **docker_install_details(command.host_os)
+            )
+        )
+
+    _verify_docker_can_run(command) 
+    # will raise BriefcaseCommandError and print help message
+    # if a test docker command fails
+
+    # Return the Docker wrapper
+    return Docker
+
+
+def _verify_docker_can_run(command):
+    # Docker is probably installed, but it still
+    # may not have the right permissions to run
+
+    LACKS_PERMISSION_ERROR_MESSAGE = '''
+*************************************************************************
+** WARNING: docker command lacks relevant permissions                  **
+*************************************************************************
+
+docker reported an error when Briefcase attempted to use it.  It is
+possible that docker requires sudo privileges in its current config.
+
+See docs at https://docs.docker.com/engine/install/linux-postinstall/
+for information, or try running Briefcase build with the --no-docker
+option (note this may require installing additional dependencies)
+
+*************************************************************************'''
+    DAEMON_NOT_RUNNING_ERROR_MESSAGE = '''
+*************************************************************************
+** WARNING: docker daemon not running                                  **
+*************************************************************************
+
+Briefcase is unable to use docker commands because the docker daemon
+appears to not be running.
+
+See docs at https://docs.docker.com/config/daemon/ for help
+ensuring that it is running or debugging any issues, or try
+running Briefcase build with the --no-docker option
+(note this may require installing addtional dependencies)
+
+*************************************************************************'''
+
+    try:
         _ = command.subprocess.check_output(
             ['docker', 'info'],  # any docker command will work to check permissions; this one is quick
             universal_newlines=True,
@@ -132,42 +185,15 @@ need to restart your terminal session.
         if (
             'Got permission denied while trying to connect to the Docker daemon socket' in failure_output
         ):
-            print('''
-*************************************************************************
-** WARNING: docker command lacks relevant permissions                  **
-*************************************************************************
-
-   docker reported an error when Briefcase attempted to use it.  It is
-   possible that docker requires sudo privileges in its current config.
-
-   See docs at https://docs.docker.com/engine/install/linux-postinstall/
-   for information, or try running Briefcase build with the --no-docker
-   option (note this may require installing additional dependencies)
-
-*************************************************************************
-    ''')
+            print(LACKS_PERMISSION_ERROR_MESSAGE)
             raise BriefcaseCommandError("docker lacks required permissions")
-        if 'Is the docker daemon running?' in failure_output:
-            print('''
-*************************************************************************
-** WARNING: docker daemon not running                                  **
-*************************************************************************
-
-   Briefcase is unable to use docker commands because the docker daemon
-   appears to not be running.
-
-   See docs at https://docs.docker.com/config/daemon/ for help
-   ensuring that it is running or debugging any issues, or try
-   running Briefcase build with the --no-docker option
-   (note this may require installing addtional dependencies)
-
-*************************************************************************
-    ''')
+        if (
+            'Is the docker daemon running?' in failure_output or # error message on ubuntu
+            'connect: connection refused' in failure_output # error message on macos
+        ):
+            print(DAEMON_NOT_RUNNING_ERROR_MESSAGE)
             raise BriefcaseCommandError("docker daemon not running")
         raise BriefcaseCommandError("docker command failed with error: {}".format(failure_output))
-
-    # Return the Docker wrapper
-    return Docker
 
 
 class Docker:

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -175,7 +175,7 @@ running Briefcase build with the --no-docker option
 docker command failed with error: {error_message}'''
 
     try:
-        _ = command.subprocess.check_output(
+        command.subprocess.check_output(
             ['docker', 'info'],  # any docker command will work to check permissions; this one is quick
             universal_newlines=True,
             stderr=subprocess.STDOUT,
@@ -185,16 +185,13 @@ docker command failed with error: {error_message}'''
         if (
             'Got permission denied while trying to connect to the Docker daemon socket' in failure_output
         ):
-            print(LACKS_PERMISSION_ERROR_MESSAGE)
-            raise BriefcaseCommandError("docker lacks required permissions")
+            raise BriefcaseCommandError(LACKS_PERMISSION_ERROR_MESSAGE)
         if (
             'Is the docker daemon running?' in failure_output or  # error message on ubuntu
             'connect: connection refused' in failure_output  # error message on macos
         ):
-            print(DAEMON_NOT_RUNNING_ERROR_MESSAGE)
-            raise BriefcaseCommandError("docker daemon not running")
+            raise BriefcaseCommandError(DAEMON_NOT_RUNNING_ERROR_MESSAGE)
 
-        print(GENERIC_ERROR_MESSAGE.format(error_message=failure_output))
         raise BriefcaseCommandError(GENERIC_ERROR_MESSAGE.format(error_message=failure_output))
 
 

--- a/tests/integrations/docker/test_verify_docker.py
+++ b/tests/integrations/docker/test_verify_docker.py
@@ -58,6 +58,7 @@ def test_docker_doesnt_exist(test_command):
         stderr=subprocess.STDOUT,
     )
 
+
 @mock.patch('briefcase.integrations.docker._verify_docker_can_run')
 def test_docker_failure(test_command, capsys):
     "If docker failed during execution, the Docker wrapper is returned with a warning"
@@ -96,6 +97,7 @@ def test_docker_bad_version(test_command, capsys):
     ):
         verify_docker(command=test_command)
 
+
 @mock.patch('briefcase.integrations.docker._verify_docker_can_run')
 def test_docker_unknown_version(test_command, capsys):
     "If docker exists but the version string doesn't make sense, the Docker wrapper is returned with a warning."
@@ -119,22 +121,30 @@ def test_docker_unknown_version(test_command, capsys):
     assert '** WARNING: Unable to determine the version of Docker' in output.out
     assert output.err == ''
 
+
 def test_docker_exists_but_process_lacks_permission_to_use_it(test_command, capsys):
-    error_message = '''
+    message1 = '''
 Client:
  Debug Mode: false
 
 Server:
-ERROR: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.40/info: dial unix /var/run/docker.sock: connect: permission denied
+ERROR: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: '''
+
+    message2 = '''Get http://%2Fvar%2Frun%2Fdocker.sock/v1.40/info: dial unix /var/run/docker.sock: connect: permission denied
 errors pretty printing info'''
+
+    error_message = message1 + message2
+    # splitting it up is to appease flake8 line length - not sure how to add noqa to a triple quoted string line
+
     test_command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        returncode=1, cmd="docker info", output = error_message
+        returncode=1, cmd="docker info", output=error_message
     )
     with pytest.raises(BriefcaseCommandError):
-        _verify_docker_can_run(command = test_command)
+        _verify_docker_can_run(command=test_command)
 
     output = capsys.readouterr()
     assert 'ERROR: docker command lacks relevant permissions' in output.out
+
 
 def test_docker_exists_but_is_not_running(test_command, capsys):
     error_message = '''
@@ -146,23 +156,24 @@ ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is th
 errors pretty printing info'''
 
     test_command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        returncode=1, cmd='docker info', output = error_message,
+        returncode=1, cmd='docker info', output=error_message,
     )
     with pytest.raises(BriefcaseCommandError):
-        _verify_docker_can_run(command = test_command)
+        _verify_docker_can_run(command=test_command)
 
     output = capsys.readouterr()
     assert 'ERROR: docker daemon not running' in output.out
+
 
 def test_docker_exists_but_unknown_error_when_running_command(test_command, capsys):
 
     error_message = 'This command failed!'
     test_command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        returncode=1, cmd = 'docker info', output = error_message,
+        returncode=1, cmd='docker info', output=error_message,
     )
 
     with pytest.raises(BriefcaseCommandError):
-        _verify_docker_can_run(command = test_command)
+        _verify_docker_can_run(command=test_command)
 
     output = capsys.readouterr()
     assert output.out.strip() == 'docker command failed with error: {}'.format(error_message)

--- a/tests/integrations/docker/test_verify_docker.py
+++ b/tests/integrations/docker/test_verify_docker.py
@@ -30,11 +30,11 @@ def test_docker_exists(test_command, capsys):
         docker_info_called_with,
     ) = test_command.subprocess.check_output.call_args_list
 
-    assert docker_version_called_with.args == (['docker', '--version'],)
-    assert docker_version_called_with.kwargs == {'universal_newlines': True, 'stderr': -2}
+    assert docker_version_called_with[0] == (['docker', '--version'],)
+    assert docker_version_called_with[1] == {'universal_newlines': True, 'stderr': -2}
 
-    assert docker_info_called_with.args == (['docker', 'info'],)
-    assert docker_info_called_with.kwargs == {'universal_newlines': True, 'stderr': -2}
+    assert docker_info_called_with[0] == (['docker', 'info'],)
+    assert docker_info_called_with[1] == {'universal_newlines': True, 'stderr': -2}
 
     # No console output
     output = capsys.readouterr()

--- a/tests/integrations/docker/test_verify_docker.py
+++ b/tests/integrations/docker/test_verify_docker.py
@@ -25,11 +25,16 @@ def test_docker_exists(test_command, capsys):
     # The verify call should return the Docker wrapper
     assert result == Docker
 
-    test_command.subprocess.check_output.assert_called_with(
-        ['docker', '--version'],
-        universal_newlines=True,
-        stderr=subprocess.STDOUT,
-    )
+    (
+        docker_version_called_with,
+        docker_info_called_with,
+    ) = test_command.subprocess.check_output.call_args_list
+
+    assert docker_version_called_with.args == (['docker', '--version'],)
+    assert docker_version_called_with.kwargs == {'universal_newlines': True, 'stderr': -2}
+
+    assert docker_info_called_with.args == (['docker', 'info'],)
+    assert docker_info_called_with.kwargs == {'universal_newlines': True, 'stderr': -2}
 
     # No console output
     output = capsys.readouterr()


### PR DESCRIPTION
Code now uses a preflight `docker info` command to check the availabilty of docker commands.  Tested only on linux
Addresses issue #442

Unfortunately I don't have access to a Mac environment or a Windows install that is capable of running docker (you need to have the professional edition or sign up for advanced telemetry to get WSL2 to run docker for windows :cry: ), so I am not sure if these changes are safe enough to be run cross-platform.  Appreciate any advice in this regard

Limitations: On linux (ubuntu 20.04 specifically) the docker commands will just fail with error code 1 in a variety of error cases.  The 2 I check for here I differentiate by examining the text of the error message - I don't know if docker considers these errors part of their API, so these checks may be brittle.  I think the worst that happens is it just hits the fallback to the generic error message, so this should be at worst extra code that can never get run, if docker changes the text of the errors.