### PR TITLE
Specify the host architecture when compiling for iOS.

### DIFF
--- a/changes/739.feature.rst
+++ b/changes/739.feature.rst
@@ -1,0 +1,1 @@
+The iOS emulator will now run apps natively on M1 hardware, rather than through Rosetta emulation.

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -165,7 +165,7 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
         devices = simulators[iOS_version]
 
         if len(devices) == 0:
-            raise BriefcaseCommandError(f"No simulators available for iOS {iOS_version}.")
+            raise BriefcaseCommandError(f"No simulators available for {iOS_version}.")
         elif len(devices) == 1:
             udid = list(devices.keys())[0]
         else:
@@ -280,7 +280,7 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
 
         self.logger.info()
         self.logger.info(
-            f"[{app.app_name}] Starting app on an {device} running iOS {iOS_version} (device UDID {udid})"
+            f"[{app.app_name}] Starting app on an {device} running {iOS_version} (device UDID {udid})"
         )
 
         # The simulator needs to be booted before being started.
@@ -298,23 +298,23 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         # if it's shut down, start it again.
         if device_state == DeviceState.SHUTDOWN:
             try:
-                self.logger.info(f"Booting {device} simulator running iOS {iOS_version}...")
+                self.logger.info(f"Booting {device} simulator running {iOS_version}...")
                 self.subprocess.run(
                     ['xcrun', 'simctl', 'boot', udid],
                     check=True
                 )
             except subprocess.CalledProcessError:
-                raise BriefcaseCommandError(f"Unable to boot {device} simulator running iOS {iOS_version}")
+                raise BriefcaseCommandError(f"Unable to boot {device} simulator running {iOS_version}")
 
         # We now know the simulator is *running*, so we can open it.
         try:
-            self.logger.info(f"Opening {device} simulator running iOS {iOS_version}...")
+            self.logger.info(f"Opening {device} simulator running {iOS_version}...")
             self.subprocess.run(
                 ['open', '-a', 'Simulator', '--args', '-CurrentDeviceUDID', udid],
                 check=True
             )
         except subprocess.CalledProcessError:
-            raise BriefcaseCommandError(f"Unable to open {device} simulator running iOS {iOS_version}")
+            raise BriefcaseCommandError(f"Unable to open {device} simulator running {iOS_version}")
 
         # Try to uninstall the app first. If the app hasn't been installed
         # before, this will still succeed.

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -238,7 +238,7 @@ class iOSXcodeBuildCommand(iOSXcodeMixin, BuildCommand):
                     f'platform="iOS Simulator,name={device},OS={iOS_version}"',
                     '-quiet',
                     '-configuration', 'Debug',
-                    '-arch', 'x86_64',
+                    '-arch', self.host_arch,
                     '-sdk', 'iphonesimulator',
                     'build'
                 ],

--- a/tests/platforms/iOS/xcode/test_build.py
+++ b/tests/platforms/iOS/xcode/test_build.py
@@ -19,6 +19,9 @@ def test_build_app(first_app_config, tmp_path):
     )
     command.subprocess = mock.MagicMock()
 
+    # Mock the host's CPU architecture to ensure it's reflected in the Xcode call
+    command.host_arch = 'weird'
+
     command.build_app(first_app_config)
 
     command.subprocess.run.assert_called_with(
@@ -29,7 +32,7 @@ def test_build_app(first_app_config, tmp_path):
             'platform="iOS Simulator,name=iPhone 11,OS=13.2"',
             '-quiet',
             '-configuration', 'Debug',
-            '-arch', 'x86_64',
+            '-arch', 'weird',
             '-sdk', 'iphonesimulator',
             'build'
         ],
@@ -54,6 +57,9 @@ def test_build_app_failed(first_app_config, tmp_path):
         returncode=1
     )
 
+    # Mock the host's CPU architecture to ensure it's reflected in the Xcode call
+    command.host_arch = 'weird'
+
     with pytest.raises(BriefcaseCommandError):
         command.build_app(first_app_config)
 
@@ -65,7 +71,7 @@ def test_build_app_failed(first_app_config, tmp_path):
             'platform="iOS Simulator,name=iPhone 11,OS=13.2"',
             '-quiet',
             '-configuration', 'Debug',
-            '-arch', 'x86_64',
+            '-arch', 'weird',
             '-sdk', 'iphonesimulator',
             'build'
         ],


### PR DESCRIPTION
Briefcase currently hard-codes the x86_64 architecture when compiling for iOS. This works on M1, but results in the app running through Rosetta. Passing the host architecture to `xcodebuild` ensures that the app always runs natively.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
