### PR TITLE
moved package command arguments specific to macOs to base package

### DIFF
--- a/changes/486.doc.rst
+++ b/changes/486.doc.rst
@@ -1,1 +1,0 @@
-moved signing options as a macOS specific extension on the app and dmg commands to reference docs for the package command

--- a/changes/486.doc.rst
+++ b/changes/486.doc.rst
@@ -1,0 +1,1 @@
+moved signing options as a macOS specific extension on the app and dmg commands to reference docs for the package command

--- a/changes/486.feature.rst
+++ b/changes/486.feature.rst
@@ -1,1 +1,2 @@
-moved package command arguments(adhoc,identity and no-sign) specific to macOs to the base package command
+Added signing options for all platforms. App signing is only implemented on
+macOS, but ``--no-sign`` can now be used regardless of your target platform.

--- a/changes/486.feature.rst
+++ b/changes/486.feature.rst
@@ -1,0 +1,1 @@
+moved package command arguments(adhoc,identity and no-sign) specific to macOs to the base package command

--- a/docs/reference/commands/package.rst
+++ b/docs/reference/commands/package.rst
@@ -43,3 +43,25 @@ running::
 
     $ briefcase update
     $ briefcase package
+
+
+publish
+-------
+
+``--no-sign``
+~~~~~~~~~~~~~
+
+Don't perform code signing on the app.
+
+``--adhoc-sign``
+~~~~~~~~~~~~~~~~
+
+Sign app with adhoc identity.
+
+``-i <identity>`` / ``--identity <identity>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The code signing identity to use when signing the app.
+
+
+

--- a/docs/reference/platforms/macOS/app.rst
+++ b/docs/reference/platforms/macOS/app.rst
@@ -19,26 +19,3 @@ Splash Image format
 
 ``.app`` bundles do not support splash screens or installer images.
 
-Additional options
-==================
-
-The following options can be provided at the command line when producing
-``.app`` bundles.
-
-publish
--------
-
-``--no-sign``
-~~~~~~~~~~~~~
-
-Don't perform code signing on the ``.app`` bundles.
-
-``--adhoc-sign``
-~~~~~~~~~~~~~~~~
-
-Sign ``.app`` bundles with adhoc identity.
-
-``-i <identity>`` / ``--identity <identity>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The code signing identity to use when signing the ``.app`` bundles.

--- a/docs/reference/platforms/macOS/dmg.rst
+++ b/docs/reference/platforms/macOS/dmg.rst
@@ -27,26 +27,3 @@ macOS DMGs do not support splash screens.
 
 The installer background must be in ``.png`` format.
 
-Additional options
-==================
-
-The following options can be provided at the command line when producing
-DMGs.
-
-publish
--------
-
-``--no-sign``
-~~~~~~~~~~~~~
-
-Don't perform code signing on the ``.app`` bundles in the DMG.
-
-``--adhoc-sign``
-~~~~~~~~~~~~~~~~
-
-Sign ``.app`` bundles with adhoc identity.
-
-``-i <identity>`` / ``--identity <identity>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The code signing identity to use when signing the ``.app`` bundles in the DMG.

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -47,8 +47,6 @@ class PackageCommand(BaseCommand):
         ))
         return state
 
-    
-
     def add_options(self, parser):
         parser.add_argument(
             '--no-sign',
@@ -69,8 +67,6 @@ class PackageCommand(BaseCommand):
                  'checksum, or the full name of the identity.',
             required=False,
         )
-
-
 
     def __call__(
         self,

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -47,6 +47,31 @@ class PackageCommand(BaseCommand):
         ))
         return state
 
