### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/changes/643.misc.rst
+++ b/changes/643.misc.rst
@@ -1,0 +1,1 @@
+Officially support Python 3.10.

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3 :: Only
     Topic :: Software Development
     Topic :: Utilities

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -205,8 +205,6 @@ def test_bare_command_help(monkeypatch, capsys):
         "usage: briefcase create macOS app [-h] [-v] [-V] [--no-input]\n"
         "\n"
         "Create and populate a macOS app.\n"
-        "\n"
-        "optional arguments:"
     )
 
 
@@ -295,8 +293,6 @@ def test_command_explicit_platform_help(monkeypatch, capsys):
         "usage: briefcase create macOS app [-h] [-v] [-V] [--no-input]\n"
         "\n"
         "Create and populate a macOS app.\n"
-        "\n"
-        "optional arguments:"
     )
 
 
@@ -362,8 +358,6 @@ def test_command_explicit_format_help(monkeypatch, capsys):
         "usage: briefcase create macOS app [-h] [-v] [-V] [--no-input]\n"
         "\n"
         "Create and populate a macOS app.\n"
-        "\n"
-        "optional arguments:"
     )
 
 


### PR DESCRIPTION
This PR introduces Python 3.10 compatibility.

Changes are:

1. Update classifiers in setup.cfg.
2. Add Python 3.10 to test matrix.
3. Update `tests/test_cmdline.py` to reflect the default argpase help output in Python 3.10. `"optional arguments:"` has been replaced by `"options:"`. Instead of having an if-clause for Python > 3.9, I've opted to just remove this line from the tests.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
