### PR TITLE
Fixes #762 - Decouple verification of Android system image from emulator

### DIFF
--- a/changes/762.bugfix.rst
+++ b/changes/762.bugfix.rst
@@ -1,0 +1,1 @@
+The existence of an appropriate Android system image is now verified independently to the existence of the emulator.

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -182,6 +182,11 @@ class GradleRunCommand(GradleMixin, RunCommand):
         if device is None:
             if avd is None:
                 avd = self.android_sdk.create_emulator()
+            else:
+                # Ensure the system image for the requested emulator is available.
+                # This step is only needed if the AVD already existed; you have to
+                # have an image available to create an AVD.
+                self.android_sdk.verify_avd(avd)
 
             self.logger.info(f"Starting emulator {avd}...", prefix=app.app_name)
             device, name = self.android_sdk.start_emulator(avd)

--- a/tests/integrations/android_sdk/AndroidSDK/test_avd_config.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_avd_config.py
@@ -1,0 +1,42 @@
+import pytest
+
+
+@pytest.fixture
+def test_device(tmp_path):
+    """Create an AVD configuration file."""
+    config_file = tmp_path / ".android" / "avd" / "testDevice.avd" / "config.ini"
+    config_file.parent.mkdir(parents=True)
+
+    # Write a default config. It contains:
+    # * blank lines
+    # * a key whose value explicitly contains an equals sign.
+    with config_file.open("w") as f:
+        f.write(
+            """
+avd.ini.encoding=UTF-8
+hw.device.manufacturer=Google
+hw.device.name=pixel
+weird.key=good=bad
+
+PlayStore.enabled=no
+avd.name=testDevice
+disk.cachePartition=yes
+disk.cachePartition.size=37MB
+"""
+        )
+
+    return config_file
+
+
+def test_avd_config(mock_sdk, test_device):
+    """An AVD configuration can be read."""
+    assert mock_sdk.avd_config("testDevice") == {
+        "avd.ini.encoding": "UTF-8",
+        "hw.device.manufacturer": "Google",
+        "hw.device.name": "pixel",
+        "weird.key": "good=bad",
+        "PlayStore.enabled": "no",
+        "avd.name": "testDevice",
+        "disk.cachePartition": "yes",
+        "disk.cachePartition.size": "37MB",
+    }

--- a/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
@@ -59,6 +59,9 @@ def test_create_emulator(mock_sdk, tmp_path, host_os, host_arch, emulator_abi):
         "new-emulator",
     ]
 
+    # Mock system image verification
+    mock_sdk.verify_system_image = MagicMock()
+
     # Consider to remove if block when we drop py3.7 support, only keep statements from else.
     # MagicMock below py3.8 doesn't has __fspath__ attribute.
     if sys.version_info < (3, 8):
@@ -79,6 +82,11 @@ def test_create_emulator(mock_sdk, tmp_path, host_os, host_arch, emulator_abi):
 
     # The expected device AVD was created.
     assert avd == "new-emulator"
