### PR TITLE
Allow nested wait bars by updating onscreen message

### DIFF
--- a/changes/810.misc.rst
+++ b/changes/810.misc.rst
@@ -1,0 +1,1 @@
+Wait Bars can be nested by allowing a new Wait Bar to be started while one is already running.

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -277,6 +277,8 @@ class Console:
         # Therefore, all output must be printed to the screen by Rich to
         # prevent corruption of dynamic elements like Wait Bars.
         self.is_output_controlled = False
+        # Track the active Wait Bar to allow dynamic updates to it
+        self._active_wait_bar: Progress = None
 
     def prompt(self, *values, markup=False, **kwargs):
         """Print to the screen for soliciting user interaction.
@@ -308,7 +310,11 @@ class Console:
         transient=False,
         markup=False,
     ):
-        """Returns a wait bar as a context manager.
+        """Returns the Wait Bar as a context manager.
+
+        If the Wait Bar is already active, then its message is updated for the new
+        context. Once the new context is complete, the previous Wait Bar message
+        is restored.
 
         :param message: text explaining what is being awaited
         :param done_message: text appended to the message after exiting
@@ -317,32 +323,63 @@ class Console:
         :param markup: whether to interpret Rich styling markup in the message; if True,
             the message must already be escaped; defaults False.
         """
-        wait_bar = Progress(
-            TextColumn("    "),
-            BarColumn(bar_width=20, style="black", pulse_style="white"),
-            TextColumn(message),
-            transient=True,
-            console=self.print.console,
-        )
-        # setting start=False causes the progress bar to pulse
-        wait_bar.add_task("", start=False)
+        # Create the Wait Bar since it is not already active
+        if self._active_wait_bar is None:
+            wait_bar = Progress(
+                TextColumn("    "),
+                BarColumn(bar_width=20, style="black", pulse_style="white"),
+                TextColumn("{task.fields[message]}"),
+                transient=True,
+                console=self.print.console,
+            )
+            # setting start=False causes the progress bar to pulse
+            wait_bar.add_task("", start=False, message=message)
+            try:
+                self.is_output_controlled = True
+                with wait_bar as current_wait_bar:
+                    self._active_wait_bar = current_wait_bar
+                    yield from self._start_wait_bar(
+                        message=message,
+                        done_message=done_message,
+                        transient=transient,
+                        markup=markup,
+                    )
+            finally:
+                self.is_output_controlled = False
+                self._active_wait_bar = None
+
+        # If the Wait Bar is already active, update its message in the console
+        else:
+            wait_bar_task = self._active_wait_bar.tasks[0]
+            orig_message = wait_bar_task.fields["message"]
+            self._active_wait_bar.update(wait_bar_task.id, message=message)
+            try:
+                yield from self._start_wait_bar(
+                    message=message,
+                    done_message=done_message,
+                    transient=transient,
+                    markup=markup,
+                )
+            finally:
+                # Restore Wait Bar message to previous value
+                self._active_wait_bar.update(wait_bar_task.id, message=orig_message)
+
+    def _start_wait_bar(self, message, done_message, transient, markup):
+        """Activate the Wait Bar and manage its exit conditions."""
         try:
-            self.is_output_controlled = True
-            with wait_bar:
-                yield
+            yield
         except BaseException:
             # ensure the message is left on the screen even if user sends CTRL+C
             if message and not transient:
-                self.print(message, markup=markup)
+                self.print(message, markup=markup, stack_offset=4)
             raise
         else:
             if message and not transient:
                 self.print(
                     f'{message}{f" {done_message}" if done_message else ""}',
                     markup=markup,
+                    stack_offset=6,
                 )
-        finally:
-            self.is_output_controlled = False
 
     def boolean_input(self, question, default=False):
         """Get a boolean input from user, in the form of y/n.

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -268,6 +268,8 @@ class Subprocess:
         kwargs["stdout"] = subprocess.PIPE
         # if stderr isn't explicitly redirected, then send it to stdout.
         kwargs.setdefault("stderr", subprocess.STDOUT)
+        # use line-buffered output by default
+        kwargs.setdefault("bufsize", 1)
 
         stderr = None
         with self.Popen(args, **kwargs) as process:

--- a/tests/commands/create/test_install_image.py
+++ b/tests/commands/create/test_install_image.py
@@ -51,7 +51,7 @@ def test_no_requested_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "\nInstalling input/original.png as sample image... done\n"
+    expected = "Installing input/original.png as sample image... done\n\n"
     assert capsys.readouterr().out == expected
 
     # The file was copied into position
@@ -62,7 +62,7 @@ def test_no_requested_size(create_command, tmp_path, capsys):
 
 
 def test_no_requested_size_invalid_path(create_command, tmp_path, capsys):
-    """If the app specifies an no-size image that doesn't exist, an error is
+    """If the app specifies a no-size image that doesn't exist, an error is
     raised."""
     create_command.shutil = mock.MagicMock()
     create_command.shutil.copy.side_effect = FileNotFoundError
@@ -107,7 +107,7 @@ def test_requested_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "\nInstalling input/original-3742.png as 3742px sample image... done\n"
+    expected = "Installing input/original-3742.png as 3742px sample image... done\n\n"
     assert capsys.readouterr().out == expected
 
     # The file was copied into position
@@ -165,7 +165,7 @@ def test_variant_with_no_requested_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "\nInstalling input/original.png as round sample image... done\n"
+    expected = "Installing input/original.png as round sample image... done\n\n"
     assert capsys.readouterr().out == expected
 
     # The file was copied into position
@@ -261,7 +261,7 @@ def test_variant_with_size(create_command, tmp_path, capsys):
 
     # The right message was written to output
     expected = (
-        "\nInstalling input/original-3742.png as 3742px round sample image... done\n"
+        "Installing input/original-3742.png as 3742px round sample image... done\n\n"
     )
     assert capsys.readouterr().out == expected
 
