### PR TITLE
Support for Popen start_new_session Flag

### DIFF
--- a/changes/733.bugfix.rst
+++ b/changes/733.bugfix.rst
@@ -1,0 +1,1 @@
+Using CTRL+C to stop showing Android emulator logs while running the app will no longer cause the emulator to shutdown.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -684,6 +684,7 @@ In future, you can specify this device by running:
                 env=self.env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                start_new_session=True,
             )
 
             # The boot process happens in 2 phases.

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -112,6 +112,7 @@ def test_start_emulator(mock_sdk):
         env=mock_sdk.env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        start_new_session=True,
     )
 
     # There were 5 calls to run
@@ -200,6 +201,7 @@ def test_emulator_fail_to_start(mock_sdk):
         env=mock_sdk.env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        start_new_session=True,
     )
 
     # There were 2 calls to run, both to get AVD name
@@ -282,6 +284,7 @@ def test_emulator_fail_to_boot(mock_sdk):
         env=mock_sdk.env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        start_new_session=True,
     )
 
     # There were 4 calls to run before failure

--- a/tests/integrations/subprocess/conftest.py
+++ b/tests/integrations/subprocess/conftest.py
@@ -5,6 +5,10 @@ import pytest
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.console import Log
 
+# hardcoded here since subprocess will only include these constants if Python is literally on Windows
+CREATE_NO_WINDOW = 0x8000000
+CREATE_NEW_PROCESS_GROUP = 0x200
+
 
 @pytest.fixture
 def mock_sub():
@@ -26,5 +30,8 @@ def mock_sub():
     sub._subprocess.run.return_value = run_result
 
     sub._subprocess.check_output.return_value = "some output line 1\nmore output line 2"
+
+    sub._subprocess.CREATE_NO_WINDOW = CREATE_NO_WINDOW
+    sub._subprocess.CREATE_NEW_PROCESS_GROUP = CREATE_NEW_PROCESS_GROUP
 
     return sub

--- a/tests/integrations/subprocess/test_Subprocess__Popen.py
+++ b/tests/integrations/subprocess/test_Subprocess__Popen.py
@@ -3,11 +3,14 @@ import os
 import pytest
 
 from briefcase.console import Log
+from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW
 
 
-def test_call(mock_sub, capsys):
+@pytest.mark.parametrize("platform", ["Linux", "Darwin", "Windows"])
+def test_call(mock_sub, capsys, platform):
     "A simple call will be invoked"
 
+    mock_sub.command.host_os = platform
     mock_sub.Popen(['hello', 'world'])
 
     mock_sub._subprocess.Popen.assert_called_with(['hello', 'world'], text=True)
@@ -37,6 +40,68 @@ def test_call_with_path_arg(mock_sub, capsys, tmp_path):
         text=True,
     )
     assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize(
+    ("platform", "start_new_session", "popen_kwargs"),
+    [
+        ("Linux", None, {}),
+        ("Linux", True, {}),
+        ("Linux", False, {}),
+        ("Darwin", None, {}),
+        ("Darwin", True, {}),
+        ("Darwin", False, {}),
+        ("Windows", None, {}),
+        ("Windows", True, {'creationflags': CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW}),
+        ("Windows", False, {})
+    ]
+)
+def test_call_with_start_new_session(mock_sub, capsys, platform, start_new_session, popen_kwargs):
+    "start_new_session is passed thru on Linux and macOS but converted for Windows"
+
+    mock_sub.command.host_os = platform
+    mock_sub.Popen(['hello', 'world'], start_new_session=start_new_session)
+
+    if platform == "Windows":
+        mock_sub._subprocess.Popen.assert_called_with(
+            ['hello', 'world'],
+            text=True,
+            **popen_kwargs,
+        )
+        assert capsys.readouterr().out == ""
+    else:
+        mock_sub._subprocess.Popen.assert_called_with(
+            ['hello', 'world'],
+            start_new_session=start_new_session,
+            text=True,
+            **popen_kwargs,
+        )
+        assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize(
+    ("creationflags", "final_creationflags"),
+    [
+        (0x1, CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | 1),
+        (CREATE_NEW_PROCESS_GROUP, CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW),
+        (0, CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW),
+    ]
+)
+def test_call_windows_with_start_new_session_and_creationflags(mock_sub, capsys, creationflags, final_creationflags):
+    "creationflags used to simulate start_new_session=True should be merged with any existing flags"
+
+    mock_sub.command.host_os = "Windows"
+
+    # use commented test below when merging creationflags is allowed
+    with pytest.raises(AssertionError, match="Subprocess called with creationflags set"):
+        mock_sub.Popen(['hello', 'world'], start_new_session=True, creationflags=creationflags)
+
+    # mock_sub._subprocess.Popen.assert_called_with(
+    #     ['hello', 'world'],
+    #     creationflags=final_creationflags,
+    #     text=True,
+    # )
+    # assert capsys.readouterr().out == ""
 
 
 def test_debug_call(mock_sub, capsys):

