### PR TITLE
fix docker tag case sensitivity

### DIFF
--- a/changes/475.misc.rst
+++ b/changes/475.misc.rst
@@ -1,0 +1,1 @@
+Fix problem with docker tag for project with uppercase in name.

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -60,9 +60,10 @@ class LinuxAppImageMixin(LinuxMixin):
 
     def docker_image_tag(self, app):
         "The Docker image tag for an app"
-        return 'briefcase/{app.bundle}.{app.app_name}:py{self.python_version_tag}'.format(
+        return 'briefcase/{app.bundle}.{app_name}:py{self.python_version_tag}'.format(
             app=app,
             self=self,
+            app_name=app.app_name.lower()
         )
 
     def verify_tools(self):

--- a/tests/platforms/conftest.py
+++ b/tests/platforms/conftest.py
@@ -14,3 +14,16 @@ def first_app_config():
         description='The first simple app',
         sources=['src/first_app'],
     )
+
+
+@pytest.fixture
+def uppercase_app_config():
+    return AppConfig(
+        app_name='First-App',
+        project_name='First Project',
+        formal_name='First App',
+        bundle='com.example',
+        version='0.0.1',
+        description='The first simple app',
+        sources=['src/First_App'],
+    )

--- a/tests/platforms/linux/appimage/test_mixin.py
+++ b/tests/platforms/linux/appimage/test_mixin.py
@@ -37,6 +37,16 @@ def test_docker_image_tag(first_app_config, tmp_path):
     )
 
 
+def test_docker_image_tag_uppercase_name(uppercase_app_config, tmp_path):
+    command = LinuxAppImageCreateCommand(base_path=tmp_path)
+
+    image_tag = command.docker_image_tag(uppercase_app_config)
+
+    assert image_tag == 'briefcase/com.example.first-app:py3.{minor}'.format(
+        minor=sys.version_info.minor
+    )
+
+
 def test_dockerize(first_app_config, tmp_path):
     command = LinuxAppImageCreateCommand(base_path=tmp_path)
     command.Docker = Docker


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Docker tag does not allow to use uppercase letter in tag. Python Package could have uppercase letters in name. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