@@ -326,7 +326,7 @@ def test_unsized_variant(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "\nInstalling input/original.png as round sample image... done\n"
+    expected = "Installing input/original.png as round sample image... done\n\n"
     assert capsys.readouterr().out == expected
 
     # The file was copied into position

--- a/tests/console/Console/test_wait_bar.py
+++ b/tests/console/Console/test_wait_bar.py
@@ -6,13 +6,23 @@ def test_wait_bar_done_message(console, capsys):
     with console.wait_bar("Wait message...", done_message="finished"):
         pass
 
-    assert capsys.readouterr().out == "\nWait message... finished\n"
+    assert capsys.readouterr().out == "Wait message... finished\n\n"
+
+
+def test_wait_bar_done_message_nested(console, capsys):
+    """Custom done_message is printed when wait bar normally exits."""
+    with console.wait_bar("Wait message 1...", done_message="finished"):
+        with console.wait_bar("Wait message 2...", done_message="finished"):
+            pass
+
+    expected = "Wait message 2... finished\nWait message 1... finished\n\n"
+    assert capsys.readouterr().out == expected
 
 
 @pytest.mark.parametrize(
     ("message", "transient", "output"),
     (
-        ("Wait message...", False, "\nWait message... done\n"),
+        ("Wait message...", False, "Wait message... done\n\n"),
         ("", False, "\n"),
         ("Wait Message...", True, "\n"),
         ("", True, "\n"),
@@ -28,9 +38,40 @@ def test_wait_bar_transient(console, message, transient, output, capsys):
 
 
 @pytest.mark.parametrize(
+    ("message_one", "message_two", "transient", "output"),
+    (
+        (
+            "Wait message 1...",
+            "Wait message 2...",
+            False,
+            "Wait message 2... done\nWait message 1... done\n\n",
+        ),
+        ("", "", False, "\n"),
+        ("Wait message 1...", "Wait message 2...", True, "\n"),
+        ("", "", True, "\n"),
+    ),
+)
+def test_wait_bar_transient_nested(
+    console,
+    message_one,
+    message_two,
+    transient,
+    output,
+    capsys,
+):
+    """Output is present or absent based on presence of message and transient
+    value."""
+    with console.wait_bar(message_one, transient=transient):
+        with console.wait_bar(message_two, transient=transient):
+            pass
+
+    assert capsys.readouterr().out == output
+
+
+@pytest.mark.parametrize(
     ("message", "transient", "output"),
     (
-        ("Wait message...", False, "\nWait message...\n"),
+        ("Wait message...", False, "Wait message...\n\n"),
         ("", False, "\n"),
         ("Wait Message...", True, "\n"),
         ("", True, "\n"),
@@ -42,5 +83,37 @@ def test_wait_bar_keyboard_interrupt(console, message, transient, output, capsys
     with pytest.raises(KeyboardInterrupt):
         with console.wait_bar(message, transient=transient):
             raise KeyboardInterrupt
+
+    assert capsys.readouterr().out == output
+
+
+@pytest.mark.parametrize(
+    ("message_one", "message_two", "transient", "output"),
+    (
+        (
+            "Wait message 1...",
+            "Wait message 2...",
+            False,
+            "Wait message 2...\nWait message 1...\n\n",
+        ),
+        ("", "", False, "\n"),
+        ("Wait message 1...", "Wait message 2...", True, "\n"),
+        ("", "", True, "\n"),
+    ),
+)
+def test_wait_bar_keyboard_interrupt_nested(
+    console,
+    message_one,
+    message_two,
+    transient,
+    output,
+    capsys,
+):
+    """If the wait bar is interrupted, output is present or absent based on
+    presence of message and transient value."""
+    with pytest.raises(KeyboardInterrupt):
+        with console.wait_bar(message_one, transient=transient):
+            with console.wait_bar(message_two, transient=transient):
+                raise KeyboardInterrupt
 
     assert capsys.readouterr().out == output

--- a/tests/integrations/docker/test_Docker__prepare.py
+++ b/tests/integrations/docker/test_Docker__prepare.py
@@ -34,6 +34,7 @@ def test_prepare(mock_docker, tmp_path):
         ],
         stdout=-1,
         stderr=-2,
+        bufsize=1,
         text=True,
         encoding=ANY,
     )
@@ -71,6 +72,7 @@ def test_prepare_failure(mock_docker, tmp_path):
         ],
         stdout=-1,
         stderr=-2,
+        bufsize=1,
         text=True,
         encoding=ANY,
     )

--- a/tests/integrations/subprocess/test_Subprocess__run_in_wait_bar.py
+++ b/tests/integrations/subprocess/test_Subprocess__run_in_wait_bar.py
@@ -123,11 +123,15 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path):
 @pytest.mark.parametrize(
     "in_kwargs, kwargs",
     [
-        ({}, {"text": True, "encoding": ANY}),
-        ({"text": True}, {"text": True, "encoding": ANY}),
-        ({"text": False}, {"text": False}),
-        ({"universal_newlines": False}, {"universal_newlines": False}),
-        ({"universal_newlines": True}, {"universal_newlines": True, "encoding": ANY}),
+        ({}, {"text": True, "encoding": ANY, "bufsize": 1}),
+        ({"text": True}, {"text": True, "encoding": ANY, "bufsize": 1}),
+        ({"text": False}, {"text": False, "bufsize": 1}),
+        ({"text": False, "bufsize": 42}, {"text": False, "bufsize": 42}),
+        ({"universal_newlines": False}, {"universal_newlines": False, "bufsize": 1}),
+        (
+            {"universal_newlines": True},
+            {"universal_newlines": True, "encoding": ANY, "bufsize": 1},
+        ),
     ],
 )
 def test_text_eq_true_default_overriding(mock_sub, in_kwargs, kwargs):
@@ -139,7 +143,6 @@ def test_text_eq_true_default_overriding(mock_sub, in_kwargs, kwargs):
         ["hello", "world"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        bufsize=1,
         **kwargs,
     )
 

--- a/tests/integrations/subprocess/test_Subprocess__run_in_wait_bar.py
+++ b/tests/integrations/subprocess/test_Subprocess__run_in_wait_bar.py
@@ -25,6 +25,7 @@ def test_call(mock_sub, capsys):
         ["hello", "world"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        bufsize=1,
         text=True,
         encoding=ANY,
     )
@@ -42,6 +43,7 @@ def test_call_with_arg(mock_sub, capsys):
         ["hello", "world"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        bufsize=1,
         universal_newlines=True,
         encoding=ANY,
     )
@@ -60,6 +62,7 @@ def test_debug_call(mock_sub, capsys):
         ["hello", "world"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        bufsize=1,
         text=True,
         encoding=ANY,
     )
@@ -96,6 +99,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path):
         cwd=os.fsdecode(tmp_path / "cwd"),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        bufsize=1,
         text=True,
         encoding=ANY,
     )