--- a/tests/integrations/subprocess/test_Subprocess__check_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__check_output.py
@@ -4,11 +4,14 @@ from subprocess import CalledProcessError
 import pytest
 
 from briefcase.console import Log
+from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW
 
 
-def test_call(mock_sub, capsys):
+@pytest.mark.parametrize("platform", ["Linux", "Darwin", "Windows"])
+def test_call(mock_sub, capsys, platform):
     "A simple call will be invoked"
 
+    mock_sub.command.host_os = platform
     mock_sub.check_output(['hello', 'world'])
 
     mock_sub._subprocess.check_output.assert_called_with(['hello', 'world'], text=True)
@@ -38,6 +41,68 @@ def test_call_with_path_arg(mock_sub, capsys, tmp_path):
         text=True,
     )
     assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize(
+    ("platform", "start_new_session", "check_output_kwargs"),
+    [
+        ("Linux", None, {}),
+        ("Linux", True, {}),
+        ("Linux", False, {}),
+        ("Darwin", None, {}),
+        ("Darwin", True, {}),
+        ("Darwin", False, {}),
+        ("Windows", None, {}),
+        ("Windows", True, {'creationflags': CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW}),
+        ("Windows", False, {})
+    ]
+)
+def test_call_with_start_new_session(mock_sub, capsys, platform, start_new_session, check_output_kwargs):
+    "start_new_session is passed thru on Linux and macOS but converted for Windows"
+
+    mock_sub.command.host_os = platform
+    mock_sub.check_output(['hello', 'world'], start_new_session=start_new_session)
+
+    if platform == "Windows":
+        mock_sub._subprocess.check_output.assert_called_with(
+            ['hello', 'world'],
+            text=True,
+            **check_output_kwargs,
+        )
+        assert capsys.readouterr().out == ""
+    else:
+        mock_sub._subprocess.check_output.assert_called_with(
+            ['hello', 'world'],
+            start_new_session=start_new_session,
+            text=True,
+            **check_output_kwargs,
+        )
+        assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize(
+    ("creationflags", "final_creationflags"),
+    [
+        (0x1, CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | 1),
+        (CREATE_NEW_PROCESS_GROUP, CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW),
+        (0, CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW),
+    ]
+)
+def test_call_windows_with_start_new_session_and_creationflags(mock_sub, capsys, creationflags, final_creationflags):
+    "creationflags used to simulate start_new_session=True should be merged with any existing flags"
+
+    mock_sub.command.host_os = "Windows"
+
+    # use commented test below when merging creationflags is allowed
+    with pytest.raises(AssertionError, match="Subprocess called with creationflags set"):
+        mock_sub.check_output(['hello', 'world'], start_new_session=True, creationflags=creationflags)
+
+    # mock_sub._subprocess.check_output.assert_called_with(
+    #     ['hello', 'world'],
+    #     creationflags=final_creationflags,
+    #     text=True,
+    # )
+    # assert capsys.readouterr().out == ""
 
 
 def test_debug_call(mock_sub, capsys):

--- a/tests/integrations/subprocess/test_Subprocess__run.py
+++ b/tests/integrations/subprocess/test_Subprocess__run.py
@@ -4,11 +4,14 @@ from subprocess import CalledProcessError
 import pytest
 
 from briefcase.console import Log
+from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW
 
 
-def test_call(mock_sub, capsys):
+@pytest.mark.parametrize("platform", ["Linux", "Darwin", "Windows"])
+def test_call(mock_sub, capsys, platform):
     "A simple call will be invoked"
 
+    mock_sub.command.sys.platform = platform
     mock_sub.run(['hello', 'world'])
 
     mock_sub._subprocess.run.assert_called_with(['hello', 'world'], text=True)
