### PR TITLE
Drop Jinja2 version pin

### DIFF
--- a/changes/598.misc.rst
+++ b/changes/598.misc.rst
@@ -1,0 +1,1 @@
+Dropped the Jinja2 version pin as Python 3.5 is no longer supported.

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,8 +60,7 @@ install_requires =
     requests >= 2.22.0
     GitPython >= 3.0.8
     dmgbuild >= 1.3.3; sys_platform == "darwin"
-    # Jinja2 3.0 drops support for Python 3.5
-    Jinja2 < 3.0
+    Jinja2
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
In response to #305, the Jinja2 requirement was pinned in order to maintain support for Python 3.5.

Now that Python 3.5 is no longer supported, we can drop this pin.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
