### PR TITLE
Include python3 executable in code signing

### DIFF
--- a/changes/514.bugfix.rst
+++ b/changes/514.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed missing signature for Python executable in macOS app bundle.
+This enables the packaged dmg to be notarized by Apple.

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -184,6 +184,7 @@ class macOSAppPackageCommand(macOSAppMixin, PackageCommand):
             for path in itertools.chain(
                 self.binary_path(app).glob('**/*.so'),
                 self.binary_path(app).glob('**/*.dylib'),
+                self.binary_path(app).glob('**/python3'),
                 [self.binary_path(app)],
             ):
                 self.sign(


### PR DESCRIPTION
This fixes #513 by explicitly signing the Python executable in the Resources folder.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
