### PR TITLE
Develop

### DIFF
--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -81,7 +81,9 @@ class NewCommand(BaseCommand):
         :param formal_name: The formal name
         :returns: The app's class name
         """
-        class_name = re.sub('[^0-9a-zA-Z_]+', '', formal_name)
+        # class_name = re.sub('[^0-9a-zA-Z_]+', '', formal_name)  # creates an empty string for non-ascii
+        class_name = re.sub('\s', '', formal_name)  # changed reg expression to remove spaces
+
         if class_name[0].isdigit():
             class_name = '_' + class_name
         return class_name

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -95,7 +95,8 @@ class NewCommand(BaseCommand):
         :param formal_name: The formal name
         :returns: The candidate app name
         """
-        return re.sub('[^0-9a-zA-Z_]+', '', formal_name).lstrip('_').lower()
+        # return re.sub('[^0-9a-zA-Z_]+', '', formal_name).lstrip('_').lower()
+        return re.sub('\s', '', formal_name).lstrip('_').lower()  # prevent returning None for non-ascii
 
     def validate_app_name(self, candidate):
         """
@@ -105,7 +106,7 @@ class NewCommand(BaseCommand):
         :returns: True. If there are any validation problems, raises ValueError
             with a diagnostic message.
         """
-        if not PEP508_NAME_RE.match(candidate):
+        if not PEP508_NAME_RE.match(candidate) and candidate.isascii():  # prevent error for non-ascii characters
             raise ValueError(
                 "App name may only contain letters, numbers, hypens and "
                 "underscores, and may not start with a hyphen or underscore."


### PR DESCRIPTION
Originally, the use of non-latin characters would cause the program to crash. I've tested this with Russian, Chinese and Japanese and they would all result in an 'index out of range' error. The reason for this error is due to the fact that re.sub function would create an empty string by removing all non-latin characters. 

However, allowing the use of non-latin characters will lead to another error ("failed hook exception"). Thus, it might be best to limit user input to latin characters unless there is a sufficient workaround.

Issue: #612

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X ] I have read the **CONTRIBUTING.md** file
- [ X] I will abide by the code of conduct
