### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: "3.9"
     - name: Install dependencies
@@ -39,7 +39,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: "3.7"
     - name: Install dependencies
@@ -72,7 +72,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -91,7 +91,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: "3.9"
     - name: Install dependencies
@@ -110,7 +110,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.9
     - name: Install dependencies

--- a/changes/680.misc.rst
+++ b/changes/680.misc.rst
@@ -1,0 +1,1 @@
+Updated pinned dependency version limits.

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     setuptools >= 60
     wheel >= 0.34
     cookiecutter >= 1.0
-    toml >= 1.0.0; python_version <= "3.10"
+    toml >= 0.10.0
     requests >= 2.22.0
     GitPython >= 3.0.8
     dmgbuild >= 1.3.3; sys_platform == "darwin"

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,20 +47,19 @@ platforms = any
 [options]
 zip_safe = False
 packages = find:
-python_requires = >= 3.6
+python_requires = >= 3.7
 include_package_data = True
 package_dir =
     = src
 install_requires =
-    pip >= 20
-    setuptools >= 45
+    pip >= 22
+    setuptools >= 60
     wheel >= 0.34
     cookiecutter >= 1.0
-    toml >= 0.10.0
+    toml >= 1.0.0; python_version <= "3.10"
     requests >= 2.22.0
     GitPython >= 3.0.8
     dmgbuild >= 1.3.3; sys_platform == "darwin"
-    Jinja2
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Identified by @carlosperate in [this comment](https://github.com/beeware/briefcase/pull/653#issuecomment-1062833204); we neglected to update the minimal Python version when we deprecated Python 3.6. 

While we're at it, update some other pinned versions of core libraries.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
