### PR TITLE
Improve visual appearance of dmg

### DIFF
--- a/changes/512.misc.rst
+++ b/changes/512.misc.rst
@@ -1,0 +1,1 @@
+Reducing the size of icons in the macOS dmg for a nicer visual appearance.

--- a/src/briefcase/platforms/macOS/dmg.py
+++ b/src/briefcase/platforms/macOS/dmg.py
@@ -78,9 +78,12 @@ class macOSDmgPackageCommand(macOSDmgMixin, macOSAppPackageCommand):
             'files': [str(self.binary_path(app))],
             'symlinks': {'Applications': '/Applications'},
             'icon_locations': {
-                '{app.formal_name}.app'.format(app=app): (100, 100),
-                'Applications': (300, 100),
+                '{app.formal_name}.app'.format(app=app): (75, 75),
+                'Applications': (225, 75),
             },
+            'window_rect': ((600, 600), (350, 150)),
+            'icon_size': 64,
+            'text_size': 12,
         }
 
         try:

--- a/tests/platforms/macOS/dmg/test_package.py
+++ b/tests/platforms/macOS/dmg/test_package.py
@@ -41,9 +41,12 @@ def test_build_dmg(first_app_config, tmp_path):
             'files': [str(tmp_path / 'macOS' / 'First App' / 'First App.app')],
             'symlinks': {'Applications': '/Applications'},
             'icon_locations': {
-                'First App.app': (100, 100),
-                'Applications': (300, 100),
+                'First App.app': (75, 75),
+                'Applications': (225, 75),
             },
+            'window_rect': ((600, 600), (350, 150)),
+            'icon_size': 64,
+            'text_size': 12,
         }
     )
 
@@ -86,10 +89,13 @@ def test_installer_icon(first_app_config, tmp_path):
             'files': [str(tmp_path / 'macOS' / 'First App' / 'First App.app')],
             'symlinks': {'Applications': '/Applications'},
             'icon_locations': {
-                'First App.app': (100, 100),
-                'Applications': (300, 100),
+                'First App.app': (75, 75),
+                'Applications': (225, 75),
             },
-            'icon': str(tmp_path / 'resources' / 'installer_icon.icns')
+            'window_rect': ((600, 600), (350, 150)),
+            'icon_size': 64,
+            'text_size': 12,
+            'icon': str(tmp_path / 'resources' / 'installer_icon.icns'),
         }
     )
 
@@ -129,9 +135,12 @@ def test_installer_icon_missing(first_app_config, tmp_path):
             'files': [str(tmp_path / 'macOS' / 'First App' / 'First App.app')],
             'symlinks': {'Applications': '/Applications'},
             'icon_locations': {
-                'First App.app': (100, 100),
-                'Applications': (300, 100),
+                'First App.app': (75, 75),
+                'Applications': (225, 75),
             },
+            'window_rect': ((600, 600), (350, 150)),
+            'icon_size': 64,
+            'text_size': 12,
         }
     )
 
@@ -174,10 +183,13 @@ def test_app_icon(first_app_config, tmp_path):
             'files': [str(tmp_path / 'macOS' / 'First App' / 'First App.app')],
             'symlinks': {'Applications': '/Applications'},
             'icon_locations': {
-                'First App.app': (100, 100),
-                'Applications': (300, 100),
+                'First App.app': (75, 75),
+                'Applications': (225, 75),
             },
-            'icon': str(tmp_path / 'resources' / 'icon.icns')
+            'window_rect': ((600, 600), (350, 150)),
+            'icon_size': 64,
+            'text_size': 12,
+            'icon': str(tmp_path / 'resources' / 'icon.icns'),
         }
     )
 
@@ -217,9 +229,12 @@ def test_app_icon_missing(first_app_config, tmp_path):
             'files': [str(tmp_path / 'macOS' / 'First App' / 'First App.app')],
             'symlinks': {'Applications': '/Applications'},
             'icon_locations': {
-                'First App.app': (100, 100),
-                'Applications': (300, 100),
+                'First App.app': (75, 75),
+                'Applications': (225, 75),
             },
+            'window_rect': ((600, 600), (350, 150)),
+            'icon_size': 64,
+            'text_size': 12,
         }
     )
 
@@ -262,10 +277,13 @@ def test_build_with_background(first_app_config, tmp_path):
             'files': [str(tmp_path / 'macOS' / 'First App' / 'First App.app')],
             'symlinks': {'Applications': '/Applications'},
             'icon_locations': {
-                'First App.app': (100, 100),
-                'Applications': (300, 100),
+                'First App.app': (75, 75),
+                'Applications': (225, 75),
             },
-            'background': str(tmp_path / 'resources' / 'background.png')
+            'window_rect': ((600, 600), (350, 150)),
+            'icon_size': 64,
+            'text_size': 12,
+            'background': str(tmp_path / 'resources' / 'background.png'),
         }
     )
 
@@ -305,8 +323,11 @@ def test_build_with_background_missing(first_app_config, tmp_path):
             'files': [str(tmp_path / 'macOS' / 'First App' / 'First App.app')],
             'symlinks': {'Applications': '/Applications'},
             'icon_locations': {
-                'First App.app': (100, 100),
-                'Applications': (300, 100),
+                'First App.app': (75, 75),
+                'Applications': (225, 75),
             },
+            'window_rect': ((600, 600), (350, 150)),
+            'icon_size': 64,
+            'text_size': 12,
         }
     )


### PR DESCRIPTION
At the moment, the app icon and application folder symlink are rather large. This PR reduces the icon size to 64 px and adapts the icon positions and window size accordingly. In the medium term, it may be nice to provide options to customise the installer appearance in the pyproject.toml.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
