### PR TITLE
Improve `parse_config` error message

### DIFF
--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -452,7 +452,10 @@ class BaseCommand(ABC):
                     )
 
         except FileNotFoundError as e:
-            raise BriefcaseConfigError("configuration file not found") from e
+            raise BriefcaseConfigError(
+                f"configuration {filename!r} file not found, "
+                "it may be in a different directory or not exist."
+            ) from e
 
     def download_url(self, url, download_path):
         """Download a given URL, caching it. If it has already been downloaded,


### PR DESCRIPTION
### Describe your changes in detail:
Improve an error message that seem to trip people up when starting (including me). This provides the developer with more information about why the command failed.  (see diff)

### Rational
I came back to beeware after several year and while following the instructions tripped up by running `briefcase create` in the wrong folder. The "From the helloworld directory, run:" line is quite easy to miss in the [Packaging for Distribution](https://docs.beeware.org/en/latest/tutorial/tutorial-3.html) guide.

examples of other people having the same issue:
- https://gitter.im/beeware/general?at=5e782503846f9b7ca61a3fc5
- https://github.com/beeware/briefcase/issues/553

## PR Checklist:
- [x] All new features have been tested
- [ ] All new features have been documented (N/A)
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
