### PR TITLE
Disable stripping for appimage

### DIFF
--- a/changes/583.bugfix.rst
+++ b/changes/583.bugfix.rst
@@ -1,0 +1,1 @@
+Stripping is now disabled for appimage, because stripping shared objects can lead to some issues - e.g NumPy.

--- a/changes/583.bugfix.rst
+++ b/changes/583.bugfix.rst
@@ -1,1 +1,1 @@
-Stripping is now disabled for appimage, because stripping shared objects can lead to some issues - e.g NumPy.
+Stripping is now disabled for AppImage binaries. Some libraries (e.g., NumPy) rely on the metadata that was being stripped.

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -171,7 +171,8 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
             # For some reason, the version has to be passed in as an
             # environment variable, *not* in the configuration...
             env = {
-                'VERSION': app.version
+                'VERSION': app.version,
+                'NO_STRIP': 1
             }
 
             # Find all the .so files in app and app_packages,

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -129,6 +129,7 @@ def test_build_appimage(build_command, first_app, tmp_path):
         env={
             'PATH': '/usr/local/bin:/usr/bin',
             'VERSION': '0.0.1',
+            'NO_STRIP': 1,
         },
         check=True,
         cwd=os.fsdecode(tmp_path / 'linux')
@@ -169,6 +170,7 @@ def test_build_failure(build_command, first_app, tmp_path):
         env={
             'PATH': '/usr/local/bin:/usr/bin',
             'VERSION': '0.0.1',
+            'NO_STRIP': 1,
         },
         check=True,
         cwd=os.fsdecode(tmp_path / 'linux')
@@ -205,6 +207,7 @@ def test_build_appimage_with_docker(build_command, first_app, tmp_path):
                 dot_briefcase_path=build_command.dot_briefcase_path
             ),
             '--env', 'VERSION=0.0.1',
+            '--env', 'NO_STRIP=1',
             'briefcase/com.example.first-app:py3.{minor}'.format(
                 minor=sys.version_info.minor
             ),


### PR DESCRIPTION
We discovered that stripping some shared object can cause issues, e.g numpy.

This PR relates to #583

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
