### PR TITLE
Fixes #709 - Allow valid 2-letter country codes in bundle identifiers.

### DIFF
--- a/changes/709.bugfix.rst
+++ b/changes/709.bugfix.rst
@@ -1,0 +1,1 @@
+Bundle name validation no longer excludes valid country identifiers (like ``in.example``).

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -199,7 +199,12 @@ def is_valid_bundle_identifier(bundle):
         return False
 
     for part in bundle.split('.'):
-        if is_reserved_keyword(part):
+        # *Some* 2-letter country codes are valid identifiers,
+        # even though they're reserved words; see:
+        #    https://www.oracle.com/java/technologies/javase/codeconventions-namingconventions.html
+        # `.do` *should* be on this list, but as of Apr 2022, `.do` breaks
+        # the Android build tooling.
+        if is_reserved_keyword(part) and part not in {'in', 'is'}:
             return False
 
     return True

--- a/tests/config/test_is_valid_bundle_identifier.py
+++ b/tests/config/test_is_valid_bundle_identifier.py
@@ -10,6 +10,9 @@ from briefcase.config import is_valid_bundle_identifier
         'com.example.more',
         'com.example42.more',
         'com.example-42.more',
+        'in.example',  # Valid identifier with a country code as the TLD
+        'is.example',  # Valid identifier with a country code as the TLD
+        'com.example.in',  # Country codes can appear anywhere.
     ]
 )
 def test_valid_bundle(bundle):
@@ -29,6 +32,8 @@ def test_valid_bundle(bundle):
         'com.pass.example',  # Python reserved word
         'com.switch',  # Java reserved word
         'com.switch.example',  # Java reserved word
+        'int.example',  # Valid identifier with a reserved word as the TLD
+        'do.example',  # This *should* be valid by the Java spec, but Android chokes.
     ]
 )
 def test_invalid_bundle(bundle):


### PR DESCRIPTION
`in.example` and `is.example` are both valid bundle identifiers. They were excluded by previous the validation code.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
