### PR TITLE
Avoid deadlocks while joining the output streamer

### DIFF
--- a/changes/809.bugfix.rst
+++ b/changes/809.bugfix.rst
@@ -1,0 +1,1 @@
+Python 3.7 and 3.8 on Windows will no longer deadlock when CTRL+C is sent during a subprocess command.

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -5,8 +5,8 @@ import shlex
 import subprocess
 import sys
 import threading
-import time
 from pathlib import Path
+from time import sleep, time
 
 import psutil
 
@@ -277,6 +277,7 @@ class Subprocess:
             if process.stderr and kwargs["stderr"] != subprocess.STDOUT:
                 stderr = process.stderr.read()
             return_code = process.poll()
+        self._log_return_code(return_code)
 
         if check and return_code:
             raise subprocess.CalledProcessError(return_code, args, stderr=stderr)
@@ -367,7 +368,7 @@ class Subprocess:
             [str(arg) for arg in args], **self.final_kwargs(**kwargs)
         )
 
-    def stream_output(self, label, popen_process, stop_func=None):
+    def stream_output(self, label, popen_process, stop_func=lambda: False):
         """Stream the output of a Popen process until the process exits. If the
         user sends CTRL+C, the process will be terminated.
 
@@ -385,19 +386,22 @@ class Subprocess:
             name=f"{label} output streamer",
             target=self._stream_output_thread,
             args=(popen_process,),
+            daemon=True,
         )
         try:
             output_streamer.start()
-            if stop_func:
-                while output_streamer.is_alive() and not stop_func():
-                    time.sleep(0.1)
-            else:
-                output_streamer.join()
+            # joining the thread is avoided due to demonstrated
+            # instability of thread interruption via CTRL+C (#809)
+            while not stop_func() and output_streamer.is_alive():
+                sleep(0.1)
         except KeyboardInterrupt:
-            pass  # allow CTRL+C to gracefully stop streaming
+            # allow time for CTRL+C to propagate to the child process
+            sleep(0.25)
         finally:
             self.cleanup(label, popen_process)
-            output_streamer.join()
+            streamer_deadline = time() + 3
+            while output_streamer.is_alive() and time() < streamer_deadline:
+                sleep(0.1)
 
     def _stream_output_thread(self, popen_process):
         """Stream output for a Popen process in a Thread.
@@ -411,13 +415,7 @@ class Subprocess:
             if output_line:
                 self.command.logger.info(output_line)
             elif output_line == "":
