### PR TITLE
Pin sphinx requirement to prevent use of Sphinx 4.

### DIFF
--- a/changes/587.misc.rst
+++ b/changes/587.misc.rst
@@ -1,0 +1,1 @@
+Pinned the version of Sphinx used to build on Read The Docs.

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx<4
 sphinxcontrib-spelling
 pyenchant
 sphinx-autobuild


### PR DESCRIPTION
Sphinx 4 causes problems with some plugins; pin the Sphinx version to prevent problems.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
