### PR TITLE
Avoid ModuleNotFoundError Exception for Local Installs

### DIFF
--- a/changes/800.misc.rst
+++ b/changes/800.misc.rst
@@ -1,0 +1,1 @@
+Remove ``src`` from path to Briefcase version via ``attr:`` to avoid ``ModuleNotFoundError`` on Python 3.9 and below.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = briefcase
-version = attr: src.briefcase.__version__
+version = attr: briefcase.__version__
 url = http://beeware.org/briefcase
 project_urls =
     Funding = https://beeware.org/contributing/membership/


### PR DESCRIPTION
Something must have changed with `pip==22.2`; for Python 3.9 and below, `pip install .` broke for `briefcase`. Although, this issue is somewhat limited since `pip install ./briefcase` succeeds... (the issue exists for editable installs as well).

<details>
<summary>Error on Python 3.9</summary>

```
❯ python -m pip install . -vv
Using pip 22.2 from /home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip (python 3.9)
Non-user install because user site-packages disabled
Created temporary directory: /tmp/pip-ephem-wheel-cache-zx6jw7n6
Created temporary directory: /tmp/pip-build-tracker-7o9eqcjn
Initialized build tracking at /tmp/pip-build-tracker-7o9eqcjn
Created build tracker: /tmp/pip-build-tracker-7o9eqcjn
Entered build tracker: /tmp/pip-build-tracker-7o9eqcjn
Created temporary directory: /tmp/pip-install-0or95xug
Processing /home/user/github/rmartin16/briefcase
  Added file:///home/user/github/rmartin16/briefcase to build tracker '/tmp/pip-build-tracker-7o9eqcjn'
  Created temporary directory: /tmp/pip-build-env-knlmeiyj
  Running command pip subprocess to install build dependencies
  Using pip 22.2 from /home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip (python 3.9)
  Collecting setuptools>=40.8.0
    Using cached setuptools-63.2.0-py3-none-any.whl (1.2 MB)
  Collecting wheel
    Using cached wheel-0.37.1-py2.py3-none-any.whl (35 kB)
  Installing collected packages: wheel, setuptools
  ERROR: Exception:
  Traceback (most recent call last):
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/cli/base_command.py", line 167, in exc_logging_wrapper
      status = run_func(*args)
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/cli/req_command.py", line 247, in wrapper
      return func(self, options, args)
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/commands/install.py", line 461, in run
      installed = install_given_reqs(
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/req/__init__.py", line 73, in install_given_reqs
      requirement.install(
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/req/req_install.py", line 752, in install
      scheme = get_scheme(
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/locations/__init__.py", line 246, in get_scheme
      old = _distutils.get_scheme(
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/locations/_distutils.py", line 130, in get_scheme
      scheme = distutils_scheme(dist_name, user, home, root, isolated, prefix)
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/locations/_distutils.py", line 46, in distutils_scheme
      d.parse_config_files()
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/setuptools/dist.py", line 864, in parse_config_files
      setupcfg.parse_configuration(
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/setuptools/config/setupcfg.py", line 172, in parse_configuration
      meta.parse()
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/setuptools/config/setupcfg.py", line 451, in parse
      section_parser_method(section_options)
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/setuptools/config/setupcfg.py", line 422, in parse_section
      self[name] = value
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/setuptools/config/setupcfg.py", line 243, in __setitem__
      value = parser(value)
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/setuptools/config/setupcfg.py", line 557, in _parse_version
      return expand.version(self._parse_attr(value, self.package_dir, self.root_dir))
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/setuptools/config/setupcfg.py", line 377, in _parse_attr
      return expand.read_attr(attr_desc, package_dir, root_dir)
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/setuptools/config/expand.py", line 186, in read_attr
      spec = _find_spec(module_name, path)
    File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/setuptools/config/expand.py", line 198, in _find_spec
      spec = spec or importlib.util.find_spec(module_name)
    File "/home/user/.pyenv/versions/3.9.13/lib/python3.9/importlib/util.py", line 94, in find_spec
      parent = __import__(parent_name, fromlist=['__path__'])
  ModuleNotFoundError: No module named 'src'
  error: subprocess-exited-with-error
  
  × pip subprocess to install build dependencies did not run successfully.
  │ exit code: 2
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/bin/python /home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/__pip-runner__.py install --ignore-installed --no-user --prefix /tmp/pip-build-env-knlmeiyj/overlay --no-warn-script-location -v --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.8.0' wheel
  cwd: [inherit]
  Installing build dependencies ... error
error: subprocess-exited-with-error

× pip subprocess to install build dependencies did not run successfully.
│ exit code: 2
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
Exception information:
Traceback (most recent call last):
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/cli/base_command.py", line 167, in exc_logging_wrapper
    status = run_func(*args)
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/cli/req_command.py", line 247, in wrapper
    return func(self, options, args)
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/commands/install.py", line 369, in run
    requirement_set = resolver.resolve(
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 73, in resolve
    collected = self.factory.collect_root_requirements(root_reqs)
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 491, in collect_root_requirements
    req = self._make_requirement_from_install_req(
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 453, in _make_requirement_from_install_req
    cand = self._make_candidate_from_link(
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 206, in _make_candidate_from_link
    self._link_candidate_cache[link] = LinkCandidate(
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 297, in __init__
    super().__init__(
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 162, in __init__
    self.dist = self._prepare()
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 231, in _prepare
    dist = self._prepare_distribution()
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 308, in _prepare_distribution
    return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/operations/prepare.py", line 438, in prepare_linked_requirement
    return self._prepare_linked_requirement(req, parallel_builds)
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/operations/prepare.py", line 524, in _prepare_linked_requirement
    dist = _get_prepared_distribution(
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/operations/prepare.py", line 68, in _get_prepared_distribution
    abstract_dist.prepare_distribution_metadata(
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/distributions/sdist.py", line 38, in prepare_distribution_metadata
    self._prepare_build_backend(finder)
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/distributions/sdist.py", line 70, in _prepare_build_backend
    self.req.build_env.install_requirements(
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/build_env.py", line 196, in install_requirements
    self._install_requirements(
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/build_env.py", line 254, in _install_requirements
    call_subprocess(
  File "/home/user/github/rmartin16/briefcase/venv-3.9-rmartin16-briefcase/lib/python3.9/site-packages/pip/_internal/utils/subprocess.py", line 224, in call_subprocess
    raise error
pip._internal.exceptions.InstallationSubprocessError: pip subprocess to install build dependencies exited with 2
Remote version of pip: 22.2
Local version of pip:  22.2
Was pip installed by pip? True
Removed file:///home/user/github/rmartin16/briefcase from build tracker '/tmp/pip-build-tracker-7o9eqcjn'
Removed build tracker: '/tmp/pip-build-tracker-7o9eqcjn'
```

</details>

The underlying exception occurs in `setuptools` but installing previous version of `setuptools` doesn't help....only reverting to `pip==22.1.2` helped.

Nonetheless, the problem is with the argument for `attr:` in `verison` in `setup.cfg`. Based on everything I've seen, the configuration of `options.packages`, `options.package_dir`, and `options.packages.find.where` should be enough to indicate `src` is where to look. I'm far from an expert here so just offering this up for consideration.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
