### PR TITLE
Fixes #662 - Set a current working directory when running apps

### DIFF
--- a/changes/662.bugfix.rst
+++ b/changes/662.bugfix.rst
@@ -1,0 +1,1 @@
+Apps now have better isolation against the current working directory. This ensures that code in the current working directory isn't inadvertently included when an app runs.

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -87,7 +87,15 @@ class DevCommand(BaseCommand):
         try:
             # Invoke the app.
             self.subprocess.run(
-                [sys.executable, "-m", app.module_name],
+                [
+                    sys.executable,
+                    "-c",
+                    (
+                        "import runpy, sys;"
+                        "sys.path.pop(0);"
+                        f'runpy.run_module("{app.module_name}", run_name="__main__", alter_sys=True)'
+                    ),
+                ],
                 env=env,
                 check=True,
                 cwd=self.home_path,

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -90,7 +90,7 @@ class DevCommand(BaseCommand):
                 [sys.executable, "-m", app.module_name],
                 env=env,
                 check=True,
-                cwd=self.platform_path,
+                cwd=self.home_path,
             )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 from typing import Optional
 
 from briefcase.config import BaseConfig
@@ -89,6 +90,7 @@ class DevCommand(BaseCommand):
                 [sys.executable, "-m", app.module_name],
                 env=env,
                 check=True,
+                cwd=self.platform_path,
             )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(
@@ -98,7 +100,11 @@ class DevCommand(BaseCommand):
     def get_environment(self, app):
         # Create a shell environment where PYTHONPATH points to the source
         # directories described by the app config.
-        return {"PYTHONPATH": os.pathsep.join(app.PYTHONPATH)}
+        return {
+            "PYTHONPATH": os.pathsep.join(
+                os.fsdecode(Path.cwd() / path) for path in app.PYTHONPATH
+            )
+        }
 
     def __call__(
         self,

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import threading
 import time
+from pathlib import Path
 
 import psutil
 
@@ -217,6 +218,7 @@ class Subprocess:
 
         # Otherwise, invoke run() normally.
         self._log_command(args)
+        self._log_cwd(kwargs.get("cwd"))
         self._log_environment(kwargs.get("env"))
 
         try:
@@ -291,6 +293,7 @@ class Subprocess:
            is returned as strings instead of bytes.
         """
         self._log_command(args)
+        self._log_cwd(kwargs.get("cwd"))
         self._log_environment(kwargs.get("env"))
 
         try:
@@ -355,6 +358,7 @@ class Subprocess:
            is returned as strings instead of bytes.
         """
         self._log_command(args)
+        self._log_cwd(kwargs.get("cwd"))
         self._log_environment(kwargs.get("env"))
 
         return self._subprocess.Popen(
@@ -435,6 +439,12 @@ class Subprocess:
         self.command.logger.debug(
             f"    {' '.join(shlex.quote(str(arg)) for arg in args)}"
         )
+
+    def _log_cwd(self, cwd):
+        """Log the working directory for the  command being executed."""
+        effective_cwd = Path.cwd() if cwd is None else cwd
+        self.command.logger.debug("Working Directory:")
+        self.command.logger.debug(f"    {effective_cwd}")
 
     def _log_environment(self, overrides):
         """Log the environment variables overrides prior to command execution.

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -266,6 +266,7 @@ class LinuxAppImageRunCommand(LinuxAppImageMixin, RunCommand):
                     os.fsdecode(self.binary_path(app)),
                 ],
                 check=True,
+                cwd=self.platform_path,
             )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(f"Unable to start app {app.app_name}.") from e

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -266,7 +266,7 @@ class LinuxAppImageRunCommand(LinuxAppImageMixin, RunCommand):
                     os.fsdecode(self.binary_path(app)),
                 ],
                 check=True,
-                cwd=self.platform_path,
+                cwd=self.home_path,
             )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(f"Unable to start app {app.app_name}.") from e

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -172,7 +172,10 @@ class LinuxFlatpakRunCommand(LinuxFlatpakMixin, RunCommand):
         :param app: The config object for the app
         """
         self.logger.info("Starting app...", prefix=app.app_name)
-        self.flatpak.run(bundle=app.bundle, app_name=app.app_name)
+        self.flatpak.run(
+            bundle=app.bundle,
+            app_name=app.app_name,
+        )
 
 
 class LinuxFlatpakPackageCommand(LinuxFlatpakMixin, PackageCommand):

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -78,7 +78,7 @@ class macOSRunMixin:
                         "-n",  # Force a new app to be launched
                         os.fsdecode(self.binary_path(app)),
                     ],
-                    cwd=self.platform_path,
+                    cwd=self.home_path,
                     check=True,
                 )
             except subprocess.CalledProcessError:

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -78,6 +78,7 @@ class macOSRunMixin:
                         "-n",  # Force a new app to be launched
                         os.fsdecode(self.binary_path(app)),
                     ],
+                    cwd=self.platform_path,
                     check=True,
                 )
             except subprocess.CalledProcessError:

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -86,6 +86,7 @@ class WindowsRunCommand(RunCommand):
             self.logger.info("=" * 75)
             self.subprocess.run(
                 [os.fsdecode(self.binary_path(app))],
+                cwd=self.platform_path,
                 check=True,
             )
         except subprocess.CalledProcessError as e:

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -86,7 +86,7 @@ class WindowsRunCommand(RunCommand):
             self.logger.info("=" * 75)
             self.subprocess.run(
                 [os.fsdecode(self.binary_path(app))],
-                cwd=self.platform_path,
+                cwd=self.home_path,
                 check=True,
             )
         except subprocess.CalledProcessError as e:

--- a/tests/commands/dev/conftest.py
+++ b/tests/commands/dev/conftest.py
@@ -6,9 +6,13 @@ from briefcase.commands import DevCommand
 from briefcase.config import AppConfig
 
 
+class DummyDevCommand(DevCommand):
+    platform = "C64"
+
+
 @pytest.fixture
 def dev_command(tmp_path):
-    command = DevCommand(base_path=tmp_path)
+    command = DummyDevCommand(base_path=tmp_path)
     command.subprocess = mock.MagicMock()
     return command
 

--- a/tests/commands/dev/conftest.py
+++ b/tests/commands/dev/conftest.py
@@ -6,13 +6,9 @@ from briefcase.commands import DevCommand
 from briefcase.config import AppConfig
 
 
-class DummyDevCommand(DevCommand):
-    platform = "C64"
-
-
 @pytest.fixture
 def dev_command(tmp_path):
-    command = DummyDevCommand(base_path=tmp_path)
+    command = DevCommand(base_path=tmp_path)
     command.subprocess = mock.MagicMock()
     return command
 

--- a/tests/commands/dev/test_get_environment.py
+++ b/tests/commands/dev/test_get_environment.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -8,18 +9,18 @@ PYTHONPATH = "PYTHONPATH"
 def test_pythonpath_with_one_source(dev_command, first_app):
     """Test get environment with one source."""
     env = dev_command.get_environment(first_app)
-    assert env[PYTHONPATH] == "src"
+    assert env[PYTHONPATH] == f"{Path.cwd() / 'src'}"
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Relevant only for windows")
 def test_pythonpath_with_two_sources_in_windows(dev_command, third_app):
     """Test get environment with two sources in windows."""
     env = dev_command.get_environment(third_app)
-    assert env[PYTHONPATH] == "src;other"
+    assert env[PYTHONPATH] == f"{Path.cwd() / 'src'};{Path.cwd() / 'other'}"
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Relevant only for non-windows")
 def test_pythonpath_with_two_sources_in_linux(dev_command, third_app):
     """Test get environment with two sources in linux."""
     env = dev_command.get_environment(third_app)
-    assert env[PYTHONPATH] == "src:other"
+    assert env[PYTHONPATH] == f"{Path.cwd() / 'src'}:{Path.cwd() / 'other'}"

--- a/tests/commands/dev/test_run_dev_app.py
+++ b/tests/commands/dev/test_run_dev_app.py
@@ -12,7 +12,7 @@ def test_subprocess_running_successfully(dev_command, first_app, tmp_path):
     dev_command.subprocess.run.assert_called_once_with(
         [sys.executable, "-m", first_app.app_name],
         env=env,
-        cwd=tmp_path / "C64",
+        cwd=dev_command.home_path,
         check=True,
     )
 
@@ -27,6 +27,6 @@ def test_subprocess_throws_error(dev_command, first_app, tmp_path):
     dev_command.subprocess.run.assert_called_once_with(
         [sys.executable, "-m", first_app.app_name],
         env=env,
-        cwd=tmp_path / "C64",
+        cwd=dev_command.home_path,
         check=True,
     )

--- a/tests/commands/dev/test_run_dev_app.py
+++ b/tests/commands/dev/test_run_dev_app.py
@@ -10,7 +10,15 @@ def test_subprocess_running_successfully(dev_command, first_app, tmp_path):
     env = dict(a=1, b=2, c=3)
     dev_command.run_dev_app(first_app, env)
     dev_command.subprocess.run.assert_called_once_with(
-        [sys.executable, "-m", first_app.app_name],
+        [
+            sys.executable,
+            "-c",
+            (
+                "import runpy, sys;"
+                "sys.path.pop(0);"
+                'runpy.run_module("first", run_name="__main__", alter_sys=True)'
+            ),
+        ],
         env=env,
         cwd=dev_command.home_path,
         check=True,
@@ -25,7 +33,15 @@ def test_subprocess_throws_error(dev_command, first_app, tmp_path):
     ):
         dev_command.run_dev_app(first_app, env)
     dev_command.subprocess.run.assert_called_once_with(
-        [sys.executable, "-m", first_app.app_name],
+        [
+            sys.executable,
+            "-c",
+            (
+                "import runpy, sys;"
+                "sys.path.pop(0);"
+                'runpy.run_module("first", run_name="__main__", alter_sys=True)'
+            ),
+        ],
         env=env,
         cwd=dev_command.home_path,
         check=True,

--- a/tests/commands/dev/test_run_dev_app.py
+++ b/tests/commands/dev/test_run_dev_app.py
@@ -6,15 +6,18 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError
 
 
-def test_subprocess_running_successfully(dev_command, first_app):
+def test_subprocess_running_successfully(dev_command, first_app, tmp_path):
     env = dict(a=1, b=2, c=3)
     dev_command.run_dev_app(first_app, env)
     dev_command.subprocess.run.assert_called_once_with(
-        [sys.executable, "-m", first_app.app_name], env=env, check=True
+        [sys.executable, "-m", first_app.app_name],
+        env=env,
+        cwd=tmp_path / "C64",
+        check=True,
     )
 
 
-def test_subprocess_throws_error(dev_command, first_app):
+def test_subprocess_throws_error(dev_command, first_app, tmp_path):
     env = dict(a=1, b=2, c=3)
     dev_command.subprocess.run.side_effect = CalledProcessError(returncode=2, cmd="cmd")
     with pytest.raises(
@@ -22,5 +25,8 @@ def test_subprocess_throws_error(dev_command, first_app):
     ):
         dev_command.run_dev_app(first_app, env)
     dev_command.subprocess.run.assert_called_once_with(
-        [sys.executable, "-m", first_app.app_name], env=env, check=True
+        [sys.executable, "-m", first_app.app_name],
+        env=env,
+        cwd=tmp_path / "C64",
+        check=True,
     )

--- a/tests/integrations/docker/test_Docker__check_output.py
+++ b/tests/integrations/docker/test_Docker__check_output.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 from unittest.mock import ANY
 
 import pytest
@@ -144,6 +145,8 @@ def test_simple_verbose_call(mock_docker, tmp_path, capsys):
         "--rm "
         "briefcase/com.example.myapp:py3.X "
         "hello world\n"
+        ">>> Working Directory:\n"
+        f">>>     {Path.cwd()}\n"
         ">>> Command Output:\n"
         ">>>     goodbye\n"
         ">>> Return code: 0\n"

--- a/tests/integrations/docker/test_Docker__run.py
+++ b/tests/integrations/docker/test_Docker__run.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 from unittest.mock import ANY
 
 import pytest
@@ -141,5 +142,7 @@ def test_simple_verbose_call(mock_docker, tmp_path, capsys):
         "--rm "
         "briefcase/com.example.myapp:py3.X "
         "hello world\n"
+        ">>> Working Directory:\n"
+        f">>>     {Path.cwd()}\n"
         ">>> Return code: 3\n"
     )

