### PR TITLE
Log details of a fatal CalledProcessError even in non-debug mode

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,6 @@
 source = src/briefcase
 omit =
     src/**/__init__.py
-    src/briefcase/__main__.py
 
 [report]
 show_missing = True

--- a/changes/764.feature.rst
+++ b/changes/764.feature.rst
@@ -1,0 +1,1 @@
+If Briefcase is terminated by a failed subprocess, then its command line, return code, stdout and stderr are now logged to the console even in non-verbose mode.

--- a/src/briefcase/__main__.py
+++ b/src/briefcase/__main__.py
@@ -1,14 +1,17 @@
+import subprocess
 import sys
 
 from .cmdline import parse_cmdline
 from .console import Log
 from .exceptions import BriefcaseError, HelpText
+from .integrations.subprocess import log_command, log_output, log_return_code
 
 
 def main():
     try:
         log = Log()
         command, options = parse_cmdline(sys.argv[1:])
+        log = command.logger
         command.parse_config("pyproject.toml")
         command(**options)
         result = 0
@@ -17,6 +20,7 @@ def main():
         log.info(str(e))
         result = e.error_code
     except BriefcaseError as e:
+        log_subprocess(log, e)
         log.error()
         log.error(str(e))
         result = e.error_code
@@ -27,6 +31,21 @@ def main():
         result = -42
 
     sys.exit(result)
+
+
+def log_subprocess(log, e):
+    """If e is a CalledProcessError, or is directly or indirectly caused by
+    one, log the details of the subprocess."""
+    if log.verbosity >= log.DEBUG:
+        return  # Everything's already been logged.
+
+    while e:
+        if isinstance(e, subprocess.CalledProcessError):
+            log_command(log, "info", e.cmd)
+            log_output(log, "info", e.output, e.stderr)
+            log_return_code(log, "info", e.returncode)
+            break
+        e = e.__cause__ or e.__context__
 
 
 if __name__ == "__main__":

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -400,12 +400,7 @@ class Subprocess:
             popen_process.kill()
 
     def _log_command(self, args):
