### PR TITLE
Supplant appdirs with platformdirs

### DIFF
--- a/changes/783.misc.rst
+++ b/changes/783.misc.rst
@@ -1,0 +1,1 @@
+Use platformdirs instead of appdirs to determine OS-native user data directory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ install_requires =
     dmgbuild >= 1.3.3; sys_platform == "darwin"
     psutil >= 5.9.0
     rich >= 12.4.1
-    appdirs >= 1.4.4
+    platformdirs >= 2.5.2
 
 [options.packages.find]
 where = src

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import requests
-from appdirs import AppDirs
 from cookiecutter.main import cookiecutter
 from cookiecutter.repository import is_repo_url
+from platformdirs import PlatformDirs
 
 try:
     import tomllib
@@ -118,7 +118,7 @@ class BaseCommand(ABC):
         self,
         base_path,
         home_path=Path.home(),
-        data_path=Path(AppDirs(appname="briefcase", appauthor="BeeWare").user_data_dir),
+        data_path=PlatformDirs(appname="briefcase", appauthor="BeeWare").user_data_path,
         apps=None,
         input_enabled=True,
     ):


### PR DESCRIPTION
Based on @dgelessus astute [comment](https://github.com/beeware/briefcase/pull/777#issuecomment-1182861374) that `appdirs` has been effectively [superseded](https://github.com/ActiveState/appdirs/issues/79) by `platformdirs` in the python ecosystem, this PR updates the OS-native data directory implementation in #777 from using `appdirs` to `platformdirs`.

`platformdirs` explicitly advertises itself as a drop-in replacement for `appdirs` by even aliasing `platformdirs.PlatformDirs` to `platformdirs.AppDirs`.

Additionally, `platformdirs` goes the extra step and provides APIs that return `pathlib.Path` objects directly.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
