### PR TITLE
Ensure custom support URLs don't collide in the download cache

### DIFF
--- a/changes/797.bugfix.rst
+++ b/changes/797.bugfix.rst
@@ -1,0 +1,1 @@
+Collision protection has been added to custom support packages that have the same name, but are served by different URLs.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -316,21 +316,6 @@ class CreateCommand(BaseCommand):
                 self.logger.info(f"Using support package {support_package_url}")
 
             if support_package_url.startswith(("https://", "http://")):
-                if custom_support_package:
-                    # If the support package is custom, cache it using a hash of
-                    # the download URL. This is needed to differentiate to support
-                    # packages with the same filename, served at different URLs.
-                    # (or a custom package that collides with an official package name)
-                    download_path = (
-                        self.data_path
-                        / "support"
-                        / hashlib.sha256(
-                            support_package_url.encode("utf-8")
-                        ).hexdigest()
-                    )
-                else:
-                    download_path = self.data_path / "support"
-
                 try:
                     self.logger.info(f"... pinned to revision {app.support_revision}")
                     # If a revision has been specified, add the revision
@@ -347,6 +332,21 @@ class CreateCommand(BaseCommand):
                 except AttributeError:
                     # No support revision specified.
                     self.logger.info("... using most recent revision")
+
+                if custom_support_package:
+                    # If the support package is custom, cache it using a hash of
+                    # the download URL. This is needed to differentiate to support
+                    # packages with the same filename, served at different URLs.
+                    # (or a custom package that collides with an official package name)
+                    download_path = (
+                        self.data_path
+                        / "support"
+                        / hashlib.sha256(
+                            support_package_url.encode("utf-8")
+                        ).hexdigest()
+                    )
+                else:
+                    download_path = self.data_path / "support"
 
                 # Download the support file, caching the result
                 # in the user's briefcase support cache directory.

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -270,7 +270,7 @@ def test_install_pinned_custom_app_support_package_url(
         download_path=(
             create_command.data_path
             / "support"
-            / "55441abbffa311f65622df45a943afc347a21ab40e8dcec79472c92ef467db24"
+            / "7c4f3b671064f584508d6bd326b7840ee6b8faa5cd6424f5e5cca7bd0eb9f2b6"
         ),
         url="https://example.com/custom/support.zip?revision=42",
     )
@@ -324,7 +324,7 @@ def test_install_pinned_custom_app_support_package_url_with_args(
     create_command.download_url.assert_called_with(
         download_path=create_command.data_path
         / "support"
-        / "eb2519992f3776ae59dd0eb1ed6c79fa446a438e2bf4a6d5d61f1adad922f2dd",
+        / "e765dbdacdac39d26c8a8ba0c75a5a3f281d7dd38f3d7013257c03df6ea37516",
         url="https://example.com/custom/support.zip?cool=Yes&revision=42",
     )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+import zipfile
 from unittest.mock import MagicMock
 
 from briefcase.console import Console, InputDisabled
@@ -28,3 +29,73 @@ class FsPathMock(MagicMock):
     def _get_child_mock(self, **kw):
         """Create child mocks with right MagicMock class."""
         return MagicMock(**kw)
+
+
+def create_file(filepath, content, mode="w"):
+    """A test utility to create a file with known content.
+
+    Ensures that the directory for the file exists, and writes a file with
+    specific content.
+
+    :param filepath: The path for the file to create
+    :param content: A string containing the content to write.
+    :param mode: The mode to open the file. This is `w` by default;
+        use `wb` and provide content as a bitstring if you need to
+        write a binary file.
+    :returns: The path to the file that was created.
+    """
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    with filepath.open(mode) as f:
+        f.write(content)
+
+    return filepath
+
+
+def create_zip_file(zippath, content):
+    """A test utility to create a file with known content.
+
+    Ensures that the directory for the file exists, and writes a file with
+    specific content.
+
+    :param zippath: The path for the ZIP file to create
+    :param content: A list of pairs; each pair is (path, data) describing
+        an item to be added to the zip file.
+    :returns: The path to the file that was created.
+    """
+    zippath.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zippath, "w") as f:
+        for path, data in content:
+            f.writestr(path, data=data)
+
+    return zippath
+
+
+def mock_file_download(filename, content, mode="w"):
+    """Create a side effect function that mocks the download of a zip file.
+
+    :param filename: The file name (*not* the path - just the file name) to
+        create as a side effect
+    :param content: A string containing the content to write.
+    :param mode: The mode to open the file. This is `w` by default;
+        use `wb` and provide content as a bitstring if you need to
+        write a binary file.
+    :returns: a function that can act as a mock side effect for `download_url()`
+    """
+
+    def _download_url(url, download_path):
+        return create_file(download_path / filename, content, mode=mode)
+
+    return _download_url
+
+
+def mock_zip_download(filename, content):
+    """Create a side effect function that mocks the download of a zip file.
+
+    :param content: A string containing the content to write.
+    :returns: a function that can act as a mock side effect for `download_url()`
+    """
+
+    def _download_url(url, download_path):
+        return create_zip_file(download_path / filename, content)
+
+    return _download_url


### PR DESCRIPTION
This came up in the context of the work of #756.

At present, support packages are all cached in `<data path>/support`, regardless of origin.

This means that:
* An official macOS 3.10 b3 support package
* https://example.com/development/Python-3.10-macOS-support.b3.tar.gz
* https://example.com/release/Python-3.10-macOS-support.b3.tar.gz
* https://example.com/archive/?platform=macOS&release=b3 (returning Python-3.10-macOS-support.b3.tar.gz)

will all save the same file: `<data path>/support/Python-3.10-macOS-support.b3.tar.gz`. Since this location is used as a download cache, the first version of the package that is downloaded will become the version that is used, regardless of local project configuration. If you have 2 apps, one using the default location, and one using a custom location, the support package that will be used on a specific user's machine will depend on which app they built first. This would also cause a problem if a single project changes the URL for the custom support package but doesn't change the package name; or adds a custom support URL to a project and the URL using the same filename as a default support package.

#756 addresses this with linuxdeploy plugins by differentiating between "official" URLs and custom URLs; and adding a hash of the URL to the cache path for custom URLs. 

This PR applies the same approach to support URLs. Using this approach, the four examples provided above would cache as:
* `<data path>/support/Python-3.10-macOS-support.b3.tar.gz` (same as before)
* `<data path>/support/4dd6df92767f88ba4309d3690bb16f7c7e915c6f1ac46cc79495f145c1d07b26/Python-3.10-macOS-support.b3.tar.gz`
* `<data path>/support/5f7b7dbfdd014859b4032fc3d99e298fa783a88c37e05c45ece1f5f40c337b00/Python-3.10-macOS-support.b3.tar.gz`
* `<data path>/support/0016f4c533b48e84f03663aa7af8249a99f85c21255812d819ed1f46325acbdb/Python-3.10-macOS-support.b3.tar.gz`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
