### PR TITLE
Simplify Nested Wait Bar Support

### DIFF
--- a/changes/815.misc.rst
+++ b/changes/815.misc.rst
@@ -1,0 +1,1 @@
+Streamline the Wait Bar's support for nesting.


### PR DESCRIPTION
The Wait Bar update (#810) to allow nesting them was unnecessarily complicated; I just didn't see through it the first time. I apologize for the churn....this should be the last time I touch the Wait Bar.

These changes provide a uniform code path for all Wait Bar usage and is quite a bit more eloquent IMO. As an added benefit, the code locations in the log of the Wait Bar message is now always accurate.

<details>
<summary>Nested Wait Bar Demo</summary>

```python
from time import sleep
from briefcase.console import Console
#
console = Console()
#
with console.wait_bar("Wait Bar 1...", done_message=""):
    console.prompt("Inside the first wait bar")
    sleep(1)
    #
    with console.wait_bar("Wait Bar 2 (transient)...", transient=True):
        console.prompt("Inside the second wait bar")
        sleep(1)
        #
        with console.wait_bar("Wait Bar 3..."):
            console.prompt("Inside the third wait bar")
            for idx in range(3):
                console.prompt(idx)
                sleep(.5)
            console.prompt("Leaving third wait bar")
        #
        sleep(1)
        console.prompt("Leaving second wait bar")
        # raise Exception("error")
    #
    sleep(1)
    console.prompt("Leaving first wait bar")

```
</details>

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct