### PR TITLE
Use Rich for Printing and Robust Progress/Wait Bars

### DIFF
--- a/changes/740.feature.rst
+++ b/changes/740.feature.rst
@@ -1,0 +1,1 @@
+Console output now uses Rich to provide visual highlights and progress bars.

--- a/changes/740.misc.rst
+++ b/changes/740.misc.rst
@@ -1,1 +1,0 @@
-Use Rich to print to the terminal and render progress and status bars.

--- a/changes/740.misc.rst
+++ b/changes/740.misc.rst
@@ -1,0 +1,1 @@
+Use Rich to print to the terminal and render progress and status bars.

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,8 @@ install_requires =
     requests >= 2.22.0
     GitPython >= 3.0.8
     dmgbuild >= 1.3.3; sys_platform == "darwin"
-    psutil ~= 5.9.0
+    psutil >= 5.9.0
+    rich >= 12.4.1
 
 [options.packages.find]
 where = src

--- a/src/briefcase/__main__.py
+++ b/src/briefcase/__main__.py
@@ -1,23 +1,25 @@
 import sys
 
 from .cmdline import parse_cmdline
+from .console import Log
 from .exceptions import BriefcaseError
 
 
 def main():
     try:
+        log = Log()
         command, options = parse_cmdline(sys.argv[1:])
         command.parse_config("pyproject.toml")
         command(**options)
         result = 0
     except BriefcaseError as e:
-        print()
-        print(e, file=sys.stdout if e.error_code == 0 else sys.stderr)
+        log.error()
+        log.error(str(e))
         result = e.error_code
     except KeyboardInterrupt:
-        print()
-        print("Aborted by user.")
-        print()
+        log.warning()
+        log.warning("Aborted by user.")
+        log.warning()
         result = -42
 
     sys.exit(result)

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -38,8 +38,7 @@ class TemplateUnsupportedVersion(BriefcaseCommandError):
             f"""\
 Could not find template for Python {self.python_version_tag}.
 
-This is likely because Python {self.python_version_tag}
-is not yet supported. You will need to:
+This is likely because Python {self.python_version_tag} is not yet supported. You will need to:
   * Use an older version of Python; or
   * Define your own custom template.
 """

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -40,7 +40,8 @@ class BuildCommand(BaseCommand):
 
         self.logger.info()
         self.logger.info(
-            f"[{app.app_name}] Built {self.binary_path(app).relative_to(self.base_path)}"
+            f"Built {self.binary_path(app).relative_to(self.base_path)}",
+            prefix=app.app_name,
         )
         return state
 

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -570,40 +570,41 @@ class CreateCommand(BaseCommand):
         if bundle_path.exists():
             self.logger.info()
             confirm = self.input.boolean_input(
-                f"Application {app.app_name} already exists; overwrite", default=False
+                f"Application {app.app_name!r} already exists; overwrite", default=False
             )
             if not confirm:
                 self.logger.error(
-                    f"Aborting creation of app {app.app_name}; existing application will not be overwritten."
+                    f"Aborting creation of app {app.app_name!r}; existing application will not be overwritten."
                 )
                 return
             self.logger.info()
-            self.logger.info(f"[{app.app_name}] Removing old application bundle...")
+            self.logger.info("Removing old application bundle...", prefix=app.app_name)
             self.shutil.rmtree(bundle_path)
 
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Generating application template...")
+        self.logger.info("Generating application template...", prefix=app.app_name)
         self.generate_app_template(app=app)
 
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Installing support package...")
+        self.logger.info("Installing support package...", prefix=app.app_name)
         self.install_app_support_package(app=app)
 
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Installing dependencies...")
+        self.logger.info("Installing dependencies...", prefix=app.app_name)
         self.install_app_dependencies(app=app)
 
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Installing application code...")
+        self.logger.info("Installing application code...", prefix=app.app_name)
         self.install_app_code(app=app)
 
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Installing application resources...")
+        self.logger.info("Installing application resources...", prefix=app.app_name)
         self.install_app_resources(app=app)
 
         self.logger.info()
         self.logger.info(
-            f"[{app.app_name}] Created {self.bundle_path(app).relative_to(self.base_path)}"
+            f"Created {self.bundle_path(app).relative_to(self.base_path)}",
+            prefix=app.app_name,
         )
 
     def verify_tools(self):

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -139,12 +139,12 @@ class DevCommand(BaseCommand):
             update_dependencies = True
         if update_dependencies or not dist_info_path.exists():
             self.logger.info()
-            self.logger.info(f"[{app.app_name}] Installing dependencies...")
+            self.logger.info("Installing dependencies...", prefix=app.app_name)
             self.install_dev_dependencies(app, **options)
             write_dist_info(app, dist_info_path)
 
         if run_app:
             self.logger.info()
