### PR TITLE
Fix for Issue #460: On Android, if your app is called `x.y.switch`, it fails to build

### DIFF
--- a/changes/562.misc.rst
+++ b/changes/562.misc.rst
@@ -1,1 +1,0 @@
-Drop python 3.5 support!

--- a/changes/562.misc.rst
+++ b/changes/562.misc.rst
@@ -1,0 +1,1 @@
+Drop python 3.5 support!

--- a/changes/565.bugfix.rst
+++ b/changes/565.bugfix.rst
@@ -1,0 +1,1 @@
+Fix for Issue #460 by adding a check in `briefcase new` for use of Python or Java keywords.

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -16,7 +16,7 @@ from .create import InvalidTemplateRepository
 
 VALID_BUNDLE_RE = re.compile(r'[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+$')
 
-javareserved = [
+reservedwords = {
     "abstract", "assert", "boolean", "break", "byte", "case", "catch",
     "char", "class", "const", "continue", "default", "do", "double",
     "else", "enum", "extends", "final", "finally", "float", "for",
@@ -26,7 +26,7 @@ javareserved = [
     "super", "switch", "synchronized", "this", "throw", "throws",
     "transient", "try", "void", "volatile", "while", "true", "false",
     "null"
-]
+}
 
 
 def titlecase(s):
@@ -125,11 +125,15 @@ class NewCommand(BaseCommand):
             raise ValueError(
                 "A '{candidate}' directory already exists. Select a different "
                 "name, move to a different parent directory, or delete the "
-                "existing folder.".format(candidate=candidate)
+                "existing folder.".format(
+                    candidate=candidate,
+                )
             )
-        if iskeyword(candidate) or candidate in javareserved:
+        if iskeyword(candidate) or candidate in reservedwords:
             raise ValueError(
-                "App name may not contain Java or Python reserved words."
+                f"App name may not contain the reserved word '{candidate}'.".format(
+                    candidate=candidate,
+                )
             )
         return True
 
@@ -158,9 +162,11 @@ class NewCommand(BaseCommand):
                 "include letters, numbers, and hyphens."
             )
         for word in candidate.split("."):
-            if word in javareserved:
+            if word in reservedwords:
                 raise ValueError(
-                    "Bundle name components may not contain Java reserved words."
+                    "Bundle name component may not contain the reserved word '{candidate}'.".format(
+                        candidate=candidate,
+                    )
                 )
         return True
 
@@ -349,7 +355,7 @@ for your application. This name must be PEP508-compliant - that means the name
 may only contain letters, numbers, hyphens and underscores; it can't contain
 spaces or punctuation, and it can't start with a hyphen or underscore.
 
-Due to build requirements, the app name may also not be a Java or Python keyword.
+Due to build requirements, the app name should avoid reserved words in common programming languages.
 Based on your formal name, we suggest an app name of '{default_app_name}',
 but you can use another name if you want.""".format(
                 default_app_name=default_app_name

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -9,12 +9,24 @@ from cookiecutter import exceptions as cookiecutter_exceptions
 from briefcase.config import PEP508_NAME_RE
 from briefcase.exceptions import NetworkFailure
 
+from keyword import iskeyword
+
 from .base import BaseCommand, BriefcaseCommandError
 from .create import InvalidTemplateRepository
 
 VALID_BUNDLE_RE = re.compile(r'[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+$')
 
-
+javareserved = [
+    "abstract", "assert", "boolean", "break", "byte", "case", "catch",
+    "char", "class", "const", "continue", "default", "do", "double",
+    "else", "enum", "extends", "final", "finally", "float", "for",
+    "goto", "if", "implements", "import", "instanceof", "int",
+    "interface", "long", "native", "new", "package", "private",
+    "protected", "public", "return", "short", "static", "strictfp",
+    "super", "switch", "synchronized", "this", "throw", "throws",
+    "transient", "try", "void", "volatile", "while", "true", "false",
+    "null"
+]
 def titlecase(s):
     """
     Convert a string to titlecase.
@@ -113,7 +125,10 @@ class NewCommand(BaseCommand):
                 "name, move to a different parent directory, or delete the "
                 "existing folder.".format(candidate=candidate)
             )
-
+        if iskeyword(candidate) or candidate in javareserved:
+            raise ValueError(
+                "App name may not contain Java or Python reserved words."
+            )
         return True
 
     def make_module_name(self, app_name):
@@ -140,6 +155,11 @@ class NewCommand(BaseCommand):
                 "least 2 dot-separated sections, and each section may only "
                 "include letters, numbers, and hyphens."
             )
