### PR TITLE
Add no-run option to dev command

### DIFF
--- a/changes/522.feature.rst
+++ b/changes/522.feature.rst
@@ -1,0 +1,2 @@
+Added the `--no-run` flag to the *Dev* command, which installs the app dependencies
+without running it.

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -52,7 +52,9 @@ class DevCommand(BaseCommand):
         )
         parser.add_argument(
             '--no-run',
-            action="store_true",
+            dest="run_app",
+            action="store_false",
+            default=True,
             help='Do not run the app, just install dependencies.'
         )
 
@@ -109,7 +111,7 @@ class DevCommand(BaseCommand):
         self,
         appname: Optional[str] = None,
         update_dependencies: Optional[bool] = False,
-        no_run: Optional[bool] = False,
+        run_app: Optional[bool] = True,
         **options
     ):
         # Confirm all required tools are available
@@ -139,7 +141,10 @@ class DevCommand(BaseCommand):
         # installed. If a dependency update has been manually requested,
         # do it regardless.
         dist_info_path = self.app_module_path(app).parent / '{app.module_name}.dist-info'.format(app=app)
-        if update_dependencies or no_run or not dist_info_path.exists():
+        if not run_app:
+            # If we are not running the app, it means we should update dependencies.
+            update_dependencies = True
+        if update_dependencies or not dist_info_path.exists():
             print()
             print('[{app.app_name}] Installing dependencies...'.format(
                 app=app
@@ -147,7 +152,7 @@ class DevCommand(BaseCommand):
             self.install_dev_dependencies(app, **options)
             write_dist_info(app, dist_info_path)
 
-        if not no_run:
+        if run_app:
             print()
             print('[{app.app_name}] Starting in dev mode...'.format(
                 app=app

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -50,6 +50,11 @@ class DevCommand(BaseCommand):
             action="store_true",
             help='Update dependencies for app'
         )
+        parser.add_argument(
+            '--no-run',
+            action="store_true",
+            help='Do not run the app, just install dependencies.'
+        )
 
     def install_dev_dependencies(self, app: BaseConfig, **options):
         """
@@ -104,6 +109,7 @@ class DevCommand(BaseCommand):
         self,
         appname: Optional[str] = None,
         update_dependencies: Optional[bool] = False,
+        no_run: Optional[bool] = False,
         **options
     ):
         # Confirm all required tools are available
@@ -133,7 +139,7 @@ class DevCommand(BaseCommand):
         # installed. If a dependency update has been manually requested,
         # do it regardless.
         dist_info_path = self.app_module_path(app).parent / '{app.module_name}.dist-info'.format(app=app)
-        if update_dependencies or not dist_info_path.exists():
+        if update_dependencies or no_run or not dist_info_path.exists():
             print()
             print('[{app.app_name}] Installing dependencies...'.format(
                 app=app
@@ -141,10 +147,11 @@ class DevCommand(BaseCommand):
             self.install_dev_dependencies(app, **options)
             write_dist_info(app, dist_info_path)
 
-        print()
-        print('[{app.app_name}] Starting in dev mode...'.format(
-            app=app
-        ))
-        env = self.get_environment(app)
-        state = self.run_dev_app(app, env, **options)
-        return state
+        if not no_run:
+            print()
+            print('[{app.app_name}] Starting in dev mode...'.format(
+                app=app
+            ))
+            env = self.get_environment(app)
+            state = self.run_dev_app(app, env, **options)
+            return state

--- a/tests/commands/dev/test_call.py
+++ b/tests/commands/dev/test_call.py
@@ -231,3 +231,26 @@ def test_update_uninstalled(dev_command, first_app_uninstalled):
         # Then, it will be started
         ("run_dev", "first", {}, dev_command.env),
     ]
+
+
+def test_no_run(dev_command, first_app_uninstalled):
+    "Install dependencies without running the app"
+    # Add a single app
+    dev_command.apps = {
+        "first": first_app_uninstalled,
+    }
+
+    # Configure no command line options
+    options = dev_command.parse_options(["--no-run"])
+
+    # Run the run command
+    dev_command(**options)
+
+    # The right sequence of things will be done
+    assert dev_command.actions == [
+        # Tools are verified
+        ('verify', ),
+
+        # Only update dependencies without running the app
+        ("dev_dependencies", "first", {}),
+    ]

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -111,7 +111,7 @@ def test_dev_command(monkeypatch):
     assert options == {
         'appname': None,
         'update_dependencies': False,
-        'no_run': False
+        'run_app': True
     }
 
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -111,6 +111,7 @@ def test_dev_command(monkeypatch):
     assert options == {
         'appname': None,
         'update_dependencies': False,
+        'no_run': False
     }
 
 


### PR DESCRIPTION
One can now install dev-mode dependencies without actually running the app.
This is good for testing and CI/CD purposes.

This is a retry of #506

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
