### PR TITLE
If support_path is missing from briefcase.toml, don't download a support package

### DIFF
--- a/changes/805.misc.rst
+++ b/changes/805.misc.rst
@@ -1,0 +1,1 @@
+Allow a template to disable support packages entirely by omitting support_path from briefcase.toml.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -298,10 +298,14 @@ class CreateCommand(BaseCommand):
             # Branch does not exist for python version
             raise TemplateUnsupportedVersion(app.template_branch) from e
 
-    def _unpack_support_package(self, app, support_file_path):
+    def _unpack_support_package(self, support_file_path, support_path):
+        """Unpack a support package into a specific location.
+
+        :param support_file_path: The path to the support file to be unpacked.
+        :param support_path: The path where support files should unpacked.
+        """
         try:
             with self.input.wait_bar("Unpacking support package..."):
-                support_path = self.support_path(app)
                 support_path.mkdir(parents=True, exist_ok=True)
                 self.shutil.unpack_archive(
                     support_file_path,
@@ -316,12 +320,12 @@ class CreateCommand(BaseCommand):
         :param app: The config object for the app
         """
         try:
-            self.support_path(app)
+            support_path = self.support_path(app)
         except KeyError:
-            self.logger.info("No support_path in briefcase.toml: skipping")
+            self.logger.info("No support package required.")
         else:
             support_file_path = self._download_support_package(app)
-            self._unpack_support_package(app, support_file_path)
+            self._unpack_support_package(support_file_path, support_path)
 
     def _download_support_package(self, app):
         try:

--- a/tests/commands/create/conftest.py
+++ b/tests/commands/create/conftest.py
@@ -189,6 +189,18 @@ def app_requirements_path_index(bundle_path):
 
 
 @pytest.fixture
+def no_support_path_index(bundle_path):
+    with (bundle_path / "briefcase.toml").open("wb") as f:
+        index = {
+            "paths": {
+                "app_path": "path/to/app",
+                "app_requirements_path": "path/to/requirements.txt",
+            }
+        }
+        tomli_w.dump(index, f)
+
+
+@pytest.fixture
 def support_path(bundle_path):
     return bundle_path / "path" / "to" / "support"
 

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -142,7 +142,7 @@ def test_install_custom_app_support_package_file(
 
 
 def test_support_package_url_with_invalid_custom_support_packge_url(
-    create_command, myapp
+    create_command, myapp, app_requirements_path_index
 ):
     """Invalid URL for a custom support package raises
     MissingNetworkResourceError."""
@@ -171,7 +171,9 @@ def test_support_package_url_with_invalid_custom_support_packge_url(
     )
 
 
-def test_support_package_url_with_unsupported_platform(create_command, myapp):
+def test_support_package_url_with_unsupported_platform(
+    create_command, myapp, app_requirements_path_index
+):
     """An unsupported platform raises MissingSupportPackage."""
     # Set the host architecture to something unsupported
     create_command.host_arch = "unknown"
@@ -407,3 +409,11 @@ def test_missing_support_package(
     # Installing the bad support package raises an error
     with pytest.raises(InvalidSupportPackage):
         create_command.install_app_support_package(myapp)
+
+
+def test_no_support_path(create_command, myapp, no_support_path_index):
+    """If support_path is not listed in briefcase.toml, a support package will
+    not be downloaded."""
+    create_command.download_url = mock.MagicMock()
+    create_command.install_app_support_package(myapp)
+    create_command.download_url.assert_not_called()

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -142,7 +142,9 @@ def test_install_custom_app_support_package_file(
 
 
 def test_support_package_url_with_invalid_custom_support_packge_url(
-    create_command, myapp, app_requirements_path_index
+    create_command,
+    myapp,
+    app_requirements_path_index,
 ):
     """Invalid URL for a custom support package raises
     MissingNetworkResourceError."""
@@ -172,7 +174,9 @@ def test_support_package_url_with_invalid_custom_support_packge_url(
 
 
 def test_support_package_url_with_unsupported_platform(
-    create_command, myapp, app_requirements_path_index
+    create_command,
+    myapp,
+    app_requirements_path_index,
 ):
     """An unsupported platform raises MissingSupportPackage."""
     # Set the host architecture to something unsupported


### PR DESCRIPTION
Chaquopy installs all of its runtime libraries with a Gradle plugin, so it won't need a support package. This PR provides a way for a template to disable support packages entirely.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
