### PR TITLE
Deploy and Integrate Rich Implementation

### DIFF
--- a/changes/755.misc.rst
+++ b/changes/755.misc.rst
@@ -1,0 +1,1 @@
+Increase consistency displaying messages in the terminal regardless of command, platform, etc.

--- a/changes/755.misc.rst
+++ b/changes/755.misc.rst
@@ -1,1 +1,1 @@
-Increase consistency displaying messages in the terminal regardless of command, platform, etc.
+Deploy Rich implementation of progress/wait bars and increase consistency for logging.

--- a/src/briefcase/__main__.py
+++ b/src/briefcase/__main__.py
@@ -2,7 +2,7 @@ import sys
 
 from .cmdline import parse_cmdline
 from .console import Log
-from .exceptions import BriefcaseError
+from .exceptions import BriefcaseError, HelpText
 
 
 def main():
@@ -12,6 +12,10 @@ def main():
         command.parse_config("pyproject.toml")
         command(**options)
         result = 0
+    except HelpText as e:
+        log.info()
+        log.info(str(e))
+        result = e.error_code
     except BriefcaseError as e:
         log.error()
         log.error(str(e))

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -38,7 +38,6 @@ class BuildCommand(BaseCommand):
 
         state = self.build_app(app, **full_options(state, options))
 