--- a/tests/integrations/subprocess/test_Subprocess__check_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__check_output.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from subprocess import CalledProcessError
 from unittest.mock import ANY
 
@@ -138,6 +139,8 @@ def test_debug_call(mock_sub, capsys):
         "\n"
         ">>> Running Command:\n"
         ">>>     hello world\n"
+        ">>> Working Directory:\n"
+        f">>>     {Path.cwd()}\n"
         ">>> Command Output:\n"
         ">>>     some output line 1\n"
         ">>>     more output line 2\n"
@@ -147,12 +150,12 @@ def test_debug_call(mock_sub, capsys):
     assert capsys.readouterr().out == expected_output
 
 
-def test_debug_call_with_env(mock_sub, capsys):
+def test_debug_call_with_env(mock_sub, capsys, tmp_path):
     """If verbosity is turned up, injected env vars are included in output."""
     mock_sub.command.logger = Log(verbosity=2)
 
     env = {"NewVar": "NewVarValue"}
-    mock_sub.check_output(["hello", "world"], env=env)
+    mock_sub.check_output(["hello", "world"], env=env, cwd=tmp_path / "cwd")
 
     merged_env = mock_sub.command.os.environ.copy()
     merged_env.update(env)
@@ -160,6 +163,7 @@ def test_debug_call_with_env(mock_sub, capsys):
     mock_sub._subprocess.check_output.assert_called_with(
         ["hello", "world"],
         env=merged_env,
+        cwd=os.fsdecode(tmp_path / "cwd"),
         text=True,
         encoding=ANY,
     )
@@ -168,6 +172,8 @@ def test_debug_call_with_env(mock_sub, capsys):
         "\n"
         ">>> Running Command:\n"
         ">>>     hello world\n"
+        ">>> Working Directory:\n"
+        f">>>     {tmp_path / 'cwd'}\n"
         ">>> Environment Overrides:\n"
         ">>>     NewVar=NewVarValue\n"
         ">>> Command Output:\n"
@@ -198,6 +204,8 @@ def test_calledprocesserror_exception_logging(mock_sub, capsys):
         "\n"
         ">>> Running Command:\n"
         ">>>     hello world\n"
+        ">>> Working Directory:\n"
+        f">>>     {Path.cwd()}\n"
         ">>> Command Output:\n"
         ">>>     output line 1\n"
         ">>>     output line 2\n"

--- a/tests/platforms/linux/appimage/test_run.py
+++ b/tests/platforms/linux/appimage/test_run.py
@@ -50,7 +50,9 @@ def test_run_app(first_app_config, tmp_path):
     command.run_app(first_app_config)
 
     command.subprocess.run.assert_called_with(
-        [os.fsdecode(tmp_path / "linux" / "First_App-0.0.1-wonky.AppImage")], check=True
+        [os.fsdecode(tmp_path / "linux" / "First_App-0.0.1-wonky.AppImage")],
+        cwd=tmp_path / "linux",
+        check=True,
     )
 
 
