### PR TITLE
Drop python 3.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
         - 'package'
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         pip install --upgrade pip
@@ -33,15 +33,15 @@ jobs:
         tox -e ${{ matrix.task }}
 
   smoke:
-    name: Smoke test (3.5)
+    name: Smoke test (3.6)
     needs: beefore
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.5
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.6
     - name: Install dependencies
       run: |
         pip install --upgrade pip
@@ -68,7 +68,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -90,10 +90,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         pip install --upgrade pip
@@ -109,10 +109,10 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         pip install --upgrade pip

--- a/changes/562.misc.rst
+++ b/changes/562.misc.rst
@@ -1,0 +1,1 @@
+Drop python 3.5 support!

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ platforms = any
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.5
+python_requires = >= 3.6
 include_package_data = True
 package_dir =
     = src

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,towncrier-check,docs,package,py{35,36,37,38},pypy3
+envlist = flake8,towncrier-check,docs,package,py{36,37,38,39},pypy3
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Finally, dropping support for Python 3.5, as discussed in beeware/toga#1199

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
