### PR TITLE
Briefcase success stories: add the napari project to success.rst

### DIFF
--- a/changes/518.doc.rst
+++ b/changes/518.doc.rst
@@ -1,0 +1,1 @@
+Added the napari project to the briefcase success stories documentation page.

--- a/docs/background/success.rst
+++ b/docs/background/success.rst
@@ -9,3 +9,7 @@ Want to see examples of Briefcase in use? Here's some:
 
 * `Mu <https://codewith.mu>`_ is a simple code editor for beginner programmers.
   It uses Briefcase to prepare a macOS installer.
+
+* `Napari <https://napari.org/>`_ is a multi-dimensional image viewer for python.
+  It uses Briefcase to prepare bundled Windows, MacOS, and Linux installers.
+  


### PR DESCRIPTION
This PR adds a link to the [napari](https://napari.org/) project to the briefcase success stories page.

Xref: https://github.com/napari/napari/issues/1600

