### PR TITLE
Add ELF patcher for linuxtools

### DIFF
--- a/changes/667.bugfix.rst
+++ b/changes/667.bugfix.rst
@@ -1,0 +1,1 @@
+Added binary patcher for linuxtools AppImage to increase compatibility.

--- a/src/briefcase/exceptions.py
+++ b/src/briefcase/exceptions.py
@@ -140,6 +140,7 @@ class InvalidDeviceError(BriefcaseCommandError):
             )
         )
 
+
 class CorruptToolError(BriefcaseCommandError):
     def __init__(self, tool):
         self.tool = tool

--- a/src/briefcase/exceptions.py
+++ b/src/briefcase/exceptions.py
@@ -139,3 +139,12 @@ class InvalidDeviceError(BriefcaseCommandError):
                 device=device,
             )
         )
+
+class CorruptToolError(BriefcaseCommandError):
+    def __init__(self, tool):
+        self.tool = tool
+        super().__init__(
+            msg="{tool!r} found, but it appears to be corrupted.".format(
+                tool=tool,
+            )
+        )

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -62,7 +62,7 @@ class LinuxDeploy:
                 download_path=self.command.tools_path
             )
             self.command.os.chmod(linuxdeploy_appimage_path, 0o755)
-            self.elf_header_patch()
+            self.patch_elf_header()
         except requests_exceptions.ConnectionError:
             raise NetworkFailure('downloading linuxdeploy AppImage')
 
@@ -79,7 +79,7 @@ class LinuxDeploy:
         else:
             raise MissingToolError('linuxdeploy')
 
-    def elf_header_patch(self):
+    def patch_elf_header(self):
         """
         Patch the ELF header of the AppImage to ensure it's always executable.
 
@@ -123,4 +123,4 @@ class LinuxDeploy:
                     # wrong and we should raise an exception.
                     raise MissingToolError("linuxdeploy")
         else:
-            print("linuxdeploy AppImage not found. Skipping ELF header patch.")
+            raise MissingToolError("linuxdeploy")

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -101,7 +101,6 @@ class LinuxDeploy:
         - https://github.com/AppImage/AppImageKit/issues/828
         """
 
