### PR TITLE
Add option for PySide6

### DIFF
--- a/changes/670.misc.rst
+++ b/changes/670.misc.rst
@@ -1,0 +1,1 @@
+Add PySide6 to the GUI Framework template options

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -426,6 +426,7 @@ What GUI toolkit do you want to use for this project?""",
             options=[
                 'Toga',
                 'PySide2 (does not support iOS/Android deployment)',
+                'PySide6 (does not support iOS/Android deployment)',
                 'PursuedPyBear (does not support iOS/Android deployment)',
                 'None',
             ],


### PR DESCRIPTION
Include an option to select PySide6 from the list of UI  frameworks.

This patch was motivated by https://github.com/beeware/briefcase/issues/560 and it depends of this Pull Request https://github.com/beeware/briefcase-template/pull/27 which adds the template on the `briefcase-template`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

I didn't find a place where the non-default gui framework were documented, and because there is already a test for a PySide2 project, I didn't want to include another with only that little change.
In case it's necessary, please let me know I can do it without any problem.