### PR TITLE
Clarified the error message when a configuration file can't be found.

### DIFF
--- a/changes/786.misc.rst
+++ b/changes/786.misc.rst
@@ -1,0 +1,1 @@
+Clarified the error message when the configuration file can't be found.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -543,7 +543,9 @@ or delete the old data directory, and re-run Briefcase.
                     )
 
         except FileNotFoundError as e:
-            raise BriefcaseConfigError("configuration file not found") from e
+            raise BriefcaseConfigError(
+                f"""Configuration file not found. Did you run briefcase in the directory that contains {filename!r}?"""
+            ) from e
 
     def download_url(self, url, download_path):
         """Download a given URL, caching it. If it has already been downloaded,

--- a/tests/commands/base/test_parse_config.py
+++ b/tests/commands/base/test_parse_config.py
@@ -6,7 +6,7 @@ from briefcase.exceptions import BriefcaseConfigError
 def test_missing_config(base_command):
     """If the configuration file doesn't exit, raise an error."""
     filename = base_command.base_path / "does_not_exist.toml"
-    with pytest.raises(BriefcaseConfigError, match="configuration file not found"):
+    with pytest.raises(BriefcaseConfigError, match="Configuration file not found"):
         base_command.parse_config(filename)
 
 


### PR DESCRIPTION
Following the suggestion from #751.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
