### PR TITLE
Add invalid Windows filenames to the reserved words list

### DIFF
--- a/changes/685.feature.rst
+++ b/changes/685.feature.rst
@@ -1,0 +1,1 @@
+Names that are invalid on Windows as filenames (such as CON and LPT0) are now invalid as app names.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -62,8 +62,13 @@ or are are common to all applications in this repository.
 
 Configuration options for a specific application.
 
-``<app name>`` must adhere to a valid Python distribution name as
-specified in `PEP508 <https://www.python.org/dev/peps/pep-0508/#names>`__.
+``<app name>`` must adhere to a valid Python distribution name as specified in
+`PEP508 <https://www.python.org/dev/peps/pep-0508/#names>`__. The app name must
+also *not* be a reserved word in Python, Java or JavaScript (i.e., app names
+like ``switch`` or ``pass`` would not be valid); and it may not include any of
+the `filenames prohibited by Windows
+<https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions>`__
+(i.e., ``CON``, ``PRN``, or ``LPT1``).
 
 ``[tool.briefcase.app.<app name>.<platform>]``
 ----------------------------------------------

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -137,9 +137,40 @@ JAVA_RESERVED_WORDS = {
     'strictfp',
 }
 
+
+# Names that are illegal as Windows filenames
+# https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+WINDOWS_RESERVED_WORDS = {
+    'con',
+    'prn',
+    'aux',
+    'nul',
+    'com1',
+    'com2',
+    'com3',
+    'com4',
+    'com5',
+    'com6',
+    'com7',
+    'com8',
+    'com9',
+    'com0',
+    'lpt1',
+    'lpt2',
+    'lpt3',
+    'lpt4',
+    'lpt5',
+    'lpt6',
+    'lpt7',
+    'lpt8',
+    'lpt9',
+    'lpt0',
+}
+
 NON_PYTHON_RESERVED_WORDS = set.union(
     JAVASCRIPT_RESERVED_WORDS,
     JAVA_RESERVED_WORDS,
+    WINDOWS_RESERVED_WORDS,
 )
 
 

--- a/tests/config/test_is_reserved_keyword.py
+++ b/tests/config/test_is_reserved_keyword.py
@@ -40,6 +40,11 @@ def test_is_not_reserved_keyword_violation(name):
         'false',
         'False',
         'FALSE',
+        # Windows reserved keywords
+        'CON',
+        'con',  # lower case version of reserved name
+        'LPT5',
+        'Lpt5',  # unconventional spelling of reserved name
     ]
 )
 def test_is_reserved_keyword(name):


### PR DESCRIPTION
Some Windows filenames (CON, AUX, LPT0 etc) are not valid as filenames, and are not advised even with extensions. These names should be prohibited as app names.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
