### PR TITLE
Catch invalid windows names and issue warning for other systems

### DIFF
--- a/changes/576.misc.rst
+++ b/changes/576.misc.rst
@@ -1,0 +1,1 @@
+Added check for illegal filenames like CON or PRN in briefcase new. Prevents these names in Windows, and adds warnings for them in mac/linux.


### PR DESCRIPTION
New PR, made with fork this time. Suggestions such as verification message implemented. Does not need to be immediately merged if not desirable, as a larger solution for invalid filenames may be found in conjunction with PR #565.

<!--- Describe your changes in detail -->
Prevent windows users from calling their files invalid names, and issue a warning for Mac/linux users.
<!--- What problem does this change solve? -->
(copied from previous PR) 
This code (line 123) prevents an app being called invalid filenames such as PRN or CON on windows, which would result in a long error not easily understandable:

![](https://user-images.githubusercontent.com/79451920/109308346-2fcbeb80-7842-11eb-8fc4-7f494c4129a1.png)
![](https://user-images.githubusercontent.com/79451920/109308363-365a6300-7842-11eb-9fcc-ae95eb814c05.png)

The names CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, COM0, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9 and LPT0 are not allowed on windows.
This PR checks for these invalid names, and (checking the system by importing platform) throws a ValueError which tells the user exactly what the error is. It also adds a warning for mac/linux users who call their file these names, telling them that this makes them incompatible with Windows and adding a confirmation question. These filenames make creating on mac/linux then downloading to windows impossible - the download is stuck in the middle and gives no error message with some downloading methods like Drive. For obvious reasons, this is confusing and problematic. This PR gives an early warning of it.



## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
