### PR TITLE
Fixes #749 - Support non ASCII files in MSI projects

### DIFF
--- a/changes/749.bugfix.rst
+++ b/changes/749.bugfix.rst
@@ -1,0 +1,1 @@
+Windows MSI projects are now able to support files with non-ASCII filenames.

--- a/src/briefcase/platforms/windows/msi.py
+++ b/src/briefcase/platforms/windows/msi.py
@@ -208,6 +208,8 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
                         "WixUtilExtension",
                         "-ext",
                         "WixUIExtension",
+                        "-loc",
+                        "unicode.wxl",
                         "-o",
                         self.distribution_path(app, packaging_format="msi"),
                         f"{app.app_name}.wixobj",

--- a/tests/platforms/windows/msi/test_package.py
+++ b/tests/platforms/windows/msi/test_package.py
@@ -70,6 +70,8 @@ def test_package_msi(package_command, first_app_config, tmp_path):
                     "WixUtilExtension",
                     "-ext",
                     "WixUIExtension",
+                    "-loc",
+                    "unicode.wxl",
                     "-o",
                     tmp_path / "windows" / "First App-0.0.1.msi",
                     "first-app.wixobj",


### PR DESCRIPTION
WiX doesn't support non-ASCII filenames out of the box; it needs to be manually enabled by configuration a localisation that enables UTF-8 in the MSI database.

Requires [this change](https://github.com/beeware/briefcase-windows-msi-template/commit/9b2d21834dea7c9a0ce346a1ae3f54308cb66bd4) to the Windows MSI template.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