+    
+
+    def add_options(self, parser):
+        parser.add_argument(
+            '--no-sign',
+            dest='sign_app',
+            help='Disable code signing of the app.',
+            action='store_false',
+        )
+        parser.add_argument(
+            '--adhoc-sign',
+            help='Sign the app with adhoc identity.',
+            action='store_true',
+        )
+        parser.add_argument(
+            '-i',
+            '--identity',
+            dest='identity',
+            help='The code signing identity to use; either the 40-digit hex '
+                 'checksum, or the full name of the identity.',
+            required=False,
+        )
+
+
+
     def __call__(
         self,
         app: Optional[BaseConfig] = None,

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -78,28 +78,7 @@ class macOSAppPackageCommand(macOSAppMixin, PackageCommand):
         # These are abstracted to enable testing without patching.
         self.get_identities = get_identities
 
-    def add_options(self, parser):
-        super().add_options(parser)
-        parser.add_argument(
-            '--no-sign',
-            dest='sign_app',
-            help='Disable code signing of .app bundles.',
-            action='store_false',
-        )
-        parser.add_argument(
-            '--adhoc-sign',
-            help='Sign .app bundles with adhoc identity.',
-            action='store_true',
-        )
-        parser.add_argument(
-            '-i',
-            '--identity',
-            dest='identity',
-            help='The code signing identity to use; either the 40-digit hex '
-                 'checksum, or the full name of the identity.',
-            required=False,
-        )
-
+    
     def select_identity(self, identity=None):
         """
         Get the codesigning identity to use.

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -78,7 +78,6 @@ class macOSAppPackageCommand(macOSAppMixin, PackageCommand):
         # These are abstracted to enable testing without patching.
         self.get_identities = get_identities
 
-    
     def select_identity(self, identity=None):
         """
         Get the codesigning identity to use.

--- a/tests/commands/package/conftest.py
+++ b/tests/commands/package/conftest.py
@@ -86,7 +86,7 @@ def first_app_unbuilt(first_app_config, tmp_path):
 
     return first_app_config
 
- 
+
 @pytest.fixture
 def first_app(first_app_unbuilt, tmp_path):
     # The same fixture as first_app_uncompiled,

--- a/tests/commands/package/conftest.py
+++ b/tests/commands/package/conftest.py
@@ -7,7 +7,7 @@ from briefcase.config import AppConfig
 
 class DummyPackageCommand(PackageCommand):
     """
-    A dummy run command that doesn't actually do anything.
+    A dummy package command that doesn't actually do anything.
     It only serves to track which actions would be performend.
     """
     platform = 'tester'

--- a/tests/commands/package/conftest.py
+++ b/tests/commands/package/conftest.py
@@ -1,0 +1,130 @@
+import pytest
+
+from briefcase.commands import PackageCommand
+from briefcase.commands.base import full_options
+from briefcase.config import AppConfig
+
+
+class DummyPackageCommand(PackageCommand):
+    """
+    A dummy run command that doesn't actually do anything.
+    It only serves to track which actions would be performend.
+    """
+    platform = 'tester'
+    output_format = 'dummy'
+    description = 'Dummy package command'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, apps=[], **kwargs)
+
+        self.actions = []
+
+    def bundle_path(self, app):
+        return self.platform_path / app.app_name
+
+    def binary_path(self, app):
+        return self.platform_path / app.app_name / '{app.app_name}.bin'.format(app=app)
+
+    def distribution_path(self, app):
+        return self.platform_path / app.app_name / '{app.app_name}.dist'.format(app=app)
+
+    def verify_tools(self):
+        super().verify_tools()
+        self.actions.append(('verify',))
+
+    def package_app(self, app, **kwargs):
+        self.actions.append(('package', app.app_name, kwargs))
+        return full_options({
+            'package_state': app.app_name
+        }, kwargs)
+
+    # These commands override the default behavior, simply tracking that
+    # they were invoked, rather than instantiating a Create/Update/Build command.
+    # This is for testing purposes.
+    def create_command(self, app, **kwargs):
+        self.actions.append(('create', app.app_name, kwargs))
+        return full_options({
+            'create_state': app.app_name
+        }, kwargs)
+
+    def update_command(self, app, **kwargs):
+        self.actions.append(('update', app.app_name, kwargs))
+        return full_options({
+            'update_state': app.app_name
+        }, kwargs)
+
+    def build_command(self, app, **kwargs):
+        self.actions.append(('build', app.app_name, kwargs))
+        return full_options({
+            'build_state': app.app_name
+        }, kwargs)
+
+
+@pytest.fixture
+def package_command(tmp_path):
+    return DummyPackageCommand(base_path=tmp_path)
+
+
+@pytest.fixture
+def first_app_config():
+    return AppConfig(
+        app_name='first',
+        bundle='com.example',
+        version='0.0.1',
+        description='The first simple app',
+        sources=['src/first'],
+    )
+
+
+@pytest.fixture
+def first_app_unbuilt(first_app_config, tmp_path):
+    # The same fixture as first_app_config,
+    # but ensures that the bundle for the app exists
+    (tmp_path / 'tester' / 'first').mkdir(parents=True, exist_ok=True)
+    with (tmp_path / 'tester' / 'first' / 'first.dummy').open('w') as f:
+        f.write('first.dummy')
+
+    return first_app_config
+
+ 
+@pytest.fixture
+def first_app(first_app_unbuilt, tmp_path):
+    # The same fixture as first_app_uncompiled,
+    # but ensures that the binary for the app exists
+    with (tmp_path / 'tester' / 'first' / 'first.bin').open('w') as f:
+        f.write('first.bin')
+
+    return first_app_unbuilt
+
+
+@pytest.fixture
+def second_app_config():
+    return AppConfig(
+        app_name='second',
+        bundle='com.example',
+        version='0.0.2',
+        description='The second simple app',
+        sources=['src/second'],
+    )
+
+
+@pytest.fixture
+def second_app_uncompiled(second_app_config, tmp_path):
+    # The same fixture as second_app_config,
+    # but ensures that the bundle for the app exists
+    (tmp_path / 'tester' / 'second').mkdir(parents=True, exist_ok=True)
+    with (tmp_path / 'tester' / 'second' / 'second.dummy').open('w') as f:
+        f.write('second.dummy')
+
+    return second_app_config
+
+
+@pytest.fixture
+def second_app(second_app_uncompiled, tmp_path):
+    # The same fixture as second_app_uncompiled,
+    # but ensures that the binary for the app exists
+    (tmp_path / 'tester').mkdir(parents=True, exist_ok=True)
+    with (tmp_path / 'tester' / 'second' / 'second.bin').open('w') as f:
+        f.write('second.bin')
+
+    return second_app_uncompiled