@@ -38,6 +41,68 @@ def test_call_with_path_arg(mock_sub, capsys, tmp_path):
         text=True,
     )
     assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize(
+    ("platform", "start_new_session", "run_kwargs"),
+    [
+        ("Linux", None, {}),
+        ("Linux", True, {}),
+        ("Linux", False, {}),
+        ("Darwin", None, {}),
+        ("Darwin", True, {}),
+        ("Darwin", False, {}),
+        ("Windows", None, {}),
+        ("Windows", True, {'creationflags': CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW}),
+        ("Windows", False, {})
+    ]
+)
+def test_call_with_start_new_session(mock_sub, capsys, platform, start_new_session, run_kwargs):
+    "start_new_session is passed thru on Linux and macOS but converted for Windows"
+
+    mock_sub.command.host_os = platform
+    mock_sub.run(['hello', 'world'], start_new_session=start_new_session)
+
+    if platform == "Windows":
+        mock_sub._subprocess.run.assert_called_with(
+            ['hello', 'world'],
+            text=True,
+            **run_kwargs,
+        )
+        assert capsys.readouterr().out == ""
+    else:
+        mock_sub._subprocess.run.assert_called_with(
+            ['hello', 'world'],
+            start_new_session=start_new_session,
+            text=True,
+            **run_kwargs,
+        )
+        assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize(
+    ("creationflags", "final_creationflags"),
+    [
+        (0x1, CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | 1),
+        (CREATE_NEW_PROCESS_GROUP, CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW),
+        (0, CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW),
+    ]
+)
+def test_call_windows_with_start_new_session_and_creationflags(mock_sub, capsys, creationflags, final_creationflags):
+    "creationflags used to simulate start_new_session=True should be merged with any existing flags"
+
+    mock_sub.command.host_os = "Windows"
+
+    # use commented test below when merging creationflags is allowed
+    with pytest.raises(AssertionError, match="Subprocess called with creationflags set"):
+        mock_sub.run(['hello', 'world'], start_new_session=True, creationflags=creationflags)
+
+    # mock_sub._subprocess.run.assert_called_with(
+    #     ['hello', 'world'],
+    #     creationflags=final_creationflags,
+    #     text=True,
+    # )
+    # assert capsys.readouterr().out == ""
 
 
 def test_debug_call(mock_sub, capsys):

--- a/tests/integrations/subprocess/test_creationflag_constants.py
+++ b/tests/integrations/subprocess/test_creationflag_constants.py
@@ -1,0 +1,12 @@
+import subprocess
+import sys
+
+import pytest
+
+from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW
+
+
+@pytest.mark.skipif(sys.platform != 'win32', reason="requires Windows")
+def test_creationflag_constants():
+    assert subprocess.CREATE_NEW_PROCESS_GROUP == CREATE_NEW_PROCESS_GROUP
+    assert subprocess.CREATE_NO_WINDOW == CREATE_NO_WINDOW


### PR DESCRIPTION
## Problem
Currently, all processes invoked by Briefcase are added to the process group of the python interpreter running Briefcase. This can be beneficial since it allows the OS to handle these processes as a single entity.

However, in certain cases, it is necessary for a spawned process to run independently of its parent process. For example, after the Android emulator is started and adb's `logcat` is running, the user is instructed to use CTRL+C to return to the command prompt. Sending `SIGINT` (via CTRL+C) will return the user to the prompt but also kills the process for the emulator (and any other spawned processes for that matter). This happens because the `SIGINT` is propagated to all processes in the group.

## Solution
Add `start_new_session=True` to the relevant `subprocess` calls that need to be treated independently of Briefcase itself.

This is now implemented for invoking the Android emulator to prevent CTRL+C for adb's `logcat` also killing the process for the emulator.

## Implementation
The `Popen` parameter `start_new_session` implements the POSIX syscall `setsid` which ensures a spawned process runs in a new session (and therefore, by definition, a new process group). (The `start_new_session` parameter was added to replace the idiom of passing `preexec_fn=os.setsid` to `Popen` since it has problematic edge cases....and it's being [deprecated](https://bugs.python.org/issue38435).) Since a `console` or controlling terminal is not shared across sessions, the new process will be unaffected by even terminating the originating terminal window.

Windows, though, is a different story. The approach of `subprocess` in the `stdlib` appears to be to expose several underlying process spawn APIs (largely dependent on the underlying platform) instead of an approach that might produce a single API where the underlying implementations aren't so exposed. At any rate, `start_new_session` is not respected on Windows.

To convert `start_new_session=True` for Windows, the two [process creation flags](https://docs.microsoft.com/en-us/windows/win32/procthread/process-creation-flags) below are used:
- `CREATE_NEW_PROCESS_GROUP`: Makes the new process the root process of a new process group. This also disables CTRL+C signal handlers for all processes of the new process group.
- `CREATE_NO_WINDOW`: Creates a new console for the process but does not open a visible window for that console. This flag is used instead of `DETACHED_PROCESS` since the new process can spawn a new console itself (in the absence of one being available) but that console creation will spawn a visible console window. (Related: [Issue 41619](https://bugs.python.org/issue41619))

This configuration conversion for Windows was added to `Subprocess.final_kwargs()`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
