### PR TITLE
Fixes #460 - Bundle identifiers are now validated against reserved words

### DIFF
--- a/changes/460.bugfix.rst
+++ b/changes/460.bugfix.rst
@@ -1,0 +1,1 @@
+Bundle identifiers are now validated to ensure they don't contain reserved words.

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -7,13 +7,11 @@ from urllib.parse import urlparse
 
 from cookiecutter import exceptions as cookiecutter_exceptions
 
-from briefcase.config import is_valid_app_name
+from briefcase.config import is_valid_app_name, is_valid_bundle_identifier
 from briefcase.exceptions import NetworkFailure
 
 from .base import BaseCommand, BriefcaseCommandError
 from .create import InvalidTemplateRepository
-
-VALID_BUNDLE_RE = re.compile(r'[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+$')
 
 
 def titlecase(s):
@@ -138,12 +136,15 @@ class NewCommand(BaseCommand):
         :returns: True. If there are any validation problems, raises ValueError
             with a diagnostic message.
         """
-        if not VALID_BUNDLE_RE.match(candidate):
+        if not is_valid_bundle_identifier(candidate):
             raise ValueError(
-                "Bundle should be a reversed domain name. It must contain at "
-                "least 2 dot-separated sections, and each section may only "
-                "include letters, numbers, and hyphens."
+                f"{candidate!r} is not a valid bundle identifier.\n\n"
+                "The bundle should be a reversed domain name. It must contain at least 2\n"
+                "dot-separated sections; each section may only include letters, numbers,\n"
+                "and hyphens; and each section may not contain any reserved words (like\n"
+                "'switch', or 'while')."
             )
+
         return True
 
     def make_domain(self, bundle):

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -159,6 +159,21 @@ def is_valid_app_name(app_name):
     return False
 
 
+VALID_BUNDLE_RE = re.compile(r'[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+$')
+
+
+def is_valid_bundle_identifier(bundle):
+    # Ensure the bundle identifier follows the basi
+    if not VALID_BUNDLE_RE.match(bundle):
+        return False
+
+    for part in bundle.split('.'):
+        if is_reserved_keyword(part):
+            return False
+
+    return True
+
+
 # This is the canonical definition from PEP440, modified to include named groups
 PEP440_CANONICAL_VERSION_PATTERN_RE = re.compile(
     r'^((?P<epoch>[1-9][0-9]*)!)?'
@@ -293,6 +308,15 @@ class AppConfig(BaseConfig):
                 "App names must not be reserved keywords such as 'and', 'for' and 'while'.\n"
                 "They must also be PEP508 compliant (i.e., they can only include letters,\n"
                 "numbers, '-' and '_'; must start with a letter; and cannot end with '-' or '_')."
+            )
+
+        if not is_valid_bundle_identifier(self.bundle):
+            raise BriefcaseConfigError(
+                f"{self.bundle!r} is not a valid bundle identifier.\n\n"
+                "The bundle should be a reversed domain name. It must contain at least 2\n"
+                "dot-separated sections; each section may only include letters, numbers,\n"
+                "and hyphens; and each section may not contain any reserved words (like\n"
+                "'switch', or 'while')."
             )
 
         # Version number is PEP440 compliant:

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -133,6 +133,53 @@ def test_invalid_app_name(name):
         )
 
 
+@pytest.mark.parametrize(
+    'bundle',
+    [
+        'com.example',
+        'com.example.more',
+        'com.example42.more',
+        'com.example-42.more',
+    ]
+)
+def test_valid_bundle(bundle):
+    try:
+        AppConfig(
+            app_name='myapp',
+            version="1.2.3",
+            bundle=bundle,
+            description="A simple app",
+            sources=['src/myapp']
+        )
+    except BriefcaseConfigError:
+        pytest.fail(f'{bundle} should be valid')
+
+
+@pytest.mark.parametrize(
+    'bundle',
+    [
+        'not a bundle!',  # Free text.
+        'home',  # Only one section.
+        'com.hello_world',  # underscore
+        'com.hello,world',  # comma
+        'com.hello world!',  # exclamation point
+        'com.pass',  # Python reserved word
+        'com.pass.example',  # Python reserved word
+        'com.switch',  # Java reserved word
+        'com.switch.example',  # Java reserved word
+    ]
+)
+def test_invalid_bundle_identifier(bundle):
+    with pytest.raises(BriefcaseConfigError, match=r"is not a valid bundle identifier\."):
+        AppConfig(
+            app_name="myapp",
+            version="1.2.3",
+            bundle=bundle,
+            description="A simple app",
+            sources=['src/invalid']
+        )
+
+
 def test_valid_app_version():
     try:
         AppConfig(

--- a/tests/config/test_is_valid_bundle_identifier.py
+++ b/tests/config/test_is_valid_bundle_identifier.py
@@ -1,5 +1,7 @@
 import pytest
 
+from briefcase.config import is_valid_bundle_identifier
+
 
 @pytest.mark.parametrize(
     'bundle',
@@ -10,9 +12,9 @@ import pytest
         'com.example-42.more',
     ]
 )
-def test_valid_bundle(new_command, bundle):
+def test_valid_bundle(bundle):
     "Test that valid bundles are accepted"
-    assert new_command.validate_bundle(bundle)
+    assert is_valid_bundle_identifier(bundle)
 
 
 @pytest.mark.parametrize(
@@ -23,10 +25,12 @@ def test_valid_bundle(new_command, bundle):
         'com.hello_world',  # underscore
         'com.hello,world',  # comma
         'com.hello world!',  # exclamation point
-        'com.pass.example',  # Reserved word
+        'com.pass',  # Python reserved word
+        'com.pass.example',  # Python reserved word
+        'com.switch',  # Java reserved word
+        'com.switch.example',  # Java reserved word
     ]
 )
-def test_invalid_bundle(new_command, bundle):
+def test_invalid_bundle(bundle):
     "Test that invalid bundles are rejected"
-    with pytest.raises(ValueError):
-        new_command.validate_bundle(bundle)
+    assert not is_valid_bundle_identifier(bundle)


### PR DESCRIPTION
Adds validation to ensure that bundle identifiers don't contain reserved words. This ensures you can't create an app called `com.switch.example`, as this will cause issues in Java code.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