-                # a return code will be available once the process returns one to the OS.
-                # by definition, that should mean the process has exited.
-                return_code = popen_process.poll()
-                # only return once all output has been read and the process has exited.
-                if return_code is not None:
-                    self._log_return_code(return_code)
-                    return
+                return
 
     def cleanup(self, label, popen_process):
         """Clean up after a Popen process, gracefully terminating if possible;

--- a/tests/integrations/subprocess/conftest.py
+++ b/tests/integrations/subprocess/conftest.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -41,18 +42,20 @@ def mock_sub():
 @pytest.fixture
 def popen_process():
     process = MagicMock()
-    # There are extra empty strings at the end to simulate readline
-    # continuously returning "" once it reaches EOF
-    process.stdout.readline.side_effect = [
-        "output line 1\n",
-        "\n",
-        "output line 3\n",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-    ]
+
+    # Mock the readline values of an actual process. The final return value is "",
+    # indicating that the process has exited; however, we insert a short sleep
+    # to ensure that any other threads will have a chance to run before this
+    # thread acutally terminates.
+    def mock_readline():
+        yield from [
+            "output line 1\n",
+            "\n",
+            "output line 3\n",
+        ]
+        time.sleep(0.1)
+        yield ""
+
+    process.stdout.readline.side_effect = mock_readline()
     process.poll.return_value = -3
     return process

--- a/tests/integrations/subprocess/conftest.py
+++ b/tests/integrations/subprocess/conftest.py
@@ -54,5 +54,5 @@ def popen_process():
         "",
         "",
     ]
-    process.poll.side_effect = [None, None, None, -3, -3, -3]
+    process.poll.return_value = -3
     return process

--- a/tests/integrations/subprocess/test_Subprocess__check_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__check_output.py
@@ -187,7 +187,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path):
 
 def test_calledprocesserror_exception_logging(mock_sub, capsys):
     """If command errors, ensure command output is printed."""
-    mock_sub.command.logger = Log(verbosity=3)
+    mock_sub.command.logger = Log(verbosity=2)
 
     called_process_error = CalledProcessError(
         returncode=-1,

--- a/tests/integrations/subprocess/test_Subprocess__cleanup.py
+++ b/tests/integrations/subprocess/test_Subprocess__cleanup.py
@@ -28,4 +28,4 @@ def test_dirty_termination(mock_sub, capsys):
     process.kill.assert_called_once_with()
 
     # Log contains a contextual message.
-    assert capsys.readouterr().out == ("Forcibly killing testing process...\n")
+    assert capsys.readouterr().out == "Forcibly killing testing process...\n"

--- a/tests/integrations/subprocess/test_Subprocess__run.py
+++ b/tests/integrations/subprocess/test_Subprocess__run.py
@@ -179,7 +179,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path):
 
 
 def test_calledprocesserror_exception_logging(mock_sub, capsys):
-    mock_sub.command.logger = Log(verbosity=3)
+    mock_sub.command.logger = Log(verbosity=2)
 
     called_process_error = CalledProcessError(
         returncode=-1,

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -1,3 +1,4 @@
+from threading import Event
 from time import sleep
 from unittest import mock
 
@@ -14,15 +15,15 @@ def mock_sub(mock_sub):
 
 
 def test_output(mock_sub, popen_process, capsys):
-    """Readline output is printed."""
+    """Process output is printed."""
     mock_sub.stream_output("testing", popen_process)
 
-    assert capsys.readouterr().out == ("output line 1\n" "\n" "output line 3\n")
+    assert capsys.readouterr().out == "output line 1\n" "\n" "output line 3\n"
     mock_sub.cleanup.assert_called_once_with("testing", popen_process)
 
 
 def test_output_debug(mock_sub, popen_process, capsys):
-    """Readline output is printed; debug mode should not add extra output."""
+    """Process output is printed; no debug output for only stream_output."""
     mock_sub.command.logger = Log(verbosity=2)
 
     mock_sub.stream_output("testing", popen_process)
@@ -32,26 +33,6 @@ def test_output_debug(mock_sub, popen_process, capsys):
         "output line 1\n"
         "\n"
         "output line 3\n"
-        ">>> Return code: -3\n"
-    )
-    # fmt: on
-    assert capsys.readouterr().out == expected_output
-
-    mock_sub.cleanup.assert_called_once_with("testing", popen_process)
-
-
-def test_output_deep_debug(mock_sub, popen_process, capsys):
-    """Readline output is printed with debug return code in deep debug mode."""
-    mock_sub.command.logger = Log(verbosity=3)
-
-    mock_sub.stream_output("testing", popen_process)
-
-    # fmt: off
-    expected_output = (
-        "output line 1\n"
-        "\n"
-        "output line 3\n"
-        ">>> Return code: -3\n"
     )
     # fmt: on
     assert capsys.readouterr().out == expected_output
@@ -63,22 +44,12 @@ def test_keyboard_interrupt(mock_sub, popen_process, capsys):
     """KeyboardInterrupt is suppressed if user sends CTRL+C and all output is
     printed."""
 
-    def slow_poll(*a):
-        sleep(0.5)
-        return -3
-
-    # this helps ensure that the output streaming thread doesn't
-    # finish before is_alive() is called and therefore ensures
-    # that stop_func is always executed during this test.
-    popen_process.poll = mock.MagicMock()
-    popen_process.poll.side_effect = slow_poll
-
     send_ctrl_c = mock.MagicMock()
     send_ctrl_c.side_effect = [False, KeyboardInterrupt]
 
     mock_sub.stream_output("testing", popen_process, stop_func=send_ctrl_c)
 
-    assert capsys.readouterr().out == ("output line 1\n" "\n" "output line 3\n")
+    assert capsys.readouterr().out == "output line 1\n" "\n" "output line 3\n"
     mock_sub.cleanup.assert_called_once_with("testing", popen_process)
 
 
@@ -87,7 +58,7 @@ def test_process_exit_with_queued_output(mock_sub, popen_process, capsys):
     popen_process.poll.side_effect = [None, -3, -3, -3]
 
     mock_sub.stream_output("testing", popen_process)
-    assert capsys.readouterr().out == ("output line 1\n" "\n" "output line 3\n")
+    assert capsys.readouterr().out == "output line 1\n" "\n" "output line 3\n"
     mock_sub.cleanup.assert_called_once_with("testing", popen_process)
 
 
@@ -97,5 +68,34 @@ def test_stop_func(mock_sub, popen_process, stop_func_ret_val, capsys):
     mock_sub.stream_output(
         "testing", popen_process, stop_func=lambda: stop_func_ret_val
     )
-    assert capsys.readouterr().out == ("output line 1\n" "\n" "output line 3\n")
+    assert capsys.readouterr().out == "output line 1\n" "\n" "output line 3\n"
     mock_sub.cleanup.assert_called_once_with("testing", popen_process)
+
+
+def test_stuck_streamer(mock_sub, popen_process, monkeypatch, capsys):
+    """Following a KeyboardInterrupt, output streaming returns even if the
+    output streamer becomes stuck."""
+
+    # Flag for the mock streamer to exit and prevent it
+    # potentially printing in the middle of a later test.
+    monkeypatched_streamer_should_exit = Event()
+
+    def monkeypatched_blocked_streamer(*a, **kw):
+        """Simulate a streamer that blocks longer than it will be waited on."""
+        sleep(10)
+        if monkeypatched_streamer_should_exit.is_set():
+            return
+        print("This should not be printed while waiting on the streamer to exit")
+
+    monkeypatch.setattr(
+        mock_sub,
+        "_stream_output_thread",
+        monkeypatched_blocked_streamer,
+    )
+
+    send_ctrl_c = mock.MagicMock()
+    send_ctrl_c.side_effect = [False, KeyboardInterrupt]
+    mock_sub.stream_output("testing", popen_process, stop_func=send_ctrl_c)
+
+    assert capsys.readouterr().out == ""
+    monkeypatched_streamer_should_exit.set()


### PR DESCRIPTION
Interrupting the joining of a thread with CTRL+C can lead to deadlocking certain versions of Python (python/cpython#89437).

Changes:
 - Replaces calls to `join()` the streamer thread with waiting on `is_alive()`.
 - Instantiate the streamer thread as a daemon to prevent Python itself trying to join the thread.
 - Remove all logic from streamer thread that is not necessary to stream output.
   - This limits any race conditions between the streamer finishing and Python exiting.
   - This was noticeably a problem when the streamer thread was trying to print the return code.
 - As seen in Python itself, give some [cushion of time](https://github.com/python/cpython/blob/main/Lib/subprocess.py#L911) for the CTRL+C to propagate to child processes.
   - python/cpython#70130
   - This is necessary since subprocess commands run by `briefcase` can exit differently based on whether they are aborted by the user or encounter a different error.
   - For instance, when `adb` is streaming logs, it will emit a return code of `0xC000013A` when exiting from CTRL+C.

 - Fixes #809

CC: @mhsmith 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct