### PR TITLE
Include Prompts to the User in the Log File

### DIFF
--- a/changes/785.misc.rst
+++ b/changes/785.misc.rst
@@ -1,0 +1,1 @@
+The prompts to users are now included in the briefcase log file.

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -439,6 +439,7 @@ class Console:
             raise InputDisabled()
         try:
             input_value = self.input(prompt, markup=markup)
+            self.print.to_log(prompt)
             self.print.to_log(f"{Log.DEBUG_PREFACE}User input: {input_value}")
             return input_value
         except EOFError:


### PR DESCRIPTION
While we explicitly captured user's input to prompts, the prompts themselves were not captured in the log. Usually, the prompt can be inferred from surrounding logs but other times it is less clear. A simple example to demonstrate this is `briefcase create --log` when the app has already been created.

This PR simply includes the prompt in the log before the user's input value.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
