### PR TITLE
Fixes #696 - Allow for punctuation in Android formal names

### DIFF
--- a/changes/696.bugfix.rst
+++ b/changes/696.bugfix.rst
@@ -1,0 +1,1 @@
+Android projects that have punctuation in their formal names can now build without error.

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -17,15 +17,15 @@ from briefcase.integrations.android_sdk import AndroidSDK
 def safe_formal_name(name):
     """Converts the name into a safe name on Android.
 
-    Certain characters (``/\:<>"\?\*\|``) can't be used as app names
-    on Android; `!` causes problems with Android build tooling.
+    Certain characters (``/\\:<>"?*|``) can't be used as app names
+    on Android; ``!`` causes problems with Android build tooling.
     Also ensure that trailing, leading, and consecutive whitespace
     caused by removing punctuation is collapsed.
 
     :param name: The candidate name
     :returns: The safe version of the name.
     """
-    return re.sub('\s+', ' ', re.sub(r'[!/\\:<>"\?\*\|]', "", name)).strip()
+    return re.sub(r'\s+', ' ', re.sub(r'[!/\\:<>"\?\*\|]', "", name)).strip()
 
 
 class GradleMixin:

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 
 from briefcase.commands import (
@@ -11,6 +12,20 @@ from briefcase.commands import (
 from briefcase.config import BaseConfig, parsed_version
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.android_sdk import AndroidSDK
+
+
+def safe_formal_name(name):
+    """Converts the name into a safe name on Android.
+
+    Certain characters (``/\:<>"\?\*\|``) can't be used as app names
+    on Android; `!` causes problems with Android build tooling.
+    Also ensure that trailing, leading, and consecutive whitespace
+    caused by removing punctuation is collapsed.
+
+    :param name: The candidate name
+    :returns: The safe version of the name.
+    """
+    return re.sub('\s+', ' ', re.sub(r'[!/\\:<>"\?\*\|]', "", name)).strip()
 
 
 class GradleMixin:
@@ -27,6 +42,20 @@ class GradleMixin:
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    def bundle_path(self, app):
+        """
+        The path to the bundle for the app in the output format.
+
+        The bundle is the template-generated source form of the app.
+        The path will usually be a directory, the existence of which is
+        indicative that the template has been rolled out for an app.
+
+        This overrides the default behavior, using a "safe" formal name
+
+        :param app: The app config
+        """
+        return self.platform_path / self.output_format / safe_formal_name(app.formal_name)
 
     def binary_path(self, app):
         return (
@@ -88,6 +117,7 @@ class GradleCreateCommand(GradleMixin, CreateCommand):
 
         return {
             'version_code': version_code,
+            'safe_formal_name': safe_formal_name(app.formal_name),
         }
 
 

--- a/tests/platforms/android/gradle/test_create.py
+++ b/tests/platforms/android/gradle/test_create.py
@@ -43,7 +43,8 @@ def test_version_code(create_command, first_app_config, version, build, version_
     if build:
         first_app_config.build = build
     assert create_command.output_format_template_context(first_app_config) == {
-        'version_code': version_code
+        'version_code': version_code,
+        'safe_formal_name': 'First App',
     }
     # Version code must be less than a 32 bit signed integer MAXINT.
     assert int(version_code) < 2147483647

--- a/tests/platforms/android/gradle/test_safe_formal_name.py
+++ b/tests/platforms/android/gradle/test_safe_formal_name.py
@@ -1,0 +1,38 @@
+import pytest
+
+from briefcase.platforms.android.gradle import safe_formal_name
+
+
+@pytest.mark.parametrize(
+    'formal_name, safe_name',
+    [
+        ('Hello World', 'Hello World'),
+
+        # The invalid list is all stripped
+        ('Hello/World/', 'HelloWorld'),
+        ('Hello\\World', 'HelloWorld'),
+        ('Hello:World', 'HelloWorld'),
+        ('Hello<World', 'HelloWorld'),
+        ('Hello>World', 'HelloWorld'),
+        ('Hello "World"', 'Hello World'),
+        ('Hello World?', 'Hello World'),
+        ('Hello|World', 'HelloWorld'),
+        ('Hello World!', 'Hello World'),
+
+        # All invalid punctuation is removed
+        # Valid punctuation is preserved
+        ('Hello! (World?)', 'Hello (World)'),
+
+        # Position of punctuation doesn't matter
+        ('Hello! World', 'Hello World'),
+        ('!Hello World', 'Hello World'),
+
+        # If removing punctuation leads to double spaces, reduce the double spaces
+        ('Hello | World', 'Hello World'),
+        ('Hello World |', 'Hello World'),
+        ('| Hello World', 'Hello World'),
+
+    ]
+)
+def test_safe_formal_name(formal_name, safe_name):
+    assert safe_formal_name(formal_name) == safe_name


### PR DESCRIPTION
Cleans prohibited punctuation out of Android formal names, and passes the "clean" name to the Android template.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
