### PR TITLE
Switch to using Tomli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11.0-alpha - 3.11.0']
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/changes/681.misc.rst
+++ b/changes/681.misc.rst
@@ -1,0 +1,1 @@
+Switch to using tomli instead of toml, to support Python 3.11 transition.

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-tldr
+pytest-cov

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-tldr
 pytest-cov
+tomli_w

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     setuptools >= 60
     wheel >= 0.34
     cookiecutter >= 1.0
-    toml >= 0.10.0
+    tomli >= 2.0.0; python_version <= "3.10"
     requests >= 2.22.0
     GitPython >= 3.0.8
     dmgbuild >= 1.3.3; sys_platform == "darwin"

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -12,9 +12,13 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import requests
-import toml
 from cookiecutter.main import cookiecutter
 from cookiecutter.repository import is_repo_url
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 from briefcase import __version__, integrations
 from briefcase.config import AppConfig, BaseConfig, GlobalConfig, parse_config
@@ -272,8 +276,8 @@ class BaseCommand(ABC):
         :param app: The config object for the app
         :return: The contents of the application path index.
         """
-        with (self.bundle_path(app) / 'briefcase.toml').open() as f:
-            self._path_index[app] = toml.load(f)['paths']
+        with (self.bundle_path(app) / 'briefcase.toml').open('rb') as f:
+            self._path_index[app] = tomllib.load(f)['paths']
         return self._path_index[app]
 
     def support_path(self, app: BaseConfig):
@@ -435,7 +439,7 @@ class BaseCommand(ABC):
 
     def parse_config(self, filename):
         try:
-            with open(filename) as config_file:
+            with open(filename, 'rb') as config_file:
                 # Parse the content of the pyproject.toml file, extracting
                 # any platform and output format configuration for each app,
                 # creating a single set of configuration options.

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -2,7 +2,10 @@ import copy
 import re
 from types import SimpleNamespace
 
-import toml
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 from briefcase.platforms import get_output_formats, get_platforms
 
@@ -259,10 +262,10 @@ def parse_config(config_file, platform, output_format):
         format definitions.
     """
     try:
-        pyproject = toml.load(config_file)
+        pyproject = tomllib.load(config_file)
 
         global_config = pyproject['tool']['briefcase']
-    except toml.TomlDecodeError as e:
+    except tomllib.TOMLDecodeError as e:
         raise BriefcaseConfigError('Invalid pyproject.toml: {e}'.format(e=e))
     except KeyError:
         raise BriefcaseConfigError('No tool.briefcase section in pyproject.toml')

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -1,6 +1,10 @@
 from requests import exceptions as requests_exceptions
 
-from briefcase.exceptions import CorruptToolError, MissingToolError, NetworkFailure
+from briefcase.exceptions import (
+    CorruptToolError,
+    MissingToolError,
+    NetworkFailure
+)
 
 ELF_PATCH_OFFSET = 0x08
 ELF_PATCH_ORIGINAL_BYTES = bytes.fromhex('414902')

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -228,7 +228,7 @@ class iOSXcodeBuildCommand(iOSXcodeMixin, BuildCommand):
             )
 
         print()