@@ -69,5 +71,7 @@ def test_run_app_failed(first_app_config, tmp_path):
 
     # The run command was still invoked, though
     command.subprocess.run.assert_called_with(
-        [os.fsdecode(tmp_path / "linux" / "First_App-0.0.1-wonky.AppImage")], check=True
+        [os.fsdecode(tmp_path / "linux" / "First_App-0.0.1-wonky.AppImage")],
+        cwd=tmp_path / "linux",
+        check=True,
     )

--- a/tests/platforms/linux/appimage/test_run.py
+++ b/tests/platforms/linux/appimage/test_run.py
@@ -9,7 +9,10 @@ from briefcase.platforms.linux.appimage import LinuxAppImageRunCommand
 
 def test_verify_linux(tmp_path):
     """A linux App can be started on linux."""
-    command = LinuxAppImageRunCommand(base_path=tmp_path)
+    command = LinuxAppImageRunCommand(
+        base_path=tmp_path / "base",
+        home_path=tmp_path / "home",
+    )
     command.use_docker = True
     command.host_os = "Linux"
 
@@ -24,7 +27,10 @@ def test_verify_linux(tmp_path):
 
 def test_verify_non_linux(tmp_path):
     """A linux App can be started on linux, even if Docker is enabled."""
-    command = LinuxAppImageRunCommand(base_path=tmp_path)
+    command = LinuxAppImageRunCommand(
+        base_path=tmp_path / "base",
+        home_path=tmp_path / "home",
+    )
     command.use_docker = True
     command.host_os = "WierdOS"
 
@@ -40,7 +46,10 @@ def test_verify_non_linux(tmp_path):
 
 def test_run_app(first_app_config, tmp_path):
     """A linux App can be started."""
-    command = LinuxAppImageRunCommand(base_path=tmp_path)
+    command = LinuxAppImageRunCommand(
+        base_path=tmp_path / "base",
+        home_path=tmp_path / "home",
+    )
 
     # Set the host architecture for test purposes.
     command.host_arch = "wonky"
@@ -50,15 +59,18 @@ def test_run_app(first_app_config, tmp_path):
     command.run_app(first_app_config)
 
     command.subprocess.run.assert_called_with(
-        [os.fsdecode(tmp_path / "linux" / "First_App-0.0.1-wonky.AppImage")],
-        cwd=tmp_path / "linux",
+        [os.fsdecode(tmp_path / "base" / "linux" / "First_App-0.0.1-wonky.AppImage")],
+        cwd=tmp_path / "home",
         check=True,
     )
 
 
 def test_run_app_failed(first_app_config, tmp_path):
     """If there's a problem started the app, an exception is raised."""
-    command = LinuxAppImageRunCommand(base_path=tmp_path)
+    command = LinuxAppImageRunCommand(
+        base_path=tmp_path / "base",
+        home_path=tmp_path / "home",
+    )
 
     # Set the host architecture for test purposes.
     command.host_arch = "wonky"
@@ -71,7 +83,7 @@ def test_run_app_failed(first_app_config, tmp_path):
 
     # The run command was still invoked, though
     command.subprocess.run.assert_called_with(
-        [os.fsdecode(tmp_path / "linux" / "First_App-0.0.1-wonky.AppImage")],
-        cwd=tmp_path / "linux",
+        [os.fsdecode(tmp_path / "base" / "linux" / "First_App-0.0.1-wonky.AppImage")],
+        cwd=tmp_path / "home",
         check=True,
     )

