### PR TITLE
Added and updated validations

### DIFF
--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -74,7 +74,7 @@ class NewCommand(BaseCommand):
             help='The cookiecutter template to use for the new project'
         )
 
-    def validate_formal_name(selfs, candidate):
+    def validate_formal_name(self, candidate):
         """
         Determine if the formal name is valid.
 
@@ -102,7 +102,6 @@ class NewCommand(BaseCommand):
             return "MainApp"  # name cannot start with a digit
         else:
             return re.sub('[^0-9a-zA-Z_]+', '', formal_name).lstrip('_').lower()
-
 
     def validate_app_name(self, candidate):
         """
@@ -135,7 +134,7 @@ class NewCommand(BaseCommand):
     def make_class_name(self, candidate):
         """
         Construct a valid class name from a candidate name.
-        :param formal_name: The candidate name
+        :param candidate: The candidate name
         :returns: The app's class name
         """
         return re.sub('[^0-9a-zA-Z_]+', '', candidate)

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -74,6 +74,22 @@ class NewCommand(BaseCommand):
             help='The cookiecutter template to use for the new project'
         )
 
+    def validate_formal_name(selfs, candidate):
+        """
+        Determine if the formal name is valid.
+
+        :param candidate: The candidate name
+        :returns: True. If there are any validation problems, raises ValueError
+            with a diagnostic message.
+        """
+        try:
+            candidate.encode(encoding="ascii", errors="strict")
+        except UnicodeEncodeError:
+            raise ValueError(
+                "Formal name may only contain letters, numbers, spaces "
+                "and punctuations.")
+        return True
+
     def make_app_name(self, formal_name):
         """
         Construct a candidate app name from a formal name.
@@ -327,6 +343,7 @@ can have spaces and punctuation if you like, and any capitalization will be
 used as you type it.""",
             variable="formal name",
             default='Hello World',
+            validator=self.validate_formal_name
         )
 
         default_app_name = self.make_app_name(formal_name)

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -99,7 +99,7 @@ class NewCommand(BaseCommand):
         """
 
         if formal_name[0].isdigit():
-            return "default_app_name"  # name cannot start with a digit
+            return "MainApp"  # name cannot start with a digit
         else:
             return re.sub('[^0-9a-zA-Z_]+', '', formal_name).lstrip('_').lower()
 
@@ -134,19 +134,11 @@ class NewCommand(BaseCommand):
 
     def make_class_name(self, candidate):
         """
-        Construct a candidate class name from an app name.
-
-        :param candidate: The app name
-        :returns: The candidate class name
+        Construct a valid class name from a candidate name.
+        :param formal_name: The candidate name
+        :returns: The app's class name
         """
-
-        class_name = re.sub('[^0-9a-zA-Z_]+', '', candidate)
-        if not class_name:
-            class_name = "MainApp"
-        elif class_name[0].isdigit():
-            class_name = '_' + class_name
-
-        return class_name
+        return re.sub('[^0-9a-zA-Z_]+', '', candidate)
 
     def make_module_name(self, app_name):
         """
@@ -172,6 +164,7 @@ class NewCommand(BaseCommand):
                 "least 2 dot-separated sections, and each section may only "
                 "include letters, numbers, and hyphens."
             )
+
         return True
 
     def make_domain(self, bundle):
@@ -367,6 +360,7 @@ but you can use another name if you want.""".format(
             validator=self.validate_app_name,
         )
 
+        # Class name can be derived from app name
         class_name = self.make_class_name(app_name)
 
         # The module name can be completely derived from the app name.

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -98,7 +98,10 @@ class NewCommand(BaseCommand):
         :returns: The candidate app name
         """
 
-        return re.sub('[^0-9a-zA-Z_]+', '', formal_name).lstrip('_').lower()
+        if formal_name[0].isdigit():
+            return "default_app_name"  # name cannot start with a digit
+        else:
+            return re.sub('[^0-9a-zA-Z_]+', '', formal_name).lstrip('_').lower()
 
 
     def validate_app_name(self, candidate):
@@ -112,7 +115,7 @@ class NewCommand(BaseCommand):
         if not PEP508_NAME_RE.match(candidate):
             raise ValueError(
                 "App name may only contain letters, numbers, hypens and "
-                "underscores, and may not start with a hyphen or underscore."
+                "underscores, and may not start with a number, hyphen or underscore."
             )
 
         if candidate[0].isdigit():


### PR DESCRIPTION
Added more validation options that prevent non-latin characters from throwing an error. This includes:
 - Added validation to formal name to prevent non-latin characters, else this will throw an error
 - Added validation to app name to prevent it from starting with a number, else this will throw an error. If the default name starts with a number, the default app name will be a generic MainApp.
 - Changed class name to be derived from app name, as this will prevent non-latin characters and names starting with numbers

Related to issue #612

These changes will hopefully stop the program from crashing when using non-latin characters, or app and class names start with a number.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ x] All new features have been documented
- [ x] I have read the **CONTRIBUTING.md** file
- [ x] I will abide by the code of conduct