+        for word in candidate.split("."):
+            if word in javareserved:
+                raise ValueError(
+                    "Bundle name components may not contain Java reserved words."
+                )
         return True
 
     def make_domain(self, bundle):
@@ -327,6 +347,7 @@ for your application. This name must be PEP508-compliant - that means the name
 may only contain letters, numbers, hyphens and underscores; it can't contain
 spaces or punctuation, and it can't start with a hyphen or underscore.
 
+Due to build requirements, the app name may also not be a Java or Python keyword.
 Based on your formal name, we suggest an app name of '{default_app_name}',
 but you can use another name if you want.""".format(
                 default_app_name=default_app_name

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -164,8 +164,8 @@ class NewCommand(BaseCommand):
         for word in candidate.split("."):
             if word in reservedwords:
                 raise ValueError(
-                    "Bundle name component may not contain the reserved word '{candidate}'.".format(
-                        candidate=candidate,
+                    "Bundle name component may not contain the reserved word '{word}'.".format(
+                        word=word,
                     )
                 )
         return True

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -27,6 +27,8 @@ javareserved = [
     "transient", "try", "void", "volatile", "while", "true", "false",
     "null"
 ]
+
+
 def titlecase(s):
     """
     Convert a string to titlecase.

--- a/tests/commands/new/test_validate_app_name.py
+++ b/tests/commands/new/test_validate_app_name.py
@@ -25,8 +25,8 @@ def test_valid_app_name(new_command, name):
         '_helloworld',  # leading underscore
         '-helloworld',  # leading hyphen
         'existing',  # pre-existing directory
-	'def', # python reserved word
-	'switch', # java reserved word
+        'def',  # python reserved word
+        'switch',  # java reserved word
     ]
 )
 def test_invalid_app_name(new_command, name, tmp_path):

--- a/tests/commands/new/test_validate_app_name.py
+++ b/tests/commands/new/test_validate_app_name.py
@@ -25,6 +25,8 @@ def test_valid_app_name(new_command, name):
         '_helloworld',  # leading underscore
         '-helloworld',  # leading hyphen
         'existing',  # pre-existing directory
+	'def', # python reserved word
+	'switch', # java reserved word
     ]
 )
 def test_invalid_app_name(new_command, name, tmp_path):

--- a/tests/commands/new/test_validate_bundle.py
+++ b/tests/commands/new/test_validate_bundle.py
@@ -8,6 +8,7 @@ import pytest
         'com.example.more',
         'com.example42.more',
         'com.example-42.more',
+	'com.def', # python reserved words are allowed in bundles
     ]
 )
 def test_valid_bundle(new_command, bundle):

--- a/tests/commands/new/test_validate_bundle.py
+++ b/tests/commands/new/test_validate_bundle.py
@@ -8,7 +8,7 @@ import pytest
         'com.example.more',
         'com.example42.more',
         'com.example-42.more',
-	'com.def', # python reserved words are allowed in bundles
+        'com.def',  # python reserved words are allowed in bundles
     ]
 )
 def test_valid_bundle(new_command, bundle):

--- a/tests/commands/new/test_validate_bundle.py
+++ b/tests/commands/new/test_validate_bundle.py
@@ -24,7 +24,7 @@ def test_valid_bundle(new_command, bundle):
         'com.hello_world',  # underscore
         'com.hello,world',  # comma
         'com.hello world!',  # exclamation point
-	'com.switch', # java reserved word
+        'com.switch',  # java reserved word
     ]
 )
 def test_invalid_bundle(new_command, bundle):

--- a/tests/commands/new/test_validate_bundle.py
+++ b/tests/commands/new/test_validate_bundle.py
@@ -23,6 +23,7 @@ def test_valid_bundle(new_command, bundle):
         'com.hello_world',  # underscore
         'com.hello,world',  # comma
         'com.hello world!',  # exclamation point
+	'com.switch', # java reserved word
     ]
 )
 def test_invalid_bundle(new_command, bundle):


### PR DESCRIPTION
Stumbled upon this issue while looking for where I could attempt my first GitHub contribution.
After some testing involving Issue #460 I made this quick desk check.

Name: switch | BUILD FAILED
Bundle: com.switch | BUILD FAILED
Name: def | BUILD SUCCESS & DOES NOT RUN
Bundle: com.def | BUILD SUCCESS & RUNS

Using this information I have made changes to `briefcase new` which prevents users from setting a package name or bundle identifier which triggers this issue.