--- a/tests/commands/package/test_call.py
+++ b/tests/commands/package/test_call.py
@@ -1,0 +1,201 @@
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError
+
+
+def test_no_args_package_one_app(package_command, first_app):
+    "If there is one app, package that app by default"
+    # Add a single app
+    package_command.apps = {
+        "first": first_app,
+    }
+
+    # Configure no command line options
+    options = package_command.parse_options([])
+
+    # Run the run command
+    package_command(**options)
+
+    # The right sequence of things will be done
+    assert package_command.actions == [
+        # Tools are verified
+        ("verify", ),   
+        # Package the first app
+        ("package", "first", {'adhoc_sign': False, 'identity': None, 'sign_app': True}),
+    ]
+
+
+def test_no_args_package_two_app(package_command, first_app,second_app):
+    "If there are multiple apps, publish all of them"
+    # Add two apps
+    package_command.apps = {
+        "first": first_app,
+        "second": second_app,
+    }
+
+    # Configure no command line options
+    options = package_command.parse_options([])
+
+    # Run the package command
+    package_command(**options)
+
+    # The right sequence of things will be done
+    assert package_command.actions == [
+        # Tools are verified
+        ("verify", ),   
+        # Package the first app
+        ("package", "first", {'adhoc_sign': False, 'identity': None, 'sign_app': True}),
+        #package the second app
+        ("package", "second", {'adhoc_sign': False, 'identity': None, 'sign_app': True,'package_state':'first'}),
+    ]
+
+
+
+def test_no_sign_package_one_app(package_command, first_app):
+    "If there is one app, and a --no-sign argument,package doesnt sign the app"
+    # Add a single app
+    package_command.apps = {
+        "first": first_app,
+    }
+
+    # Configure no command line options
+    options = package_command.parse_options(["--no-sign"])
+
+    # Run the run command
+    package_command(**options)
+
+    # The right sequence of things will be done
+    assert package_command.actions == [
+        # Tools are verified
+        ("verify", ),   
+        # Package the first app
+        ("package", "first", {'adhoc_sign': False, 'identity': None, 'sign_app': False}),
+
+    ]
+
+
+
+def test_identity_arg_package_one_app(package_command, first_app):
+    "If there is one app,and an --identity argument, package signs the app with the specified identity"
+    # Add a single app
+    package_command.apps = {
+        "first": first_app,
+
+    }
+
+    # Configure no command line options
+    options = package_command.parse_options(["--identity","test"])
+
+    # Run the run command
+    package_command(**options)
+
+    # The right sequence of things will be done
+    assert package_command.actions == [
+        # Tools are verified
+        ("verify", ),   
+        # Package the first app
+        ("package", "first", {'adhoc_sign': False, 'identity': "test", 'sign_app': True}),
+
+    ]
+
+
+def test_adhoc_sign_package_one_app(package_command, first_app):
+    "If there is one app,and an --adhoc argument, package signs the app using adhoc option"
+    # Add a single app
+    package_command.apps = {
+        "first": first_app,
+    }
+
+    # Configure no command line options
+    options = package_command.parse_options(["--adhoc"])
+
+    # Run the run command
+    package_command(**options)
+
+    # The right sequence of things will be done
+    assert package_command.actions == [
+        # Tools are verified
+        ("verify", ),   
+        # Package the first app
+        ("package", "first", {'adhoc_sign': True, 'identity': None, 'sign_app': True}),
+
+    ]
+
+
+def test_no_sign_args_package_two_app(package_command, first_app,second_app):
+    "If there are multiple apps, and a --no-sign argument,package doesnt sign all the app"
+    # Add a single app
+    package_command.apps = {
+        "first": first_app,
+        "second": second_app,
+    }
+
+    # Configure no command line options
+    options = package_command.parse_options(["--no-sign"])
+
+    # Run the run command
+    package_command(**options)
+
+    # The right sequence of things will be done
+    assert package_command.actions == [
+        # Tools are verified
+        ("verify", ),   
+        # Package the first app
+        ("package", "first", {'adhoc_sign': False, 'identity': None, 'sign_app': False}),
+        #package the second app
+        ("package", "second", {'adhoc_sign': False, 'identity': None, 'sign_app': False,'package_state':'first'}),
+    ]
+
+
+
+def test_adhoc_sign_args_package_two_app(package_command, first_app,second_app):
+    "If there are multiple apps,and an --adhoc argument, package signs all apps using adhoc option"
+    
+    package_command.apps = {
+        #Add the first app
+        "first": first_app,
+        #Add the second app
+        "second": second_app,
+    }
+
+    # Configure adhoc command line options
+    options = package_command.parse_options(["--adhoc"])
+
+    # Run the package command
+    package_command(**options)
+
+    # The right sequence of things will be done
+    assert package_command.actions == [
+        # Tools are verified
+        ("verify", ),   
+        # Package the first app
+        ("package", "first", {'adhoc_sign': True, 'identity': None, 'sign_app': True}),
+        #package the second app
+        ("package", "second", {'adhoc_sign': True, 'identity': None, 'sign_app': True,'package_state':'first'}),
+    ]
+
+
+
+def test_identity_sign_args_package_two_app(package_command, first_app,second_app):
+    "If there are multiple app,and an --identity argument, package signs all the apps with the specified identity"
+    # Add a single app
+    package_command.apps = {
+        "first": first_app,
+        "second": second_app,
+    }
+
+    # Configure no command line options
+    options = package_command.parse_options(["--identity","test"])
+
+    # Run the run command
+    package_command(**options)
+
+    # The right sequence of things will be done
+    assert package_command.actions == [
+        # Tools are verified
+        ("verify", ),   
+        # Package the first app
+        ("package", "first", {'adhoc_sign': False, 'identity': "test", 'sign_app': True}),
+        #package the second app
+        ("package", "second", {'adhoc_sign': False, 'identity': "test", 'sign_app': True,'package_state':'first'}),
+    ]

