### PR TITLE
Fixed re-installation of Android apps

### DIFF
--- a/changes/395.bugfix.rst
+++ b/changes/395.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed re-installation of Android apps by adding ``-r`` option to ``adb install``.

--- a/changes/395.bugfix.rst
+++ b/changes/395.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed re-installation of Android apps by adding ``-r`` option to ``adb install``.
+Updating an Android app now forces a re-install of the app. This corrects a problem (usually seen on physical devices) where app updates wouldn't be deployed if the app was already on the device.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1012,7 +1012,7 @@ class ADB:
         Returns `None` on success; raises an exception on failure.
         """
         try:
-            self.run("install", apk_path)
+            self.run("install", "-r", apk_path)
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(
                 f"Unable to install APK {apk_path} on {self.device}"

--- a/tests/integrations/android_sdk/ADB/test_install_apk.py
+++ b/tests/integrations/android_sdk/ADB/test_install_apk.py
@@ -18,7 +18,7 @@ def test_install_apk(mock_sdk, capsys):
     adb.install_apk("example.apk")
 
     # Validate call parameters.
-    adb.run.assert_called_once_with("install", "example.apk")
+    adb.run.assert_called_once_with("install", "-r", "example.apk")
 
     # Validate that the normal output of the command was not printed (since there
     # was no error).
@@ -38,7 +38,7 @@ def test_install_failure(mock_sdk, capsys):
         adb.install_apk("example.apk")
 
     # Validate call parameters.
-    adb.run.assert_called_once_with("install", "example.apk")
+    adb.run.assert_called_once_with("install", "-r", "example.apk")
 
 
 def test_invalid_device(mock_sdk, capsys):
@@ -52,4 +52,4 @@ def test_invalid_device(mock_sdk, capsys):
         adb.install_apk("example.apk")
 
     # Validate call parameters.
-    adb.run.assert_called_once_with("install", "example.apk")
+    adb.run.assert_called_once_with("install", "-r", "example.apk")


### PR DESCRIPTION
I reproduced #395, and saw this line in the device log:
```
2022-06-01 14:04:09.460 768-800/? W/PackageManager: Attempt to re-install com.example.helloworld without first uninstalling.
```

This is caused by missing the `-r` option of [`adb install`](https://developer.android.com/studio/command-line/adb#pm), which enables updating an existing app. From my tests, the emulator doesn't always require this option, but physical devices do.

If the app doesn't already exist on the device, the option is harmless, so I've made briefcase use it unconditionally.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
