### PR TITLE
Fix issue on fedora, caused by docker and SELinux

### DIFF
--- a/changes/500.bugfix.rst
+++ b/changes/500.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed docker build error on Linux

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -246,10 +246,10 @@ class Docker:
         docker_args = [
             "docker", "run",
             "--tty",
-            "--volume", "{self.command.platform_path}:/app".format(
+            "--volume", "{self.command.platform_path}:/app:z".format(
                 self=self
             ),
-            "--volume", "{self.command.dot_briefcase_path}:/home/brutus/.briefcase".format(
+            "--volume", "{self.command.dot_briefcase_path}:/home/brutus/.briefcase:z".format(
                 self=self
             ),
         ]

--- a/tests/integrations/docker/test_Docker__run.py
+++ b/tests/integrations/docker/test_Docker__run.py
@@ -12,10 +12,10 @@ def test_simple_call(mock_docker, tmp_path, capsys):
         [
             'docker',
             'run', '--tty',
-            '--volume', '{platform_path}:/app'.format(
+            '--volume', '{platform_path}:/app:z'.format(
                 platform_path=tmp_path / 'platform'
             ),
-            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase'.format(
+            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase:z'.format(
                 dot_briefcase_path=tmp_path / '.briefcase'
             ),
             'briefcase/com.example.myapp:py3.X',
@@ -35,10 +35,10 @@ def test_simple_call_with_arg(mock_docker, tmp_path, capsys):
         [
             'docker',
             'run', '--tty',
-            '--volume', '{platform_path}:/app'.format(
+            '--volume', '{platform_path}:/app:z'.format(
                 platform_path=tmp_path / 'platform'
             ),
-            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase'.format(
+            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase:z'.format(
                 dot_briefcase_path=tmp_path / '.briefcase'
             ),
             'briefcase/com.example.myapp:py3.X',
@@ -59,10 +59,10 @@ def test_simple_call_with_path_arg(mock_docker, tmp_path, capsys):
         [
             'docker',
             'run',  '--tty',
-            '--volume', '{platform_path}:/app'.format(
+            '--volume', '{platform_path}:/app:z'.format(
                 platform_path=tmp_path / 'platform'
             ),
-            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase'.format(
+            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase:z'.format(
                 dot_briefcase_path=tmp_path / '.briefcase'
             ),
             'briefcase/com.example.myapp:py3.X',
@@ -88,10 +88,10 @@ def test_simple_verbose_call(mock_docker, tmp_path, capsys):
         [
             'docker',
             'run', '--tty',
-            '--volume', '{platform_path}:/app'.format(
+            '--volume', '{platform_path}:/app:z'.format(
                 platform_path=tmp_path / 'platform'
             ),
-            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase'.format(
+            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase:z'.format(
                 dot_briefcase_path=tmp_path / '.briefcase'
             ),
             'briefcase/com.example.myapp:py3.X',
@@ -101,8 +101,8 @@ def test_simple_verbose_call(mock_docker, tmp_path, capsys):
     )
     assert capsys.readouterr().out == (
         ">>> docker run --tty "
-        "--volume {platform_path}:/app "
-        "--volume {dot_briefcase_path}:/home/brutus/.briefcase "
+        "--volume {platform_path}:/app:z "
+        "--volume {dot_briefcase_path}:/home/brutus/.briefcase:z "
         "briefcase/com.example.myapp:py3.X "
         "hello world\n"
     ).format(

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -197,10 +197,10 @@ def test_build_appimage_with_docker(build_command, first_app, tmp_path):
         [
             "docker",
             "run", "--tty",
-            '--volume', '{platform_path}:/app'.format(
+            '--volume', '{platform_path}:/app:z'.format(
                 platform_path=build_command.platform_path
             ),
-            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase'.format(
+            '--volume', '{dot_briefcase_path}:/home/brutus/.briefcase:z'.format(
                 dot_briefcase_path=build_command.dot_briefcase_path
             ),
             '--env', 'VERSION=0.0.1',


### PR DESCRIPTION
Problem
======
<!--- What problem does this change solve? -->
Briefcase doesn't work on Fedora 32 because of SELinux policy. It most likely doesn't work on any Linux distribution with enforced SELinux.

Solution
======
<!--- Describe your changes in detail -->
as it's described in [docker docs](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label), to modify the SELinux label of file or directory, which is being mounted, you need to add :z flag at the end. This will allow docker to properly mount volumes and briefcase to create and run docker image. This shouldn't interfere with other Linux distributions as it will be ignored.

Related
----------
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Issue #493  

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
