### PR TITLE
Fixes #420 - Ensure all libraries are fully deployed in AppImage.

### DIFF
--- a/changes/420.bugfix.rst
+++ b/changes/420.bugfix.rst
@@ -1,0 +1,1 @@
+Binary modules in Linux AppImages are now processed correctly, ensuring that no references to system libraries are retained in the AppImage.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Optional
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-import toml
 from cookiecutter import exceptions as cookiecutter_exceptions
 from requests import exceptions as requests_exceptions
 
@@ -114,7 +113,6 @@ class CreateCommand(BaseCommand):
 
     def __init__(self, *args, **options):
         super().__init__(*args, **options)
-        self._path_index = {}
         self._s3 = None
 
     @property
@@ -140,59 +138,6 @@ class CreateCommand(BaseCommand):
         return "https://briefcase-support.org/python?{query}".format(
             query=urlencode(self.support_package_url_query)
         )
-
-    def _load_path_index(self, app: BaseConfig):
-        """
-        Load the path index from the index file provided by the app template
-
-        :param app: The config object for the app
-        :return: The contents of the application path index.
-        """
-        with (self.bundle_path(app) / 'briefcase.toml').open() as f:
-            self._path_index[app] = toml.load(f)['paths']
-        return self._path_index[app]
-
-    def support_path(self, app: BaseConfig):
-        """
-        Obtain the path into which the support package should be unpacked
-
-        :param app: The config object for the app
-        :return: The full path where the support package should be unpacked.
-        """
-        # If the index file hasn't been loaded for this app, load it.
-        try:
-            path_index = self._path_index[app]
-        except KeyError:
-            path_index = self._load_path_index(app)
-        return self.bundle_path(app) / path_index['support_path']
-
-    def app_packages_path(self, app: BaseConfig):
-        """
-        Obtain the path into which dependencies should be installed
-
-        :param app: The config object for the app
-        :return: The full path where application dependencies should be installed.
-        """
-        # If the index file hasn't been loaded for this app, load it.
-        try:
-            path_index = self._path_index[app]
-        except KeyError:
-            path_index = self._load_path_index(app)
-        return self.bundle_path(app) / path_index['app_packages_path']
-
-    def app_path(self, app: BaseConfig):
-        """
-        Obtain the path into which the application should be installed.
-
-        :param app: The config object for the app
-        :return: The full path where application code should be installed.
-        """
-        # If the index file hasn't been loaded for this app, load it.
-        try:
-            path_index = self._path_index[app]
-        except KeyError:
-            path_index = self._load_path_index(app)
-        return self.bundle_path(app) / path_index['app_path']
 
     def icon_targets(self, app: BaseConfig):
         """

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -1,0 +1,29 @@
+from requests import exceptions as requests_exceptions
+
+from briefcase.exceptions import NetworkFailure
+
+
+def verify_linuxdeploy(command):
+    """
+    Verify that LinuxDeploy is available.
+    """
+
+    linuxdeploy_download_url = (
+        'https://github.com/linuxdeploy/linuxdeploy/'
+        'releases/download/continuous/linuxdeploy-{command.host_arch}.AppImage'.format(
+            command=command
+        )
+    )
+
+    try:
+        print()
+        print("Ensure we have the linuxdeploy AppImage...")
+        linuxdeploy_appimage_path = command.download_url(
+            url=linuxdeploy_download_url,
+            download_path=command.dot_briefcase_path / 'tools'
+        )
+        command.os.chmod(str(linuxdeploy_appimage_path), 0o755)
+    except requests_exceptions.ConnectionError:
+        raise NetworkFailure('downloading linuxdeploy AppImage')
+
+    return linuxdeploy_appimage_path

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -6,6 +6,9 @@ from briefcase.exceptions import NetworkFailure
 def verify_linuxdeploy(command):
     """
     Verify that LinuxDeploy is available.
+
+    :param command: The command that needs to use linuxdeploy
+    :returns: The path to the linuxdeploy AppImage.
     """
 
     linuxdeploy_download_url = (

--- a/tests/integrations/docker/test_verify_docker.py
+++ b/tests/integrations/docker/test_verify_docker.py
@@ -4,7 +4,11 @@ from unittest import mock
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
-from briefcase.integrations.docker import Docker, verify_docker, _verify_docker_can_run
+from briefcase.integrations.docker import (
+    Docker,
+    _verify_docker_can_run,
+    verify_docker
+)
 
 
 @pytest.fixture

--- a/tests/integrations/linuxdeploy/test_verify_linuxdeploy.py
+++ b/tests/integrations/linuxdeploy/test_verify_linuxdeploy.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+
+import pytest
+from requests import exceptions as requests_exceptions
+
+from briefcase.exceptions import NetworkFailure
+from briefcase.integrations.linuxdeploy import verify_linuxdeploy
+
+
+@pytest.fixture
+def mock_command():
+    command = MagicMock()
+    command.host_os = 'wonky'
+
+    return command
+
+
+def test_verify_linuxdeploy(mock_command):
+    "The build process invokes verify_tools, which retrieves linuxdeploy"
+    # Mock a successful download
+    mock_command.download_url.return_value = 'new-downloaded-file'
+
+    # Verify the
+    linuxdeploy_appimage = verify_linuxdeploy(mock_command)
+
+    # The downloaded file will be made executable
+    mock_command.os.chmod.assert_called_with('new-downloaded-file', 0o755)
+
+    # The build command retains the path to the downloaded file.
+    assert linuxdeploy_appimage == 'new-downloaded-file'
+
+
+def test_verify_linuxdeploy_download_failure(mock_command):
+    "If the download of linuxdeploy fails, an error is raised"
+
+    mock_command.download_url.side_effect = requests_exceptions.ConnectionError
+
+    with pytest.raises(NetworkFailure):
+        verify_linuxdeploy(mock_command)

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -198,7 +198,6 @@ def test_build_appimage_with_docker(build_command, first_app, tmp_path):
     assert type(build_command.subprocess) != Docker
 
     # linuxdeploy was invoked inside Docker
-    app_dir = tmp_path / 'linux' / 'First App' / 'First App.AppDir'
     build_command._subprocess.run.assert_called_with(
         [
             "docker",


### PR DESCRIPTION
AppImages process all the dynamic libraries needed by an app, copying them into the AppImage, and re-writing any references to ensure that the AppImage is portable.

However, the default behavior of linuxdeploy is to *only* look in the `/usr/lib` folder. Python dynamic modules will be in the Python folder, or in the app/app_packages folder.

This modifies the call to linuxdeploy to provide the name of any other folder in the AppDir that contains a .so file, so that those files will also be marked for processing.

**NOTE**: This requires a *very* fresh version of linuxdeploy. If you've got a version of linuxdeploy from before 15 July, you'll get an error about the `--deploy-deps-only` option. To fix this, delete '~/.briefcase/tools/linuxdeploy-x86_64.AppImage` and re-run. #450 has been logged to provide an easier path for this.