### PR TITLE
Support defining an msi installer scope as "per machine"

### DIFF
--- a/changes/498.feature.rst
+++ b/changes/498.feature.rst
@@ -1,1 +1,1 @@
-User can now define an MSI file to be "per user" or "per machine"
+Windows MSI installers can be configured to be per-machine, system-wide installers.

--- a/changes/498.feature.rst
+++ b/changes/498.feature.rst
@@ -1,0 +1,1 @@
+User can now define an MSI file to be "per user" or "per machine"

--- a/docs/reference/platforms/windows/msi.rst
+++ b/docs/reference/platforms/windows/msi.rst
@@ -34,6 +34,17 @@ The following options can be added to the
 ``tool.briefcase.app.<appname>.windows`` section of your ``pyproject.toml``
 file.
 
+``system_installer``
+--------------------
+
+Controls whether the app will be installed as a per-user or per-machine app.
+Per-machine apps are "system" apps, and require admin permissions to run the
+installer; however, they are installed once and shared between all users on a
+computer.
+
+If ``true`` the installer will attempt to install the app as a per-machine app,
+available to all users. Defaults to a per-user install.
+
 ``version_triple``
 ------------------
 

--- a/src/briefcase/platforms/windows/msi.py
+++ b/src/briefcase/platforms/windows/msi.py
@@ -79,10 +79,8 @@ class WindowsMSICreateCommand(WindowsMSIMixin, CreateCommand):
                 guid=guid,
             ))
 
-        try:
-            install_scope = app.install_scope
-        except AttributeError:
-            install_scope = "perUser"
+        system_installer = getattr(app, "system_installer", False)
+        install_scope = "perMachine" if system_installer else "perUser"
 
         return {
             'version_triple': version_triple,

--- a/src/briefcase/platforms/windows/msi.py
+++ b/src/briefcase/platforms/windows/msi.py
@@ -79,9 +79,15 @@ class WindowsMSICreateCommand(WindowsMSIMixin, CreateCommand):
                 guid=guid,
             ))
 
+        try:
+            install_scope = app.install_scope
+        except AttributeError:
+            install_scope = "perUser"
+
         return {
             'version_triple': version_triple,
             'guid': str(guid),
+            'install_scope': install_scope
         }
 
     def install_app_support_package(self, app: BaseConfig):

--- a/src/briefcase/platforms/windows/msi.py
+++ b/src/briefcase/platforms/windows/msi.py
@@ -79,8 +79,14 @@ class WindowsMSICreateCommand(WindowsMSIMixin, CreateCommand):
                 guid=guid,
             ))
 
-        system_installer = getattr(app, "system_installer", False)
-        install_scope = "perMachine" if system_installer else "perUser"
+        try:
+            if app.system_installer:
+                install_scope = "perMachine"
+            else:
+                install_scope = "perUser"
+        except AttributeError:
+            # system_installer not defined in config; default to perUser install.
+            install_scope = "perUser"
 
         return {
             'version_triple': version_triple,

--- a/tests/platforms/windows/msi/test_create.py
+++ b/tests/platforms/windows/msi/test_create.py
@@ -74,3 +74,22 @@ def test_support_package_url(first_app_config, tmp_path):
         ('version', '3.{minor}'.format(minor=sys.version_info.minor)),
         ('arch', arch),
     ]
+
+
+def test_default_install_scope(first_app_config, tmp_path):
+    "By default, app should be installed per user."
+    command = WindowsMSICreateCommand(base_path=tmp_path)
+
+    context = command.output_format_template_context(first_app_config)
+
+    assert context['install_scope'] == 'perUser'
+
+
+def test_per_machine_install_scope(first_app_config, tmp_path):
+    "By default, app should be installed per user."
+    command = WindowsMSICreateCommand(base_path=tmp_path)
+    first_app_config.install_scope = "perMachine"
+
+    context = command.output_format_template_context(first_app_config)
+
+    assert context['install_scope'] == "perMachine"

--- a/tests/platforms/windows/msi/test_create.py
+++ b/tests/platforms/windows/msi/test_create.py
@@ -88,7 +88,7 @@ def test_default_install_scope(first_app_config, tmp_path):
 def test_per_machine_install_scope(first_app_config, tmp_path):
     "By default, app should be installed per user."
     command = WindowsMSICreateCommand(base_path=tmp_path)
-    first_app_config.install_scope = "perMachine"
+    first_app_config.system_installer = True
 
     context = command.output_format_template_context(first_app_config)
 

--- a/tests/platforms/windows/msi/test_create.py
+++ b/tests/platforms/windows/msi/test_create.py
@@ -93,3 +93,13 @@ def test_per_machine_install_scope(first_app_config, tmp_path):
     context = command.output_format_template_context(first_app_config)
 
     assert context['install_scope'] == "perMachine"
+
+
+def test_per_user_install_scope(first_app_config, tmp_path):
+    "App can be set to have explocit per-user scope."
+    command = WindowsMSICreateCommand(base_path=tmp_path)
+    first_app_config.system_installer = False
+
+    context = command.output_format_template_context(first_app_config)
+
+    assert context['install_scope'] == "perUser"


### PR DESCRIPTION
Now users can define an MSI installer to be "per user" or "per machine".

Fixes #498

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
