### PR TITLE
Fix --no-docker option help for AppImage build

### DIFF
--- a/changes/496.misc.rst
+++ b/changes/496.misc.rst
@@ -1,0 +1,1 @@
+ Fix --no-docker option help for AppImage build

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -39,9 +39,7 @@ class LinuxAppImageMixin(LinuxMixin):
             '--no-docker',
             dest='use_docker',
             action='store_false',
-            help='The device to target; either a UDID, '
-                 'a device name ("iPhone 11"), '
-                 'or a device name and OS version ("iPhone 11::iOS 13.3")',
+            help="Don't use Docker for building the AppImage",
             required=False,
         )
 


### PR DESCRIPTION
appimage's `--no-docker` option help was a bad copy/paste of xcode's `--device` one

#148  PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
