### PR TITLE
Fix failed test in test_create.py

### DIFF
--- a/changes/521.bugfix.rst
+++ b/changes/521.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed failed windows test

--- a/changes/521.bugfix.rst
+++ b/changes/521.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed failed windows test
+Modified a Windows test to allow it to pass on 32-bit machines.

--- a/tests/platforms/windows/msi/test_create.py
+++ b/tests/platforms/windows/msi/test_create.py
@@ -67,7 +67,7 @@ def test_support_package_url(first_app_config, tmp_path):
     command.platform = 'tester'
 
     # This test result is dependent on whether we're using a 32-bit (win32)
-    # or 64-bit (amd64) machine. 
+    # or 64-bit (amd64) machine.
     arch = "amd64" if sys.maxsize.bit_length() == 63 else "win32"
     assert command.support_package_url_query == [
         ('platform', 'tester'),

--- a/tests/platforms/windows/msi/test_create.py
+++ b/tests/platforms/windows/msi/test_create.py
@@ -66,8 +66,8 @@ def test_support_package_url(first_app_config, tmp_path):
     command.host_arch = 'wonky'
     command.platform = 'tester'
 
-    # This test result assumes we're on ARM64. However, we will be
-    # on almost every Windows box (and definite will be in CI)
+    # This test result is dependent on whether we're using a 32-bit (win32)
+    # or 64-bit (amd64) machine. 
     arch = "amd64" if sys.maxsize.bit_length() == 63 else "win32"
     assert command.support_package_url_query == [
         ('platform', 'tester'),

--- a/tests/platforms/windows/msi/test_create.py
+++ b/tests/platforms/windows/msi/test_create.py
@@ -68,8 +68,9 @@ def test_support_package_url(first_app_config, tmp_path):
 
     # This test result assumes we're on ARM64. However, we will be
     # on almost every Windows box (and definite will be in CI)
+    arch = "amd64" if sys.maxsize.bit_length() == 63 else "win32"
     assert command.support_package_url_query == [
         ('platform', 'tester'),
         ('version', '3.{minor}'.format(minor=sys.version_info.minor)),
-        ('arch', 'amd64'),
+        ('arch', arch),
     ]


### PR DESCRIPTION
Fixed a failed test on windows. When running the test `test_support_package_url` in *platform/windows/msi/test_create.py*, It fails on some computers:

```
[('platform', 'tester'), ('version', '3.8'), ('arch', 'win32')] != [('platform', 'tester'), ('version', '3.8'), ('arch', 'amd64')]

Expected :[('platform', 'tester'), ('version', '3.8'), ('arch', 'amd64')]
Actual   :[('platform', 'tester'), ('version', '3.8'), ('arch', 'win32')]
```
I fixed that.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
