### PR TITLE
Prevent invalid app names on Windows

### DIFF
--- a/changes/573.misc.rst
+++ b/changes/573.misc.rst
@@ -1,0 +1,1 @@
+Added check for invalid filenames like CON on windows, and warning for non-windows users.

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -1,5 +1,6 @@
 import re
 import subprocess
+import platform  # For Windows invalid filenames like CON
 from email.utils import parseaddr
 from typing import Optional
 from urllib.parse import urlparse
@@ -113,6 +114,36 @@ class NewCommand(BaseCommand):
                 "name, move to a different parent directory, or delete the "
                 "existing folder.".format(candidate=candidate)
             )
+
+        """
+        Make sure name is valid in Windows. Otherwise downloading to Windows
+        for building is impossible.
+        """
+
+        if (candidate.upper() in [
+            "CON", "PRN", "AUX", "NUL"
+            "COM1", "COM2", "COM3",
+            "COM4", "COM5", "COM6",
+            "COM7", "COM8", "COM9"
+            "LPT1", "LPT2", "LPT3",
+            "LPT4", "LPT5", "LPT6",
+            "LPT7", "LPT8", "LPT9"
+        ]):
+
+            if platform.system() == "Windows":
+                raise ValueError(
+                    "'{candidate}' is one of the following filenames not allowed\n"
+                    "on Windows systems: CON, PRN, AUX, NUL, COM1, COM2, COM3,\n"
+                    "COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4,\n"
+                    "LPT5, LPT6, LPT7, LPT8, and LPT9. Select a different name."
+                    .format(candidate=candidate)
+                    )
+            else:
+                print("""
+Warning: This filename is not allowed on Windows
+systems. This means that it cannot be downloaded and built
+on Windows. Consider changing it to prevent incompatibility
+issues.""")
 
         return True
 


### PR DESCRIPTION
I am aware that this is too much of a special case to be committed, and I coded it for some practice. However, I thought I might as well submit a pull request.

 This code (line 123) prevents an app being called invalid filenames such as PRN or CON on windows, which would result in a long error not easily understandable:
![image](https://user-images.githubusercontent.com/79451920/109308346-2fcbeb80-7842-11eb-8fc4-7f494c4129a1.png)
![image](https://user-images.githubusercontent.com/79451920/109308363-365a6300-7842-11eb-9fcc-ae95eb814c05.png)

The names CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, COM0, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9 and LPT0 are not allowed on windows.
This PR checks for these invalid names, and (checking the system by importing platform) throws a ValueError which tells the user exactly what the error is. It also adds a warning for mac/linux users who call their file these names, telling them that this makes them incompatible with Windows. These filenames make creating on mac/linux then downloading to windows impossible - the download is stuck in the middle and gives no error message with some downloading methods like Drive. For obvious reasons, this is confusing and problematic. This PR gives an early warning of it.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
Checked with flake8 and tox, as well as manually
- [x] All new features have been documented
Towncrier fragment added, but Docs have not been updated.
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
