### PR TITLE
Allow print() calls from non-Briefcase code during tests

### DIFF
--- a/changes/794.misc.rst
+++ b/changes/794.misc.rst
@@ -1,0 +1,1 @@
+Allow non-Briefcase code to use print() during tests.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,19 +21,22 @@ def mock_git():
     return git
 
 
-def monkeypatched_print(*arg, **kwargs):
-    """Raise an error for calls to print."""
+# alias print() to allow non-briefcase code to use it
+_print = print
+
+
+def monkeypatched_print(*args, **kwargs):
+    """Raise an error for calls to print() from briefcase."""
     frame = inspect.currentframe().f_back
     module = inspect.getmodule(frame.f_code)
 
     # Disallow any use of a bare print() in the briefcase codebase
-    if (
-        module.__name__.startswith("briefcase.")
-        and module.__name__ != "briefcase.console"
-    ):
+    if module.__name__.startswith("briefcase."):
         pytest.fail(
             "print() should not be invoked directly. Use Log or Console for printing."
         )
+
+    _print(*args, **kwargs)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
d0b74c6 removed the fallback in the tests' monkeypatched `builtin.print` to actually print if the calling code wasn't in Briefcase. My assumption at the time must have been "well, `console.py` no longer uses `print()` directly, so no need to support `print()` at all during tests".

This PR updates the monkeypatch to continue failing tests if `print()` is called from any Briefcase code but uses of `print()` outside of Briefcase code are allowed. This specifically addresses #794 to allow `pdb` to use `print()`.

- Fixes #794.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