-        """Log the entire console command being executed."""
-        self.command.logger.debug()
-        self.command.logger.debug("Running Command:")
-        self.command.logger.debug(
-            f"    {' '.join(shlex.quote(str(arg)) for arg in args)}"
-        )
+        log_command(self.command.logger, "debug", args)
 
     def _log_environment(self, overrides):
         """Log the state of environment variables prior to command execution.
@@ -429,17 +424,40 @@ class Subprocess:
                     self.command.logger.debug(f"    {env_var}={value}")
 
     def _log_output(self, output, stderr=None):
-        """Log the output of the executed command."""
-        if output:
-            self.command.logger.debug("Command Output:")
-            for line in ensure_str(output).splitlines():
-                self.command.logger.debug(f"    {line}")
-
-        if stderr:
-            self.command.logger.debug("Command Error Output (stderr):")
-            for line in ensure_str(stderr).splitlines():
-                self.command.logger.debug(f"    {line}")
+        log_output(self.command.logger, "debug", output, stderr)
 
     def _log_return_code(self, return_code):
-        """Log the output value of the executed command."""
-        self.command.logger.debug(f"Return code: {return_code}")
+        log_return_code(self.command.logger, "debug", return_code)
+
+
+def log_command(logger, level, args):
+    """Log the entire console command being executed."""
+    log_method = getattr(logger, level)
+    log_method()
+    log_method("Running Command:")
+    cmd_line = (
+        args
+        if isinstance(args, str)
+        else " ".join(shlex.quote(str(arg)) for arg in args)
+    )
+    log_method(f"    {cmd_line}")
+
+
+def log_output(logger, level, output, stderr=None):
+    """Log the output of the executed command."""
+    log_method = getattr(logger, level)
+    if output:
+        log_method("Command Output:")
+        for line in ensure_str(output).splitlines():
+            log_method(f"    {line}")
+
+    if stderr:
+        log_method("Command Error Output (stderr):")
+        for line in ensure_str(stderr).splitlines():
+            log_method(f"    {line}")
+
+
+def log_return_code(logger, level, return_code):
+    """Log the output value of the executed command."""
+    log_method = getattr(logger, level)
+    log_method(f"Return code: {return_code}")

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -13,7 +13,7 @@ from briefcase.integrations.android_sdk import AndroidSDK
 
 
 @pytest.fixture
-def mock_command(tmp_path):
+def mock_command(tmp_path, monkeypatch):
     command = MagicMock()
 
     command.logger = Log(verbosity=1)
@@ -24,6 +24,7 @@ def mock_command(tmp_path):
 
     # Make the `os` module and `host_os` live.
     command.os = os
+    monkeypatch.setattr("os.environ", {})
 
     # Identify the host platform
     command.host_os = platform.system()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,152 @@
+from subprocess import CalledProcessError
+from unittest.mock import Mock
+
+from pytest import fixture, raises
+
+from briefcase.__main__ import main
+from briefcase.console import Log
+from briefcase.exceptions import BriefcaseCommandError
+
+
+@fixture
+def command(monkeypatch):
+    command = Mock()
+    command.logger = Log()
+    monkeypatch.setattr("briefcase.__main__.parse_cmdline", lambda argv: (command, {}))
+    return command
+
+
+def test_no_cause(command, capsys):
+    """A BriefcaseError is logged, and does not print a stack trace."""
+    e = BriefcaseCommandError("error message")
+    command.side_effect = e
+
+    with raises(SystemExit):
+        main()
+    assert capsys.readouterr() == ("\nerror message\n", "")
+
+
+def test_cpe_cause(command, capsys):
+    """A BriefcaseError caused by a CalledProcessError logs the subprocess
+    details."""
+    e = BriefcaseCommandError("error message")
+    command.side_effect = e
+    cpe = CalledProcessError(1, ["command", "arg1"])
+    expected_out = (
+        "\nRunning Command:\n"
+        "    command arg1\n"
+        "Return code: 1\n"
+        "\n"
+        "error message\n"
+    )
+
+    e.__cause__ = cpe
+    with raises(SystemExit):
+        main()
+    assert capsys.readouterr() == (expected_out, "")
+
+    e.__cause__ = None
+    e.__context__ = cpe
+    with raises(SystemExit):
+        main()
+    assert capsys.readouterr() == (expected_out, "")
+
+
+def test_other_cause(command, capsys):
+    """A BriefcaseError caused by any other exception does not log the
+    cause."""
+    e = BriefcaseCommandError("error message")
+    command.side_effect = e
+    ve = ValueError("we have a problem")
+
+    e.__cause__ = ve
+    with raises(SystemExit):
+        main()
+    assert capsys.readouterr() == ("\nerror message\n", "")
+
+    e.__cause__ = None
+    e.__context__ = ve
+    with raises(SystemExit):
+        main()
+    assert capsys.readouterr() == ("\nerror message\n", "")
+
+
+def test_cpe_output(command, capsys):
+    """CalledProcessError stdout and stderr is logged."""
+    e = BriefcaseCommandError("error message")
+    command.side_effect = e
+    cpe = CalledProcessError(
+        1,
+        ["command", "arg1"],
+        output="out line 1\nout line 2\n",
+        stderr="err line 1\nerr line 2\n",
+    )
+    expected_out = (
+        "\nRunning Command:\n"
+        "    command arg1\n"
+        "Command Output:\n"
+        "    out line 1\n"
+        "    out line 2\n"
+        "Command Error Output (stderr):\n"
+        "    err line 1\n"
+        "    err line 2\n"
+        "Return code: 1\n"
+        "\n"
+        "error message\n"
+    )
+    e.__cause__ = cpe
+
+    with raises(SystemExit):
+        main()
+    assert capsys.readouterr() == (expected_out, "")
+
+
+def test_cpe_cmd_as_str(command, capsys):
+    """CalledProcessError cmd as a single string is logged correctly."""
+    e = BriefcaseCommandError("error message")
+    command.side_effect = e
+    cpe = CalledProcessError(2, "command as one string")
+    expected_out = (
+        "\nRunning Command:\n"
+        "    command as one string\n"
+        "Return code: 2\n"
+        "\n"
+        "error message\n"
+    )
+    e.__cause__ = cpe
+
+    with raises(SystemExit):
+        main()
+    assert capsys.readouterr() == (expected_out, "")
+
+
+def test_cpe_cmd_with_spaces(command, capsys):
+    """CalledProcessError arguments with spaces are quoted in the log."""
+    e = BriefcaseCommandError("error message")
+    command.side_effect = e
+    cpe = CalledProcessError(3, ["command2", "two words"])
+    expected_out = (
+        "\nRunning Command:\n"
+        "    command2 'two words'\n"
+        "Return code: 3\n"
+        "\n"
+        "error message\n"
+    )
+    e.__cause__ = cpe
+
+    with raises(SystemExit):
+        main()
+    assert capsys.readouterr() == (expected_out, "")
+
+
+def test_cpe_verbosity(command, capsys):
+    """CalledProcessError is not logged a second time if verbosity is high."""
+    e = BriefcaseCommandError("error message")
+    command.side_effect = e
+    cpe = CalledProcessError(1, ["command", "arg1"])
+    e.__cause__ = cpe
+
+    command.logger.verbosity = 2
+    with raises(SystemExit):
+        main()
+    assert capsys.readouterr() == ("\nerror message\n", "")


### PR DESCRIPTION
This PR ensures that if Briefcase is terminated by a failed subprocess, then its command line, return code, stdout and stderr are logged to the console even in non-verbose mode.

This is implemented in `main` rather than in `integrations.subprocess`, because there are some subprocesses (e.g. `xcode-select --install`) where a non-zero return code is normal and is caught by the calling code. Such subprocesses are not affected by this PR.

Examples of issues where this would have helped:
* #762 -- We had to ask the user to re-run Briefcase with debug logging turned on.
* #395 -- The ADB output contained the error code "INSTALL_FAILED_ALREADY_EXISTS", and searching for that would have led directly to the solution.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