+
+    # The system image was verified
+    mock_sdk.verify_system_image.assert_called_once_with(
+        f"system-images;android-31;default;{emulator_abi}"
+    )
 
     # avdmanager was invoked
     mock_sdk.command.subprocess.check_output.assert_called_once_with(
@@ -135,6 +143,9 @@ def test_create_preexisting_skins(mock_sdk, tmp_path):
     # Mock the user getting a valid name first time
     mock_sdk.command.input.return_value = "new-emulator"
 
+    # Mock system image verification
+    mock_sdk.verify_system_image = MagicMock()
+
     # Mock a pre-existing skin folder
     (mock_sdk.root_path / "skins" / "pixel_3a").mkdir(parents=True)
 
@@ -184,6 +195,9 @@ def test_create_failure(mock_sdk):
     """If avdmanager fails, an error is raised."""
     # Mock the user getting a valid name first time
     mock_sdk.command.input.return_value = "new-emulator"
+
+    # Mock system image verification
+    mock_sdk.verify_system_image = MagicMock()
 
     # Mock an avdmanager failure.
     mock_sdk.command.subprocess.check_output.side_effect = (

--- a/tests/integrations/android_sdk/AndroidSDK/test_update_emulator_config.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_update_emulator_config.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.fixture
-def test_device(tmp_path):
+def test_device(mock_sdk, tmp_path):
     """Create an AVD configuration file."""
     config_file = tmp_path / ".android" / "avd" / "testDevice.avd" / "config.ini"
     config_file.parent.mkdir(parents=True)
@@ -43,7 +43,6 @@ def test_update_existing(mock_sdk, test_device):
         content = f.read()
 
     # Keys have been updated, order is preserved.
-    # Blank lines have been dropped.
     assert (
         content
         == """avd.ini.encoding=UTF-8

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_avd.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_avd.py
@@ -1,0 +1,82 @@
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError
+
+
+def test_missing_avd_config(mock_sdk):
+    """If an AVD config can't be found, raise an error."""
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r"Unable to read configuration of AVD @unknownDevice",
+    ):
+        mock_sdk.verify_avd("unknownDevice")
+
+
+def test_incomplete_avd_config(mock_sdk, capsys):
+    """If the AVD config doesn't contain an image.sysdir.1 key, raise a
+    warning, but continue."""
+    # Mock an AVD configuration that doesn't contain an image.sysdir.1 key
+    mock_sdk.avd_config = mock.MagicMock(
+        return_value={
+            "avd.ini.encoding": "UTF-8",
+            "hw.device.manufacturer": "Google",
+            "hw.device.name": "pixel",
+            "weird.key": "good=bad",
+            "PlayStore.enabled": "no",
+            "avd.name": "beePhone",
+            "disk.cachePartition": "yes",
+            "disk.cachePartition.size": "42M",
+        }
+    )
+    mock_sdk.verify_system_image = mock.MagicMock()
+
+    # Verify the AVD
+    mock_sdk.verify_avd("incompleteDevice")
+
+    # The AVD config was loaded.
+    mock_sdk.avd_config.assert_called_with("incompleteDevice")
+
+    # A warning message was output
+    assert "WARNING: Unable to read AVD configuration" in capsys.readouterr().out
+
+    # The system image was not verified
+    mock_sdk.verify_system_image.assert_not_called()
+
+
+def test_valid_avd_config(mock_sdk):
+    """If the AVD config contains an image.sysdir.1 key, it is used to create a
+    system image name."""
+    # Mock an AVD configuration that contains an image.sysdir.1 key
+    mock_sdk.avd_config = mock.MagicMock(
+        return_value={
+            "avd.ini.encoding": "UTF-8",
+            "hw.device.manufacturer": "Google",
+            "hw.device.name": "pixel",
+            "weird.key": "good=bad",
+            "PlayStore.enabled": "no",
+            "avd.name": "beePhone",
+            "disk.cachePartition": "yes",
+            "disk.cachePartition.size": "42M",
+            # Create an OS-dependent image.sysdir.1 value, with a trailing slash.
+            "image.sysdir.1": os.fsdecode(
+                Path("system-images") / "android-31" / "default" / "arm64-v8a"
+            )
+            + "/",
+        }
+    )
+    mock_sdk.verify_system_image = mock.MagicMock()
+
+    # Verify the AVD
+    mock_sdk.verify_avd("goodDevice")
+
+    # The AVD config was loaded.
+    mock_sdk.avd_config.assert_called_with("goodDevice")
+
+    # The system image was not verified
+    mock_sdk.verify_system_image.assert_called_once_with(
+        "system-images;android-31;default;arm64-v8a"
+    )

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
@@ -21,7 +21,7 @@ def test_succeeds_immediately_if_emulator_installed(mock_sdk):
 
 
 def test_succeeds_immediately_if_emulator_installed_with_debug(mock_sdk, tmp_path):
-    """If the emulator exist and debug is turned on, the list of packages is
+    """If the emulator exists and debug is turned on, the list of packages is
     displayed."""
     # Turn up logging to debug levels
     mock_sdk.command.logger.verbosity = 2
@@ -45,21 +45,8 @@ def test_succeeds_immediately_if_emulator_installed_with_debug(mock_sdk, tmp_pat
     )
 
 
-@pytest.mark.parametrize(
-    "host_os, host_arch, emulator_abi",
-    [
-        ("Darwin", "x86_64", "x86_64"),
-        ("Darwin", "arm64", "arm64-v8a"),
-        ("Windows", "x86_64", "x86_64"),
-        ("Linux", "x86_64", "x86_64"),
-    ],
-)
-def test_installs_android_emulator(mock_sdk, host_os, host_arch, emulator_abi):
+def test_installs_android_emulator(mock_sdk):
     """The emulator tools will be installed if needed."""
-    # Mock the hardware and OS
-    mock_sdk.command.host_os = host_os
-    mock_sdk.command.host_arch = host_arch
-
     mock_sdk.verify_emulator()
 
     mock_sdk.command.subprocess.run.assert_called_once_with(
@@ -67,34 +54,10 @@ def test_installs_android_emulator(mock_sdk, host_os, host_arch, emulator_abi):
             os.fsdecode(mock_sdk.sdkmanager_path),
             "platform-tools",
             "emulator",
-            f"system-images;android-31;default;{emulator_abi}",
         ],
         env=mock_sdk.env,
         check=True,
     )
-
-
-@pytest.mark.parametrize(
-    "host_os, host_arch",
-    [
-        ("Windows", "arm64"),
-        ("Linux", "arm64"),
-    ],
-)
-def test_unsupported_emulator_platform(mock_sdk, host_os, host_arch):
-    """If the platform isn't supported by the Android emulator, an error is
-    raised."""
-
-    mock_sdk.command.host_os = host_os
-    mock_sdk.command.host_arch = host_arch
-
-    with pytest.raises(
-        BriefcaseCommandError,
-        match=f"The Android emulator does not currently support {host_os} {host_arch} hardware",
-    ):
-        mock_sdk.verify_emulator()
-
-    mock_sdk.command.subprocess.run.assert_not_called()
 
 
 def test_install_problems_are_reported(mock_sdk):

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
@@ -1,0 +1,141 @@
+import os
+from subprocess import CalledProcessError
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError
+
+
+@pytest.mark.parametrize(
+    "host_os, host_arch",
+    [
+        ("Windows", "arm64"),
+        ("Linux", "arm64"),
+    ],
+)
+def test_unsupported_abi(mock_sdk, host_os, host_arch):
+    """If the system has an unsupported ABI, raise an error."""
+    # Mock the hardware and OS
+    mock_sdk.command.host_os = host_os
+    mock_sdk.command.host_arch = host_arch
+
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=f"The Android emulator does not currently support {host_os} {host_arch} hardware",
+    ):
+        mock_sdk.verify_system_image("system-images;android-31;default;x86_64")
+
+
+@pytest.mark.parametrize(
+    "bad_image_name",
+    [
+        # Patently invalid
+        "cheesecake",
+        # Only the prefix
+        "system-images",
+        # Not enough parts
+        "system-images;android-31;default",
+        # Broadly good structure, but bad initial prefix
+        "system-image;android-31;default;anything",
+    ],
+)
+def test_invalid_system_image(mock_sdk, bad_image_name):
+    """If the system image name doesn't make sense, raise an error."""
+    # Mock the host arch
+    mock_sdk.command.host_arch = "x86_64"
+
+    # Verify an system image that doesn't match the host architecture
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=rf"{bad_image_name!r} is not a valid system image name.",
+    ):
+        mock_sdk.verify_system_image(bad_image_name)
+
+
+def test_incompatible_abi(mock_sdk, capsys):
+    """If the system image doesn't match the emulator ABI, warn the user, but
+    continue."""
+    # Mock the host arch
+    mock_sdk.command.host_arch = "x86_64"
+
+    # Verify an system image that doesn't match the host architecture
+    mock_sdk.verify_system_image("system-images;android-31;default;anything")
+
+    # A warning message was output
+    assert "WARNING: Unexpected emulator ABI" in capsys.readouterr().out
+
+    # The system image was installed.
+    mock_sdk.command.subprocess.run.assert_called_once_with(
+        [
+            os.fsdecode(mock_sdk.sdkmanager_path),
+            "system-images;android-31;default;anything",
+        ],
+        env=mock_sdk.env,
+        check=True,
+    )
+
+
+def test_existing_system_image(mock_sdk):
+    """If the system image already exists, don't attempt to download it
+    again."""
+    # Mock the host arch
+    mock_sdk.command.host_arch = "x86_64"
+
+    # Mock the existence of a system image
+    (mock_sdk.root_path / "system-images" / "android-31" / "default" / "x86_64").mkdir(
+        parents=True
+    )
+
+    # Verify the system image that we already have
+    mock_sdk.verify_system_image("system-images;android-31;default;x86_64")
+
+    # sdkmanager was *not* called.
+    mock_sdk.command.subprocess.run.assert_not_called()
+
+
+def test_new_system_image(mock_sdk):
+    """If the system image doesn't exist locally, it will be installed."""
+    # Mock the host arch
+    mock_sdk.command.host_arch = "x86_64"
+
+    # Verify the system image, triggering a download
+    mock_sdk.verify_system_image("system-images;android-31;default;x86_64")
+
+    # The system image was installed.
+    mock_sdk.command.subprocess.run.assert_called_once_with(
+        [
+            os.fsdecode(mock_sdk.sdkmanager_path),
+            "system-images;android-31;default;x86_64",
+        ],
+        env=mock_sdk.env,
+        check=True,
+    )
+
+
+def test_problem_downloading_system_image(mock_sdk):
+    """If there is a failure downloading the system image, an error is
+    raised."""
+    # Mock the host arch
+    mock_sdk.command.host_arch = "x86_64"
+
+    # Mock a failure condition on subprocess.run
+    mock_sdk.command.subprocess.run.side_effect = CalledProcessError(
+        returncode=1, cmd="sdkmanager"
+    )
+
+    # Attempt to verify the system image
+    with pytest.raises(
+        BriefcaseCommandError,
+        match="Error while installing the 'system-images;android-31;default;x86_64' Android system image.",
+    ):
+        mock_sdk.verify_system_image("system-images;android-31;default;x86_64")
+
+    # An attempt to install the system image was made
+    mock_sdk.command.subprocess.run.assert_called_once_with(
+        [
+            os.fsdecode(mock_sdk.sdkmanager_path),
+            "system-images;android-31;default;x86_64",
+        ],
+        env=mock_sdk.env,
+        check=True,
+    )

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -70,6 +70,7 @@ def test_run_created_emulator(run_command, first_app_config):
         return_value=(None, None, None)
     )
     run_command.android_sdk.create_emulator = MagicMock(return_value="newDevice")
