### PR TITLE
Fixes #831 - Improve documentation of release process.

### DIFF
--- a/changes/831.misc.rst
+++ b/changes/831.misc.rst
@@ -1,0 +1,1 @@
+Update release script to include pushing to main, and adding a RTD tag.

--- a/docs/how-to/internal/release.rst
+++ b/docs/how-to/internal/release.rst
@@ -58,19 +58,20 @@ The procedure for cutting a new release is as follows:
    once the workflow completes, there should be a new `draft release
    <https://github.com/beeware/briefcase/releases>`__.
 
-5. Edit the GitHub release. Add release notes (you can use the text generated
+5. Log into ReadTheDocs, visit the `Versions tab
+   <https://readthedocs.org/projects/briefcase/versions/>`__, and activate the
+   new version. Ensure that the build completes; if there's a problem, you
+   may need to correct the build configuration, roll back and re-tag the release.
+
+6. Edit the GitHub release. Add release notes (you can use the text generated
    by towncrier). Check the pre-release checkbox (if necessary).
 
-6. Double check everything, then click Publish. This will trigger a
+7. Double check everything, then click Publish. This will trigger a
    `publication workflow on GitHub
    <https://github.com/beeware/briefcase/actions?query=workflow%3A%22Upload+Python+Package%22>`__.
 
-7. Wait for the `package to appear on PyPI
+8. Wait for the `package to appear on PyPI
 <https://pypi.org/project/briefcase/>`__.
-
-8. Log into ReadTheDocs, visit the `Versions tab
-   <https://readthedocs.org/projects/briefcase/versions/>`__, and activate the
-   new version.
 
 Congratulations, you've just published a release!
 

--- a/docs/how-to/internal/release.rst
+++ b/docs/how-to/internal/release.rst
@@ -46,9 +46,10 @@ The procedure for cutting a new release is as follows:
    to generate the updated release notes. Submit the PR; once it's been
    reviewed and merged, you can restart the release process from step 1.
 
-3. Tag the release, and push the tag upstream::
+3. Tag the release, and push the branch and tag upstream::
 
     $ git tag v1.2.3
+    $ git push upstream main
     $ git push upstream v1.2.3
 
 4. Pushing the tag will start a workflow to create a draft release on GitHub.
@@ -66,6 +67,10 @@ The procedure for cutting a new release is as follows:
 
 7. Wait for the `package to appear on PyPI
 <https://pypi.org/project/briefcase/>`__.
+
+8. Log into ReadTheDocs, visit the `Versions tab
+   <https://readthedocs.org/projects/briefcase/versions/>`__, and activate the
+   new version.
 
 Congratulations, you've just published a release!
 


### PR DESCRIPTION
The 0.3.9 release revealed some small gaps in our release process. This adds the missing steps to the release script.

In addition, historical tagged releases have been made public on RTD. There are some missing tags (0.3.8, and releases before 03.6); this is because the docs configuration in those tags cannot built with the versions of Sphinx et al that are currently in the wild. This is because they have version pins that are incompatible with the currently available packages. If they had been built at the time, the historical build would have been preserved.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
