### PR TITLE
Ensure that Java detection errors contain JAVA_HOME

### DIFF
--- a/changes/727.bugfix.rst
+++ b/changes/727.bugfix.rst
@@ -1,0 +1,1 @@
+Errors related to Java JDK detection now properly contain the value of JAVA_HOME instead of the word None

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -106,7 +106,6 @@ class JDK:
                     return JDK(command, java_home=Path(java_home))
                 else:
                     # It's not a Java 8 JDK.
-                    java_home = None
                     install_message = """
 *************************************************************************
 ** WARNING: JAVA_HOME does not point to a Java 8 JDK                   **
@@ -126,7 +125,6 @@ class JDK:
 """.format(java_home=java_home, version_str=version_str)
 
             except FileNotFoundError:
-                java_home = None
                 install_message = """
 *************************************************************************
 ** WARNING: JAVA_HOME does not point to a JDK                          **
@@ -145,7 +143,6 @@ class JDK:
 """.format(java_home=java_home)
 
             except subprocess.CalledProcessError:
-                java_home = None
                 install_message = """
     *************************************************************************
     ** WARNING: Unable to invoke the Java compiler                         **
@@ -173,7 +170,6 @@ class JDK:
     """.format(java_home=java_home)
 
             except IndexError:
-                java_home = None
                 install_message = """
     *************************************************************************
     ** WARNING: Unable to determine the version of Java that is installed  **


### PR DESCRIPTION
Prior to building the Java detection error strings, the value for `JAVA_HOME` was being cleared; therefore, the error displayed to users was missing the value of `JAVA_HOME` that likely was causing the problem.

These changes ensure that the errors contain the value of `JAVA_HOME`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