--- a/tests/platforms/macOS/app/test_run.py
+++ b/tests/platforms/macOS/app/test_run.py
@@ -42,7 +42,9 @@ def test_run_app(first_app_config, tmp_path, monkeypatch):
         bufsize=1,
     )
     command.subprocess.run.assert_called_with(
-        ["open", "-n", os.fsdecode(bin_path)], check=True
+        ["open", "-n", os.fsdecode(bin_path)],
+        cwd=tmp_path / "macOS",
+        check=True,
     )
     command.subprocess.stream_output.assert_called_with(
         "log stream", log_stream_process, stop_func=mock.ANY
@@ -83,7 +85,9 @@ def test_run_app_failed(first_app_config, tmp_path):
         bufsize=1,
     )
     command.subprocess.run.assert_called_with(
-        ["open", "-n", os.fsdecode(bin_path)], check=True
+        ["open", "-n", os.fsdecode(bin_path)],
+        cwd=tmp_path / "macOS",
+        check=True,
     )
 
     # No attempt was made to stream the log; but there was a cleanup
@@ -122,7 +126,9 @@ def test_run_app_find_pid_failed(first_app_config, tmp_path, monkeypatch, capsys
         bufsize=1,
     )
     command.subprocess.run.assert_called_with(
-        ["open", "-n", os.fsdecode(bin_path)], check=True
+        ["open", "-n", os.fsdecode(bin_path)],
+        cwd=tmp_path / "macOS",
+        check=True,
     )
     assert capsys.readouterr().out == (
         "\n"

--- a/tests/platforms/macOS/app/test_run.py
+++ b/tests/platforms/macOS/app/test_run.py
@@ -10,7 +10,10 @@ from briefcase.platforms.macOS.app import macOSAppRunCommand
 
 def test_run_app(first_app_config, tmp_path, monkeypatch):
     """A macOS app can be started."""
-    command = macOSAppRunCommand(base_path=tmp_path)
+    command = macOSAppRunCommand(
+        base_path=tmp_path / "base",
+        home_path=tmp_path / "home",
+    )
     command.subprocess = mock.MagicMock()
     log_stream_process = mock.MagicMock()
     command.subprocess.Popen.return_value = log_stream_process
@@ -43,7 +46,7 @@ def test_run_app(first_app_config, tmp_path, monkeypatch):
     )
     command.subprocess.run.assert_called_with(
         ["open", "-n", os.fsdecode(bin_path)],
-        cwd=tmp_path / "macOS",
+        cwd=tmp_path / "home",
         check=True,
     )
     command.subprocess.stream_output.assert_called_with(
@@ -54,7 +57,10 @@ def test_run_app(first_app_config, tmp_path, monkeypatch):
 
 def test_run_app_failed(first_app_config, tmp_path):
     """If there's a problem started the app, an exception is raised."""
-    command = macOSAppRunCommand(base_path=tmp_path)
+    command = macOSAppRunCommand(
+        base_path=tmp_path / "base",
+        home_path=tmp_path / "home",
+    )
     command.subprocess = mock.MagicMock()
     log_stream_process = mock.MagicMock()
     command.subprocess.Popen.return_value = log_stream_process
@@ -86,7 +92,7 @@ def test_run_app_failed(first_app_config, tmp_path):
     )
     command.subprocess.run.assert_called_with(
         ["open", "-n", os.fsdecode(bin_path)],
-        cwd=tmp_path / "macOS",
+        cwd=tmp_path / "home",
         check=True,
     )
 
@@ -97,7 +103,10 @@ def test_run_app_failed(first_app_config, tmp_path):
 
 def test_run_app_find_pid_failed(first_app_config, tmp_path, monkeypatch, capsys):
     """If after app is started, its pid is not found, do not stream output."""
-    command = macOSAppRunCommand(base_path=tmp_path)
+    command = macOSAppRunCommand(
+        base_path=tmp_path / "base",
+        home_path=tmp_path / "home",
+    )
     command.subprocess = mock.MagicMock()
     log_stream_process = mock.MagicMock()
     command.subprocess.Popen.return_value = log_stream_process
