### PR TITLE
Fixes #382, #688 - Configure and correct the Windows install location

### DIFF
--- a/changes/382.feature.rst
+++ b/changes/382.feature.rst
@@ -1,0 +1,1 @@
+Windows MSI installers can now be configured to ask the user whether they want a per-user or per-machine install.

--- a/changes/688.bugfix.rst
+++ b/changes/688.bugfix.rst
@@ -1,0 +1,1 @@
+Windows MSI installers now install in ``Program Files``, rather than ``Program Files (x86)``.

--- a/docs/reference/platforms/windows/msi.rst
+++ b/docs/reference/platforms/windows/msi.rst
@@ -43,7 +43,8 @@ installer; however, they are installed once and shared between all users on a
 computer.
 
 If ``true`` the installer will attempt to install the app as a per-machine app,
-available to all users. Defaults to a per-user install.
+available to all users. If ``false``, the installer will install as a per-user
+app. If undefined the installer will ask the user for their preference.
 
 ``version_triple``
 ------------------

--- a/src/briefcase/platforms/windows/msi.py
+++ b/src/briefcase/platforms/windows/msi.py
@@ -84,6 +84,10 @@ class WindowsMSICreateCommand(WindowsMSIMixin, CreateCommand):
             "version_triple": version_triple,
             "guid": str(guid),
             "install_scope": install_scope,
+            # Template forward compatibility flags
+            # 2022-06-29: #775 added the need to pass for -arch 64 to candle.exe;
+            # Briefcase v0.3.8 didn't use that flag.
+            "_use_arch64": True,
         }
 
     def install_app_support_package(self, app: BaseConfig):

--- a/src/briefcase/platforms/windows/msi.py
+++ b/src/briefcase/platforms/windows/msi.py
@@ -77,8 +77,8 @@ class WindowsMSICreateCommand(WindowsMSIMixin, CreateCommand):
         try:
             install_scope = "perMachine" if app.system_installer else "perUser"
         except AttributeError:
-            # system_installer not defined in config; default to perUser install.
-            install_scope = "perUser"
+            # system_installer not defined in config; default to asking the user
+            install_scope = None
 
         return {
             "version_triple": version_triple,
@@ -187,6 +187,8 @@ class WindowsMSIPackageCommand(WindowsMSIMixin, PackageCommand):
                         "WixUtilExtension",
                         "-ext",
                         "WixUIExtension",
+                        "-arch",
+                        "x64",
                         "-dSourceDir=src",
                         f"{app.app_name}.wxs",
                         f"{app.app_name}-manifest.wxs",

--- a/tests/platforms/windows/msi/test_create.py
+++ b/tests/platforms/windows/msi/test_create.py
@@ -83,7 +83,12 @@ def test_default_install_scope(first_app_config, tmp_path):
 
     context = command.output_format_template_context(first_app_config)
 
-    assert context["install_scope"] is None
+    assert context == {
+        "guid": "d666a4f1-c7b7-52cc-888a-3a35a7cc97e5",
+        "version_triple": "0.0.1",
+        "install_scope": None,
+        "_use_arch64": True,
+    }
 
 
 def test_per_machine_install_scope(first_app_config, tmp_path):
@@ -93,7 +98,12 @@ def test_per_machine_install_scope(first_app_config, tmp_path):
 
     context = command.output_format_template_context(first_app_config)
 
-    assert context["install_scope"] == "perMachine"
+    assert context == {
+        "guid": "d666a4f1-c7b7-52cc-888a-3a35a7cc97e5",
+        "version_triple": "0.0.1",
+        "install_scope": "perMachine",
+        "_use_arch64": True,
+    }
 
 
 def test_per_user_install_scope(first_app_config, tmp_path):
@@ -103,4 +113,9 @@ def test_per_user_install_scope(first_app_config, tmp_path):
 
     context = command.output_format_template_context(first_app_config)
 
-    assert context["install_scope"] == "perUser"
+    assert context == {
+        "guid": "d666a4f1-c7b7-52cc-888a-3a35a7cc97e5",
+        "version_triple": "0.0.1",
+        "install_scope": "perUser",
+        "_use_arch64": True,
+    }

--- a/tests/platforms/windows/msi/test_create.py
+++ b/tests/platforms/windows/msi/test_create.py
@@ -83,7 +83,7 @@ def test_default_install_scope(first_app_config, tmp_path):
 
     context = command.output_format_template_context(first_app_config)
 
-    assert context["install_scope"] == "perUser"
+    assert context["install_scope"] is None
 
 
 def test_per_machine_install_scope(first_app_config, tmp_path):

--- a/tests/platforms/windows/msi/test_package.py
+++ b/tests/platforms/windows/msi/test_package.py
@@ -54,6 +54,8 @@ def test_package_msi(package_command, first_app_config, tmp_path):
                     "WixUtilExtension",
                     "-ext",
                     "WixUIExtension",
+                    "-arch",
+                    "x64",
                     "-dSourceDir=src",
                     "first-app.wxs",
                     "first-app-manifest.wxs",


### PR DESCRIPTION
Modifies the MSI installer so that:

* It installs into ``Program Files``, rather than ``Program Files (x86)`` (since we only produce x64 binaries)
* If ``pyproject.toml`` does not express a preference for user or machine installs, the installer will ask the user which they want when the project is installed. If pyproject.toml contains an explicit `system_installer=True` or `system_installer=False`, the question will not be asked.

Requires the template changes in https://github.com/beeware/briefcase-windows-msi-template/pull/11. This can be tested by adding ``template_branch = "optional-user-install"`` in your pyproject.toml. **EDIT** These changes have now been merged into production.

To test the handling of installer scope, you will also need to delete any ``system_installer`` definition in pyproject.toml.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
