### PR TITLE
fix crash when running with verbose output

### DIFF
--- a/changes/532.bugfix.rst
+++ b/changes/532.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a crash when running with verbose output.

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -56,7 +56,7 @@ class Subprocess:
         # All exceptions are propegated back to the caller.
         if self.command.verbosity >= 2:
             print(">>> {cmdline}".format(
-                cmdline=' '.join(shlex.quote(arg) for arg in args)
+                cmdline=' '.join(shlex.quote(str(arg)) for arg in args)
             ))
 
         return self._subprocess.run(


### PR DESCRIPTION
Some arguments are passed as pathlib.Path objects, so convert them to str first.