-
         if self.exists():
             with open(self.appimage_path, 'r+b') as appimage:
                 appimage.seek(ELF_PATCH_OFFSET)

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -81,18 +81,18 @@ class LinuxDeploy:
 
     def elf_header_patch(self):
         """
-        Patch the ELF header of the AppImage to ensure it's always executable. 
+        Patch the ELF header of the AppImage to ensure it's always executable.
 
-        This patch is necessary on Linux hosts that use AppImageLauncher. 
+        This patch is necessary on Linux hosts that use AppImageLauncher.
         AppImages use a modified ELF binary header starting at offset 0x08
-        for additional identification. If a system has AppImageLauncher, 
+        for additional identification. If a system has AppImageLauncher,
         the Linux kernel module `binfmt-misc` will try to load the AppImage
-        with AppImageLauncher. As this binary does not exist in the Docker  
-        container context, we patch the ELF header of linuxdeploy to remove 
-        the AppImage bits, thus making the system treat it like a regular 
-        ELF binary. 
+        with AppImageLauncher. As this binary does not exist in the Docker
+        container context, we patch the ELF header of linuxdeploy to remove
+        the AppImage bits, thus making the system treat it like a regular
+        ELF binary.
 
-        Citations: 
+        Citations:
         - https://github.com/AppImage/AppImageKit/issues/1027#issuecomment-1028232809
         - https://github.com/AppImage/AppImageKit/issues/828
         """

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -101,11 +101,6 @@ class LinuxDeploy:
         - https://github.com/AppImage/AppImageKit/issues/828
         """
 
-        patch = {
-            'offset': 0x08,
-            'original': bytes.fromhex('414902'),
-            'patch': bytes.fromhex('000000')
-        }
 
         if self.exists():
             with open(self.appimage_path, 'r+b') as appimage:

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -102,19 +102,22 @@ class LinuxDeploy:
             'original': bytes.fromhex('414902'),
             'patch': bytes.fromhex('000000')
         }
-
-        with open(self.appimage_path, 'r+b') as appimage:
-            appimage.seek(patch['offset'])
-            # Check if the header at the offset is the original value
-            if appimage.read(len(patch['original'])) == patch['original']:
+        # We should only attempt to patch if the AppImage exists.
+        if self.exists():
+            with open(self.appimage_path, 'r+b') as appimage:
                 appimage.seek(patch['offset'])
-                appimage.write(patch['patch'])
-                appimage.flush()
-                appimage.seek(0)
-                print("Patched ELF header of linuxdeploy AppImage.")
-            elif appimage.read(len(patch['original'])) == patch['patch']:
-                print("ELF header of linuxdeploy AppImage is already patched.")
-            else:
-                # We should only get here if the AppImage didn't download correctly.
-                # In this case, we can't patch the header, so we'll just warn the user.
-                print("AppImage header doesn't match expected value. Unable to patch linuxdeploy.")
+                # Check if the header at the offset is the original value
+                if appimage.read(len(patch['original'])) == patch['original']:
+                    appimage.seek(patch['offset'])
+                    appimage.write(patch['patch'])
+                    appimage.flush()
+                    appimage.seek(0)
+                    print("Patched ELF header of linuxdeploy AppImage.")
+                elif appimage.read(len(patch['original'])) == patch['patch']:
+                    print("ELF header of linuxdeploy AppImage is already patched.")
+                else:
+                    # We should only get here if the AppImage didn't download correctly.
+                    # In this case, we can't patch the header, so we'll throw an exception.
+                    raise MissingToolError("linuxdeploy")
+        else:
+            raise MissingToolError("linuxdeploy")

--- a/tests/integrations/linuxdeploy/test_LinuxDeploy__elf_patch.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeploy__elf_patch.py
@@ -1,0 +1,89 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.exceptions import MissingToolError
+from briefcase.integrations.linuxdeploy import LinuxDeploy
+from random import randrange
+
+PATCH = {
+        'offset': 0x08,
+        'original': bytes.fromhex('414902'),
+        'patch': bytes.fromhex('000000')
+    }
+
+
+@pytest.fixture
+def mock_command(tmp_path):
+    command = MagicMock()
+    command.host_arch = 'wonky'
+    command.tools_path = tmp_path / 'tools'
+    command.tools_path.mkdir()
+
+    return command
+
+
+def test_patch_linuxdeploy_elf_header_unpatched(mock_command, tmp_path):
+    "If linuxdeploy is not patched, patch it."
+    appimage_path = tmp_path / 'tools' / 'linuxdeploy-wonky.AppImage'
+
+    # Mock an unpatched linuxdeploy AppImage
+    appimage_path.touch()
+    with open(appimage_path, 'r+b') as mock_appimage:
+        unpatched_header = bytes.fromhex('7f454c46020101004149020000000000')
+        mock_appimage.write(unpatched_header)
+        mock_appimage.seek(PATCH['offset'])
+        pre_patch_header = mock_appimage.read(len(PATCH['original']))
+
+    # Create a linuxdeploy wrapper, then patch the elf header
+    linuxdeploy = LinuxDeploy(mock_command)
+    linuxdeploy.elf_header_patch()
+
+    # Ensure the patch was applied.
+    with open(appimage_path, 'rb') as mock_appimage:
+        mock_appimage.seek(PATCH['offset'])
+        patched_header = mock_appimage.read(len(PATCH['patch']))
+
+    assert pre_patch_header == PATCH['original']
+    assert patched_header == PATCH['patch']
+
+
+def test_patch_linuxdeploy_elf_header_already_patched(mock_command, tmp_path):
+    "If linuxdeploy is already patched, don't patch it."
+    appimage_path = tmp_path / 'tools' / 'linuxdeploy-wonky.AppImage'
+
+    # Mock a patched linuxdeploy AppImage
+    appimage_path.touch()
+    with open(appimage_path, 'r+b') as mock_appimage:
+        patched_header = bytes.fromhex('7f454c46020101000000000000000000')
+        mock_appimage.write(patched_header)
+        mock_appimage.seek(PATCH['offset'])
+        pre_patch_header = mock_appimage.read(len(PATCH['original']))
+
+    # Create a linuxdeploy wrapper, then patch the elf header
+    linuxdeploy = LinuxDeploy(mock_command)
+    linuxdeploy.elf_header_patch()
+
+    # Ensure the patch was applied.
+    with open(appimage_path, 'rb') as mock_appimage:
+        mock_appimage.seek(PATCH['offset'])
+        patched_header = mock_appimage.read(len(PATCH['patch']))
+
+    assert pre_patch_header == PATCH['patch']
+    assert patched_header == PATCH['patch']
+
+
+def test_patch_linuxdeploy_elf_header_bad_appimage(mock_command, tmp_path):
+    "If linuxdeploy does not have a valid header, raise an error."
+    appimage_path = tmp_path / 'tools' / 'linuxdeploy-wonky.AppImage'
+
+    # Mock an bad linuxdeploy AppImage
+    appimage_path.touch()
+    with open(appimage_path, 'r+b') as mock_appimage:
+        unpatched_header = bytes.fromhex('%030x' % randrange(16**30))
+        mock_appimage.write(unpatched_header)
+
+    # Create a linuxdeploy wrapper, then patch the elf header
+    linuxdeploy = LinuxDeploy(mock_command)
+    with pytest.raises(MissingToolError):
+        linuxdeploy = linuxdeploy.elf_header_patch()

--- a/tests/integrations/linuxdeploy/test_LinuxDeploy__patch_elf_binary.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeploy__patch_elf_binary.py
@@ -2,10 +2,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.exceptions import MissingToolError
-from briefcase.integrations.linuxdeploy import LinuxDeploy
+from briefcase.exceptions import CorruptToolError, MissingToolError
+from briefcase.integrations.linuxdeploy import LinuxDeploy, ELF_PATCH_OFFSET, \
+    ELF_PATCH_ORIGINAL_BYTES, ELF_PATCH_PATCHED_BYTES
 
-from tests.integrations.linuxdeploy.utils import create_mock_appimage, PATCH
+from tests.integrations.linuxdeploy.utils import create_mock_appimage
 
 
 @pytest.fixture
@@ -31,11 +32,11 @@ def test_patch_linuxdeploy_elf_header_unpatched(mock_command, tmp_path):
 
     # Ensure the patch was applied.
     with open(appimage_path, 'rb') as mock_appimage:
-        mock_appimage.seek(PATCH['offset'])
-        patched_header = mock_appimage.read(len(PATCH['patch']))
+        mock_appimage.seek(ELF_PATCH_OFFSET)
+        patched_header = mock_appimage.read(len(ELF_PATCH_PATCHED_BYTES))
 
-    assert pre_patch_header == PATCH['original']
-    assert patched_header == PATCH['patch']
+    assert pre_patch_header == ELF_PATCH_ORIGINAL_BYTES
+    assert patched_header == ELF_PATCH_PATCHED_BYTES
 
 
 def test_patch_linuxdeploy_elf_header_already_patched(mock_command, tmp_path):
@@ -51,11 +52,11 @@ def test_patch_linuxdeploy_elf_header_already_patched(mock_command, tmp_path):
 
     # Ensure the patch was applied.
     with open(appimage_path, 'rb') as mock_appimage:
-        mock_appimage.seek(PATCH['offset'])
-        patched_header = mock_appimage.read(len(PATCH['patch']))
+        mock_appimage.seek(ELF_PATCH_OFFSET)
+        patched_header = mock_appimage.read(len(ELF_PATCH_PATCHED_BYTES))
 
-    assert pre_patch_header == PATCH['patch']
-    assert patched_header == PATCH['patch']
+    assert pre_patch_header == ELF_PATCH_PATCHED_BYTES
+    assert patched_header == ELF_PATCH_PATCHED_BYTES
 
 
 def test_patch_linuxdeploy_elf_header_bad_appimage(mock_command, tmp_path):
@@ -67,7 +68,7 @@ def test_patch_linuxdeploy_elf_header_bad_appimage(mock_command, tmp_path):
 
     # Create a linuxdeploy wrapper, then patch the elf header
     linuxdeploy = LinuxDeploy(mock_command)
-    with pytest.raises(MissingToolError):
+    with pytest.raises(CorruptToolError):
         linuxdeploy = linuxdeploy.patch_elf_header()
 
 

--- a/tests/integrations/linuxdeploy/test_LinuxDeploy__patch_elf_binary.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeploy__patch_elf_binary.py
@@ -3,8 +3,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from briefcase.exceptions import CorruptToolError, MissingToolError
-from briefcase.integrations.linuxdeploy import LinuxDeploy, ELF_PATCH_OFFSET, \
-    ELF_PATCH_ORIGINAL_BYTES, ELF_PATCH_PATCHED_BYTES
+from briefcase.integrations.linuxdeploy import (LinuxDeploy, ELF_PATCH_OFFSET,
+    ELF_PATCH_ORIGINAL_BYTES, ELF_PATCH_PATCHED_BYTES)
 
 from tests.integrations.linuxdeploy.utils import create_mock_appimage
 

--- a/tests/integrations/linuxdeploy/test_LinuxDeploy__patch_elf_binary.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeploy__patch_elf_binary.py
@@ -3,8 +3,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from briefcase.exceptions import CorruptToolError, MissingToolError
-from briefcase.integrations.linuxdeploy import (LinuxDeploy, ELF_PATCH_OFFSET,
-    ELF_PATCH_ORIGINAL_BYTES, ELF_PATCH_PATCHED_BYTES)
+from briefcase.integrations.linuxdeploy import (
+    LinuxDeploy, ELF_PATCH_OFFSET, ELF_PATCH_ORIGINAL_BYTES, ELF_PATCH_PATCHED_BYTES
+    )
 
 from tests.integrations.linuxdeploy.utils import create_mock_appimage
 

--- a/tests/integrations/linuxdeploy/test_LinuxDeploy__verify.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeploy__verify.py
@@ -6,6 +6,8 @@ from requests import exceptions as requests_exceptions
 from briefcase.exceptions import MissingToolError, NetworkFailure
 from briefcase.integrations.linuxdeploy import LinuxDeploy
 
+from tests.integrations.linuxdeploy.utils import create_mock_appimage
+
 
 @pytest.fixture
 def mock_command(tmp_path):
@@ -55,7 +57,10 @@ def test_verify_does_not_exist(mock_command, tmp_path):
     appimage_path = tmp_path / 'tools' / 'linuxdeploy-wonky.AppImage'
 
     # Mock a successful download
-    mock_command.download_url.return_value = 'new-downloaded-file'
+    def side_effect_create_mock_appimage(*args, **kwargs):
+        create_mock_appimage(appimage_path=appimage_path)
+        return 'new-downloaded-file'
+    mock_command.download_url.side_effect = side_effect_create_mock_appimage
 
     # Create a linuxdeploy wrapper by verification
     linuxdeploy = LinuxDeploy.verify(mock_command)

--- a/tests/integrations/linuxdeploy/utils.py
+++ b/tests/integrations/linuxdeploy/utils.py
@@ -1,0 +1,43 @@
+from random import randrange
+from pathlib import Path
+
+PATCH = {
+    'offset': 0x08,
+    'original': bytes.fromhex('414902'),
+    'patch': bytes.fromhex('000000')
+}
+
+
+def create_mock_appimage(appimage_path: Path, mock_appimage_kind: str = 'original'):
+    """
+    Create a mock AppImage for testing purposes.
+
+    Args:
+        appimage_path (Path): Path to the appimage to create.
+        mock_appimage_kind (str): The kind of mock appimage to create.
+            'original' creates an unpatched mock appimage.
+            'patched' creates a patched mock appimage.
+            'corrupt' creates a corrupted mock appimage.
+
+    Returns:
+        bytes_to_be_patched (bytes): The bytes to be patched of the created AppImage.
+    """
+
+    bytes_to_be_patched = None
+
+    appimage_headers = {
+        'original': bytes.fromhex('7f454c46020101004149020000000000'),
+        'patched': bytes.fromhex('7f454c46020101000000000000000000'),
+        'corrupt': bytes.fromhex('%030x' % randrange(16**30))
+    }
+
+    appimage_path.touch()
+    with open(appimage_path, 'w+b') as mock_appimage:
+        if mock_appimage_kind in appimage_headers:
+            mock_appimage.write(appimage_headers[mock_appimage_kind])
+        else:
+            raise ValueError(f'Unknown mock_appimage_kind: {mock_appimage_kind}')
+        mock_appimage.seek(PATCH['offset'])
+        bytes_to_be_patched = mock_appimage.read(len(PATCH['original']))
+
+    return bytes_to_be_patched

--- a/tests/integrations/linuxdeploy/utils.py
+++ b/tests/integrations/linuxdeploy/utils.py
@@ -1,26 +1,20 @@
 from random import randrange
 from pathlib import Path
 
-PATCH = {
-    'offset': 0x08,
-    'original': bytes.fromhex('414902'),
-    'patch': bytes.fromhex('000000')
-}
+from briefcase.integrations.linuxdeploy import ELF_PATCH_OFFSET, ELF_PATCH_ORIGINAL_BYTES
 
 
 def create_mock_appimage(appimage_path: Path, mock_appimage_kind: str = 'original'):
     """
     Create a mock AppImage for testing purposes.
 
