### PR TITLE
Print Android Emulator Output if Startup Errors/Fails

### DIFF
--- a/changes/799.feature.rst
+++ b/changes/799.feature.rst
@@ -1,0 +1,1 @@
+Android emulator output is printed to the console if it fails to start properly.

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -119,7 +119,8 @@ def test_start_emulator(mock_sdk):
         ],
         env=mock_sdk.env,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
         start_new_session=True,
     )
 
@@ -215,7 +216,8 @@ def test_emulator_fail_to_start(mock_sdk):
         ],
         env=mock_sdk.env,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
         start_new_session=True,
     )
 
@@ -314,7 +316,8 @@ def test_emulator_fail_to_boot(mock_sdk):
         ],
         env=mock_sdk.env,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
         start_new_session=True,
     )
 


### PR DESCRIPTION
## Summary
Inspired by #764, this PR simply prints the warning and error logs from the Android emulator if something goes wrong during start up. Currently, Briefcase only instructs users to attempt to run the emulator themselves to see potential issues; this leaves that instruction in place but allows the user to immediately see those logs as well.

For example, here is the new experience when users try to use the emulator without hardware acceleration:
```
❯ briefcase run android -d @beePhone

[helloworld] Starting emulator beePhone...
Starting emulator...
WARNING | unexpected system image feature string, emulator might not function correctly, please try updating the emulator.
ERROR   | x86_64 emulation currently requires hardware acceleration!
CPU acceleration status: KVM requires a CPU that supports vmx or svm
More info on configuring VM acceleration on Linux:
https://developer.android.com/studio/run/emulator-acceleration#vm-linux
General information on acceleration: https://developer.android.com/studio/run/emulator-acceleration.


Android emulator was unable to start!

Try starting the emulator manually by running:

    $ /home/user/.cache/briefcase/tools/android_sdk/emulator/emulator @beePhone -dns-server 8.8.8.8

Resolve any problems you discover, then try running your app again. You may
find this page helpful in diagnosing emulator problems.

    https://developer.android.com/studio/run/emulator-acceleration#accel-vm

Log saved to /home/user/tmp/beeware/helloworld/briefcase.2022_07_23-13_28_41.run.log
```

## Opinion
Probably the most controversial aspect of this is only printing `stderr` from the Android emulator. The emulator sends normal logs like `INFO` to `stdout` while `WARNING` and `ERROR` logs are sent to `stderr`. I choose to only print the warnings and errors since I thought it might help remove some clutter and allow users to zero in on the problem themselves. I could be convinced otherwise.

CC: @mhsmith

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