-            self.logger.info(f"[{app.app_name}] Starting in dev mode...")
+            self.logger.info("Starting in dev mode...", prefix=app.app_name)
             env = self.get_environment(app)
             return self.run_dev_app(app, env, **options)

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -56,7 +56,7 @@ class PackageCommand(BaseCommand):
             app, packaging_format=packaging_format
         ).relative_to(self.base_path)
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Packaged {filename}")
+        self.logger.info(f"Packaged {filename}", prefix=app.app_name)
         return state
 
     def add_options(self, parser):

--- a/src/briefcase/commands/update.py
+++ b/src/briefcase/commands/update.py
@@ -41,28 +41,28 @@ class UpdateCommand(CreateCommand):
         if not bundle_path.exists():
             self.logger.error()
             self.logger.error(
-                f"[{app.app_name}] Application does not exist; call create first!"
+                "Application does not exist; call create first!", prefix=app.app_name
             )
             return
 
         if update_dependencies:
             self.logger.info()
-            self.logger.info(f"[{app.app_name}] Updating dependencies...")
+            self.logger.info("Updating dependencies...", prefix=app.app_name)
             self.install_app_dependencies(app=app)
 
         self.logger.info()
-        self.logger.info(f"{app.app_name}] Updating application code...")
+        self.logger.info("Updating application code...", prefix=app.app_name)
         self.install_app_code(app=app)
 
         if update_resources:
             self.logger.info()
             self.logger.info(
-                f"[{app.app_name}] Updating extra application resources..."
+                "Updating extra application resources...", prefix=app.app_name
             )
             self.install_app_resources(app=app)
 
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Application updated.")
+        self.logger.info("Application updated.", prefix=app.app_name)
 
     def __call__(
         self,

--- a/src/briefcase/commands/upgrade.py
+++ b/src/briefcase/commands/upgrade.py
@@ -98,7 +98,7 @@ class UpgradeCommand(BaseCommand):
 
                 for name in found_tools:
                     tool = managed_tools[name]
-                    self.logger.info(f"[{tool.name}] Upgrading {tool.full_name}...")
+                    self.logger.info(f"Upgrading {tool.full_name}...", prefix=tool.name)
                     self.logger.info()
                     tool.upgrade()
 

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -168,7 +168,7 @@ class Console:
         """
         wait_bar = Progress(
             TextColumn("     "),
-            BarColumn(bar_width=40, style="black", pulse_style="white"),
+            BarColumn(bar_width=20, style="black", pulse_style="white"),
             TextColumn(message),
             transient=True,
             console=self.rich_console,

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -112,11 +112,11 @@ class Log:
 
     def warning(self, message="", *, prefix="", markup=False):
         """Log message at warning level; always included in output."""
-        self._log(prefix=prefix, message=message, markup=markup)
+        self._log(prefix=prefix, message=message, markup=markup, style="bold yellow")
 
     def error(self, message="", *, prefix="", markup=False):
         """Log message at error level; always included in output."""
-        self._log(prefix=prefix, message=message, markup=markup)
+        self._log(prefix=prefix, message=message, markup=markup, style="bold red")
 
 
 class Console:

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -29,6 +29,10 @@ class RichConsoleHighlighter(RegexHighlighter):
     prints for concepts like UUIDs, markup, IP addresses, numbers, etc.
     All these colorful additions to the text can become overbearing and
     distracting given much of the output does not benefit from coloring.
+
+    This defines a visually simpler style that highlights URLs in a way
+    that is vaguely consistent with a default HTML stylesheet, but
+    otherwise renders content as-is.
     """
 
     base_style = "repr."

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -857,13 +857,10 @@ briefcase run android -d @{avd}
         # Step 1: Wait for the device to appear so we can get an
         # ADB instance for the new device.
         self.command.logger.info()
-        with self.command.input.wait_bar(
-            "Waiting for emulator to start..."
-        ) as startup_wait_bar:
+        with self.command.input.wait_bar("Waiting for emulator to start..."):
             adb = None
             known_devices = set()
             while adb is None:
-                startup_wait_bar.update()
                 if emulator_popen.poll() is not None:
                     raise BriefcaseCommandError(
                         f"""\
@@ -900,7 +897,7 @@ find this page helpful in diagnosing emulator problems.
                 self.sleep(2)
 
         # Phase 2: Wait for the boot process to complete
-        with self.command.input.wait_bar("Booting...") as boot_wait_bar:
+        with self.command.input.wait_bar("Booting..."):
             while not adb.has_booted():
                 if emulator_popen.poll() is not None:
                     raise BriefcaseCommandError(
@@ -920,7 +917,6 @@ find this page helpful in diagnosing emulator problems.
 
                 # Try again in 2 seconds...
                 self.sleep(2)
-                boot_wait_bar.update()
 
         # Return the device ID and full name.
         return device, full_name

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -203,7 +203,7 @@ class Docker:
         try:
             self.command.logger.info()
             self.command.logger.info(
-                f"[{self.app.app_name}] Building Docker container image..."
+                "Building Docker container image...", prefix=self.app.app_name
             )
             self.command.logger.info()
             try:

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -129,7 +129,7 @@ class GradleBuildCommand(GradleMixin, BuildCommand):
 
         :param app: The application to build
         """
-        self.logger.info(f"[{app.app_name}] Building Android APK...")
+        self.logger.info("Building Android APK...", prefix=app.app_name)
         try:
             self.subprocess.run(
                 # Windows needs the full path to `gradlew`; macOS & Linux can find it
@@ -187,7 +187,7 @@ class GradleRunCommand(GradleMixin, RunCommand):
 
         self.logger.info()
         self.logger.info(
-            f"[{app.app_name}] Starting app on {name} (device ID {device})"
+            f"Starting app on {name} (device ID {device})", prefix=app.app_name
         )
 
         # Create an ADB wrapper for the selected device
@@ -199,26 +199,27 @@ class GradleRunCommand(GradleMixin, RunCommand):
 
         # We force-stop the app to ensure the activity launches freshly.
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Stopping old versions of the app...")
+        self.logger.info("Stopping old versions of the app...", prefix=app.app_name)
         adb.force_stop_app(package)
 
         # Install the latest APK file onto the device.
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Installing app...")
+        self.logger.info("Installing app...", prefix=app.app_name)
         adb.install_apk(self.binary_path(app))
 
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Clearing device log...")
+        self.logger.info("Clearing device log...", prefix=app.app_name)
         adb.clear_log()
 
         # To start the app, we launch `org.beeware.android.MainActivity`.
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Launching app...")
+        self.logger.info("Launching app...", prefix=app.app_name)
         adb.start_app(package, "org.beeware.android.MainActivity")
 
         self.logger.info()
         self.logger.info(
-            f"[{app.app_name}] Following device log output (type CTRL-C to stop log)..."
+            "Following device log output (type CTRL-C to stop log)...",
+            prefix=app.app_name,
         )
         self.logger.info("=" * 75)
         adb.logcat()
@@ -235,7 +236,8 @@ class GradlePackageCommand(GradleMixin, PackageCommand):
         :param app: The application to build
         """
         self.logger.info(
-            f"[{app.app_name}] Building Android App Bundle and APK in release mode..."
+            "Building Android App Bundle and APK in release mode...",
+            prefix=app.app_name,
         )
         try:
             self.subprocess.run(

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -291,13 +291,14 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
             f"Starting app on an {device} running {iOS_version} (device UDID {udid})",
             prefix=app.app_name,
         )
+        self.logger.info()
 
         # The simulator needs to be booted before being started.
         # If it's shut down, we can boot it again; but if it's currently
         # shutting down, we need to wait for it to shut down before restarting.
         device_state = self.get_device_state(self, udid)
         if device_state not in {DeviceState.SHUTDOWN, DeviceState.BOOTED}:
-            with self.input.wait_bar("Waiting for simulator..."):
+            with self.input.wait_bar("Waiting for simulator shutdown..."):
                 while device_state not in {DeviceState.SHUTDOWN, DeviceState.BOOTED}:
                     self.sleep(2)
                     device_state = self.get_device_state(self, udid)
@@ -306,21 +307,32 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         # if it's shut down, start it again.
         if device_state == DeviceState.SHUTDOWN:
             try:
-                self.logger.info(f"Booting {device} simulator running {iOS_version}...")
-                self.subprocess.run(["xcrun", "simctl", "boot", udid], check=True)
+                with self.input.wait_bar("Booting simulator..."):
+                    self.subprocess.run(
+                        ["xcrun", "simctl", "boot", udid],
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    )
             except subprocess.CalledProcessError as e:
+                self.logger.error()
+                self.logger.error(e.stdout)
                 raise BriefcaseCommandError(
                     f"Unable to boot {device} simulator running {iOS_version}"
                 ) from e
 
         # We now know the simulator is *running*, so we can open it.
         try:
-            self.logger.info(f"Opening {device} simulator running {iOS_version}...")
-            self.subprocess.run(
-                ["open", "-a", "Simulator", "--args", "-CurrentDeviceUDID", udid],
-                check=True,
-            )
+            with self.input.wait_bar("Opening simulator..."):
+                self.subprocess.run(
+                    ["open", "-a", "Simulator", "--args", "-CurrentDeviceUDID", udid],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
         except subprocess.CalledProcessError as e:
+            self.logger.error()
+            self.logger.error(e.stdout)
             raise BriefcaseCommandError(
                 f"Unable to open {device} simulator running {iOS_version}"
             ) from e
@@ -328,26 +340,33 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         # Try to uninstall the app first. If the app hasn't been installed
         # before, this will still succeed.
         app_identifier = ".".join([app.bundle, app.app_name])
-        self.logger.info()
-        self.logger.info("Uninstalling old app version...", prefix=app.app_name)
         try:
-            self.subprocess.run(
-                ["xcrun", "simctl", "uninstall", udid, app_identifier], check=True
-            )
+            with self.input.wait_bar("Uninstalling old app version..."):
+                self.subprocess.run(
+                    ["xcrun", "simctl", "uninstall", udid, app_identifier],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
         except subprocess.CalledProcessError as e:
+            self.logger.error()
+            self.logger.error(e.stdout)
             raise BriefcaseCommandError(
                 f"Unable to uninstall old version of app {app.app_name}."
             ) from e
 
         # Install the app.
-        self.logger.info()
-        self.logger.info("Installing new app version...", prefix=app.app_name)
         try:
-            self.subprocess.run(
-                ["xcrun", "simctl", "install", udid, self.binary_path(app)],
-                check=True,
-            )
+            with self.input.wait_bar("Installing new app version..."):
+                self.subprocess.run(
+                    ["xcrun", "simctl", "install", udid, self.binary_path(app)],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
         except subprocess.CalledProcessError as e:
+            self.logger.error()
+            self.logger.error(e.stdout)
             raise BriefcaseCommandError(
                 f"Unable to install new version of app {app.app_name}."
             ) from e
@@ -374,14 +393,18 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         # Wait for the log stream start up
         self.sleep(0.25)
 
-        self.logger.info()
-        self.logger.info("Starting app...", prefix=app.app_name)
         try:
-            self.subprocess.run(
-                ["xcrun", "simctl", "launch", udid, app_identifier], check=True
-            )
+            with self.input.wait_bar("Starting app..."):
+                self.subprocess.run(
+                    ["xcrun", "simctl", "launch", udid, app_identifier],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
         except subprocess.CalledProcessError as e:
             self.subprocess.cleanup("log stream", simulator_log_popen)
+            self.logger.error()
+            self.logger.error(e.stdout)
             raise BriefcaseCommandError(f"Unable to launch app {app.app_name}.") from e
 
         # Start streaming logs for the app.

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -232,7 +232,7 @@ class iOSXcodeBuildCommand(iOSXcodeMixin, BuildCommand):
         )
 
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Building XCode project...")
+        self.logger.info("Building XCode project...", prefix=app.app_name)
 
         try:
             self.subprocess.run(
@@ -288,7 +288,8 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
 
         self.logger.info()
         self.logger.info(
-            f"[{app.app_name}] Starting app on an {device} running {iOS_version} (device UDID {udid})"
+            f"Starting app on an {device} running {iOS_version} (device UDID {udid})",
+            prefix=app.app_name,
         )
 
         # The simulator needs to be booted before being started.
@@ -296,10 +297,9 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         # shutting down, we need to wait for it to shut down before restarting.
         device_state = self.get_device_state(self, udid)
         if device_state not in {DeviceState.SHUTDOWN, DeviceState.BOOTED}:
-            with self.input.wait_bar("Waiting for simulator...") as wait_bar:
+            with self.input.wait_bar("Waiting for simulator..."):
                 while device_state not in {DeviceState.SHUTDOWN, DeviceState.BOOTED}:
                     self.sleep(2)
-                    wait_bar.update()
                     device_state = self.get_device_state(self, udid)
 
         # We now know the simulator is either shut down or booted;
@@ -329,7 +329,7 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         # before, this will still succeed.
         app_identifier = ".".join([app.bundle, app.app_name])
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Uninstalling old app version...")
+        self.logger.info("Uninstalling old app version...", prefix=app.app_name)
         try:
             self.subprocess.run(
                 ["xcrun", "simctl", "uninstall", udid, app_identifier], check=True
@@ -341,10 +341,11 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
 
         # Install the app.
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Installing new app version...")
+        self.logger.info("Installing new app version...", prefix=app.app_name)
         try:
             self.subprocess.run(
-                ["xcrun", "simctl", "install", udid, self.binary_path(app)], check=True
+                ["xcrun", "simctl", "install", udid, self.binary_path(app)],
+                check=True,
             )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(
@@ -374,7 +375,7 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         self.sleep(0.25)
 
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Starting app...")
+        self.logger.info("Starting app...", prefix=app.app_name)
         try:
             self.subprocess.run(
                 ["xcrun", "simctl", "launch", udid, app_identifier], check=True
@@ -386,7 +387,8 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         # Start streaming logs for the app.
         self.logger.info()
         self.logger.info(
-            f"[{app.app_name}] Following simulator log output (type CTRL-C to stop log)..."
+            "Following simulator log output (type CTRL-C to stop log)...",
+            prefix=app.app_name,
         )
         self.logger.info("=" * 75)
         self.subprocess.stream_output("log stream", simulator_log_popen)

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -98,14 +98,14 @@ class LinuxAppImageMixin(LinuxMixin):
         if self.use_docker:
             # Enter the Docker context.
             self.logger.info()
-            self.logger.info(f"[{app.app_name}] Entering Docker context...")
+            self.logger.info("Entering Docker context...", prefix=app.app_name)
             orig_subprocess = self.subprocess
             self.subprocess = self.Docker(self, app)
 
             yield self.subprocess
 
             self.logger.info()
-            self.logger.info(f"[{app.app_name}] Leaving Docker context.")
+            self.logger.info("Leaving Docker context.", prefix=app.app_name)
             self.subprocess = orig_subprocess
         else:
             yield self.subprocess
@@ -153,7 +153,7 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
         :param app: The application to build
         """
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Building AppImage...")
+        self.logger.info("Building AppImage...", prefix=app.app_name)
 
         try:
             # Build the AppImage.
@@ -218,7 +218,7 @@ class LinuxAppImageRunCommand(LinuxAppImageMixin, RunCommand):
         :param app: The config object for the app
         """
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Starting app...")
+        self.logger.info("Starting app...", prefix=app.app_name)
         try:
             self.subprocess.run(
                 [

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -69,7 +69,7 @@ class macOSRunMixin:
 
         try:
             self.logger.info()
-            self.logger.info(f"[{app.app_name}] Starting app...")
+            self.logger.info("Starting app...", prefix=app.app_name)
             try:
                 self.subprocess.run(
                     [
@@ -95,7 +95,8 @@ class macOSRunMixin:
                 # Start streaming logs for the app.
                 self.logger.info()
                 self.logger.info(
-                    f"[{app.app_name}] Following system log output (type CTRL-C to stop log)..."
+                    "Following system log output (type CTRL-C to stop log)...",
+                    prefix=app.app_name,
                 )
                 self.logger.info("=" * 75)
                 self.subprocess.stream_output(
@@ -327,20 +328,22 @@ class macOSPackageMixin(macOSSigningMixin):
                 identity = "-"
 
                 self.logger.info()
-                self.logger.info(f"[{app.app_name}] Signing app with adhoc identity...")
+                self.logger.info(
+                    "Signing app with adhoc identity...", prefix=app.app_name
+                )
             else:
                 identity = self.select_identity(identity=identity)
 
                 self.logger.info()
                 self.logger.info(
-                    f"[{app.app_name}] Signing app with identity {identity}..."
+                    f"Signing app with identity {identity}...", prefix=app.app_name
                 )
 
             self.sign_app(app=app, identity=identity)
 
         if packaging_format == "dmg":
             self.logger.info()
-            self.logger.info(f"[{app.app_name}] Building DMG...")
+            self.logger.info("Building DMG...", prefix=app.app_name)
 
             dmg_settings = {
                 "files": [os.fsdecode(self.binary_path(app))],

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -77,7 +77,7 @@ class macOSAppBuildCommand(macOSAppMixin, macOSSigningMixin, BuildCommand):
         # adhoc signing identity. Apply an adhoc signing identity to the
         # app bundle.
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Adhoc signing app...")
+        self.logger.info("Adhoc signing app...", prefix=app.app_name)
         self.sign_app(app=app, identity="-")
 
 

--- a/src/briefcase/platforms/macOS/xcode.py
+++ b/src/briefcase/platforms/macOS/xcode.py
@@ -74,7 +74,7 @@ class macOSXcodeBuildCommand(macOSXcodeMixin, BuildCommand):
         """
 
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Building XCode project...")
+        self.logger.info("Building XCode project...", prefix=app.app_name)
 
         try:
             self.subprocess.run(

--- a/src/briefcase/platforms/windows/msi.py
+++ b/src/briefcase/platforms/windows/msi.py
@@ -120,7 +120,7 @@ class WindowsMSIRunCommand(WindowsMSIMixin, RunCommand):
         :param app: The config object for the app
         """
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Starting app...")
+        self.logger.info("Starting app...", prefix=app.app_name)
         try:
             self.subprocess.run(
                 [
@@ -145,7 +145,7 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
         :param app: The application to build
         """
         self.logger.info()
-        self.logger.info(f"[{app.app_name}] Building MSI...")
+        self.logger.info("Building MSI...", prefix=app.app_name)
 
         try:
             self.logger.info()

--- a/tests/commands/create/test_create_app.py
+++ b/tests/commands/create/test_create_app.py
@@ -39,7 +39,7 @@ def test_create_existing_app_overwrite(tracking_create_command):
 
     # Input was required by the user
     assert tracking_create_command.input.prompts == [
-        "Application first already exists; overwrite [y/N]? "
+        "Application 'first' already exists; overwrite [y/N]? "
     ]
 
     # The right sequence of things will be done
@@ -71,7 +71,7 @@ def test_create_existing_app_no_overwrite(tracking_create_command):
 
     # Input was required by the user
     assert tracking_create_command.input.prompts == [
-        "Application first already exists; overwrite [y/N]? "
+        "Application 'first' already exists; overwrite [y/N]? "
     ]
 
     # No app creation actions will be performed
@@ -98,7 +98,7 @@ def test_create_existing_app_no_overwrite_default(tracking_create_command):
 
     # Input was required by the user
     assert tracking_create_command.input.prompts == [
-        "Application first already exists; overwrite [y/N]? "
+        "Application 'first' already exists; overwrite [y/N]? "
     ]
 
     # And no actions were necessary

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,14 @@ from unittest import mock
 import pytest
 from git import exc as git_exceptions
 
+from briefcase.console import rich_console
+
+# Stop Rich from inserting line breaks in to long lines of text.
+# Rich does this to prevent individual words being split between
+# two lines in the terminal...however, these additional line breaks
+# cause some tests to fail unexpectedly.
+rich_console.soft_wrap = True
+
 
 @pytest.fixture
 def mock_git():

--- a/tests/console/Console/test_boolean_input.py
+++ b/tests/console/Console/test_boolean_input.py
@@ -25,57 +25,57 @@ from briefcase.console import InputDisabled
 def test_boolean_input(console, user_input, expected):
     question = "Are you handsome"
     prompt = "Are you handsome [y/N]? "
-    console._input.side_effect = [user_input]
+    console.rich_console.input.side_effect = [user_input]
 
     result = console.boolean_input(question=question)
 
     assert result == expected
-    console._input.assert_called_once_with(prompt)
+    console.rich_console.input.assert_called_once_with(prompt, markup=False)
 
 
 def test_boolean_default_true(console):
     """If True is the default, it is returned."""
     question = "Are you handsome"
     prompt = "Are you handsome [Y/n]? "
-    console._input.side_effect = [""]
+    console.rich_console.input.side_effect = [""]
 
     result = console.boolean_input(question=question, default=True)
 
     assert result
-    console._input.assert_called_once_with(prompt)
+    console.rich_console.input.assert_called_once_with(prompt, markup=False)
 
 
 def test_boolean_default_false(console):
     """If False is the default, it is returned."""
     question = "Are you handsome"
     prompt = "Are you handsome [y/N]? "
-    console._input.side_effect = [""]
+    console.rich_console.input.side_effect = [""]
 
     result = console.boolean_input(question=question, default=False)
 
     assert not result
-    console._input.assert_called_once_with(prompt)
+    console.rich_console.input.assert_called_once_with(prompt, markup=False)
 
 
 def test_boolean_default_None(console):
     """If no default is specified, no response is not accepted."""
     question = "Are you handsome"
-    console._input.side_effect = ["", "y"]
+    console.rich_console.input.side_effect = ["", "y"]
 
     result = console.boolean_input(question=question, default=None)
 
     assert result
-    assert console._input.call_count == 2
+    assert console.rich_console.input.call_count == 2
 
 
 def test_bad_input(console):
     question = "Are you handsome"
-    console._input.side_effect = ["pork", "ham", "spam", "Yam"]
+    console.rich_console.input.side_effect = ["pork", "ham", "spam", "Yam"]
 
     result = console.boolean_input(question=question)
 
     assert result
-    assert console._input.call_count == 4
+    assert console.rich_console.input.call_count == 4
 
 
 def test_disabled(disabled_console):
@@ -85,7 +85,7 @@ def test_disabled(disabled_console):
     result = disabled_console.boolean_input(question=question)
 
     assert not result
-    disabled_console._input.assert_not_called()
+    disabled_console.rich_console.input.assert_not_called()
 
 
 def test_disabled_no_default(disabled_console):
@@ -95,4 +95,4 @@ def test_disabled_no_default(disabled_console):
     with pytest.raises(InputDisabled):
         disabled_console.boolean_input(question=question, default=None)
 
-    disabled_console._input.assert_not_called()
+    disabled_console.rich_console.input.assert_not_called()

--- a/tests/console/Console/test_call.py
+++ b/tests/console/Console/test_call.py
@@ -7,12 +7,12 @@ def test_call_returns_user_input_when_enabled(console):
     """If input wrapper is enabled, call returns user input."""
     value = "abs"
     prompt = "> "
-    console._input.return_value = value
+    console.rich_console.input.return_value = value
 
     actual_value = console(prompt=prompt)
 
     assert actual_value == value
-    console._input.assert_called_once_with(prompt)
+    console.rich_console.input.assert_called_once_with(prompt, markup=False)
 
 
 def test_call_raise_exception_when_disabled(disabled_console):
@@ -21,13 +21,13 @@ def test_call_raise_exception_when_disabled(disabled_console):
 
     with pytest.raises(InputDisabled):
         disabled_console(prompt=prompt)
-    disabled_console._input.assert_not_called()
+    disabled_console.rich_console.input.assert_not_called()
 
 
 def test_call_raise_keyboardinterrupt_for_eoferror(console):
     """Ensure KeyboardInterrupt is raised when users send EOF to an input
     prompt."""
-    console._input.side_effect = EOFError()
+    console.rich_console.input.side_effect = EOFError()
 
     with pytest.raises(KeyboardInterrupt):
         console(prompt="")

--- a/tests/console/Console/test_selection_input.py
+++ b/tests/console/Console/test_selection_input.py
@@ -18,7 +18,7 @@ def test_selection_input(console, value, expected, default, transform):
     prompt = "> "
     options = ["A", "B", "C", "D", "E", "F"]
 
-    console._input.side_effect = [value]
+    console.rich_console.input.side_effect = [value]
 
     actual = console.selection_input(
         prompt=prompt,
@@ -28,7 +28,7 @@ def test_selection_input(console, value, expected, default, transform):
     )
 
     assert actual == expected
-    console._input.assert_called_once_with(prompt)
+    console.rich_console.input.assert_called_once_with(prompt, markup=False)
 
 
 def test_bad_input(console):
@@ -36,15 +36,15 @@ def test_bad_input(console):
     prompt = "> "
     options = ["A", "B", "C", "D", "E", "F"]
 
-    console._input.side_effect = ["G", "Q", "C"]
+    console.rich_console.input.side_effect = ["G", "Q", "C"]
 
     actual = console.selection_input(prompt=prompt, choices=options)
 
     assert actual == "C"
-    assert console._input.call_count == 3
-    assert console._input.call_args_list[0] == call(prompt)
-    assert console._input.call_args_list[1] == call(prompt)
-    assert console._input.call_args_list[2] == call(prompt)
+    assert console.rich_console.input.call_count == 3
+    assert console.rich_console.input.call_args_list[0] == call(prompt, markup=False)
+    assert console.rich_console.input.call_args_list[1] == call(prompt, markup=False)
+    assert console.rich_console.input.call_args_list[2] == call(prompt, markup=False)
 
 
 def test_disabled(disabled_console):
@@ -56,7 +56,7 @@ def test_disabled(disabled_console):
     )
 
     assert actual == "C"
-    disabled_console._input.assert_not_called()
+    disabled_console.rich_console.input.assert_not_called()
 
 
 def test_disabled_no_default(disabled_console):
@@ -70,4 +70,4 @@ def test_disabled_no_default(disabled_console):
             default=None,
         )
 
-    disabled_console._input.assert_not_called()
+    disabled_console.rich_console.input.assert_not_called()

--- a/tests/console/Console/test_text_input.py
+++ b/tests/console/Console/test_text_input.py
@@ -14,12 +14,12 @@ def test_text_input(console, value, expected):
     prompt = "> "
     default = "Default"
 
-    console._input.return_value = value
+    console.rich_console.input.return_value = value
 
     actual = console.text_input(prompt=prompt, default=default)
 
     assert actual == expected
-    console._input.assert_called_once_with(prompt)
+    console.rich_console.input.assert_called_once_with(prompt, markup=False)
 
 
 def test_disabled(disabled_console):
@@ -29,7 +29,7 @@ def test_disabled(disabled_console):
     actual = disabled_console.text_input(prompt=prompt, default="Default")
 
     assert actual == "Default"
-    disabled_console._input.assert_not_called()
+    disabled_console.rich_console.input.assert_not_called()
 
 
 def test_disabled_no_default(disabled_console):
@@ -39,4 +39,4 @@ def test_disabled_no_default(disabled_console):
     with pytest.raises(InputDisabled):
         disabled_console.text_input(prompt=prompt, default=None)
 
-    disabled_console._input.assert_not_called()
+    disabled_console.rich_console.input.assert_not_called()

--- a/tests/console/Console/test_wait_bar.py
+++ b/tests/console/Console/test_wait_bar.py
@@ -1,0 +1,46 @@
+import pytest
+
+
+def test_wait_bar_done_message(console, capsys):
+    """Custom done_message is printed when wait bar normally exits."""
+    with console.wait_bar("Wait message...", done_message="finished"):
+        pass
+
+    assert capsys.readouterr().out == "\nWait message... finished\n"
+
+
+@pytest.mark.parametrize(
+    ("message", "transient", "output"),
+    (
+        ("Wait message...", False, "\nWait message... done\n"),
+        ("", False, "\n"),
+        ("Wait Message...", True, "\n"),
+        ("", True, "\n"),
+    ),
+)
+def test_wait_bar_transient(console, message, transient, output, capsys):
+    """Output is present or absent based on presence of message and transient
+    value."""
+    with console.wait_bar(message, transient=transient):
+        pass
+
+    assert capsys.readouterr().out == output
+
+
+@pytest.mark.parametrize(
+    ("message", "transient", "output"),
+    (
+        ("Wait message...", False, "\nWait message...\n"),
+        ("", False, "\n"),
+        ("Wait Message...", True, "\n"),
+        ("", True, "\n"),
+    ),
+)
+def test_wait_bar_keyboard_interrupt(console, message, transient, output, capsys):
+    """If the wait bar is interrupted, output is present or absent based on
+    presence of message and transient value."""
+    with pytest.raises(KeyboardInterrupt):
+        with console.wait_bar(message, transient=transient):
+            raise KeyboardInterrupt
+
+    assert capsys.readouterr().out == output

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -8,12 +8,12 @@ from briefcase.console import Console
 @pytest.fixture
 def console():
     console = Console()
-    console._input = mock.MagicMock()
+    console.rich_console.input = mock.MagicMock()
     return console
 
 
 @pytest.fixture
 def disabled_console():
     console = Console(enabled=False)
-    console._input = mock.MagicMock()
+    console.rich_console.input = mock.MagicMock()
     return console

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -41,6 +41,8 @@ def test_run_app_simulator_booted(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Uninstall the old app
             mock.call(
@@ -52,6 +54,8 @@ def test_run_app_simulator_booted(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Install the new app
             mock.call(
@@ -69,6 +73,8 @@ def test_run_app_simulator_booted(first_app_config, tmp_path):
                     / "First App.app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Launch the new app
             mock.call(
@@ -80,6 +86,8 @@ def test_run_app_simulator_booted(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -133,6 +141,8 @@ def test_run_app_simulator_shut_down(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Open the simulator
             mock.call(
@@ -145,6 +155,8 @@ def test_run_app_simulator_shut_down(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Uninstall the old app
             mock.call(
@@ -156,6 +168,8 @@ def test_run_app_simulator_shut_down(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Install the new app
             mock.call(
@@ -173,6 +187,8 @@ def test_run_app_simulator_shut_down(first_app_config, tmp_path):
                     / "First App.app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Launch the new app
             mock.call(
@@ -184,6 +200,8 @@ def test_run_app_simulator_shut_down(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -250,6 +268,8 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Open the simulator
             mock.call(
@@ -262,6 +282,8 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Uninstall the old app
             mock.call(
@@ -273,6 +295,8 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Install the new app
             mock.call(
@@ -290,6 +314,8 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
                     / "First App.app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Launch the new app
             mock.call(
@@ -301,6 +327,8 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -356,6 +384,8 @@ def test_run_app_simulator_boot_failure(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -397,6 +427,8 @@ def test_run_app_simulator_open_failure(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Open the simulator
             mock.call(
@@ -409,6 +441,8 @@ def test_run_app_simulator_open_failure(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -451,6 +485,8 @@ def test_run_app_simulator_uninstall_failure(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Open the simulator
             mock.call(
@@ -463,6 +499,8 @@ def test_run_app_simulator_uninstall_failure(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Uninstall the old app
             mock.call(
@@ -474,6 +512,8 @@ def test_run_app_simulator_uninstall_failure(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -517,6 +557,8 @@ def test_run_app_simulator_install_failure(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Open the simulator
             mock.call(
@@ -529,6 +571,8 @@ def test_run_app_simulator_install_failure(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Uninstall the old app
             mock.call(
@@ -540,6 +584,8 @@ def test_run_app_simulator_install_failure(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Install the new app
             mock.call(
@@ -557,6 +603,8 @@ def test_run_app_simulator_install_failure(first_app_config, tmp_path):
                     / "First App.app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -603,6 +651,8 @@ def test_run_app_simulator_launch_failure(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Open the simulator
             mock.call(
@@ -615,6 +665,8 @@ def test_run_app_simulator_launch_failure(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Uninstall the old app
             mock.call(
@@ -626,6 +678,8 @@ def test_run_app_simulator_launch_failure(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Install the new app
             mock.call(
@@ -643,6 +697,8 @@ def test_run_app_simulator_launch_failure(first_app_config, tmp_path):
                     / "First App.app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
             # Launch the new app
             mock.call(
@@ -654,6 +710,8 @@ def test_run_app_simulator_launch_failure(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             ),
         ]
     )


### PR DESCRIPTION
These changes leverage [Rich](https://github.com/Textualize/rich) for all terminal output.
- Since Rich is _very_ colorful by default, nearly all effects to the text are disabled by default.
  - URLs are still highlighted by default.
- Rich markup can be enabled for specific output with `markup=True`; this is true for logging as well as input prompting.
- By default, all debug and deep debug output is now less bright than other logging.
- The implemented Rich progress bar is largely modeled after the `pip` download bar.
- The wait bar is simple but succinctly informs users of ongoing tasks and that they completed.

Note: While a progress or wait bar is ongoing, additional output can only be printed via Rich. This means, for instance, a wait bar cannot be used to wrap a subprocess that may output the terminal itself; otherwise, that process' output will awkwardly be combined with the Rich bar.

<HR>

**Original Post Content**

A quick and dirty POC for much more robust progress and status bars. Although, a bit of bait and switch since this simply 
implements [Textualize/rich](https://github.com/Textualize/rich). As I was assessing what it would take to enhance the existing bars to allow for interspersed printing, it really started feeling like the wrong approach. And something that implemented more of a `curses`-like approach would be much more fitting. Although, not using an established library would definitely be a reinvention of the wheel.

@freakboy3742, if you're amenable to using rich, I can formalize this PR; please let me know your thoughts.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
