### PR TITLE
Determine Xcode location with `xcode-select -p`

### DIFF
--- a/changes/622.feature.rst
+++ b/changes/622.feature.rst
@@ -1,0 +1,1 @@
+Xcode detection code now allows for Xcode to be installed in locations other than ``/Applications/Xcode.app``.

--- a/changes/622.misc.rst
+++ b/changes/622.misc.rst
@@ -1,0 +1,1 @@
+Don't hard-code Xcode location but use Xcode installation set by xcode-select.

--- a/changes/622.misc.rst
+++ b/changes/622.misc.rst
@@ -1,1 +1,0 @@
-Don't hard-code Xcode location but use Xcode installation set by xcode-select.

--- a/src/briefcase/integrations/xcode.py
+++ b/src/briefcase/integrations/xcode.py
@@ -268,7 +268,7 @@ accepted before you can use those tools.
 You can accept these licenses by starting Xcode and clicking "Accept"; or, you
 can run:
 
-    sudo xcodebuild -license
+    $ sudo xcodebuild -license
 
 at the command line and accepting the license there.
 

--- a/src/briefcase/integrations/xcode.py
+++ b/src/briefcase/integrations/xcode.py
@@ -224,10 +224,14 @@ Re-run Briefcase once that installation is complete.
         if " is a command line tools instance" in e.output:
             raise BriefcaseCommandError("""
 Xcode may be installed, but the active developer directory is a
-command line tools instance. To make Xcode the active developer
-directory, run:
+command line tools instance. To make the default Xcode install the
+active developer directory, run:
 
-    $ sudo xcode-select --switch path/to/Xcode.app
+    $ sudo xcode-select --switch /Applications/Xcode.app
+
+Or, to use a version of Xcode installed in a non-default location:
+
+    $ sudo xcode-select --switch /path/to/Xcode.app
 
 and then re-run Briefcase.
 """)

--- a/tests/integrations/xcode/test_ensure_xcode_is_installed.py
+++ b/tests/integrations/xcode/test_ensure_xcode_is_installed.py
@@ -20,6 +20,21 @@ def test_not_installed(tmp_path):
     "If Xcode is not installed, raise an error."
     command = mock.MagicMock()
     command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
+        cmd=['xcode-select', '-p'],
+        returncode=2
+    )
+
+    # Test a location where Xcode *won't* be installed
+    with pytest.raises(BriefcaseCommandError):
+        ensure_xcode_is_installed(
+            command,
+        )
+
+
+def test_not_installed_hardcoded_path(tmp_path):
+    "If Xcode is not installed at the given location, raise an error."
+    command = mock.MagicMock()
+    command.subprocess.check_output.side_effect = subprocess.CalledProcessError(
         cmd=['xcodebuild', '-version'],
         returncode=1
     )

--- a/tests/integrations/xcode/test_ensure_xcode_is_installed.py
+++ b/tests/integrations/xcode/test_ensure_xcode_is_installed.py
@@ -48,7 +48,7 @@ def test_exists_but_command_line_tools_selected(xcode):
         "is a command line tools instance\n"
     )
 
-    with pytest.raises(BriefcaseCommandError, match=r"xcode-select -switch"):
+    with pytest.raises(BriefcaseCommandError, match=r"xcode-select --switch"):
         ensure_xcode_is_installed(command, xcode_location=xcode)
 
     # xcode-select was invoked


### PR DESCRIPTION
Fixes #622 by not hardcoding the Xcode path but determining it at runtime with `xcode-select -p`.

Note that `xcode-select -p` may return the location of the command line tools if those are installed but Xcode itself it not. This case will be properly handled when checking the output of `xcodebuild -version` later.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