+    run_command.android_sdk.verify_avd = MagicMock()
     run_command.android_sdk.start_emulator = MagicMock(
         return_value=("emulator-3742", "New Device")
     )
@@ -79,6 +80,10 @@ def test_run_created_emulator(run_command, first_app_config):
 
     # A new emulator was created
     run_command.android_sdk.create_emulator.assert_called_once_with()
+
+    # No attempt was made to verify the AVD (it is pre-verified through
+    # the creation process)
+    run_command.android_sdk.verify_avd.assert_not_called()
 
     # The emulator was started
     run_command.android_sdk.start_emulator.assert_called_once_with("newDevice")
@@ -113,6 +118,7 @@ def test_run_idle_device(run_command, first_app_config):
     )
 
     run_command.android_sdk.create_emulator = MagicMock()
+    run_command.android_sdk.verify_avd = MagicMock()
     run_command.android_sdk.start_emulator = MagicMock(
         return_value=("emulator-3742", "Idle Device")
     )
@@ -122,6 +128,9 @@ def test_run_idle_device(run_command, first_app_config):
 
     # No attempt was made to create a new emulator
     run_command.android_sdk.create_emulator.assert_not_called()
+
+    # The AVD has been verified
+    run_command.android_sdk.verify_avd.assert_called_with("idleDevice")
 
     # The emulator was started
     run_command.android_sdk.start_emulator.assert_called_once_with("idleDevice")

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.android_sdk import AndroidSDK
 from briefcase.platforms.android.gradle import GradleRunCommand
 
