### PR TITLE
fix .briefcase directory permissions in some cases for linux build

### DIFF
--- a/changes/534.bugfix.rst
+++ b/changes/534.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed broken .briefcase directory permissions in some cases during linux builds.

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -289,6 +289,10 @@ class Docker:
             else:
                 docker_args.append(arg)
 
+        # Ensure the .briefcase directory has been created before mounting it as
+        # a volume or else inside the container it will be owned by root.
+        self.command.dot_briefcase_path.mkdir(exist_ok=True)
+
         # Invoke the process.
         # Any exceptions from running the process are *not* caught.
         # This ensures that "docker.run()" behaves as closely to

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -26,6 +26,9 @@ def first_app(first_app_config, tmp_path):
     (app_dir / 'usr' / 'app_packages' / 'secondlib' / 'second_a.so').touch()
     (app_dir / 'usr' / 'app_packages' / 'secondlib' / 'second_b.so').touch()
 
+    # Create home directory
+    (tmp_path / 'home').mkdir(parents=True, exist_ok=True)
+
     return first_app_config
 
 


### PR DESCRIPTION
During `briefcase build linux`, if the `.briefcase` directory is not already present when docker is being used, docker will create the directory as root in order to mount it as a volume in the container, preventing the container from modifying its contents. This fixes that by ensuring the `.briefcase` directory has been created by the user briefcase is running as, before running docker.

In many cases, the `.briefcase` directory is created when e.g. installing the app support package, but when using a custom app support package path on the filesystem, the `.briefcase` directory doesn't get created before docker is run.

Tested this change with `briefcase build linux` on my own project.