### PR TITLE
Implement Popen Output Streamer

### DIFF
--- a/changes/731.bugfix.rst
+++ b/changes/731.bugfix.rst
@@ -1,0 +1,1 @@
+All log entries will now be displayed for the run command on iOS and macOS; previously, initial log entries may have been omitted.

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -245,18 +245,19 @@ class Subprocess:
         """
         try:
             while True:
-                # readline should always return at least a newline...if it returns an
-                # empty string, that should mean the underlying process is exiting/gone.
+                # readline should always return at least a newline (ie \n)
                 output_line = ensure_str(popen_process.stdout.readline())
-                # a return code will be available once the process returns one to the OS.
-                # by definition, that should mean the process has exited.
-                return_code = popen_process.poll()
-                # only return once all output is flushed and the process has exited.
-                if output_line == "" and return_code is not None:
-                    self._log_return_code(return_code)
-                    return
-                if output_line != "":
+                if output_line:
                     self.command.logger.info(output_line)
+                # UNLESS the underlying process is exiting/gone; then "" is returned
+                elif output_line == "":
+                    # a return code will be available once the process returns one to the OS.
+                    # by definition, that should mean the process has exited.
+                    return_code = popen_process.poll()
+                    # only return once all output has been read and the process has exited.
+                    if return_code is not None:
+                        self._log_return_code(return_code)
+                        return
 
         except KeyboardInterrupt:
             popen_process.terminate()

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -13,7 +13,6 @@ from briefcase.commands import (
 from briefcase.config import BaseConfig
 from briefcase.console import InputDisabled, select_option
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
-from briefcase.integrations.subprocess import PopenStreamingError
 from briefcase.integrations.xcode import (
     DeviceState,
     get_device_state,
@@ -366,13 +365,10 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
             raise BriefcaseCommandError(f"Unable to launch app {app.app_name}.")
 
         # Start streaming logs for the app.
-        try:
-            self.logger.info()
-            self.logger.info(f"[{app.app_name}] Following simulator log output (type CTRL-C to stop log)...")
-            self.logger.info("=" * 75)
-            self.subprocess.stream_output(simulator_log_popen)
-        except PopenStreamingError as e:
-            raise BriefcaseCommandError(f"Encountered error during log stream for app {app.app_name}: {e}")
+        self.logger.info()
+        self.logger.info(f"[{app.app_name}] Following simulator log output (type CTRL-C to stop log)...")
+        self.logger.info("=" * 75)
+        self.subprocess.stream_output(simulator_log_popen)
 
         # Preserve the device selection as state.
         return {

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -352,7 +352,7 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
             stderr=subprocess.STDOUT,
             bufsize=1,
         )
-        time.sleep(3)  # let log stream start up
+        self.sleep(0.25)  # let log stream start up
 
         self.logger.info()
         self.logger.info(f'[{app.app_name}] Starting app...')

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -352,7 +352,9 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
             stderr=subprocess.STDOUT,
             bufsize=1,
         )
-        self.sleep(0.25)  # let log stream start up
+
+        # Wait for the log stream start up
+        self.sleep(0.25)
 
         self.logger.info()
         self.logger.info(f'[{app.app_name}] Starting app...')
@@ -362,13 +364,14 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
                 check=True
             )
         except subprocess.CalledProcessError:
+            self.subprocess.cleanup("log stream", simulator_log_popen)
             raise BriefcaseCommandError(f"Unable to launch app {app.app_name}.")
 
         # Start streaming logs for the app.
         self.logger.info()
         self.logger.info(f"[{app.app_name}] Following simulator log output (type CTRL-C to stop log)...")
         self.logger.info("=" * 75)
-        self.subprocess.stream_output(simulator_log_popen)
+        self.subprocess.stream_output("log stream", simulator_log_popen)
 
         # Preserve the device selection as state.
         return {

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from briefcase.config import BaseConfig
 from briefcase.console import select_option
 from briefcase.exceptions import BriefcaseCommandError
-from briefcase.integrations.subprocess import PopenStreamingError
 from briefcase.integrations.xcode import (
     get_identities,
     verify_command_line_tools_install
@@ -78,13 +77,10 @@ class macOSRunMixin:
             raise BriefcaseCommandError(f"Unable to start app {app.app_name}.")
 
         # Start streaming logs for the app.
-        try:
-            self.logger.info()
-            self.logger.info(f"[{app.app_name}] Following system log output (type CTRL-C to stop log)...")
-            self.logger.info("=" * 75)
-            self.subprocess.stream_output(log_popen)
-        except PopenStreamingError as e:
-            raise BriefcaseCommandError(f"Encountered error during log stream for app {app.app_name}: {e}")
+        self.logger.info()
+        self.logger.info(f"[{app.app_name}] Following system log output (type CTRL-C to stop log)...")
+        self.logger.info("=" * 75)
+        self.subprocess.stream_output(log_popen)
 
 
 def is_mach_o_binary(path):

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -60,7 +60,7 @@ class macOSRunMixin:
             stderr=subprocess.STDOUT,
             bufsize=1,
         )
-        time.sleep(3)  # let log stream start up
+        time.sleep(.25)  # let log stream start up
 
         self.logger.info()
         self.logger.info(f'[{app.app_name}] Starting app...')

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -60,7 +60,9 @@ class macOSRunMixin:
             stderr=subprocess.STDOUT,
             bufsize=1,
         )
-        time.sleep(.25)  # let log stream start up
+
+        # Wait for the log stream start up
+        time.sleep(0.25)
 
         self.logger.info()
         self.logger.info(f'[{app.app_name}] Starting app...')
@@ -74,13 +76,14 @@ class macOSRunMixin:
                 check=True,
             )
         except subprocess.CalledProcessError:
+            self.subprocess.cleanup("log stream", log_popen)
             raise BriefcaseCommandError(f"Unable to start app {app.app_name}.")
 
         # Start streaming logs for the app.
         self.logger.info()
         self.logger.info(f"[{app.app_name}] Following system log output (type CTRL-C to stop log)...")
         self.logger.info("=" * 75)
-        self.subprocess.stream_output(log_popen)
+        self.subprocess.stream_output("log stream", log_popen)
 
 
 def is_mach_o_binary(path):

--- a/tests/integrations/subprocess/test_Subprocess__cleanup.py
+++ b/tests/integrations/subprocess/test_Subprocess__cleanup.py
@@ -1,0 +1,34 @@
+import subprocess
+
+from unittest import mock
+
+
+def test_clean_termination(mock_sub, capsys):
+    "A popen process can be cleanly terminated"
+    process = mock.MagicMock()
+
+    mock_sub.cleanup('testing process', process)
+
+    process.terminate.assert_called_once()
+    process.wait.assert_called_once_with(timeout=3)
+    process.kill.assert_not_called()
+
+    # No log messages for a clean exit
+    assert capsys.readouterr().out == ""
+
+
+def test_dirty_termination(mock_sub, capsys):
+    "If terminate doesn't stop the process, it will be forcibly killed"
+    process = mock.MagicMock()
+    process.wait.side_effect = subprocess.TimeoutExpired(cmd="ls", timeout=3)
+
+    mock_sub.cleanup('testing process', process)
+
+    process.terminate.assert_called_once()
+    process.wait.assert_called_once_with(timeout=3)
+    process.kill.assert_called_once_with()
+
+    # Log contains a contextual message.
+    assert capsys.readouterr().out == (
+        "Forcibly killing testing process...\n"
+    )

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -4,7 +4,6 @@ import pytest
 from unittest import mock
 
 from briefcase.console import Log
-from briefcase.integrations.subprocess import PopenStreamingError
 
 
 @pytest.fixture
@@ -24,7 +23,7 @@ def test_output(mock_sub, popen_process, capsys):
 
 
 def test_output_debug(mock_sub, popen_process, capsys):
-    "Readline output is printed"
+    "Readline output is printed; debug mode should not add extra output"
     mock_sub.command.logger = Log(verbosity=2)
 
     mock_sub.stream_output(popen_process)
@@ -32,25 +31,16 @@ def test_output_debug(mock_sub, popen_process, capsys):
 
 
 def test_output_deep_debug(mock_sub, popen_process, capsys):
-    "Readline output is printed with debug return code"
+    "Readline output is printed with debug return code in deep debug mode"
     mock_sub.command.logger = Log(verbosity=3)
 
     mock_sub.stream_output(popen_process)
     assert capsys.readouterr().out == "output line 1\n\noutput line 3\n>>> Return code: -3\n"
 
 
-def test_streaming_error(mock_sub, popen_process, capsys):
-    "Raise PopenStreamingError for any Exceptions from interacting with the OS process"
-    popen_process.stdout.readline.side_effect = Exception("error reason")
-
-    with pytest.raises(PopenStreamingError, match=r"Exception\(\'error reason\'\)"):
-        mock_sub.stream_output(popen_process)
-    assert capsys.readouterr().out == ""
-
-
-def test_keyboard_interrupt(mock_sub, popen_process):
+def test_keyboard_interrupt(mock_sub, popen_process, capsys):
     "Process is terminated if user sends CTRL+C"
-    popen_process.stdout.readline.side_effect = KeyboardInterrupt()
+    popen_process.stdout.readline.side_effect = ["output line 1\n", "\n", KeyboardInterrupt()]
     popen_process.wait.side_effect = subprocess.TimeoutExpired(cmd="ls", timeout=3)
 
     mock_sub.stream_output(popen_process)
@@ -58,6 +48,13 @@ def test_keyboard_interrupt(mock_sub, popen_process):
     popen_process.terminate.assert_called()
     popen_process.wait.assert_called()
     popen_process.kill.assert_called()
+
+    assert capsys.readouterr().out == (
+        "output line 1\n"
+        "\n"
+        "Process will be forcibly killed since "
+        "it did not exit gracefully when signaled.\n"
+    )
 
 
 def test_process_exit_with_queued_output(mock_sub, popen_process, capsys):

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -1,5 +1,3 @@
-import subprocess
-
 import pytest
 from unittest import mock
 
@@ -10,9 +8,19 @@ from briefcase.console import Log
 def popen_process():
     process = mock.MagicMock()
 
-    # there are extra empty strings at the end to simulate readline
+    # There are extra empty strings at the end to simulate readline
     # continuously returning "" once it reaches EOF
-    process.stdout.readline.side_effect = ["output line 1\n", "\n", "output line 3\n", "", "", "", "", "", ""]
+    process.stdout.readline.side_effect = [
+        "output line 1\n",
+        "\n",
+        "output line 3\n",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+    ]
     process.poll.side_effect = [None, None, None, -3]
 
     return process
@@ -20,42 +28,52 @@ def popen_process():
 
 def test_output(mock_sub, popen_process, capsys):
     "Readline output is printed"
-    mock_sub.stream_output(popen_process)
-    assert capsys.readouterr().out == "output line 1\n\noutput line 3\n"
+    mock_sub.stream_output('testing', popen_process)
+    assert capsys.readouterr().out == (
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+    )
 
 
 def test_output_debug(mock_sub, popen_process, capsys):
     "Readline output is printed; debug mode should not add extra output"
     mock_sub.command.logger = Log(verbosity=2)
 
-    mock_sub.stream_output(popen_process)
-    assert capsys.readouterr().out == "output line 1\n\noutput line 3\n"
+    mock_sub.stream_output('testing', popen_process)
+    assert capsys.readouterr().out == (
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+    )
 
 
 def test_output_deep_debug(mock_sub, popen_process, capsys):
     "Readline output is printed with debug return code in deep debug mode"
     mock_sub.command.logger = Log(verbosity=3)
 
-    mock_sub.stream_output(popen_process)
-    assert capsys.readouterr().out == "output line 1\n\noutput line 3\n>>> Return code: -3\n"
+    mock_sub.stream_output('testing', popen_process)
+    assert capsys.readouterr().out == (
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+        ">>> Return code: -3\n"
+    )
 
 
 def test_keyboard_interrupt(mock_sub, popen_process, capsys):
     "Process is terminated if user sends CTRL+C"
     popen_process.stdout.readline.side_effect = ["output line 1\n", "\n", KeyboardInterrupt()]
-    popen_process.wait.side_effect = subprocess.TimeoutExpired(cmd="ls", timeout=3)
+    mock_sub.cleanup = mock.MagicMock()
 
-    mock_sub.stream_output(popen_process)
+    mock_sub.stream_output("testing", popen_process)
 
-    popen_process.terminate.assert_called()
-    popen_process.wait.assert_called()
-    popen_process.kill.assert_called()
+    # Response to the CTRL-C is a process cleanup.
+    mock_sub.cleanup.assert_called_once_with("testing", popen_process)
 
     assert capsys.readouterr().out == (
         "output line 1\n"
         "\n"
-        "Process will be forcibly killed since "
-        "it did not exit gracefully when signaled.\n"
     )
 
 
@@ -63,5 +81,9 @@ def test_process_exit_with_queued_output(mock_sub, popen_process, capsys):
     "All output is printed despite the process exiting early"
     popen_process.poll.side_effect = [None, -3, -3, -3]
 
-    mock_sub.stream_output(popen_process)
-    assert capsys.readouterr().out == "output line 1\n\noutput line 3\n"
+    mock_sub.stream_output('testing', popen_process)
+    assert capsys.readouterr().out == (
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+    )

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -1,0 +1,68 @@
+import subprocess
+
+import pytest
+from unittest import mock
+
+from briefcase.console import Log
+from briefcase.integrations.subprocess import PopenStreamingError
+
+
+@pytest.fixture
+def popen_process():
+    process = mock.MagicMock()
+
+    process.stdout.readline.side_effect = ["output line 1\n", "\n", "output line 3\n", ""]
+    process.poll.side_effect = [None, None, None, -3]
+
+    return process
+
+
+def test_output(mock_sub, popen_process, capsys):
+    "Readline output is printed"
+    mock_sub.stream_output(popen_process)
+    assert capsys.readouterr().out == "output line 1\n\noutput line 3\n"
+
+
+def test_output_debug(mock_sub, popen_process, capsys):
+    "Readline output is printed"
+    mock_sub.command.logger = Log(verbosity=2)
+
+    mock_sub.stream_output(popen_process)
+    assert capsys.readouterr().out == "output line 1\n\noutput line 3\n"
+
+
+def test_output_deep_debug(mock_sub, popen_process, capsys):
+    "Readline output is printed with debug return code"
+    mock_sub.command.logger = Log(verbosity=3)
+
+    mock_sub.stream_output(popen_process)
+    assert capsys.readouterr().out == "output line 1\n\noutput line 3\n>>> Return code: -3\n"
+
+
+def test_streaming_error(mock_sub, popen_process, capsys):
+    "Raise PopenStreamingError for any Exceptions from interacting with the OS process"
+    popen_process.stdout.readline.side_effect = Exception("error reason")
+
+    with pytest.raises(PopenStreamingError, match=r"Exception\(\'error reason\'\)"):
+        mock_sub.stream_output(popen_process)
+    assert capsys.readouterr().out == ""
+
+
+def test_keyboard_interrupt(mock_sub, popen_process):
+    "Process is terminated if user sends CTRL+C"
+    popen_process.stdout.readline.side_effect = KeyboardInterrupt()
+    popen_process.wait.side_effect = subprocess.TimeoutExpired(cmd="ls", timeout=3)
+
+    mock_sub.stream_output(popen_process)
+
+    popen_process.terminate.assert_called()
+    popen_process.wait.assert_called()
+    popen_process.kill.assert_called()
+
+
+def test_process_exit_with_queued_output(mock_sub, popen_process, capsys):
+    "All output is printed despite the process exiting early"
+    popen_process.poll.side_effect = [None, -3, -3, -3]
+
+    mock_sub.stream_output(popen_process)
+    assert capsys.readouterr().out == "output line 1\n\noutput line 3\n"

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -10,7 +10,9 @@ from briefcase.console import Log
 def popen_process():
     process = mock.MagicMock()
 
-    process.stdout.readline.side_effect = ["output line 1\n", "\n", "output line 3\n", ""]
+    # there are extra empty strings at the end to simulate readline
+    # continuously returning "" once it reaches EOF
+    process.stdout.readline.side_effect = ["output line 1\n", "\n", "output line 3\n", "", "", "", "", "", ""]
     process.poll.side_effect = [None, None, None, -3]
 
     return process

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -190,8 +190,8 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
     # Run the app
     command.run_app(first_app_config)
 
-    # We should have slept 3 times
-    assert command.sleep.call_count == 3
+    # We should have slept 4 times
+    assert command.sleep.call_count == 4
 
     # The correct sequence of commands was issued.
     command.subprocess.run.assert_has_calls([

--- a/tests/platforms/macOS/app/test_run.py
+++ b/tests/platforms/macOS/app/test_run.py
@@ -5,7 +5,6 @@ from unittest import mock
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
-from briefcase.integrations.subprocess import PopenStreamingError
 from briefcase.platforms.macOS.app import macOSAppRunCommand
 
 
@@ -55,39 +54,3 @@ def test_run_app_failed(first_app_config, tmp_path):
         ['open', '-n', os.fsdecode(command.binary_path(first_app_config))],
         check=True
     )
-
-
-def test_run_app_log_stream_failed(first_app_config, tmp_path):
-    "If the log can't be streamed, the app still starts"
-    command = macOSAppRunCommand(base_path=tmp_path)
-    command.subprocess = mock.MagicMock()
-    # command.subprocess.run.side_effect = 0
-    command.subprocess.stream_output.side_effect = PopenStreamingError("error reason")
-
-    # The run command raises an error because the log stream couldn't start
-    with pytest.raises(
-            BriefcaseCommandError,
-            match="Encountered error during log stream for app first-app: error reason"
-    ):
-        command.run_app(first_app_config)
-
-    # Calls were made to start the app and to start a log stream.
-    bin_path = command.binary_path(first_app_config)
-    sender = bin_path / "Contents" / "MacOS" / "First App"
-    command.subprocess.Popen.assert_called_with(
-        [
-            'log', 'stream',
-            '--style', 'compact',
-            '--predicate',
-            f'senderImagePath=="{sender}"'
-            f' OR (processImagePath=="{sender}"'
-            ' AND senderImagePath=="/usr/lib/libffi.dylib")',
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
-    )
-    command.subprocess.run.assert_called_with(
-        ['open', '-n', os.fsdecode(bin_path)],
-        check=True
-    ),

--- a/tests/platforms/macOS/app/test_run.py
+++ b/tests/platforms/macOS/app/test_run.py
@@ -12,6 +12,8 @@ def test_run_app(first_app_config, tmp_path):
     "A macOS app can be started"
     command = macOSAppRunCommand(base_path=tmp_path)
     command.subprocess = mock.MagicMock()
+    log_stream_process = mock.MagicMock()
+    command.subprocess.Popen.return_value = log_stream_process
 
     command.run_app(first_app_config)
 
@@ -35,12 +37,15 @@ def test_run_app(first_app_config, tmp_path):
         ['open', '-n', os.fsdecode(bin_path)],
         check=True
     )
+    command.subprocess.stream_output.assert_called_with("log stream", log_stream_process)
 
 
 def test_run_app_failed(first_app_config, tmp_path):
     "If there's a problem started the app, an exception is raised"
     command = macOSAppRunCommand(base_path=tmp_path)
     command.subprocess = mock.MagicMock()
+    log_stream_process = mock.MagicMock()
+    command.subprocess.Popen.return_value = log_stream_process
     command.subprocess.run.side_effect = subprocess.CalledProcessError(
         cmd=['open', '-n', os.fsdecode(command.binary_path(first_app_config))],
         returncode=1
@@ -49,8 +54,27 @@ def test_run_app_failed(first_app_config, tmp_path):
     with pytest.raises(BriefcaseCommandError):
         command.run_app(first_app_config)
 
-    # The run command was still invoked, though
+    # Calls were made to start the app and to start a log stream.
+    bin_path = command.binary_path(first_app_config)
+    sender = bin_path / "Contents" / "MacOS" / "First App"
+    command.subprocess.Popen.assert_called_with(
+        [
+            'log', 'stream',
+            '--style', 'compact',
+            '--predicate',
+            f'senderImagePath=="{sender}"'
+            f' OR (processImagePath=="{sender}"'
+            ' AND senderImagePath=="/usr/lib/libffi.dylib")',
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+    )
     command.subprocess.run.assert_called_with(
-        ['open', '-n', os.fsdecode(command.binary_path(first_app_config))],
+        ['open', '-n', os.fsdecode(bin_path)],
         check=True
     )
+
+    # No attempt was made to stream the log; but there was a cleanup
+    command.subprocess.stream_output.assert_not_called()
+    command.subprocess.cleanup.assert_called_with("log stream", log_stream_process)

--- a/tests/platforms/macOS/xcode/test_run.py
+++ b/tests/platforms/macOS/xcode/test_run.py
@@ -2,6 +2,7 @@
 # Run a basic test to ensure coverage, but fall back to
 # the app backend for exhaustive tests.
 import os
+import subprocess
 from unittest import mock
 
 from briefcase.platforms.macOS.xcode import macOSXcodeRunCommand
@@ -17,20 +18,20 @@ def test_run_app(first_app_config, tmp_path):
     # Calls were made to start the app and to start a log stream.
     bin_path = command.binary_path(first_app_config)
     sender = bin_path / "Contents" / "MacOS" / "First App"
-    command.subprocess.run.assert_has_calls([
-        mock.call(
-            ['open', '-n', os.fsdecode(bin_path)],
-            check=True
-        ),
-        mock.call(
-            [
-                'log', 'stream',
-                '--style', 'compact',
-                '--predicate',
-                f'senderImagePath=="{sender}"'
-                f' OR (processImagePath=="{sender}"'
-                ' AND senderImagePath=="/usr/lib/libffi.dylib")',
-            ],
-            check=True,
-        )
-    ])
+    command.subprocess.Popen.assert_called_with(
+        [
+            'log', 'stream',
+            '--style', 'compact',
+            '--predicate',
+            f'senderImagePath=="{sender}"'
+            f' OR (processImagePath=="{sender}"'
+            ' AND senderImagePath=="/usr/lib/libffi.dylib")',
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+    )
+    command.subprocess.run.assert_called_with(
+        ['open', '-n', os.fsdecode(bin_path)],
+        check=True
+    )


### PR DESCRIPTION
As detailed in #676, the attempt to display the iOS simulator log can miss the first few seconds of log output. This is because the capturing of the log output is started after the simulator is started; therefore, there will always be a non-zero amount of time that log output is not being captured.

Log streaming for macOS and iOS simulator now start before the app is started; once the app is running, any queued log output is flushed to the screen and new log output is printed in real time.

## Implementation
 - A new function in `subprocess.py` loops on the `stdout` output of an established `Popen` process
   - The loop will properly exit when it detects the underlying process has exited
   - The loop will properly exit and terminate the underlying process if the user sends CTRL+C
 - Starting up the iOS simulator was updated to initiate `log stream` via `Popen`
 - Once the simulator is started, the new output streaming function is called to print all of the simulator log

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