-        print("Targeting an {device} running iOS {iOS_version} (device UDID {udid})".format(
+        print("Targeting an {device} running {iOS_version} (device UDID {udid})".format(
             device=device,
             iOS_version=iOS_version,
             udid=udid,

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -11,7 +11,11 @@ from briefcase.commands import (
     UpdateCommand
 )
 from briefcase.config import BaseConfig
-from briefcase.platforms.macOS import macOSMixin, macOSRunMixin, macOSPackageMixin
+from briefcase.platforms.macOS import (
+    macOSMixin,
+    macOSPackageMixin,
+    macOSRunMixin
+)
 
 
 class macOSAppMixin(macOSMixin):

--- a/src/briefcase/platforms/macOS/xcode.py
+++ b/src/briefcase/platforms/macOS/xcode.py
@@ -10,8 +10,12 @@ from briefcase.commands import (
 )
 from briefcase.config import BaseConfig
 from briefcase.exceptions import BriefcaseCommandError
-from briefcase.platforms.macOS import macOSMixin, macOSRunMixin, macOSPackageMixin
 from briefcase.integrations.xcode import verify_xcode_install
+from briefcase.platforms.macOS import (
+    macOSMixin,
+    macOSPackageMixin,
+    macOSRunMixin
+)
 
 
 class macOSXcodeMixin(macOSMixin):

--- a/tests/commands/create/conftest.py
+++ b/tests/commands/create/conftest.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-import toml
+import tomli_w
 
 from briefcase.commands import CreateCommand
 from briefcase.config import AppConfig
@@ -146,7 +146,7 @@ def bundle_path(myapp, tmp_path):
     (bundle_path / 'path' / 'to' / 'app').mkdir(parents=True, exist_ok=True)
     (bundle_path / 'path' / 'to' / 'app_packages').mkdir(parents=True, exist_ok=True)
     (bundle_path / 'path' / 'to' / 'support').mkdir(parents=True, exist_ok=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
@@ -154,7 +154,7 @@ def bundle_path(myapp, tmp_path):
                 'support_path': 'path/to/support',
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     return bundle_path
 

--- a/tests/commands/create/test_properties.py
+++ b/tests/commands/create/test_properties.py
@@ -1,4 +1,4 @@
-import toml
+import tomli_w
 
 
 def test_template_url(create_command):
@@ -9,7 +9,7 @@ def test_template_url(create_command):
 def test_app_path(create_command, myapp):
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
@@ -17,7 +17,7 @@ def test_app_path(create_command, myapp):
                 'support_path': 'path/to/support',
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.app_path(myapp) == bundle_path / 'path' / 'to' / 'app'
 
@@ -31,7 +31,7 @@ def test_app_path(create_command, myapp):
 def test_app_packages_path(create_command, myapp):
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
@@ -39,7 +39,7 @@ def test_app_packages_path(create_command, myapp):
                 'support_path': 'path/to/support',
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.app_packages_path(myapp) == bundle_path / 'path' / 'to' / 'app_packages'
 
@@ -53,7 +53,7 @@ def test_app_packages_path(create_command, myapp):
 def test_support_path(create_command, myapp):
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
@@ -61,7 +61,7 @@ def test_support_path(create_command, myapp):
                 'support_path': 'path/to/support',
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.support_path(myapp) == bundle_path / 'path' / 'to' / 'support'
 
@@ -82,13 +82,13 @@ def test_no_icon(create_command, myapp):
     "If no icon target is specified, the icon list is empty"
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.icon_targets(myapp) == {}
 
@@ -97,14 +97,14 @@ def test_single_icon(create_command, myapp):
     "If the icon target is specified as a single string, the icon list has one unsized entry"
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
                 'icon': 'path/to/icon.png',
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.icon_targets(myapp) == {
         None: 'path/to/icon.png'
@@ -115,7 +115,7 @@ def test_multiple_icon(create_command, myapp):
     "If there are multiple icon targets, they're all in the target list"
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
@@ -125,7 +125,7 @@ def test_multiple_icon(create_command, myapp):
                 },
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.icon_targets(myapp) == {
         '10': 'path/to/icon-10.png',
@@ -137,7 +137,7 @@ def test_icon_variants(create_command, myapp):
     "If there are icon variants, they are returned"
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
@@ -150,7 +150,7 @@ def test_icon_variants(create_command, myapp):
                 },
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.icon_targets(myapp) == {
         'single': 'path/to/icon.png',
@@ -165,13 +165,13 @@ def test_no_splash(create_command, myapp):
     "If no splash target is specified, the splash list is empty"
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.splash_image_targets(myapp) == {}
 
@@ -180,14 +180,14 @@ def test_single_splash(create_command, myapp):
     "If the splash target is specified as a single string, the splash list has one unsized entry"
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
                 'splash': 'path/to/splash.png',
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.splash_image_targets(myapp) == {
         None: 'path/to/splash.png'
@@ -198,7 +198,7 @@ def test_multiple_splash(create_command, myapp):
     "If there are multiple splash targets, they're all in the target list"
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
@@ -208,7 +208,7 @@ def test_multiple_splash(create_command, myapp):
                 },
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.splash_image_targets(myapp) == {
         '10x20': 'path/to/splash-10.png',
@@ -220,13 +220,13 @@ def test_no_document_types(create_command, myapp):
     "If no document type targets are specified, the document_type_icons list is empty"
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.document_type_icon_targets(myapp) == {}
 
@@ -235,7 +235,7 @@ def test_document_type_single_icon(create_command, myapp):
     "If a doctype icon target is specified as a single string, the document_type_icons list has one unsized entry"
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
@@ -245,7 +245,7 @@ def test_document_type_single_icon(create_command, myapp):
                 }
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.document_type_icon_targets(myapp) == {
         'mydoc': {
@@ -261,7 +261,7 @@ def test_document_type_multiple_icons(create_command, myapp):
     "If there are multiple document_type_icons targets, they're all in the target list"
     bundle_path = create_command.bundle_path(myapp)
     bundle_path.mkdir(parents=True)
-    with (bundle_path / 'briefcase.toml').open('w') as f:
+    with (bundle_path / 'briefcase.toml').open('wb') as f:
         index = {
             'paths': {
                 'app_path': 'path/to/app',
@@ -274,7 +274,7 @@ def test_document_type_multiple_icons(create_command, myapp):
                 }
             }
         }
-        toml.dump(index, f)
+        tomli_w.dump(index, f)
 
     assert create_command.document_type_icon_targets(myapp) == {
         'mydoc': {

--- a/tests/config/test_parse_config.py
+++ b/tests/config/test_parse_config.py
@@ -1,4 +1,4 @@
-from io import StringIO
+from io import BytesIO
 
 import pytest
 
@@ -8,7 +8,7 @@ from briefcase.exceptions import BriefcaseConfigError
 
 def test_invalid_toml():
     "If the config file isn't TOML, raise an error"
-    config_file = StringIO("this is not toml!")
+    config_file = BytesIO(b"this is not toml!")
 
     with pytest.raises(BriefcaseConfigError, match="Invalid pyproject.toml"):
         parse_config(config_file, platform='macOS', output_format='xcode')
@@ -16,8 +16,8 @@ def test_invalid_toml():
 
 def test_no_briefcase_section():
     "If the config file doesn't contain a briefcase tool section, raise an error"
-    config_file = StringIO(
-        """
+    config_file = BytesIO(
+        b"""
         [tool.section]
         name="value"
         number=42
@@ -30,8 +30,8 @@ def test_no_briefcase_section():
 
 def test_no_apps():
     "If the config file doesn't contain at least one briefcase app, raise an error"
-    config_file = StringIO(
-        """
+    config_file = BytesIO(
+        b"""
         [tool.briefcase]
         name="value"
         number=42
@@ -44,8 +44,8 @@ def test_no_apps():
 
 def test_single_minimal_app():
     "A single app can be defined, but can exist without any app attributes"
-    config_file = StringIO(
-        """
+    config_file = BytesIO(
+        b"""
         [tool.briefcase]
         value = 42
 
@@ -72,8 +72,8 @@ def test_single_minimal_app():
 
 def test_multiple_minimal_apps():
     "The configuration can contain multiple apps without an explicit tool header"
-    config_file = StringIO(
-        """
+    config_file = BytesIO(
+        b"""
         [tool.briefcase.app.first]
         number=37
 
@@ -104,8 +104,8 @@ def test_multiple_minimal_apps():
 
 def test_platform_override():
     "An app can define platform settings that override base settings"
-    config_file = StringIO(
-        """
+    config_file = BytesIO(
+        b"""
         [tool.briefcase]
         value = 0
         basevalue = "the base"
@@ -161,8 +161,8 @@ def test_platform_override():
 
 def test_platform_override_ordering():
     "The order of platform processing doesn't affect output"
-    config_file = StringIO(
-        """
+    config_file = BytesIO(
+        b"""
         [tool.briefcase]
         value = 0
         basevalue = "the base"
@@ -218,8 +218,8 @@ def test_platform_override_ordering():
 
 def test_format_override():
     "An app can define format settings that override base and platform settings"
-    config_file = StringIO(
-        """
+    config_file = BytesIO(
+        b"""
         [tool.briefcase]
         value = 0
         basevalue = "the base"
@@ -296,8 +296,8 @@ def test_format_override():
 
 def test_format_override_ordering():
     "The order of format processing doesn't affect output"
-    config_file = StringIO(
-        """
+    config_file = BytesIO(
+        b"""
         [tool.briefcase]
         value = 0
         basevalue = "the base"
@@ -373,8 +373,8 @@ def test_format_override_ordering():
 
 def test_requires():
     "Requirements can be specified"
-    config_file = StringIO(
-        """
+    config_file = BytesIO(
+        b"""
         [tool.briefcase]
         value = 0
         requires = ["base value"]
@@ -497,8 +497,8 @@ def test_requires():
 
 def test_document_types():
     "Document types can be specified"
-    config_file = StringIO(
-        """
+    config_file = BytesIO(
+        b"""
         [tool.briefcase]
         value = 0
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,towncrier-check,docs,package,py{36,37,38,39,310,311},pypy3
+envlist = flake8,towncrier-check,docs,package,py{37,38,39,310,311},pypy3
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,14 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,towncrier-check,docs,package,py{36,37,38,39},pypy3
+envlist = flake8,towncrier-check,docs,package,py{36,37,38,39,310,311},pypy3
 skip_missing_interpreters = true
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}/src
 deps =
-    pytest
-    pytest-tldr
-    pytest-cov
+    -r{toxinidir}/requirements.test.txt
+
 commands =
     pytest --cov -vv
     coverage xml


### PR DESCRIPTION
Switch to using tomli rather than toml for toml support. This enables an easy transition to Python 3.11.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