@@ -127,7 +136,7 @@ def test_run_app_find_pid_failed(first_app_config, tmp_path, monkeypatch, capsys
     )
     command.subprocess.run.assert_called_with(
         ["open", "-n", os.fsdecode(bin_path)],
-        cwd=tmp_path / "macOS",
+        cwd=tmp_path / "home",
         check=True,
     )
     assert capsys.readouterr().out == (

--- a/tests/platforms/macOS/xcode/test_run.py
+++ b/tests/platforms/macOS/xcode/test_run.py
@@ -34,5 +34,7 @@ def test_run_app(first_app_config, tmp_path):
         bufsize=1,
     )
     command.subprocess.run.assert_called_with(
-        ["open", "-n", os.fsdecode(bin_path)], check=True
+        ["open", "-n", os.fsdecode(bin_path)],
+        cwd=tmp_path / "macOS",
+        check=True,
     )

--- a/tests/platforms/macOS/xcode/test_run.py
+++ b/tests/platforms/macOS/xcode/test_run.py
@@ -10,9 +10,11 @@ from briefcase.platforms.macOS.xcode import macOSXcodeRunCommand
 
 def test_run_app(first_app_config, tmp_path):
     """A macOS Xcode app can be started."""
-    command = macOSXcodeRunCommand(base_path=tmp_path)
+    command = macOSXcodeRunCommand(
+        base_path=tmp_path / "base",
+        home_path=tmp_path / "home",
+    )
     command.subprocess = mock.MagicMock()
-
     command.run_app(first_app_config)
 
     # Calls were made to start the app and to start a log stream.
@@ -35,6 +37,6 @@ def test_run_app(first_app_config, tmp_path):
     )
     command.subprocess.run.assert_called_with(
         ["open", "-n", os.fsdecode(bin_path)],
-        cwd=tmp_path / "macOS",
+        cwd=tmp_path / "home",
         check=True,
     )

--- a/tests/platforms/windows/app/test_run.py
+++ b/tests/platforms/windows/app/test_run.py
@@ -20,6 +20,7 @@ def test_run_app(first_app_config, tmp_path):
                 tmp_path / "windows" / "app" / "First App" / "src" / "First App.exe"
             ),
         ],
+        cwd=tmp_path / "windows",
         check=True,
     )
 
@@ -40,5 +41,6 @@ def test_run_app_failed(first_app_config, tmp_path):
                 tmp_path / "windows" / "app" / "First App" / "src" / "First App.exe"
             ),
         ],
+        cwd=tmp_path / "windows",
         check=True,
     )

--- a/tests/platforms/windows/app/test_run.py
+++ b/tests/platforms/windows/app/test_run.py
@@ -9,7 +9,10 @@ from briefcase.platforms.windows.app import WindowsAppRunCommand
 
 def test_run_app(first_app_config, tmp_path):
     """A windows app can be started."""
-    command = WindowsAppRunCommand(base_path=tmp_path)
+    command = WindowsAppRunCommand(
+        base_path=tmp_path / "base",
+        home_path=tmp_path / "home",
+    )
     command.subprocess = mock.MagicMock()
 
     command.run_app(first_app_config)
@@ -17,17 +20,26 @@ def test_run_app(first_app_config, tmp_path):
     command.subprocess.run.assert_called_with(
         [
             os.fsdecode(
-                tmp_path / "windows" / "app" / "First App" / "src" / "First App.exe"
+                tmp_path
+                / "base"
+                / "windows"
+                / "app"
+                / "First App"
+                / "src"
+                / "First App.exe"
             ),
         ],
-        cwd=tmp_path / "windows",
+        cwd=tmp_path / "home",
         check=True,
     )
 
 
 def test_run_app_failed(first_app_config, tmp_path):
     """If there's a problem started the app, an exception is raised."""
-    command = WindowsAppRunCommand(base_path=tmp_path)
+    command = WindowsAppRunCommand(
+        base_path=tmp_path / "base",
+        home_path=tmp_path / "home",
+    )
     command.subprocess = mock.MagicMock()
     command.subprocess.run.side_effect = BriefcaseCommandError("problem")
 