@@ -38,7 +37,7 @@ def test_run_existing_device(run_command, first_app_config):
     # Invoke run_app
     run_command.run_app(first_app_config, device_or_avd="exampleDevice")
 
-    # selecte_target_device was invoked with a specific device
+    # select_target_device was invoked with a specific device
     run_command.android_sdk.select_target_device.assert_called_once_with(
         device_or_avd="exampleDevice"
     )
@@ -64,33 +63,85 @@ def test_run_existing_device(run_command, first_app_config):
     run_command.mock_adb.logcat.assert_called_once()
 
 
-def test_run_created_device(run_command, first_app_config):
-    """If the user chooses to run on a newly created device, an error is raised
-    (for now)"""
-    # Set up device selection to return a completely new device
+def test_run_created_emulator(run_command, first_app_config):
+    """The user can choose to run on a newly created emulator."""
+    # Set up device selection to return a completely new emulator
     run_command.android_sdk.select_target_device = MagicMock(
         return_value=(None, None, None)
     )
-    run_command.input = MagicMock(return_value="newDevice")
+    run_command.android_sdk.create_emulator = MagicMock(return_value="newDevice")
+    run_command.android_sdk.start_emulator = MagicMock(
+        return_value=("emulator-3742", "New Device")
+    )
 
-    with pytest.raises(BriefcaseCommandError):
-        run_command.run_app(first_app_config)
+    # Invoke run_app
+    run_command.run_app(first_app_config)
 
-    # The ADB wrapper wasn't even created
-    run_command.mock_adb.assert_not_called()
+    # A new emulator was created
+    run_command.android_sdk.create_emulator.assert_called_once_with()
+
+    # The emulator was started
+    run_command.android_sdk.start_emulator.assert_called_once_with("newDevice")
+
+    # The ADB wrapper is created
+    run_command.android_sdk.adb.assert_called_once_with(device="emulator-3742")
+
+    # The adb wrapper is invoked with the expected arguments
+    run_command.mock_adb.install_apk.assert_called_once_with(
+        run_command.binary_path(first_app_config)
+    )
+    run_command.mock_adb.force_stop_app.assert_called_once_with(
+        f"{first_app_config.package_name}.{first_app_config.module_name}",
+    )
+
+    run_command.mock_adb.clear_log.assert_called_once()
+
+    run_command.mock_adb.start_app.assert_called_once_with(
+        f"{first_app_config.package_name}.{first_app_config.module_name}",
+        "org.beeware.android.MainActivity",
+    )
+
+    run_command.mock_adb.logcat.assert_called_once()
 
 
 def test_run_idle_device(run_command, first_app_config):
-    """If the user chooses to run on an idle device, an error is raised (for
-    now)"""
+    """The user can choose to run on an idle device."""
     # Set up device selection to return a new device that has an AVD,
     # but not a device ID.
     run_command.android_sdk.select_target_device = MagicMock(
-        return_value=(None, "exampleDevice", "exampleDevice")
+        return_value=(None, "Idle Device", "idleDevice")
     )
 
-    with pytest.raises(BriefcaseCommandError):
-        run_command.run_app(first_app_config)
+    run_command.android_sdk.create_emulator = MagicMock()
+    run_command.android_sdk.start_emulator = MagicMock(
+        return_value=("emulator-3742", "Idle Device")
+    )
 
-    # The ADB wrapper wasn't even created
-    run_command.mock_adb.assert_not_called()
+    # Invoke run_app
+    run_command.run_app(first_app_config)
+
+    # No attempt was made to create a new emulator
+    run_command.android_sdk.create_emulator.assert_not_called()
+
+    # The emulator was started
+    run_command.android_sdk.start_emulator.assert_called_once_with("idleDevice")
+
+    # The ADB wrapper is created
+    run_command.android_sdk.adb.assert_called_once_with(device="emulator-3742")
+
+    # The adb wrapper is invoked with the expected arguments
+    run_command.mock_adb.install_apk.assert_called_once_with(
+        run_command.binary_path(first_app_config)
+    )
+    run_command.mock_adb.force_stop_app.assert_called_once_with(
+        f"{first_app_config.package_name}.{first_app_config.module_name}",
+    )
+
+    run_command.mock_adb.clear_log.assert_called_once()
+
+    run_command.mock_adb.start_app.assert_called_once_with(
+        f"{first_app_config.package_name}.{first_app_config.module_name}",
+        "org.beeware.android.MainActivity",
+    )
+
+    run_command.mock_adb.logcat.assert_called_once()


### PR DESCRIPTION
Historically,  briefcase has installed the emulator, plus the system image for the emulator, as part of a single install pass. 

However, Android has recently made a change where the emulator is now a dependency of something in the platform tools. This can lead to a situation where the user *has* the emulator, but does *not* have a valid system image with which to create an AVD. 

This PR decouples the check for the system image from the check for the emulator itself. 

This has 2 unindented (but beneficial) side effects.

1. If the user has used a different SDK install (e.g., Android Studio) to create an AVD, that AVD can now be used by Briefcase.
2. Implementing #737 is now much easier, required system image can be retrieved as part of the emulator creation process.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