--- a/tests/commands/package/test_call.py
+++ b/tests/commands/package/test_call.py
@@ -1,6 +1,3 @@
-import pytest
-
-from briefcase.exceptions import BriefcaseCommandError
 
 
 def test_no_args_package_one_app(package_command, first_app):
@@ -19,13 +16,13 @@ def test_no_args_package_one_app(package_command, first_app):
     # The right sequence of things will be done
     assert package_command.actions == [
         # Tools are verified
-        ("verify", ),   
+        ("verify", ),
         # Package the first app
         ("package", "first", {'adhoc_sign': False, 'identity': None, 'sign_app': True}),
     ]
 
 
-def test_no_args_package_two_app(package_command, first_app,second_app):
+def test_no_args_package_two_app(package_command, first_app, second_app):
     "If there are multiple apps, publish all of them"
     # Add two apps
     package_command.apps = {
@@ -42,13 +39,12 @@ def test_no_args_package_two_app(package_command, first_app,second_app):
     # The right sequence of things will be done
     assert package_command.actions == [
         # Tools are verified
-        ("verify", ),   
+        ("verify", ),
         # Package the first app
         ("package", "first", {'adhoc_sign': False, 'identity': None, 'sign_app': True}),
-        #package the second app
-        ("package", "second", {'adhoc_sign': False, 'identity': None, 'sign_app': True,'package_state':'first'}),
+        # package the second app
+        ("package", "second", {'adhoc_sign': False, 'identity': None, 'sign_app': True, 'package_state': 'first'}),
     ]
-
 
 
 def test_no_sign_package_one_app(package_command, first_app):
@@ -67,12 +63,11 @@ def test_no_sign_package_one_app(package_command, first_app):
     # The right sequence of things will be done
     assert package_command.actions == [
         # Tools are verified
-        ("verify", ),   
+        ("verify", ),
         # Package the first app
         ("package", "first", {'adhoc_sign': False, 'identity': None, 'sign_app': False}),
 
     ]
-
 
 
 def test_identity_arg_package_one_app(package_command, first_app):
@@ -84,7 +79,7 @@ def test_identity_arg_package_one_app(package_command, first_app):
     }
 
     # Configure no command line options
