### PR TITLE
Update contribute-code.rst

### DIFF
--- a/changes/621.misc.rst
+++ b/changes/621.misc.rst
@@ -1,0 +1,1 @@
+Corrected Tox command build instructions.

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -131,19 +131,19 @@ Or, to run using a specific version of Python, e.g. when you want to use Python 
 
     .. code-block:: bash
 
-      (venv) $ tox -e py3.7
+      (venv) $ tox -e py37
 
   .. group-tab:: Linux
 
     .. code-block:: bash
 
-      (venv) $ tox -e py3.7
+      (venv) $ tox -e py37
 
   .. group-tab:: Windows
 
     .. code-block:: bash
 
-      C:\...>tox -e py3.7
+      C:\...>tox -e py37
 
 substituting the version number that you want to target. You can also specify
 one of the pre-commit checks `flake8`, `docs` or `package` to check code


### PR DESCRIPTION
Changed tox command instruction to show that no decimal is required for the python version. 
An example of the problem solved: 
 ➜tox -e py3.8
ERROR: unknown environment 'py3.8'

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
