### PR TITLE
Add initial support for URI schemes

### DIFF
--- a/changes/624.feature.rst
+++ b/changes/624.feature.rst
@@ -1,0 +1,1 @@
+Added support for registering custom URI schemes.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -331,6 +331,13 @@ template is a local file, this attribute will be ignored. If not specified,
 Briefcase will use a branch matching the Python version in use (i.e., the `3.8`
 branch will be used when Python 3.8 is used to generate the app).
 
+``uri_schemes``
+~~~~~~~~~~~~~~~
+
+A list of URI scheme names. Some applications may require registering a custom
+URI scheme to the operating system. So by adding a scheme, applications can be
+launched by opening a URL prefixed with the specified scheme.
+
 ``url``
 ~~~~~~~
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -338,6 +338,10 @@ A list of URI scheme names. Some applications may require registering a custom
 URI scheme to the operating system. So by adding a scheme, applications can be
 launched by opening a URL prefixed with the specified scheme.
 
+Scheme names consist of a sequence of characters beginning with a letter and
+followed by any combination of letters, digits, plus ("+"), period ("."), 
+or hyphen ("-").
+
 ``url``
 ~~~~~~~
 

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -119,6 +119,7 @@ class AppConfig(BaseConfig):
         icon=None,
         splash=None,
         document_type=None,
+        uri_schemes=None,
         template=None,
         template_branch=None,
         supported=True,
@@ -139,6 +140,7 @@ class AppConfig(BaseConfig):
         self.icon = icon
         self.splash = splash
         self.document_types = {} if document_type is None else document_type
+        self.uri_schemes = [] if uri_schemes is None else uri_schemes
         self.template = template
         self.template_branch = template_branch
         self.supported = supported
@@ -175,6 +177,14 @@ class AppConfig(BaseConfig):
             raise BriefcaseConfigError(
                 "The `sources` list for {self.app_name} does not include a "
                 "package named '{self.module_name}'.".format(self=self)
+            )
+
+        # URI scheme list doesn't include any duplicates
+        uri_schemes_list = set(self.uri_schemes)
+        if len(uri_schemes_list) != len(self.uri_schemes):
+            raise BriefcaseConfigError(
+                "The `uri_schemes` list for {self.app_name} contains "
+                "duplicated schemes.".format(self=self)
             )
 
     def __repr__(self):

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -205,7 +205,7 @@ class AppConfig(BaseConfig):
                 "The `uri_schemes` list for {self.app_name} contains "
                 "duplicated schemes.".format(self=self)
             )
-    
+
         # One of the URI schemes is invalid
         invalid_scheme = next((scheme for scheme in uri_schemes_list if not is_uri_scheme_valid(scheme)), None)
         if invalid_scheme:

--- a/src/briefcase/integrations/cookiecutter.py
+++ b/src/briefcase/integrations/cookiecutter.py
@@ -31,3 +31,20 @@ class RGBExtension(Extension):
         environment.filters['float_red'] = float_red
         environment.filters['float_green'] = float_green
         environment.filters['float_blue'] = float_blue
+
+
+class ListExtension(Extension):
+    """Jinja2 extension to parse list as cookiecutter doesn't support lists."""
+
+    def __init__(self, environment) -> None:
+        """Initialize the extension with the given environment."""
+        super(ListExtension, self).__init__(environment)
+
+        def parse_list(obj):
+            if isinstance(obj, str):
+                return obj.strip().split(",")
+            elif isinstance(obj, list):
+                return obj
+            return []
+
+        environment.filters['parse_list'] = parse_list

--- a/tests/commands/create/test_generate_app_template.py
+++ b/tests/commands/create/test_generate_app_template.py
@@ -30,6 +30,7 @@ def full_context(extra):
         'splash': None,
         'supported': True,
         'document_types': {},
+        'uri_schemes': [],
 
         # Fields generated from other properties
         'module_name': 'my_app',

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -237,6 +237,28 @@ def test_duplicated_uri_schemes(uri_scheme):
         )
 
 
+@pytest.mark.parametrize(
+    'uri_scheme',
+    [
+        ['1invalid'],
+        ['-invalid'],
+        ['invalid uri'],
+        ['.invalid'],
+        ['1']
+    ]
+)
+def test_invalid_uri_schemes(uri_scheme):
+    with pytest.raises(BriefcaseConfigError, match=r" contains non-valid URI scheme"):
+        AppConfig(
+            app_name='my-app',
+            version="1.2.3",
+            bundle="org.beeware",
+            description="A simple app",
+            sources=['src/myapp'],
+            uri_schemes=uri_scheme
+        )
+
+
 def test_no_source_for_app():
     with pytest.raises(BriefcaseConfigError, match=r" does not include a package named 'my_app'\."):
         AppConfig(

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -24,6 +24,7 @@ def test_minimal_AppConfig():
     # Derived properties have been set.
     assert config.formal_name == 'myapp'
     assert config.document_types == {}
+    assert config.uri_schemes == []
 
     # There is no icon or splash of any kind
     assert config.icon is None
@@ -53,6 +54,7 @@ def test_extra_attrs():
                 'description': 'A document',
             }
         },
+        uri_schemes=['myapp'],
         first="value 1",
         second=42,
     )
@@ -73,6 +75,7 @@ def test_extra_attrs():
             'description': 'A document',
         }
     }
+    assert config.uri_schemes == ['myapp']
 
     # Explicit additional properties have been set
     assert config.first == "value 1"
@@ -212,6 +215,25 @@ def test_duplicated_source(sources):
             bundle="org.beeware",
             description="A simple app",
             sources=sources
+        )
+
+
+@pytest.mark.parametrize(
+    'uri_scheme',
+    [
+        ['myapp', 'myapp'],
+        ['myapp', 'other', 'myapp']
+    ]
+)
+def test_duplicated_uri_schemes(uri_scheme):
+    with pytest.raises(BriefcaseConfigError, match=r"contains duplicated schemes\."):
+        AppConfig(
+            app_name='dupe',
+            version="1.2.3",
+            bundle="org.beeware",
+            description="A simple app",
+            sources=['src/myapp'],
+            uri_schemes=uri_scheme
         )
 
 


### PR DESCRIPTION
Fixes #623 

Some applications may require registering a custom URI scheme to the operating system. So, by adding a scheme, applications can be launched by opening a URL prefixed with the specified scheme. Applications can read the passed URL with `sys.argv` (if the parameter has passed to the app correctly).

Registering URI schemes to an application is done by just modifying the manifest files of platforms separately. I will create PRs for each cookiecutter template repository, to support custom URI schemes. Without other PRs, this PR is not functional at all.

Example usage:

```toml
[tool.briefcase.app.example]
formal_name = "Example"
description = "An example app."
author = "Yusuf Cihan"
uri_schemes = [
    "myapp"
]
```

In the above example, "myapp" will be registered to the current operating system when app has installed. So when you launch a URL that starts with `myapp://` scheme (in browser or in another application) the application should be launched with URL passed as argument according to operating system.

```
python -m example "myapp://page/home"
```

### Platforms

Currently, these platforms' templates supports registering custom URI schemes. I will update the checklist with all PR references when I create PRs for each briefcase templates. As I may not test URI schemes for all platforms, some PRs can contain untested changes.

* [ ] Android
* [ ] Windows beeware/briefcase-windows-msi-template#10
* [ ] Linux beeware/briefcase-linux-appimage-template#9
* [ ] MacOS
* [ ] iOS

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