-        self.logger.info()
         self.logger.info(
             f"Built {self.binary_path(app).relative_to(self.base_path)}",
             prefix=app.app_name,

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -311,9 +311,7 @@ class CreateCommand(BaseCommand):
                 custom_support_package = False
                 self.logger.info(f"Using support package {support_package_url}")
 
-            if support_package_url.startswith(
-                "https://"
-            ) or support_package_url.startswith("http://"):
+            if support_package_url.startswith(("https://", "http://")):
                 try:
                     self.logger.info(f"... pinned to revision {app.support_revision}")
                     # If a revision has been specified, add the revision

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -352,13 +352,13 @@ class CreateCommand(BaseCommand):
         except requests_exceptions.ConnectionError as e:
             raise NetworkFailure("downloading support package") from e
         try:
-            self.logger.info("Unpacking support package...")
-            support_path = self.support_path(app)
-            support_path.mkdir(parents=True, exist_ok=True)
-            # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
-            self.shutil.unpack_archive(
-                os.fsdecode(support_filename), extract_dir=os.fsdecode(support_path)
-            )
+            with self.input.wait_bar("Unpacking support package..."):
+                support_path = self.support_path(app)
+                support_path.mkdir(parents=True, exist_ok=True)
+                # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
+                self.shutil.unpack_archive(
+                    os.fsdecode(support_filename), extract_dir=os.fsdecode(support_path)
+                )
         except (shutil.ReadError, EOFError) as e:
             raise InvalidSupportPackage(support_package_url) from e
 
@@ -411,17 +411,17 @@ class CreateCommand(BaseCommand):
         # Install app code.
         if app.sources:
             for src in app.sources:
-                self.logger.info(f"Installing {src}...")
-                original = self.base_path / src
-                target = app_path / original.name
+                with self.input.wait_bar(f"Installing {src}..."):
+                    original = self.base_path / src
+                    target = app_path / original.name
 
-                # Install the new copy of the app code.
-                if not original.exists():
-                    raise MissingAppSources(src)
-                elif original.is_dir():
-                    self.shutil.copytree(original, target)
-                else:
-                    self.shutil.copy(original, target)
+                    # Install the new copy of the app code.
+                    if not original.exists():
+                        raise MissingAppSources(src)
+                    elif original.is_dir():
+                        self.shutil.copytree(original, target)
+                    else:
+                        self.shutil.copy(original, target)
         else:
             self.logger.info(f"No sources defined for {app.app_name}.")
 
@@ -488,11 +488,13 @@ class CreateCommand(BaseCommand):
 
             full_source = self.base_path / source_filename
             if full_source.exists():
-                self.logger.info(f"Installing {source_filename} as {full_role}...")
-                # Make sure the target directory exists
-                target.parent.mkdir(parents=True, exist_ok=True)
-                # Copy the source image to the target location
-                self.shutil.copy(full_source, target)
+                with self.input.wait_bar(
+                    f"Installing {source_filename} as {full_role}..."
+                ):
+                    # Make sure the target directory exists
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    # Copy the source image to the target location
+                    self.shutil.copy(full_source, target)
             else:
                 self.logger.info(
                     f"Unable to find {source_filename} for {full_role}; using default"
@@ -577,31 +579,24 @@ class CreateCommand(BaseCommand):
                     f"Aborting creation of app {app.app_name!r}; existing application will not be overwritten."
                 )
                 return
-            self.logger.info()
             self.logger.info("Removing old application bundle...", prefix=app.app_name)
             self.shutil.rmtree(bundle_path)
 
-        self.logger.info()
         self.logger.info("Generating application template...", prefix=app.app_name)
         self.generate_app_template(app=app)
 
-        self.logger.info()
         self.logger.info("Installing support package...", prefix=app.app_name)
         self.install_app_support_package(app=app)
 
-        self.logger.info()
         self.logger.info("Installing dependencies...", prefix=app.app_name)
         self.install_app_dependencies(app=app)
 
-        self.logger.info()
         self.logger.info("Installing application code...", prefix=app.app_name)
         self.install_app_code(app=app)
 
-        self.logger.info()
         self.logger.info("Installing application resources...", prefix=app.app_name)
         self.install_app_resources(app=app)
 
-        self.logger.info()
         self.logger.info(
             f"Created {self.bundle_path(app).relative_to(self.base_path)}",
             prefix=app.app_name,

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -138,13 +138,11 @@ class DevCommand(BaseCommand):
             # If we are not running the app, it means we should update dependencies.
             update_dependencies = True
         if update_dependencies or not dist_info_path.exists():
-            self.logger.info()
             self.logger.info("Installing dependencies...", prefix=app.app_name)
             self.install_dev_dependencies(app, **options)
             write_dist_info(app, dist_info_path)
 
         if run_app:
-            self.logger.info()
             self.logger.info("Starting in dev mode...", prefix=app.app_name)
             env = self.get_environment(app)
             return self.run_dev_app(app, env, **options)

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -55,7 +55,6 @@ class PackageCommand(BaseCommand):
         filename = self.distribution_path(
             app, packaging_format=packaging_format
         ).relative_to(self.base_path)
-        self.logger.info()
         self.logger.info(f"Packaged {filename}", prefix=app.app_name)
         return state
 

--- a/src/briefcase/commands/update.py
+++ b/src/briefcase/commands/update.py
@@ -39,29 +39,24 @@ class UpdateCommand(CreateCommand):
 
         bundle_path = self.bundle_path(app)
         if not bundle_path.exists():
-            self.logger.error()
             self.logger.error(
                 "Application does not exist; call create first!", prefix=app.app_name
             )
             return
 
         if update_dependencies:
-            self.logger.info()
             self.logger.info("Updating dependencies...", prefix=app.app_name)
             self.install_app_dependencies(app=app)
 
-        self.logger.info()
         self.logger.info("Updating application code...", prefix=app.app_name)
         self.install_app_code(app=app)
 
         if update_resources:
-            self.logger.info()
             self.logger.info(
                 "Updating extra application resources...", prefix=app.app_name
             )
             self.install_app_resources(app=app)
 
-        self.logger.info()
         self.logger.info("Application updated.", prefix=app.app_name)
 
     def __call__(

--- a/src/briefcase/commands/upgrade.py
+++ b/src/briefcase/commands/upgrade.py
@@ -94,15 +94,11 @@ class UpgradeCommand(BaseCommand):
                 self.logger.info("Briefcase will upgrade the following tools:")
                 for name in found_tools:
                     self.logger.info(f" - {name}")
-                self.logger.info()
 
                 for name in found_tools:
                     tool = managed_tools[name]
                     self.logger.info(f"Upgrading {tool.full_name}...", prefix=tool.name)
-                    self.logger.info()
                     tool.upgrade()
-
-                self.logger.info()
 
         else:
             self.logger.info("Briefcase is not managing any tools.")

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -79,6 +79,8 @@ class Log:
                     )
                 prefix = f"[dim]\\[{prefix}][/dim] "
                 markup = True
+                # insert vertical space before for all messages with a prefix
+                self.rich_console.print()
             for line in message.splitlines():
                 self.rich_console.print(
                     f"{preface}{prefix}{line}", markup=markup, style=style
@@ -123,6 +125,7 @@ class Console:
     def __init__(self, enabled=True):
         self.rich_console = rich_console
         self._enabled = enabled
+        self.is_wait_bar_active = False
 
     @property
     def enabled(self):
@@ -167,7 +170,7 @@ class Console:
             the message must already be escaped; defaults False.
         """
         wait_bar = Progress(
-            TextColumn("     "),
+            TextColumn("    "),
             BarColumn(bar_width=20, style="black", pulse_style="white"),
             TextColumn(message),
             transient=True,
@@ -176,6 +179,7 @@ class Console:
         # setting start=False causes the progress bar to pulse
         wait_bar.add_task("", start=False)
         try:
+            self.is_wait_bar_active = True
             with wait_bar:
                 yield
         except BaseException:
@@ -189,6 +193,8 @@ class Console:
                     f'{message}{f" {done_message}" if done_message else ""}',
                     markup=markup,
                 )
+        finally:
+            self.is_wait_bar_active = False
 
     def boolean_input(self, question, default=False):
         """Get a boolean input from user, in the form of y/n.

--- a/src/briefcase/exceptions.py
+++ b/src/briefcase/exceptions.py
@@ -3,7 +3,12 @@ class BriefcaseError(Exception):
         self.error_code = error_code
 
 
-class NoCommandError(BriefcaseError):
+class HelpText(Exception):
+    """Exceptions that contain help text and shouldn't be displayed to users as
+    an error."""
+
+
+class NoCommandError(BriefcaseError, HelpText):
     def __init__(self, msg):
         super().__init__(-10)
         self.msg = msg
@@ -12,7 +17,7 @@ class NoCommandError(BriefcaseError):
         return self.msg
 
 
-class ShowOutputFormats(BriefcaseError):
+class ShowOutputFormats(BriefcaseError, HelpText):
     def __init__(self, platform, default, choices):
         super().__init__(0)
         self.platform = platform

--- a/src/briefcase/exceptions.py
+++ b/src/briefcase/exceptions.py
@@ -3,12 +3,12 @@ class BriefcaseError(Exception):
         self.error_code = error_code
 
 
-class HelpText(Exception):
+class HelpText(BriefcaseError):
     """Exceptions that contain help text and shouldn't be displayed to users as
     an error."""
 
 
-class NoCommandError(BriefcaseError, HelpText):
+class NoCommandError(HelpText):
     def __init__(self, msg):
         super().__init__(-10)
         self.msg = msg
@@ -17,7 +17,7 @@ class NoCommandError(BriefcaseError, HelpText):
         return self.msg
 
 
-class ShowOutputFormats(BriefcaseError, HelpText):
+class ShowOutputFormats(HelpText):
     def __init__(self, platform, default, choices):
         super().__init__(0)
         self.platform = platform

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -71,10 +71,9 @@ class AndroidSDK:
     def cmdline_tools_version(self):
         # This is the version of the Android SDK Command-line tools that
         # are current as of May 2022. These tools can generally self-update,
-        # so using an fixed download URL isn't a problem.
+        # so using a fixed download URL isn't a problem.
         # However, if/when this version number is changed, ensure that the
-        # checks done during verification include any required upgrade
-        # steps.
+        # checks done during verification include any required upgrade steps.
         return "8092744"
 
     @property
@@ -229,6 +228,10 @@ class AndroidSDK:
             command.shutil.rmtree(sdk_root_path)
 
         if install:
+            command.logger.info(
+                "The Android SDK was not found; downloading and installing...",
+                prefix=cls.name,
+            )
             sdk.install()
             return sdk
         else:
@@ -275,44 +278,46 @@ class AndroidSDK:
         #  4. Drop a marker file named <sdk_path>/cmdline-tools/<version> so we can track
         #     the version that was installed.
 
-        self.command.logger.info("Install Android SDK Command-Line Tools...")
-        self.cmdline_tools_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            self.command.shutil.unpack_archive(
-                cmdline_tools_zip_path, extract_dir=self.cmdline_tools_path.parent
-            )
-        except (shutil.ReadError, EOFError) as e:
-            raise BriefcaseCommandError(
-                f"""\
+        with self.command.input.wait_bar(
+            "Installing Android SDK Command-Line Tools..."
+        ):
+            self.cmdline_tools_path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                self.command.shutil.unpack_archive(
+                    cmdline_tools_zip_path, extract_dir=self.cmdline_tools_path.parent
+                )
+            except (shutil.ReadError, EOFError) as e:
+                raise BriefcaseCommandError(
+                    f"""\
 Unable to unpack Android SDK Command-Line Tools ZIP file. The download may have been interrupted
 or corrupted.
 
 Delete {cmdline_tools_zip_path} and run briefcase again.
 """
-            ) from e
+                ) from e
 
-        # If there's an existing version of the cmdline tools (or the version marker), delete them.
-        if self.cmdline_tools_path.exists():
-            self.command.shutil.rmtree(self.cmdline_tools_path)
-        if self.cmdline_tools_version_path.exists():
-            self.command.os.unlink(self.cmdline_tools_version_path)
+            # If there's an existing version of the cmdline tools (or the version marker), delete them.
+            if self.cmdline_tools_path.exists():
+                self.command.shutil.rmtree(self.cmdline_tools_path)
+            if self.cmdline_tools_version_path.exists():
+                self.command.os.unlink(self.cmdline_tools_version_path)
 
-        # Rename the top level zip content to the final name
-        (self.cmdline_tools_path.parent / "cmdline-tools").rename(
-            self.cmdline_tools_path
-        )
-        # Touch a file with the version that was installed.
-        self.cmdline_tools_version_path.touch()
+            # Rename the top level zip content to the final name
+            (self.cmdline_tools_path.parent / "cmdline-tools").rename(
+                self.cmdline_tools_path
+            )
+            # Touch a file with the version that was installed.
+            self.cmdline_tools_version_path.touch()
 
-        # Zip file no longer needed once unpacked.
-        cmdline_tools_zip_path.unlink()
+            # Zip file no longer needed once unpacked.
+            cmdline_tools_zip_path.unlink()
 
-        # Python zip unpacking ignores permission metadata.
-        # On non-Windows, we manually fix permissions.
-        if self.command.host_os != "Windows":
-            for binpath in (self.cmdline_tools_path / "bin").glob("*"):
-                if not self.command.os.access(binpath, self.command.os.X_OK):
-                    binpath.chmod(0o755)
+            # Python zip unpacking ignores permission metadata.
+            # On non-Windows, we manually fix permissions.
+            if self.command.host_os != "Windows":
+                for binpath in (self.cmdline_tools_path / "bin").glob("*"):
+                    if not self.command.os.access(binpath, self.command.os.X_OK):
+                        binpath.chmod(0o755)
 
         # Licences must be accepted.
         self.verify_license()
@@ -613,7 +618,7 @@ Use the -d/--device option to explicitly specify the device to use.
 """
                 ) from e
 
-        # Proces the user's choice
+        # Process the user's choice
         if choice is None:
             # Create a new emulator. No device ID or AVD.
             device = None
@@ -646,7 +651,6 @@ Use the -d/--device option to explicitly specify the device to use.
 In future, you can specify this device by running:
 
     briefcase run android -d @{avd}
-
 """
             )
         elif device:
@@ -655,7 +659,6 @@ In future, you can specify this device by running:
 In future, you can specify this device by running:
 
     briefcase run android -d {device}
-
 """
             )
 
@@ -719,26 +722,25 @@ An emulator named '{avd}' already exists.
 
         try:
             self.command.logger.info()
-            self.command.logger.info(f"Creating Android emulator {avd}...")
-            self.command.logger.info()
-            self.command.subprocess.check_output(
-                [
-                    os.fsdecode(self.avdmanager_path),
-                    "--verbose",
-                    "create",
-                    "avd",
-                    "--name",
-                    avd,
-                    "--abi",
-                    self.emulator_abi,
-                    "--package",
-                    f"system-images;android-31;default;{self.emulator_abi}",
-                    "--device",
-                    device_type,
-                ],
-                env=self.env,
-                stderr=subprocess.STDOUT,
-            )
+            with self.command.input.wait_bar(f"Creating Android emulator {avd}..."):
+                self.command.subprocess.check_output(
+                    [
+                        os.fsdecode(self.avdmanager_path),
+                        "--verbose",
+                        "create",
+                        "avd",
+                        "--name",
+                        avd,
+                        "--abi",
+                        self.emulator_abi,
+                        "--package",
+                        f"system-images;android-31;default;{self.emulator_abi}",
+                        "--device",
+                        device_type,
+                    ],
+                    env=self.env,
+                    stderr=subprocess.STDOUT,
+                )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError("Unable to create Android emulator") from e
 
@@ -763,30 +765,33 @@ An emulator named '{avd}' already exists.
                 raise NetworkFailure(f"download {skin} device skin") from e
 
             # Unpack skin archive
-            try:
-                self.command.shutil.unpack_archive(skin_tgz_path, extract_dir=skin_path)
-            except (shutil.ReadError, EOFError) as err:
-                raise BriefcaseCommandError(
-                    f"Unable to unpack {skin} device skin"
-                ) from err
+            with self.command.input.wait_bar("Installing device skin..."):
+                try:
+                    self.command.shutil.unpack_archive(
+                        skin_tgz_path, extract_dir=skin_path
+                    )
+                except (shutil.ReadError, EOFError) as err:
+                    raise BriefcaseCommandError(
+                        f"Unable to unpack {skin} device skin"
+                    ) from err
 
-            # Delete the downloaded file.
-            skin_tgz_path.unlink()
+                # Delete the downloaded file.
+                skin_tgz_path.unlink()
 
-        self.command.logger.info("Adding extra device configuration...")
-        self.update_emulator_config(
-            avd,
-            {
-                "avd.id": avd,
-                "avd.name": avd,
-                "disk.dataPartition.size": "4096M",
-                "hw.keyboard": "yes",
-                "skin.dynamic": "yes",
-                "skin.name": skin,
-                "skin.path": f"skins/{skin}",
-                "showDeviceFrame": "yes",
-            },
-        )
+        with self.command.input.wait_bar("Adding extra device configuration..."):
+            self.update_emulator_config(
+                avd,
+                {
+                    "avd.id": avd,
+                    "avd.name": avd,
+                    "disk.dataPartition.size": "4096M",
+                    "hw.keyboard": "yes",
+                    "skin.dynamic": "yes",
+                    "skin.name": skin,
+                    "skin.path": f"skins/{skin}",
+                    "showDeviceFrame": "yes",
+                },
+            )
 
         self.command.logger.info(
             f"""
@@ -794,7 +799,7 @@ Android emulator '{avd}' created.
 
 In future, you can specify this device by running:
 
-briefcase run android -d @{avd}
+    briefcase run android -d @{avd}
 """
         )
 
@@ -835,7 +840,6 @@ briefcase run android -d @{avd}
         """
         if avd not in set(self.emulators()):
             raise InvalidDeviceError("emulator AVD", avd)
-        self.command.logger.info(f"Starting emulator {avd}...")
         emulator_popen = self.command.subprocess.Popen(
             [
                 os.fsdecode(self.emulator_path),
@@ -856,8 +860,7 @@ briefcase run android -d @{avd}
 
         # Step 1: Wait for the device to appear so we can get an
         # ADB instance for the new device.
-        self.command.logger.info()
-        with self.command.input.wait_bar("Waiting for emulator to start..."):
+        with self.command.input.wait_bar("Starting emulator..."):
             adb = None
             known_devices = set()
             while adb is None:
@@ -897,8 +900,8 @@ find this page helpful in diagnosing emulator problems.
                 self.sleep(2)
 
         # Phase 2: Wait for the boot process to complete
-        with self.command.input.wait_bar("Booting..."):
-            while not adb.has_booted():
+        while not adb.has_booted():
+            with self.command.input.wait_bar("Booting emulator..."):
                 if emulator_popen.poll() is not None:
                     raise BriefcaseCommandError(
                         f"""\

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -201,11 +201,9 @@ class Docker:
 
     def prepare(self):
         try:
-            self.command.logger.info()
             self.command.logger.info(
                 "Building Docker container image...", prefix=self.app.app_name
             )
-            self.command.logger.info()
             try:
                 system_requires = " ".join(self.app.system_requires)
             except AttributeError:

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -31,11 +31,11 @@ class LinuxDeploy:
 
     @classmethod
     def verify(cls, command, install=True):
-        """Verify that LinuxDeploy is available.
+        """Verify that linuxdeploy is available.
 
         :param command: The command that needs to use linuxdeploy
         :param install: Should the tool be installed if it is not found?
-        :returns: A valid LinuxDeploy SDK wrapper. If linuxdeploy is not
+        :returns: A valid linuxdeploy tool wrapper. If linuxdeploy is not
             available, and was not installed, raises MissingToolError.
         """
         linuxdeploy = LinuxDeploy(command)
@@ -43,7 +43,7 @@ class LinuxDeploy:
         if not linuxdeploy.exists():
             if install:
                 command.logger.info(
-                    "The linuxdeploy SDK was not found; downloading and installing...",
+                    "The linuxdeploy tool was not found; downloading and installing...",
                     prefix=cls.name,
                 )
                 linuxdeploy.install()
@@ -68,13 +68,13 @@ class LinuxDeploy:
         except requests_exceptions.ConnectionError as e:
             raise NetworkFailure("downloading linuxdeploy AppImage") from e
 
-        with self.command.input.wait_bar("Updating permissions for LinuxDeploy..."):
+        with self.command.input.wait_bar("Installing linuxdeploy..."):
             self.command.os.chmod(linuxdeploy_appimage_path, 0o755)
-        self.patch_elf_header()
+            self.patch_elf_header()
 
     def uninstall(self):
         """Uninstall linuxdeploy."""
-        with self.command.input.wait_bar("Removing old LinuxDeploy install..."):
+        with self.command.input.wait_bar("Removing old linuxdeploy install..."):
             self.appimage_path.unlink()
 
     def upgrade(self):
@@ -110,13 +110,11 @@ class LinuxDeploy:
             # Check if the header at the offset is the original value
             # If so, patch it.
             if appimage.read(len(ELF_PATCH_ORIGINAL_BYTES)) == ELF_PATCH_ORIGINAL_BYTES:
-                with self.command.input.wait_bar(
-                    "Patching ELF header of linuxdeploy AppImage..."
-                ):
-                    appimage.seek(ELF_PATCH_OFFSET)
-                    appimage.write(ELF_PATCH_PATCHED_BYTES)
-                    appimage.flush()
-                    appimage.seek(0)
+                appimage.seek(ELF_PATCH_OFFSET)
+                appimage.write(ELF_PATCH_PATCHED_BYTES)
+                appimage.flush()
+                appimage.seek(0)
+                self.command.logger.info("Patched ELF header of linuxdeploy AppImage.")
             # Else if the header is the patched value, do nothing.
             elif (
                 appimage.read(len(ELF_PATCH_ORIGINAL_BYTES)) == ELF_PATCH_PATCHED_BYTES

--- a/src/briefcase/integrations/xcode.py
+++ b/src/briefcase/integrations/xcode.py
@@ -97,18 +97,18 @@ Re-run Briefcase once that installation is complete.
 ** WARNING: Unable to determine if Xcode is installed                  **
 *************************************************************************
 
-   Briefcase will proceed, assuming everything is OK. If you experience
-   problems, this is almost certainly the cause of those problems.
+    Briefcase will proceed, assuming everything is OK. If you experience
+    problems, this is almost certainly the cause of those problems.
 
-   Please report this as a bug at:
+    Please report this as a bug at:
 
-     https://github.com/beeware/briefcase/issues/new
+       https://github.com/beeware/briefcase/issues/new
 
-   In your report, please including the output from running:
+    In your report, please including the output from running:
 
-     xcode-select --install
+        $ xcode-select --install
 
-   from the command prompt.
+    from the command prompt.
 
 *************************************************************************
 """
@@ -207,18 +207,18 @@ Re-run Briefcase once that installation is complete.
 ** WARNING: Unable to determine the version of Xcode that is installed **
 *************************************************************************
 
-   Briefcase will proceed, assuming everything is OK. If you experience
-   problems, this is almost certainly the cause of those problems.
+    Briefcase will proceed, assuming everything is OK. If you experience
+    problems, this is almost certainly the cause of those problems.
 
-   Please report this as a bug at:
+    Please report this as a bug at:
 
-     https://github.com/beeware/briefcase/issues/new
+      https://github.com/beeware/briefcase/issues/new
 
-   In your report, please including the output from running:
+    In your report, please including the output from running:
 
-     xcodebuild -version
+        $ xcodebuild -version
 
-   from the command prompt.
+    from the command prompt.
 
 *************************************************************************
 """
@@ -321,18 +321,18 @@ You need to accept the Xcode license before Briefcase can package your app.
 ** WARNING: Unable to determine if the Xcode license has been accepted **
 *************************************************************************
 
-   Briefcase will proceed, assuming everything is OK. If you experience
-   problems, this is almost certainly the cause of those problems.
+    Briefcase will proceed, assuming everything is OK. If you experience
+    problems, this is almost certainly the cause of those problems.
 
-   Please report this as a bug at:
+    Please report this as a bug at:
 
-     https://github.com/beeware/briefcase/issues/new
+      https://github.com/beeware/briefcase/issues/new
 
-   In your report, please including the output from running:
+    In your report, please including the output from running:
 
-     sudo xcodebuild -license
+        $ sudo xcodebuild -license
 
-   from the command prompt.
+    from the command prompt.
 
 *************************************************************************
 """
@@ -344,18 +344,18 @@ You need to accept the Xcode license before Briefcase can package your app.
 ** WARNING: Unable to determine if the Xcode license has been accepted **
 *************************************************************************
 
-   Briefcase will proceed, assuming everything is OK. If you experience
-   problems, this is almost certainly the cause of those problems.
+    Briefcase will proceed, assuming everything is OK. If you experience
+    problems, this is almost certainly the cause of those problems.
 
-   Please report this as a bug at:
+    Please report this as a bug at:
 
-     https://github.com/beeware/briefcase/issues/new
+      https://github.com/beeware/briefcase/issues/new
 
-   In your report, please including the output from running:
+    In your report, please including the output from running:
 
-     /usr/bin/clang --version
+        $ /usr/bin/clang --version
 
-   from the command prompt.
+    from the command prompt.
 
 *************************************************************************
 """

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -231,7 +231,6 @@ class iOSXcodeBuildCommand(iOSXcodeMixin, BuildCommand):
             f"Targeting an {device} running {iOS_version} (device UDID {udid})"
         )
 
-        self.logger.info()
         self.logger.info("Building XCode project...", prefix=app.app_name)
 
         try:
@@ -286,12 +285,10 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
                 "Input has been disabled; can't select a device to target."
             ) from e
 
-        self.logger.info()
         self.logger.info(
             f"Starting app on an {device} running {iOS_version} (device UDID {udid})",
             prefix=app.app_name,
         )
-        self.logger.info()
 
         # The simulator needs to be booted before being started.
         # If it's shut down, we can boot it again; but if it's currently
@@ -308,15 +305,8 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         if device_state == DeviceState.SHUTDOWN:
             try:
                 with self.input.wait_bar("Booting simulator..."):
-                    self.subprocess.run(
-                        ["xcrun", "simctl", "boot", udid],
-                        check=True,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.STDOUT,
-                    )
+                    self.subprocess.run(["xcrun", "simctl", "boot", udid], check=True)
             except subprocess.CalledProcessError as e:
-                self.logger.error()
-                self.logger.error(e.stdout)
                 raise BriefcaseCommandError(
                     f"Unable to boot {device} simulator running {iOS_version}"
                 ) from e
@@ -327,12 +317,8 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
                 self.subprocess.run(
                     ["open", "-a", "Simulator", "--args", "-CurrentDeviceUDID", udid],
                     check=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
                 )
         except subprocess.CalledProcessError as e:
-            self.logger.error()
-            self.logger.error(e.stdout)
             raise BriefcaseCommandError(
                 f"Unable to open {device} simulator running {iOS_version}"
             ) from e
@@ -341,16 +327,12 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         # before, this will still succeed.
         app_identifier = ".".join([app.bundle, app.app_name])
         try:
-            with self.input.wait_bar("Uninstalling old app version..."):
+            self.logger.info("Installing app...", prefix=app.app_name)
+            with self.input.wait_bar("Uninstalling any existing app version..."):
                 self.subprocess.run(
-                    ["xcrun", "simctl", "uninstall", udid, app_identifier],
-                    check=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
+                    ["xcrun", "simctl", "uninstall", udid, app_identifier], check=True
                 )
         except subprocess.CalledProcessError as e:
-            self.logger.error()
-            self.logger.error(e.stdout)
             raise BriefcaseCommandError(
                 f"Unable to uninstall old version of app {app.app_name}."
             ) from e
@@ -361,12 +343,8 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
                 self.subprocess.run(
                     ["xcrun", "simctl", "install", udid, self.binary_path(app)],
                     check=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
                 )
         except subprocess.CalledProcessError as e:
-            self.logger.error()
-            self.logger.error(e.stdout)
             raise BriefcaseCommandError(
                 f"Unable to install new version of app {app.app_name}."
             ) from e
@@ -394,21 +372,16 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         self.sleep(0.25)
 
         try:
-            with self.input.wait_bar("Starting app..."):
+            self.logger.info("Starting app...", prefix=app.app_name)
+            with self.input.wait_bar("Launching app..."):
                 self.subprocess.run(
-                    ["xcrun", "simctl", "launch", udid, app_identifier],
-                    check=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
+                    ["xcrun", "simctl", "launch", udid, app_identifier], check=True
                 )
         except subprocess.CalledProcessError as e:
             self.subprocess.cleanup("log stream", simulator_log_popen)
-            self.logger.error()
-            self.logger.error(e.stdout)
             raise BriefcaseCommandError(f"Unable to launch app {app.app_name}.") from e
 
         # Start streaming logs for the app.
-        self.logger.info()
         self.logger.info(
             "Following simulator log output (type CTRL-C to stop log)...",
             prefix=app.app_name,

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -97,14 +97,12 @@ class LinuxAppImageMixin(LinuxMixin):
         """
         if self.use_docker:
             # Enter the Docker context.
-            self.logger.info()
             self.logger.info("Entering Docker context...", prefix=app.app_name)
             orig_subprocess = self.subprocess
             self.subprocess = self.Docker(self, app)
 
             yield self.subprocess
 
-            self.logger.info()
             self.logger.info("Leaving Docker context.", prefix=app.app_name)
             self.subprocess = orig_subprocess
         else:
@@ -152,7 +150,6 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
 
         :param app: The application to build
         """
-        self.logger.info()
         self.logger.info("Building AppImage...", prefix=app.app_name)
 
         try:
@@ -217,7 +214,6 @@ class LinuxAppImageRunCommand(LinuxAppImageMixin, RunCommand):
 
         :param app: The config object for the app
         """
-        self.logger.info()
         self.logger.info("Starting app...", prefix=app.app_name)
         try:
             self.subprocess.run(

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -103,7 +103,7 @@ class LinuxAppImageMixin(LinuxMixin):
 
             yield self.subprocess
 
-            self.logger.info("Leaving Docker context.", prefix=app.app_name)
+            self.logger.info("Leaving Docker context", prefix=app.app_name)
             self.subprocess = orig_subprocess
         else:
             yield self.subprocess
@@ -152,52 +152,53 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
         """
         self.logger.info("Building AppImage...", prefix=app.app_name)
 
-        try:
-            # Build the AppImage.
-            # For some reason, the version has to be passed in as an
-            # environment variable, *not* in the configuration...
-            env = {"VERSION": app.version}
+        with self.input.wait_bar("Building..."):
+            try:
+                # Build the AppImage.
+                # For some reason, the version has to be passed in as an
+                # environment variable, *not* in the configuration...
+                env = {"VERSION": app.version}
 
-            # Find all the .so files in app and app_packages,
-            # so they can be passed in to linuxdeploy to have their
-            # dependencies added to the AppImage. Looks for any .so file
-            # in the application, and make sure it is marked for deployment.
-            so_folders = set()
-            for so_file in self.appdir_path(app).glob("**/*.so"):
-                so_folders.add(so_file.parent)
+                # Find all the .so files in app and app_packages,
+                # so they can be passed in to linuxdeploy to have their
+                # dependencies added to the AppImage. Looks for any .so file
+                # in the application, and make sure it is marked for deployment.
+                so_folders = set()
+                for so_file in self.appdir_path(app).glob("**/*.so"):
+                    so_folders.add(so_file.parent)
 
-            deploy_deps_args = []
-            for folder in sorted(so_folders):
-                deploy_deps_args.extend(["--deploy-deps-only", str(folder)])
+                deploy_deps_args = []
+                for folder in sorted(so_folders):
+                    deploy_deps_args.extend(["--deploy-deps-only", str(folder)])
 
-            # Build the app image. We use `--appimage-extract-and-run`
-            # because AppImages won't run natively inside Docker.
-            with self.dockerize(app) as docker:
-                docker.run(
-                    [
-                        self.linuxdeploy.appimage_path,
-                        "--appimage-extract-and-run",
-                        f"--appdir={self.appdir_path(app)}",
-                        "-d",
-                        os.fsdecode(
-                            self.appdir_path(app)
-                            / f"{app.bundle}.{app.app_name}.desktop"
-                        ),
-                        "-o",
-                        "appimage",
-                    ]
-                    + deploy_deps_args,
-                    env=env,
-                    check=True,
-                    cwd=self.platform_path,
-                )
+                # Build the app image. We use `--appimage-extract-and-run`
+                # because AppImages won't run natively inside Docker.
+                with self.dockerize(app) as docker:
+                    docker.run(
+                        [
+                            self.linuxdeploy.appimage_path,
+                            "--appimage-extract-and-run",
+                            f"--appdir={self.appdir_path(app)}",
+                            "-d",
+                            os.fsdecode(
+                                self.appdir_path(app)
+                                / f"{app.bundle}.{app.app_name}.desktop"
+                            ),
+                            "-o",
+                            "appimage",
+                        ]
+                        + deploy_deps_args,
+                        env=env,
+                        check=True,
+                        cwd=self.platform_path,
+                    )
 
-            # Make the binary executable.
-            self.os.chmod(self.binary_path(app), 0o755)
-        except subprocess.CalledProcessError as e:
-            raise BriefcaseCommandError(
-                f"Error while building app {app.app_name}."
-            ) from e
+                # Make the binary executable.
+                self.os.chmod(self.binary_path(app), 0o755)
+            except subprocess.CalledProcessError as e:
+                raise BriefcaseCommandError(
+                    f"Error while building app {app.app_name}."
+                ) from e
 
 
 class LinuxAppImageRunCommand(LinuxAppImageMixin, RunCommand):

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -76,7 +76,6 @@ class macOSAppBuildCommand(macOSAppMixin, macOSSigningMixin, BuildCommand):
         # signed to be able to execute on M1 hardware - even if it's only an
         # adhoc signing identity. Apply an adhoc signing identity to the
         # app bundle.
-        self.logger.info()
         self.logger.info("Adhoc signing app...", prefix=app.app_name)
         self.sign_app(app=app, identity="-")
 

--- a/src/briefcase/platforms/macOS/xcode.py
+++ b/src/briefcase/platforms/macOS/xcode.py
@@ -73,7 +73,6 @@ class macOSXcodeBuildCommand(macOSXcodeMixin, BuildCommand):
         :param app: The application to build
         """
 
-        self.logger.info()
         self.logger.info("Building XCode project...", prefix=app.app_name)
 
         try:

--- a/src/briefcase/platforms/macOS/xcode.py
+++ b/src/briefcase/platforms/macOS/xcode.py
@@ -74,23 +74,25 @@ class macOSXcodeBuildCommand(macOSXcodeMixin, BuildCommand):
         """
 
         self.logger.info("Building XCode project...", prefix=app.app_name)
-
-        try:
-            self.subprocess.run(
-                [
-                    "xcodebuild",
-                    "-project",
-                    self.bundle_path(app) / f"{app.formal_name}.xcodeproj",
-                    "-quiet",
-                    "-configuration",
-                    "Release",
-                    "build",
-                ],
-                check=True,
-            )
-            self.logger.info("Build succeeded.")
-        except subprocess.CalledProcessError as e:
-            raise BriefcaseCommandError(f"Unable to build app {app.app_name}.") from e
+        with self.input.wait_bar("Building..."):
+            try:
+                self.subprocess.run(
+                    [
+                        "xcodebuild",
+                        "-project",
+                        self.bundle_path(app) / f"{app.formal_name}.xcodeproj",
+                        "-quiet",
+                        "-configuration",
+                        "Release",
+                        "build",
+                    ],
+                    check=True,
+                )
+                self.logger.info("Build succeeded.")
+            except subprocess.CalledProcessError as e:
+                raise BriefcaseCommandError(
+                    f"Unable to build app {app.app_name}."
+                ) from e
 
 
 class macOSXcodeRunCommand(macOSRunMixin, macOSXcodeMixin, RunCommand):

--- a/src/briefcase/platforms/windows/msi.py
+++ b/src/briefcase/platforms/windows/msi.py
@@ -119,7 +119,6 @@ class WindowsMSIRunCommand(WindowsMSIMixin, RunCommand):
 
         :param app: The config object for the app
         """
-        self.logger.info()
         self.logger.info("Starting app...", prefix=app.app_name)
         try:
             self.subprocess.run(
@@ -144,35 +143,34 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
 
         :param app: The application to build
         """
-        self.logger.info()
         self.logger.info("Building MSI...", prefix=app.app_name)
 
         try:
             self.logger.info()
-            self.logger.info("Compiling application manifest...")
-            self.subprocess.run(
-                [
-                    self.wix.heat_exe,
-                    "dir",
-                    "src",
-                    "-nologo",  # Don't display startup text
-                    "-gg",  # Generate GUIDs
-                    "-sfrag",  # Suppress fragment generation for directories
-                    "-sreg",  # Suppress registry harvesting
-                    "-srd",  # Suppress harvesting the root directory
-                    "-scom",  # Suppress harvesting COM components
-                    "-dr",
-                    f"{app.module_name}_ROOTDIR",  # Root directory reference name
-                    "-cg",
-                    f"{app.module_name}_COMPONENTS",  # Root component group name
-                    "-var",
-                    "var.SourceDir",  # variable to use as the source dir
-                    "-out",
-                    f"{app.app_name}-manifest.wxs",
-                ],
-                check=True,
-                cwd=self.bundle_path(app),
-            )
+            with self.input.wait_bar("Compiling application manifest..."):
+                self.subprocess.run(
+                    [
+                        self.wix.heat_exe,
+                        "dir",
+                        "src",
+                        "-nologo",  # Don't display startup text
+                        "-gg",  # Generate GUIDs
+                        "-sfrag",  # Suppress fragment generation for directories
+                        "-sreg",  # Suppress registry harvesting
+                        "-srd",  # Suppress harvesting the root directory
+                        "-scom",  # Suppress harvesting COM components
+                        "-dr",
+                        f"{app.module_name}_ROOTDIR",  # Root directory reference name
+                        "-cg",
+                        f"{app.module_name}_COMPONENTS",  # Root component group name
+                        "-var",
+                        "var.SourceDir",  # variable to use as the source dir
+                        "-out",
+                        f"{app.app_name}-manifest.wxs",
+                    ],
+                    check=True,
+                    cwd=self.bundle_path(app),
+                )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(
                 f"Unable to generate manifest for app {app.app_name}."
@@ -180,44 +178,44 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
 
         try:
             self.logger.info()
-            self.logger.info("Compiling application installer...")
-            self.subprocess.run(
-                [
-                    self.wix.candle_exe,
-                    "-nologo",  # Don't display startup text
-                    "-ext",
-                    "WixUtilExtension",
-                    "-ext",
-                    "WixUIExtension",
-                    "-dSourceDir=src",
-                    f"{app.app_name}.wxs",
-                    f"{app.app_name}-manifest.wxs",
-                ],
-                check=True,
-                cwd=self.bundle_path(app),
-            )
+            with self.input.wait_bar("Compiling application installer..."):
+                self.subprocess.run(
+                    [
+                        self.wix.candle_exe,
+                        "-nologo",  # Don't display startup text
+                        "-ext",
+                        "WixUtilExtension",
+                        "-ext",
+                        "WixUIExtension",
+                        "-dSourceDir=src",
+                        f"{app.app_name}.wxs",
+                        f"{app.app_name}-manifest.wxs",
+                    ],
+                    check=True,
+                    cwd=self.bundle_path(app),
+                )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(f"Unable to compile app {app.app_name}.") from e
 
         try:
             self.logger.info()
-            self.logger.info("Linking application installer...")
-            self.subprocess.run(
-                [
-                    self.wix.light_exe,
-                    "-nologo",  # Don't display startup text
-                    "-ext",
-                    "WixUtilExtension",
-                    "-ext",
-                    "WixUIExtension",
-                    "-o",
-                    self.distribution_path(app, packaging_format="msi"),
-                    f"{app.app_name}.wixobj",
-                    f"{app.app_name}-manifest.wixobj",
-                ],
-                check=True,
-                cwd=self.bundle_path(app),
-            )
+            with self.input.wait_bar("Linking application installer..."):
+                self.subprocess.run(
+                    [
+                        self.wix.light_exe,
+                        "-nologo",  # Don't display startup text
+                        "-ext",
+                        "WixUtilExtension",
+                        "-ext",
+                        "WixUIExtension",
+                        "-o",
+                        self.distribution_path(app, packaging_format="msi"),
+                        f"{app.app_name}.wixobj",
+                        f"{app.app_name}-manifest.wixobj",
+                    ],
+                    check=True,
+                    cwd=self.bundle_path(app),
+                )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(f"Unable to link app {app.app_name}.") from e
 

--- a/src/briefcase/platforms/windows/msi.py
+++ b/src/briefcase/platforms/windows/msi.py
@@ -146,8 +146,8 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
         self.logger.info("Building MSI...", prefix=app.app_name)
 
         try:
-            self.logger.info()
-            with self.input.wait_bar("Compiling application manifest..."):
+            self.logger.info("Compiling application manifest...")
+            with self.input.wait_bar("Compiling..."):
                 self.subprocess.run(
                     [
                         self.wix.heat_exe,
@@ -177,8 +177,8 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
             ) from e
 
         try:
-            self.logger.info()
-            with self.input.wait_bar("Compiling application installer..."):
+            self.logger.info("Compiling application installer...")
+            with self.input.wait_bar("Compiling..."):
                 self.subprocess.run(
                     [
                         self.wix.candle_exe,
@@ -198,8 +198,8 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
             raise BriefcaseCommandError(f"Unable to compile app {app.app_name}.") from e
 
         try:
-            self.logger.info()
-            with self.input.wait_bar("Linking application installer..."):
+            self.logger.info("Linking application installer...")
+            with self.input.wait_bar("Linking..."):
                 self.subprocess.run(
                     [
                         self.wix.light_exe,

--- a/tests/commands/create/test_install_image.py
+++ b/tests/commands/create/test_install_image.py
@@ -52,7 +52,8 @@ def test_no_requested_size(create_command, tmp_path, capsys):
 
     # The right message was written to output
     assert (
-        capsys.readouterr().out == "Installing input/original.png as sample image...\n"
+        capsys.readouterr().out
+        == "\nInstalling input/original.png as sample image... done\n"
     )
 
     # The file was copied into position
@@ -111,7 +112,7 @@ def test_requested_size(create_command, tmp_path, capsys):
     # The right message was written to output
     assert (
         capsys.readouterr().out
-        == "Installing input/original-3742.png as 3742px sample image...\n"
+        == "\nInstalling input/original-3742.png as 3742px sample image... done\n"
     )
 
     # The file was copied into position
@@ -172,7 +173,7 @@ def test_variant_with_no_requested_size(create_command, tmp_path, capsys):
     # The right message was written to output
     assert (
         capsys.readouterr().out
-        == "Installing input/original.png as round sample image...\n"
+        == "\nInstalling input/original.png as round sample image... done\n"
     )
 
     # The file was copied into position
@@ -273,7 +274,7 @@ def test_variant_with_size(create_command, tmp_path, capsys):
     # The right message was written to output
     assert (
         capsys.readouterr().out
-        == "Installing input/original-3742.png as 3742px round sample image...\n"
+        == "\nInstalling input/original-3742.png as 3742px round sample image... done\n"
     )
 
     # The file was copied into position
@@ -341,7 +342,7 @@ def test_unsized_variant(create_command, tmp_path, capsys):
     # The right message was written to output
     assert (
         capsys.readouterr().out
-        == "Installing input/original.png as round sample image...\n"
+        == "\nInstalling input/original.png as round sample image... done\n"
     )
 
     # The file was copied into position

--- a/tests/commands/create/test_install_image.py
+++ b/tests/commands/create/test_install_image.py
@@ -51,10 +51,8 @@ def test_no_requested_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    assert (
-        capsys.readouterr().out
-        == "\nInstalling input/original.png as sample image... done\n"
-    )
+    expected = "\nInstalling input/original.png as sample image... done\n"
+    assert capsys.readouterr().out == expected
 
     # The file was copied into position
     create_command.shutil.copy.assert_called_with(
@@ -80,9 +78,8 @@ def test_no_requested_size_invalid_path(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    assert capsys.readouterr().out == (
-        "Unable to find input/original.png for sample image; using default\n"
-    )
+    expected = "Unable to find input/original.png for sample image; using default\n"
+    assert capsys.readouterr().out == expected
 
     # The file was not copied
     assert create_command.shutil.copy.call_count == 0
@@ -110,10 +107,8 @@ def test_requested_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    assert (
-        capsys.readouterr().out
-        == "\nInstalling input/original-3742.png as 3742px sample image... done\n"
-    )
+    expected = "\nInstalling input/original-3742.png as 3742px sample image... done\n"
+    assert capsys.readouterr().out == expected
 
     # The file was copied into position
     create_command.shutil.copy.assert_called_with(
@@ -139,9 +134,8 @@ def test_requested_size_invalid_path(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    assert capsys.readouterr().out == (
-        "Unable to find input/original-3742.png for 3742px sample image; using default\n"
-    )
+    expected = "Unable to find input/original-3742.png for 3742px sample image; using default\n"
+    assert capsys.readouterr().out == expected
 
     # The file was not copied
     assert create_command.shutil.copy.call_count == 0
@@ -171,10 +165,8 @@ def test_variant_with_no_requested_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    assert (
-        capsys.readouterr().out
-        == "\nInstalling input/original.png as round sample image... done\n"
-    )
+    expected = "\nInstalling input/original.png as round sample image... done\n"
+    assert capsys.readouterr().out == expected
 
     # The file was copied into position
     create_command.shutil.copy.assert_called_with(
@@ -207,10 +199,8 @@ def test_variant_without_variant_source_and_no_requested_size(
     )
 
     # The right message was written to output
-    assert (
-        capsys.readouterr().out
-        == "Unable to find round variant for sample image; using default\n"
-    )
+    expected = "Unable to find round variant for sample image; using default\n"
+    assert capsys.readouterr().out == expected
 
     # No file was installed.
     create_command.shutil.copy.assert_not_called()
@@ -239,10 +229,8 @@ def test_unknown_variant_with_no_requested_size(create_command, tmp_path, capsys
     )
 
     # The right message was written to output
-    assert (
-        capsys.readouterr().out
-        == "Unable to find unknown variant for sample image; using default\n"
-    )
+    expected = "Unable to find unknown variant for sample image; using default\n"
+    assert capsys.readouterr().out == expected
 
     # No file was installed.
     create_command.shutil.copy.assert_not_called()
@@ -272,10 +260,10 @@ def test_variant_with_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    assert (
-        capsys.readouterr().out
-        == "\nInstalling input/original-3742.png as 3742px round sample image... done\n"
+    expected = (
+        "\nInstalling input/original-3742.png as 3742px round sample image... done\n"
     )
+    assert capsys.readouterr().out == expected
 
     # The file was copied into position
     create_command.shutil.copy.assert_called_with(
@@ -306,10 +294,8 @@ def test_variant_with_size_without_variants(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    assert (
-        capsys.readouterr().out
-        == "Unable to find 3742px round variant for sample image; using default\n"
-    )
+    expected = "Unable to find 3742px round variant for sample image; using default\n"
+    assert capsys.readouterr().out == expected
 
     # No file was installed.
     create_command.shutil.copy.assert_not_called()
@@ -340,10 +326,8 @@ def test_unsized_variant(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    assert (
-        capsys.readouterr().out
-        == "\nInstalling input/original.png as round sample image... done\n"
-    )
+    expected = "\nInstalling input/original.png as round sample image... done\n"
+    assert capsys.readouterr().out == expected
 
     # The file was copied into position
     create_command.shutil.copy.assert_called_with(

--- a/tests/integrations/docker/conftest.py
+++ b/tests/integrations/docker/conftest.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Log
+from briefcase.console import Console, Log
 from briefcase.integrations.docker import Docker
 from briefcase.integrations.subprocess import Subprocess
 
@@ -11,6 +11,7 @@ from briefcase.integrations.subprocess import Subprocess
 def mock_docker(tmp_path):
     command = MagicMock()
     command.logger = Log()
+    command.input = Console()
     command.base_path = tmp_path / "base"
     command.platform_path = tmp_path / "platform"
     command.bundle_path.return_value = tmp_path / "bundle"

--- a/tests/integrations/subprocess/conftest.py
+++ b/tests/integrations/subprocess/conftest.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Log
+from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 
 # hardcoded here since subprocess will only include these constants if Python is literally on Windows
@@ -14,6 +14,7 @@ CREATE_NEW_PROCESS_GROUP = 0x200
 def mock_sub():
     command = MagicMock()
     command.logger = Log(verbosity=1)
+    command.input = Console()
 
     command.os = MagicMock()
     command.os.environ = {
@@ -35,3 +36,23 @@ def mock_sub():
     sub._subprocess.CREATE_NEW_PROCESS_GROUP = CREATE_NEW_PROCESS_GROUP
 
     return sub
+
+
+@pytest.fixture
+def popen_process():
+    process = MagicMock()
+    # There are extra empty strings at the end to simulate readline
+    # continuously returning "" once it reaches EOF
+    process.stdout.readline.side_effect = [
+        "output line 1\n",
+        "\n",
+        "output line 3\n",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+    ]
+    process.poll.side_effect = [None, None, None, -3, -3, -3]
+    return process

--- a/tests/integrations/subprocess/test_Subprocess__run.py
+++ b/tests/integrations/subprocess/test_Subprocess__run.py
@@ -144,7 +144,6 @@ def test_debug_call_with_env(mock_sub, capsys):
     mock_sub._subprocess.run.assert_called_with(
         ["hello", "world"], env=merged_env, text=True
     )
-
     expected_output = (
         "\n"
         ">>> Running Command:\n"
@@ -153,7 +152,6 @@ def test_debug_call_with_env(mock_sub, capsys):
         ">>>     NewVar=NewVarValue\n"
         ">>> Return code: 0\n"
     )
-
     assert capsys.readouterr().out == expected_output
 
 
@@ -165,7 +163,6 @@ def test_deep_debug_call(mock_sub, capsys):
     mock_sub.run(["hello", "world"])
 
     mock_sub._subprocess.run.assert_called_with(["hello", "world"], text=True)
-
     expected_output = (
         "\n"
         ">>> Running Command:\n"
@@ -179,7 +176,6 @@ def test_deep_debug_call(mock_sub, capsys):
         ">>>     PWD=/home/user/\n"
         ">>> Return code: 0\n"
     )
-
     assert capsys.readouterr().out == expected_output
 
 
@@ -197,7 +193,6 @@ def test_deep_debug_call_with_env(mock_sub, capsys):
     mock_sub._subprocess.run.assert_called_with(
         ["hello", "world"], env=merged_env, text=True
     )
-
     expected_output = (
         "\n"
         ">>> Running Command:\n"
@@ -212,7 +207,6 @@ def test_deep_debug_call_with_env(mock_sub, capsys):
         ">>>     NewVar=NewVarValue\n"
         ">>> Return code: 0\n"
     )
-
     assert capsys.readouterr().out == expected_output
 
 
@@ -243,7 +237,6 @@ def test_calledprocesserror_exception_logging(mock_sub, capsys):
         ">>>     PWD=/home/user/\n"
         ">>> Return code: -1\n"
     )
-
     assert capsys.readouterr().out == expected_output
 
 

--- a/tests/integrations/subprocess/test_Subprocess__run_in_wait_bar.py
+++ b/tests/integrations/subprocess/test_Subprocess__run_in_wait_bar.py
@@ -58,6 +58,7 @@ def test_debug_call(mock_sub, capsys):
         "output line 1\n"
         "\n"
         "output line 3\n"
+        ">>> Return code: -3\n"
         "\n"
     )
     assert capsys.readouterr().out == expected_output
@@ -91,6 +92,7 @@ def test_debug_call_with_env(mock_sub, capsys):
         "output line 1\n"
         "\n"
         "output line 3\n"
+        ">>> Return code: -3\n"
         "\n"
     )
     assert capsys.readouterr().out == expected_output

--- a/tests/integrations/subprocess/test_Subprocess__run_in_wait_bar.py
+++ b/tests/integrations/subprocess/test_Subprocess__run_in_wait_bar.py
@@ -1,0 +1,255 @@
+import subprocess
+
+import pytest
+
+from briefcase.console import Log
+
+
+@pytest.fixture
+def mock_sub(mock_sub, popen_process):
+    # ensure Popen returns the mock process when used as a context manager
+    mock_sub._subprocess.Popen.return_value.__enter__.return_value = popen_process
+    return mock_sub
+
+
+def test_call(mock_sub, capsys):
+    """A simple call will be invoked."""
+
+    with mock_sub.command.input.wait_bar():
+        mock_sub.run(["hello", "world"])
+
+    mock_sub._subprocess.Popen.assert_called_with(
+        ["hello", "world"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
+    expected_output = "output line 1\n" "\n" "output line 3\n" "\n"
+    assert capsys.readouterr().out == expected_output
+
+
+def test_call_with_arg(mock_sub, capsys):
+    """Any extra keyword arguments are passed through as-is."""
+
+    with mock_sub.command.input.wait_bar():
+        mock_sub.run(["hello", "world"], universal_newlines=True)
+
+    mock_sub._subprocess.Popen.assert_called_with(
+        ["hello", "world"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )
+    expected_output = "output line 1\n" "\n" "output line 3\n" "\n"
+    assert capsys.readouterr().out == expected_output
+
+
+def test_debug_call(mock_sub, capsys):
+    """If verbosity is turned up, there is debug output."""
+    mock_sub.command.logger = Log(verbosity=2)
+
+    with mock_sub.command.input.wait_bar():
+        mock_sub.run(["hello", "world"])
+
+    mock_sub._subprocess.Popen.assert_called_with(
+        ["hello", "world"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
+    expected_output = (
+        "\n"
+        ">>> Running Command:\n"
+        ">>>     hello world\n"
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+        "\n"
+    )
+    assert capsys.readouterr().out == expected_output
+
+
+def test_debug_call_with_env(mock_sub, capsys):
+    """If verbosity is turned up, injected env vars are included in debug
+    output."""
+    mock_sub.command.logger = Log(verbosity=2)
+
+    env = {"NewVar": "NewVarValue"}
+    with mock_sub.command.input.wait_bar():
+        mock_sub.run(["hello", "world"], env=env)
+
+    merged_env = mock_sub.command.os.environ.copy()
+    merged_env.update(env)
+
+    mock_sub._subprocess.Popen.assert_called_with(
+        ["hello", "world"],
+        env=merged_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    expected_output = (
+        "\n"
+        ">>> Running Command:\n"
+        ">>>     hello world\n"
+        ">>> Environment:\n"
+        ">>>     NewVar=NewVarValue\n"
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+        "\n"
+    )
+    assert capsys.readouterr().out == expected_output
+
+
+def test_deep_debug_call(mock_sub, capsys):
+    """If verbosity is at the max, the full environment and return is
+    output."""
+    mock_sub.command.logger = Log(verbosity=3)
+
+    with mock_sub.command.input.wait_bar():
+        mock_sub.run(["hello", "world"])
+
+    mock_sub._subprocess.Popen.assert_called_with(
+        ["hello", "world"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
+    expected_output = (
+        "\n"
+        ">>> Running Command:\n"
+        ">>>     hello world\n"
+        ">>> Full Environment:\n"
+        ">>>     VAR1=Value 1\n"
+        ">>>     PS1=\n"
+        ">>> Line 2\n"
+        ">>> \n"
+        ">>> Line 4\n"
+        ">>>     PWD=/home/user/\n"
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+        ">>> Return code: -3\n"
+        "\n"
+    )
+    assert capsys.readouterr().out == expected_output
+
+
+def test_deep_debug_call_with_env(mock_sub, capsys):
+    """If verbosity is at the max, the full environment and return is output,
+    and the environment is merged."""
+    mock_sub.command.logger = Log(verbosity=3)
+
+    env = {"NewVar": "NewVarValue"}
+    with mock_sub.command.input.wait_bar():
+        mock_sub.run(["hello", "world"], env=env)
+
+    merged_env = mock_sub.command.os.environ.copy()
+    merged_env.update(env)
+
+    mock_sub._subprocess.Popen.assert_called_with(
+        ["hello", "world"],
+        env=merged_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    expected_output = (
+        "\n"
+        ">>> Running Command:\n"
+        ">>>     hello world\n"
+        ">>> Full Environment:\n"
+        ">>>     VAR1=Value 1\n"
+        ">>>     PS1=\n"
+        ">>> Line 2\n"
+        ">>> \n"
+        ">>> Line 4\n"
+        ">>>     PWD=/home/user/\n"
+        ">>>     NewVar=NewVarValue\n"
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+        ">>> Return code: -3\n"
+        "\n"
+    )
+    assert capsys.readouterr().out == expected_output
+
+
+@pytest.mark.parametrize(
+    "in_kwargs, kwargs",
+    [
+        ({}, {"text": True}),
+        ({"text": True}, {"text": True}),
+        ({"text": False}, {"text": False}),
+        ({"universal_newlines": False}, {"universal_newlines": False}),
+        ({"universal_newlines": True}, {"universal_newlines": True}),
+    ],
+)
+def test_text_eq_true_default_overriding(mock_sub, in_kwargs, kwargs):
+    """if text or universal_newlines is explicitly provided, those should
+    override text=true default."""
+    with mock_sub.command.input.wait_bar():
+        mock_sub.run(["hello", "world"], **in_kwargs)
+    mock_sub._subprocess.Popen.assert_called_with(
+        ["hello", "world"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs
+    )
+
+
+def test_stderr_is_redirected(mock_sub, popen_process, capsys):
+    """When stderr is redirected, it should be included in the result."""
+    stderr_output = "stderr output\nline 2"
+    popen_process.stderr.read.return_value = stderr_output
+
+    with mock_sub.command.input.wait_bar():
+        run_result = mock_sub.run(["hello", "world"], stderr=subprocess.PIPE)
+
+    mock_sub._subprocess.Popen.assert_called_with(
+        ["hello", "world"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    expected_output = "output line 1\n" "\n" "output line 3\n" "\n"
+    assert capsys.readouterr().out == expected_output
+    assert run_result.stderr == stderr_output
+
+
+def test_stderr_dev_null(mock_sub, popen_process, capsys):
+    """When stderr is discarded, it should be None in the result."""
+    popen_process.stderr = None
+
+    with mock_sub.command.input.wait_bar():
+        run_result = mock_sub.run(["hello", "world"], stderr=subprocess.DEVNULL)
+
+    mock_sub._subprocess.Popen.assert_called_with(
+        ["hello", "world"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+
+    expected_output = "output line 1\n" "\n" "output line 3\n" "\n"
+    assert capsys.readouterr().out == expected_output
+    assert run_result.stderr is None
+
+
+def test_calledprocesserror(mock_sub, popen_process, capsys):
+    """CalledProcessError is raised with check=True and non-zero return
+    value."""
+    stderr_output = "stderr output\nline 2"
+    popen_process.stderr.read.return_value = stderr_output
+
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        with mock_sub.command.input.wait_bar():
+            mock_sub.run(["hello", "world"], check=True, stderr=subprocess.PIPE)
+
+    expected_output = "output line 1\n" "\n" "output line 3\n" "\n"
+    assert capsys.readouterr().out == expected_output
+    assert exc.value.returncode == -3
+    assert exc.value.cmd == ["hello", "world"]
+    assert exc.value.stderr == stderr_output
+
+
+def test_invalid_invocations(mock_sub):
+    """Ensure run cannot be used in a Wait Bar with invalid arguments."""
+    with pytest.raises(AssertionError):
+        with mock_sub.command.input.wait_bar():
+            mock_sub.run(["hello", "world"], stdout=subprocess.PIPE)
+
+    for invalid_arg in ("timeout", "input"):
+        with pytest.raises(AssertionError):
+            with mock_sub.command.input.wait_bar():
+                mock_sub.run(["hello", "world"], **{invalid_arg: "value"})

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -13,28 +13,6 @@ def mock_sub(mock_sub):
     return mock_sub
 
 
-@pytest.fixture
-def popen_process():
-    process = mock.MagicMock()
-
-    # There are extra empty strings at the end to simulate readline
-    # continuously returning "" once it reaches EOF
-    process.stdout.readline.side_effect = [
-        "output line 1\n",
-        "\n",
-        "output line 3\n",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-    ]
-    process.poll.side_effect = [None, None, None, -3]
-
-    return process
-
-
 def test_output(mock_sub, popen_process, capsys):
     """Readline output is printed."""
     mock_sub.stream_output("testing", popen_process)

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -41,8 +41,6 @@ def test_run_app_simulator_booted(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Uninstall the old app
             mock.call(
@@ -54,8 +52,6 @@ def test_run_app_simulator_booted(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Install the new app
             mock.call(
@@ -73,8 +69,6 @@ def test_run_app_simulator_booted(first_app_config, tmp_path):
                     / "First App.app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Launch the new app
             mock.call(
@@ -86,8 +80,6 @@ def test_run_app_simulator_booted(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -141,8 +133,6 @@ def test_run_app_simulator_shut_down(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Open the simulator
             mock.call(
@@ -155,8 +145,6 @@ def test_run_app_simulator_shut_down(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Uninstall the old app
             mock.call(
@@ -168,8 +156,6 @@ def test_run_app_simulator_shut_down(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Install the new app
             mock.call(
@@ -187,8 +173,6 @@ def test_run_app_simulator_shut_down(first_app_config, tmp_path):
                     / "First App.app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Launch the new app
             mock.call(
@@ -200,8 +184,6 @@ def test_run_app_simulator_shut_down(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -268,8 +250,6 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Open the simulator
             mock.call(
@@ -282,8 +262,6 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Uninstall the old app
             mock.call(
@@ -295,8 +273,6 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Install the new app
             mock.call(
@@ -314,8 +290,6 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
                     / "First App.app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Launch the new app
             mock.call(
@@ -327,8 +301,6 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -384,8 +356,6 @@ def test_run_app_simulator_boot_failure(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -427,8 +397,6 @@ def test_run_app_simulator_open_failure(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Open the simulator
             mock.call(
@@ -441,8 +409,6 @@ def test_run_app_simulator_open_failure(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -485,8 +451,6 @@ def test_run_app_simulator_uninstall_failure(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Open the simulator
             mock.call(
@@ -499,8 +463,6 @@ def test_run_app_simulator_uninstall_failure(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Uninstall the old app
             mock.call(
@@ -512,8 +474,6 @@ def test_run_app_simulator_uninstall_failure(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -557,8 +517,6 @@ def test_run_app_simulator_install_failure(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Open the simulator
             mock.call(
@@ -571,8 +529,6 @@ def test_run_app_simulator_install_failure(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Uninstall the old app
             mock.call(
@@ -584,8 +540,6 @@ def test_run_app_simulator_install_failure(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Install the new app
             mock.call(
@@ -603,8 +557,6 @@ def test_run_app_simulator_install_failure(first_app_config, tmp_path):
                     / "First App.app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
         ]
     )
@@ -651,8 +603,6 @@ def test_run_app_simulator_launch_failure(first_app_config, tmp_path):
             mock.call(
                 ["xcrun", "simctl", "boot", "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Open the simulator
             mock.call(
@@ -665,8 +615,6 @@ def test_run_app_simulator_launch_failure(first_app_config, tmp_path):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Uninstall the old app
             mock.call(
@@ -678,8 +626,6 @@ def test_run_app_simulator_launch_failure(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Install the new app
             mock.call(
@@ -697,8 +643,6 @@ def test_run_app_simulator_launch_failure(first_app_config, tmp_path):
                     / "First App.app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
             # Launch the new app
             mock.call(
@@ -710,8 +654,6 @@ def test_run_app_simulator_launch_failure(first_app_config, tmp_path):
                     "com.example.first-app",
                 ],
                 check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
             ),
         ]
     )

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -259,7 +259,7 @@ def test_sign_file_deep_sign(dummy_command, tmp_path, capsys):
     )
 
     # The console includes a warning about the attempt to deep sign
-    assert "... file requires a deep sign; retrying\n" in capsys.readouterr().out
+    assert "File requires a deep sign; retrying... done\n" in capsys.readouterr().out
 
 
 def test_sign_file_deep_sign_failure(dummy_command, tmp_path, capsys):
@@ -287,7 +287,7 @@ def test_sign_file_deep_sign_failure(dummy_command, tmp_path, capsys):
     )
 
     # The console includes a warning about the attempt to deep sign
-    assert "... file requires a deep sign; retrying\n" in capsys.readouterr().out
+    assert "File requires a deep sign; retrying...\n" in capsys.readouterr().out
 
 
 def test_sign_file_unsupported_format(dummy_command, tmp_path, capsys):

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -259,7 +259,7 @@ def test_sign_file_deep_sign(dummy_command, tmp_path, capsys):
     )
 
     # The console includes a warning about the attempt to deep sign
-    assert "File requires a deep sign; retrying... done\n" in capsys.readouterr().out
+    assert "... file requires a deep sign; retrying\n" in capsys.readouterr().out
 
 
 def test_sign_file_deep_sign_failure(dummy_command, tmp_path, capsys):
@@ -287,7 +287,7 @@ def test_sign_file_deep_sign_failure(dummy_command, tmp_path, capsys):
     )
 
     # The console includes a warning about the attempt to deep sign
-    assert "File requires a deep sign; retrying...\n" in capsys.readouterr().out
+    assert "... file requires a deep sign; retrying\n" in capsys.readouterr().out
 
 
 def test_sign_file_unsupported_format(dummy_command, tmp_path, capsys):


### PR DESCRIPTION
Follow up PR to the implementation of Rich in #740.

## Wide Use of Wait Bar
These changes implement the Wait Bar in many places....it might be argued too many. However, I defend using Wait Bar this prolifically because it creates a more consistent user experience with active feedback for ongoing tasks. While many of the tasks will not last long enough for the pulsing bar to even be visible, the consistent `done` message after these tasks complete directly confers success to the user....especially when they are considered together with the much more long running tasks.

## Allow `subprocess.run()` Without Redirected IO within Wait Bars
A major limitation of the Wait Bar is wrapping a call to `subprocess.run()` when IO hasn't been redirected (since Rich cannot accommodate dynamic updates to the screen while other processes are also writing to it). The current workaround is to pipe output back out and print it once the command finishes....but generally speaking the output is most useful in real time; for instance, a long running process with important information presented when it starts.

These changes allow callers to wrap `run()` calls with a Wait Bar whether they redirect IO or not. This also allows callers to more arbitrarily wrap functions without regard to whether they call `run()` or not. (Although, care does need to be taken to avoid a subsequent wait bar or progress bar being instantiated since only one can be active at a time.)

If `run()` detects a wait bar is active and IO is not redirected, then it will simulate `subprocess.run()` by:
 - Redirecting output
   - `stdout` will always be piped
   - If the caller has not explicitly piped `stderr`, then it is redirected to `stdout`
 - Opening the process with `Popen`
 - Displaying output in real time using the output streamer
 - Finally, return or raise as `subprocess.run()` does

Alternatively, if the caller properly redirects `stdout` and `stderr`, then `subprocess.run()` is called normally. Although, using `check_output` is probably more appropriate at that point.

There are a couple limitations:
- The `run` arguments `timeout` and `input` are not implemented.
- The detection that the caller redirected the output is not perfect.
  - The underlying expectation is that callers will simply call `run()` without specifying `stdout/err` within a Wait Bar and it works.
  - If callers set `stdout/err`, then they should ensure it properly redirects IO.
- A wait bar should not be used to wrap `run` if the shell command has its own robust output; e.g. building an APK.

## Printing Consistency
A lot of impetus for this PR was allowing `run` in a Wait Bar for starting the iOS simulator....then I started comparing what's shown to a user when the iOS simulator starts versus the Android simulator. Then I got sucked in to a black hole of consistency in general among the different workflows. I ultimately ended up trying to create consistency among all of the workflows and even detailed all of the permutations for instantiating briefcase.

**Areas of Interest**
- Printing a message with a prefix
  - I noticed every time a message w/ a prefix was printed, an empty call to `Log` was done first...
    - So, let's print an empty line any time a prefix is used back up in `Log`
  - Additionally, I tried to make sure all messages were printed in the context of a message with a prefix
    - In this way, a message with a prefix communicates a high level task/goal and messages printed under it are smaller tasks to achieve that outcome.
- Starting a simulator
  - While iOS and Android have different semantics, I tried to make the steps similar between the two...they already weren't too dissimilar though.
- Installing/Upgrading a tool
  - Added a bit more logging structure to tool installation and upgrades.
  - Made their code structure a little more similar to each other.

<details>
  <summary>Briefcase Instantiation Permutations</summary>

```bash
briefcase new
briefcase new --template

briefcase dev
briefcase dev --app
briefcase dev --update-dependencies
briefcase dev --no-run

briefcase upgrade
briefcase upgrade --list

briefcase create android gradle
briefcase create iOS xcode
briefcase create linux appimage
briefcase create linux appimage --no-docker
briefcase create macOS app
briefcase create macOS xcode
briefcase create windows msi

briefcase update android gradle
briefcase update android gradle --update-dependencies
briefcase update android gradle --update-resources
briefcase update android gradle --update-dependencies --update-resources
briefcase update iOS xcode
briefcase update iOS xcode --update-dependencies
briefcase update iOS xcode --update-resources
briefcase update iOS xcode --update-dependencies --update-resources
briefcase update linux appimage
briefcase update linux appimage --update-dependencies
briefcase update linux appimage --update-resources
briefcase update linux appimage --update-dependencies --update-resources
briefcase update macOS app
briefcase update macOS app --update-dependencies
briefcase update macOS app --update-resources
briefcase update macOS app --update-dependencies --update-resources
briefcase update macOS xcode
briefcase update macOS xcode --update-dependencies
briefcase update macOS xcode --update-resources
briefcase update macOS xcode --update-dependencies --update-resources
briefcase update windows msi
briefcase update windows msi --update-dependencies
briefcase update windows msi --update-resources
briefcase update windows msi --update-dependencies --update-resources

briefcase build android gradle
briefcase build android gradle --update
briefcase build iOS xcode
briefcase build iOS xcode --update
briefcase build linux appimage
briefcase build linux appimage --update
briefcase build linux appimage --no-docker
briefcase build linux appimage --no-docker --update
briefcase build macOS app
briefcase build macOS app --update
briefcase build macOS xcode
briefcase build macOS xcode --update
briefcase build windows msi
briefcase build windows msi --update

briefcase run android gradle
briefcase run android gradle --update
briefcase run iOS xcode
briefcase run iOS xcode --update
briefcase run linux appimage
briefcase run linux appimage --update
briefcase run linux appimage --no-docker
briefcase run linux appimage --no-docker --update
briefcase run macOS app
briefcase run macOS app --update
briefcase run macOS xcode
briefcase run macOS xcode --update
briefcase run windows msi
briefcase run windows msi --update

briefcase package android gradle --packaging-format aab
briefcase package android gradle --packaging-format aab --update
briefcase package iOS xcode --packaging-format ipa
briefcase package iOS xcode --packaging-format ipa --update
briefcase package linux appimage --packaging-format appimage
briefcase package linux appimage --packaging-format appimage --update
briefcase package linux appimage --no-docker --packaging-format appimage
briefcase package linux appimage --no-docker --packaging-format appimage --update
briefcase package macOS app --packaging-format app
briefcase package macOS app --packaging-format app --adhoc-sign
briefcase package macOS app --packaging-format app --no-sign
briefcase package macOS app --packaging-format app --update 
briefcase package macOS app --packaging-format app --update --adhoc-sign
briefcase package macOS app --packaging-format app --update --no-sign
briefcase package macOS app --packaging-format dmg
briefcase package macOS app --packaging-format dmg --no-sign
briefcase package macOS app --packaging-format dmg --adhoc-sign
briefcase package macOS app --packaging-format dmg --update
briefcase package macOS app --packaging-format dmg --update --no-sign
briefcase package macOS app --packaging-format dmg --update --adhoc-sign
briefcase package macOS xcode --packaging-format app
briefcase package macOS xcode --packaging-format app --adhoc-sign
briefcase package macOS xcode --packaging-format app --no-sign
briefcase package macOS xcode --packaging-format app --update 
briefcase package macOS xcode --packaging-format app --update --adhoc-sign
briefcase package macOS xcode --packaging-format app --update --no-sign
briefcase package macOS xcode --packaging-format dmg
briefcase package macOS xcode --packaging-format dmg --no-sign
briefcase package macOS xcode --packaging-format dmg --adhoc-sign
briefcase package macOS xcode --packaging-format dmg --update
briefcase package macOS xcode --packaging-format dmg --update --no-sign
briefcase package macOS xcode --packaging-format dmg --update --adhoc-sign
briefcase package windows msi --packaging-format msi
briefcase package windows msi --packaging-format msi --update
```
 
</details>

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