-    Args:
-        appimage_path (Path): Path to the appimage to create.
-        mock_appimage_kind (str): The kind of mock appimage to create.
+    :param appimage_path: Path to the appimage to create.
+    :param mock_appimage_kind: The kind of mock appimage to create.
             'original' creates an unpatched mock appimage.
             'patched' creates a patched mock appimage.
             'corrupt' creates a corrupted mock appimage.
 
-    Returns:
-        bytes_to_be_patched (bytes): The bytes to be patched of the created AppImage.
+    :returns: The bytes to be patched of the created AppImage.
     """
 
     bytes_to_be_patched = None
@@ -37,7 +31,7 @@ def create_mock_appimage(appimage_path: Path, mock_appimage_kind: str = 'origina
             mock_appimage.write(appimage_headers[mock_appimage_kind])
         else:
             raise ValueError(f'Unknown mock_appimage_kind: {mock_appimage_kind}')
-        mock_appimage.seek(PATCH['offset'])
-        bytes_to_be_patched = mock_appimage.read(len(PATCH['original']))
+        mock_appimage.seek(ELF_PATCH_OFFSET)
+        bytes_to_be_patched = mock_appimage.read(len(ELF_PATCH_ORIGINAL_BYTES))
 
     return bytes_to_be_patched


### PR DESCRIPTION
This PR addresses an awkward to trace issue on Linux systems running briefcase that also have AppImageLauncher installed, first reported via the old Gitter chat room, then again in Discord.  This issue was also observed in https://github.com/beeware/briefcase/issues/416#issuecomment-640744410

On Linux systems with AppImageLauncher, AppImages that are run are hooked to start AppImageLauncher via the `binfmt-misc` kernel module. When briefcase creates a Docker container to build AppImages, that kernel module's capabilities are passed through to the container. As the container image doesn't have AppImageLauncher (nor should it), we need to ensure that linuxtools launches as a regular ELF binary. 

By patching the ELF header to remove the flags from the header that would trip `binfmt_misc` to pass execution along to AppImageLauncher, the system launches `linuxtools` as a regular ELF binary. This works, and has been tested on a system that doesn't have AppImageLauncher installed. 

Signed-off-by: Cody Wilson <cody@codywilson.co>