### PR TITLE
Fix rich import error when running tox

### DIFF
--- a/changes/779.bugfix.rst
+++ b/changes/779.bugfix.rst
@@ -1,0 +1,1 @@
+Add rich as a test dependency to fix import errors.

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -2,3 +2,4 @@ pytest
 pytest-tldr
 pytest-cov
 tomli_w
+rich

--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,7 @@ commands =
 setenv = PYTHONPATH = {toxinidir}/src
 changedir = {toxinidir}/tests/apps
 deps =
+    rich
 allowlist_externals =
     sh
     rm


### PR DESCRIPTION
After merging #755, I am getting import errors for Rich while running `tox` locally. This PR includes rich as a dependency to the `testenv:verify` environments and to the `requirements.test.txt` file.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