@@ -135,6 +139,7 @@ def test_text_eq_true_default_overriding(mock_sub, in_kwargs, kwargs):
         ["hello", "world"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        bufsize=1,
         **kwargs,
     )
 
@@ -151,6 +156,7 @@ def test_stderr_is_redirected(mock_sub, popen_process, capsys):
         ["hello", "world"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        bufsize=1,
         text=True,
         encoding=ANY,
     )
@@ -171,6 +177,7 @@ def test_stderr_dev_null(mock_sub, popen_process, capsys):
         ["hello", "world"],
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
+        bufsize=1,
         text=True,
         encoding=ANY,
     )

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -157,6 +157,7 @@ def test_build_appimage(build_command, first_app, tmp_path):
         encoding=mock.ANY,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        bufsize=1,
     )
     # Binary is marked executable
     build_command.os.chmod.assert_called_with(
@@ -230,6 +231,7 @@ def test_build_appimage_with_plugin(build_command, first_app, tmp_path):
         encoding=mock.ANY,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        bufsize=1,
     )
     # Binary is marked executable
     build_command.os.chmod.assert_called_with(
@@ -279,6 +281,7 @@ def test_build_failure(build_command, first_app, tmp_path):
         encoding=mock.ANY,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        bufsize=1,
     )
 
     # chmod isn't invoked if the binary wasn't created.
@@ -333,6 +336,7 @@ def test_build_appimage_in_docker(build_command, first_app, tmp_path):
         encoding=mock.ANY,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        bufsize=1,
     )
     # Binary is marked executable
     build_command.os.chmod.assert_called_with(
@@ -425,6 +429,7 @@ def test_build_appimage_with_plugins_in_docker(build_command, first_app, tmp_pat
         encoding=mock.ANY,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        bufsize=1,
     )
     # Binary is marked executable
     build_command.os.chmod.assert_called_with(


### PR DESCRIPTION
Allows a Wait Bar to be initiated while a Wait Bar is already active. Previously this would result in an Exception from Rich related to multiple Live displays. So support this, the `message` for the currently active Wait Bar is updated and a new manager is entered; in this way, as each Wait Bar exits, the previous Wait Bar is restored.

Nested Wait Bar Demo

```python
from time import sleep
from briefcase.console import Console
#
console = Console()
#
with console.wait_bar("Wait Bar 1..."):
    console.prompt("Inside the first wait bar")
    sleep(1)
    #
    with console.wait_bar("Wait Bar 2 (transient)...", transient=True):
        console.prompt("Inside the second wait bar")
        sleep(1)
        #
        with console.wait_bar("Wait Bar 3..."):
            console.prompt("Inside the third wait bar")
            for idx in range(3):
                console.prompt(idx)
                sleep(.5)
            console.prompt("Leaving third wait bar")
        #
        sleep(1)
        # raise Exception("error")
        console.prompt("Leaving second wait bar")
    #
    sleep(1)
    console.prompt("Leaving first wait bar")
```


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