@@ -38,9 +50,15 @@ def test_run_app_failed(first_app_config, tmp_path):
     command.subprocess.run.assert_called_with(
         [
             os.fsdecode(
-                tmp_path / "windows" / "app" / "First App" / "src" / "First App.exe"
+                tmp_path
+                / "base"
+                / "windows"
+                / "app"
+                / "First App"
+                / "src"
+                / "First App.exe"
             ),
         ],
-        cwd=tmp_path / "windows",
+        cwd=tmp_path / "home",
         check=True,
     )

--- a/tests/platforms/windows/visualstudio/test_run.py
+++ b/tests/platforms/windows/visualstudio/test_run.py
@@ -9,7 +9,10 @@ from briefcase.platforms.windows.visualstudio import WindowsVisualStudioRunComma
 
 def test_run_app(first_app_config, tmp_path):
     """A windows Visual Studio project app can be started."""
-    command = WindowsVisualStudioRunCommand(base_path=tmp_path)
+    command = WindowsVisualStudioRunCommand(
+        base_path=tmp_path / "base",
+        home_path=tmp_path / "home",
+    )
     command.subprocess = mock.MagicMock()
 
     command.run_app(first_app_config)
@@ -18,6 +21,7 @@ def test_run_app(first_app_config, tmp_path):
         [
             os.fsdecode(
                 tmp_path
+                / "base"
                 / "windows"
                 / "VisualStudio"
                 / "First App"
@@ -26,6 +30,6 @@ def test_run_app(first_app_config, tmp_path):
                 / "First App.exe"
             ),
         ],
-        cwd=tmp_path / "windows",
+        cwd=tmp_path / "home",
         check=True,
     )

--- a/tests/platforms/windows/visualstudio/test_run.py
+++ b/tests/platforms/windows/visualstudio/test_run.py
@@ -26,5 +26,6 @@ def test_run_app(first_app_config, tmp_path):
                 / "First App.exe"
             ),
         ],
+        cwd=tmp_path / "windows",
         check=True,
     )


### PR DESCRIPTION
By default, the Python interpreter will include the current working directory in the PYTHONPATH. As a result, if you create an app named `helloworld`, and create a `helloworld.py` in the root directory of the project, `briefcase dev` would pick up the `helloworld.py` in the project root, not the actual app code. 

This would also affect Linux AppImage apps. As Linux AppImages are an embedded Python interpreter, the folder where you invoke the AppImage would implicitly be on the PYTHONPATH. If you gave a `helloworld` AppImage to an end-user who has `helloworld.py` in their local folder, the *end-user's* `helloworld.py` would be executed.

macOS and Windows aren't affected by this problem, as they use an embedded interpreter that doesn't add CWD to the PythonPath. However it doesn't hurt to set the CWD for those run calls.

iOS and Android aren't affected because they're running on device in a sandbox, so they can't be affected by local code.

Linux Flatpaks are affected by this in a slightly different way, as they run with a CWD of `~`; so a `helloworld.py` in the user's home folder would get picked up. Adopting #628 (implemented in beeware/briefcase-linux-flatpak-template#3) would address this, as it would make Flatpaks isolated in the same way as Windows/macOS apps.

This PR addresses the problem by setting the CWD to the user's home folder when running the app, or when in dev mode. This doesn't provide perfect isolation in dev mode, but it's significantly better than the status quo, and leads to easier-to-diagnose end-user questions of "Why is Briefcase finding code in my home folder?", rather than "Why *isn't* briefcase finding the code in my project?" or "Why is briefcase picking up a stale version of my app?". Running apps aren't affected by this decision (other than the Flatpak leakage mentioned above, which is fixed in the linked template PR).

By way of debugging assistance, this PR also adds the CWD into the logged subprocess output.

beeware/briefcase-linux-appimage-template#17 includes a fix on the AppImage binary to force better isolation of the `AppImage itself.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