-    options = package_command.parse_options(["--identity","test"])
+    options = package_command.parse_options(["--identity", "test"])
 
     # Run the run command
     package_command(**options)
@@ -92,7 +87,7 @@ def test_identity_arg_package_one_app(package_command, first_app):
     # The right sequence of things will be done
     assert package_command.actions == [
         # Tools are verified
-        ("verify", ),   
+        ("verify", ),
         # Package the first app
         ("package", "first", {'adhoc_sign': False, 'identity': "test", 'sign_app': True}),
 
@@ -115,14 +110,14 @@ def test_adhoc_sign_package_one_app(package_command, first_app):
     # The right sequence of things will be done
     assert package_command.actions == [
         # Tools are verified
-        ("verify", ),   
+        ("verify", ),
         # Package the first app
         ("package", "first", {'adhoc_sign': True, 'identity': None, 'sign_app': True}),
 
     ]
 
 
-def test_no_sign_args_package_two_app(package_command, first_app,second_app):
+def test_no_sign_args_package_two_app(package_command, first_app, second_app):
     "If there are multiple apps, and a --no-sign argument,package doesnt sign all the app"
     # Add a single app
     package_command.apps = {
@@ -139,22 +134,21 @@ def test_no_sign_args_package_two_app(package_command, first_app,second_app):
     # The right sequence of things will be done
     assert package_command.actions == [
         # Tools are verified
-        ("verify", ),   
+        ("verify", ),
         # Package the first app
         ("package", "first", {'adhoc_sign': False, 'identity': None, 'sign_app': False}),
-        #package the second app
-        ("package", "second", {'adhoc_sign': False, 'identity': None, 'sign_app': False,'package_state':'first'}),
+        # package the second app
+        ("package", "second", {'adhoc_sign': False, 'identity': None, 'sign_app': False, 'package_state': 'first'}),
     ]
 
 
-
-def test_adhoc_sign_args_package_two_app(package_command, first_app,second_app):
+def test_adhoc_sign_args_package_two_app(package_command, first_app, second_app):
     "If there are multiple apps,and an --adhoc argument, package signs all apps using adhoc option"
-    
+
     package_command.apps = {
-        #Add the first app
+        # Add the first app
         "first": first_app,
-        #Add the second app
+        # Add the second app
         "second": second_app,
     }
 
@@ -167,16 +161,15 @@ def test_adhoc_sign_args_package_two_app(package_command, first_app,second_app):
     # The right sequence of things will be done
     assert package_command.actions == [
         # Tools are verified
-        ("verify", ),   
+        ("verify", ),
         # Package the first app
         ("package", "first", {'adhoc_sign': True, 'identity': None, 'sign_app': True}),
-        #package the second app
-        ("package", "second", {'adhoc_sign': True, 'identity': None, 'sign_app': True,'package_state':'first'}),
+        # package the second app
+        ("package", "second", {'adhoc_sign': True, 'identity': None, 'sign_app': True, 'package_state': 'first'}),
     ]
 
 
-
-def test_identity_sign_args_package_two_app(package_command, first_app,second_app):
+def test_identity_sign_args_package_two_app(package_command, first_app, second_app):
     "If there are multiple app,and an --identity argument, package signs all the apps with the specified identity"
     # Add a single app
     package_command.apps = {
@@ -185,7 +178,7 @@ def test_identity_sign_args_package_two_app(package_command, first_app,second_ap
     }
 
     # Configure no command line options
-    options = package_command.parse_options(["--identity","test"])
+    options = package_command.parse_options(["--identity", "test"])
 
     # Run the run command
     package_command(**options)
@@ -193,9 +186,9 @@ def test_identity_sign_args_package_two_app(package_command, first_app,second_ap
     # The right sequence of things will be done
     assert package_command.actions == [
         # Tools are verified
-        ("verify", ),   
+        ("verify", ),
         # Package the first app
         ("package", "first", {'adhoc_sign': False, 'identity': "test", 'sign_app': True}),
-        #package the second app
-        ("package", "second", {'adhoc_sign': False, 'identity': "test", 'sign_app': True,'package_state':'first'}),
+        # package the second app
+        ("package", "second", {'adhoc_sign': False, 'identity': "test", 'sign_app': True, 'package_state': 'first'}),
     ]


### PR DESCRIPTION

Items completed in reference to #486 :
- moved signing options as a macOS specific extension on the app and dmg commands to reference docs for the package command
- moved package command arguments(adhoc,identity and no-sign) specific to macOs to the base package command