### PR TITLE
Raise `NetworkFailure` directly for download failures

### DIFF
--- a/changes/834.misc.rst
+++ b/changes/834.misc.rst
@@ -1,0 +1,1 @@
+Raise ``NetworkFailure`` directly when a download fails instead of catching ``ConnectionError`` upstream.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -621,7 +621,7 @@ or delete the old data directory, and re-run Briefcase.
                 f"""Configuration file not found. Did you run briefcase in the directory that contains {filename!r}?"""
             ) from e
 
-    def download_file(self, url, download_path, error_fragment=None):
+    def download_file(self, url, download_path, role=None):
         """Download a given URL, caching it. If it has already been downloaded,
         return the value that has been cached.
 
@@ -632,8 +632,9 @@ or delete the old data directory, and re-run Briefcase.
         :param url: The URL to download
         :param download_path: The path to the download cache folder. This path
             will be created if it doesn't exist.
-        :param error_fragment: error text that completes "Unable to {action}"
-            error text for NetworkFailure exception.
+        :param role: A string describing the role played by the file being
+            downloaded; used to construct log and error messages. Should be
+            able to fit into the sentence "Error downloading {role}".
         :returns: The filename of the downloaded (or cached) file.
         """
         download_path.mkdir(parents=True, exist_ok=True)
@@ -678,9 +679,11 @@ or delete the old data directory, and re-run Briefcase.
                                 progress_bar.update(task_id, advance=len(data))
 
         except requests.exceptions.ConnectionError as e:
-            if not error_fragment:
-                error_fragment = f"download {filename.name if filename else url}"
-            raise NetworkFailure(error_fragment) from e
+            if role:
+                description = role
+            else:
+                description = filename.name if filename else url
+            raise NetworkFailure(f"download {description}") from e
 
         return filename
 

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -29,6 +29,7 @@ from briefcase.exceptions import (
     BriefcaseConfigError,
     InfoHelpText,
     MissingNetworkResourceError,
+    NetworkFailure,
 )
 from briefcase.integrations.subprocess import Subprocess
 
@@ -620,7 +621,7 @@ or delete the old data directory, and re-run Briefcase.
                 f"""Configuration file not found. Did you run briefcase in the directory that contains {filename!r}?"""
             ) from e
 
-    def download_url(self, url, download_path):
+    def download_file(self, url, download_path, error_fragment=None):
         """Download a given URL, caching it. If it has already been downloaded,
         return the value that has been cached.
 
@@ -631,46 +632,56 @@ or delete the old data directory, and re-run Briefcase.
         :param url: The URL to download
         :param download_path: The path to the download cache folder. This path
             will be created if it doesn't exist.
+        :param error_fragment: error text that completes "Unable to {action}"
+            error text for NetworkFailure exception.
         :returns: The filename of the downloaded (or cached) file.
         """
         download_path.mkdir(parents=True, exist_ok=True)
+        filename = None
+        try:
+            response = self.requests.get(url, stream=True)
+            if response.status_code == 404:
+                raise MissingNetworkResourceError(url=url)
+            elif response.status_code != 200:
+                raise BadNetworkResourceError(url=url, status_code=response.status_code)
 
-        response = self.requests.get(url, stream=True)
-        if response.status_code == 404:
-            raise MissingNetworkResourceError(url=url)
-        elif response.status_code != 200:
-            raise BadNetworkResourceError(url=url, status_code=response.status_code)
+            # The initial URL might (read: will) go through URL redirects, so
+            # we need the *final* response. We look at either the `Content-Disposition`
+            # header, or the final URL, to extract the cache filename.
+            cache_full_name = urlparse(response.url).path
+            header_value = response.headers.get("Content-Disposition")
+            if header_value:
+                # See also https://tools.ietf.org/html/rfc6266
+                value, parameters = parse_header(header_value)
+                content_type = value.split(":", 1)[-1].strip().lower()
+                if content_type == "attachment" and parameters.get("filename"):
+                    cache_full_name = parameters["filename"]
+            cache_name = cache_full_name.split("/")[-1]
+            filename = download_path / cache_name
 
-        # The initial URL might (read: will) go through URL redirects, so
-        # we need the *final* response. We look at either the `Content-Disposition`
-        # header, or the final URL, to extract the cache filename.
-        cache_full_name = urlparse(response.url).path
-        header_value = response.headers.get("Content-Disposition")
-        if header_value:
-            # See also https://tools.ietf.org/html/rfc6266
-            value, parameters = parse_header(header_value)
-            content_type = value.split(":", 1)[-1].strip().lower()
-            if content_type == "attachment" and parameters.get("filename"):
-                cache_full_name = parameters["filename"]
-        cache_name = cache_full_name.split("/")[-1]
-        filename = download_path / cache_name
-        if not filename.exists():
-            # We have meaningful content, and it hasn't been cached previously,
-            # so save it in the requested location
-            self.logger.info(f"Downloading {cache_name}...")
-            with filename.open("wb") as f:
-                total = response.headers.get("content-length")
-                if total is None:
-                    f.write(response.content)
-                else:
-                    progress_bar = self.input.progress_bar()
-                    task_id = progress_bar.add_task("Downloader", total=int(total))
-                    with progress_bar:
-                        for data in response.iter_content(chunk_size=1024 * 1024):
-                            f.write(data)
-                            progress_bar.update(task_id, advance=len(data))
-        else:
-            self.logger.info(f"{cache_name} already downloaded")
+            if filename.exists():
+                self.logger.info(f"{cache_name} already downloaded")
+            else:
+                # We have meaningful content, and it hasn't been cached previously,
+                # so save it in the requested location
+                self.logger.info(f"Downloading {cache_name}...")
+                with filename.open("wb") as f:
+                    total = response.headers.get("content-length")
+                    if total is None:
+                        f.write(response.content)
+                    else:
+                        progress_bar = self.input.progress_bar()
+                        task_id = progress_bar.add_task("Downloader", total=int(total))
+                        with progress_bar:
+                            for data in response.iter_content(chunk_size=1024 * 1024):
+                                f.write(data)
+                                progress_bar.update(task_id, advance=len(data))
+
+        except requests.exceptions.ConnectionError as e:
+            if not error_fragment:
+                error_fragment = f"download {filename.name if filename else url}"
+            raise NetworkFailure(error_fragment) from e
+
         return filename
 
     def update_cookiecutter_cache(self, template: str, branch="master"):

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -377,7 +377,7 @@ class CreateCommand(BaseCommand):
                 return self.download_file(
                     url=support_package_url,
                     download_path=download_path,
-                    error_fragment="download support package",
+                    role="support package",
                 )
             else:
                 return Path(support_package_url)

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -10,7 +10,6 @@ from typing import Optional
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from cookiecutter import exceptions as cookiecutter_exceptions
-from requests import exceptions as requests_exceptions
 
 import briefcase
 from briefcase.config import BaseConfig
@@ -375,9 +374,10 @@ class CreateCommand(BaseCommand):
 
                 # Download the support file, caching the result
                 # in the user's briefcase support cache directory.
-                return self.download_url(
+                return self.download_file(
                     url=support_package_url,
                     download_path=download_path,
+                    error_fragment="download support package",
                 )
             else:
                 return Path(support_package_url)
@@ -390,9 +390,6 @@ class CreateCommand(BaseCommand):
                     python_version_tag=self.python_version_tag,
                     host_arch=self.host_arch,
                 ) from e
-
-        except requests_exceptions.ConnectionError as e:
-            raise NetworkFailure("downloading support package") from e
 
     def _write_requirements_file(self, app: BaseConfig, requirements_path):
         """Configure application dependencies by writing a requirements.txt

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -245,7 +245,7 @@ class AndroidSDK:
         cmdline_tools_zip_path = self.command.download_file(
             url=self.cmdline_tools_url,
             download_path=self.command.tools_path,
-            error_fragment="download Android SDK Command-Line Tools",
+            role="Android SDK Command-Line Tools",
         )
 
         # The cmdline-tools package *must* be installed as:
@@ -582,7 +582,7 @@ connection.
         skin_tgz_path = self.command.download_file(
             url=skin_url,
             download_path=self.root_path,
-            error_fragment=f"download {skin} device skin",
+            role=f"{skin} device skin",
         )
 
         # Unpack skin archive

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -6,15 +6,12 @@ import time
 from contextlib import suppress
 from pathlib import Path
 
-from requests import exceptions as requests_exceptions
-
 from briefcase.config import PEP508_NAME_RE
 from briefcase.console import InputDisabled, select_option
 from briefcase.exceptions import (
     BriefcaseCommandError,
     InvalidDeviceError,
     MissingToolError,
-    NetworkFailure,
 )
 from briefcase.integrations.java import JDK
 
@@ -245,13 +242,11 @@ class AndroidSDK:
 
     def install(self):
         """Download and install the Android SDK."""
-        try:
-            cmdline_tools_zip_path = self.command.download_url(
-                url=self.cmdline_tools_url,
-                download_path=self.command.tools_path,
-            )
-        except requests_exceptions.ConnectionError as e:
-            raise NetworkFailure("download Android SDK Command-Line Tools") from e
+        cmdline_tools_zip_path = self.command.download_file(
+            url=self.cmdline_tools_url,
+            download_path=self.command.tools_path,
+            error_fragment="download Android SDK Command-Line Tools",
+        )
 
         # The cmdline-tools package *must* be installed as:
         #     <sdk_path>/cmdline-tools/latest
@@ -584,13 +579,11 @@ connection.
             f"artwork/resources/device-art-resources/{skin}.tar.gz"
         )
 
-        try:
-            skin_tgz_path = self.command.download_url(
-                url=skin_url,
-                download_path=self.root_path,
-            )
-        except requests_exceptions.ConnectionError as e:
-            raise NetworkFailure(f"download {skin} device skin") from e
+        skin_tgz_path = self.command.download_file(
+            url=skin_url,
+            download_path=self.root_path,
+            error_fragment=f"download {skin} device skin",
+        )
 
         # Unpack skin archive
         with self.command.input.wait_bar("Installing device skin..."):

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -233,7 +233,7 @@ class JDK:
         jdk_zip_path = self.command.download_file(
             url=self.adoptOpenJDK_download_url,
             download_path=self.command.tools_path,
-            error_fragment="download Java 8 JDK",
+            role="Java 8 JDK",
         )
 
         with self.command.input.wait_bar("Installing AdoptOpenJDK..."):

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -3,12 +3,9 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from requests import exceptions as requests_exceptions
-
 from briefcase.exceptions import (
     BriefcaseCommandError,
     MissingToolError,
-    NetworkFailure,
     NonManagedToolError,
 )
 
@@ -233,13 +230,11 @@ class JDK:
 
     def install(self):
         """Download and install a JDK."""
-        try:
-            jdk_zip_path = self.command.download_url(
-                url=self.adoptOpenJDK_download_url,
-                download_path=self.command.tools_path,
-            )
-        except requests_exceptions.ConnectionError as e:
-            raise NetworkFailure("download Java 8 JDK") from e
+        jdk_zip_path = self.command.download_file(
+            url=self.adoptOpenJDK_download_url,
+            download_path=self.command.tools_path,
+            error_fragment="download Java 8 JDK",
+        )
 
         with self.command.input.wait_bar("Installing AdoptOpenJDK..."):
             try:

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -4,13 +4,10 @@ from abc import abstractmethod
 from pathlib import Path
 from urllib.parse import urlparse
 
-from requests import exceptions as requests_exceptions
-
 from briefcase.exceptions import (
     BriefcaseCommandError,
     CorruptToolError,
     MissingToolError,
-    NetworkFailure,
 )
 
 ELF_PATCH_OFFSET = 0x08
@@ -46,13 +43,11 @@ class LinuxDeployBase:
 
     def install(self):
         """Download and install linuxdeploy or plugin."""
-        try:
-            download_path = self.command.download_url(
-                url=self.download_url,
-                download_path=self.file_path,
-            )
-        except requests_exceptions.ConnectionError as e:
-            raise NetworkFailure(f"download {self.full_name}") from e
+        download_path = self.command.download_file(
+            url=self.download_url,
+            download_path=self.file_path,
+            error_fragment=f"download {self.full_name}",
+        )
 
         with self.command.input.wait_bar(f"Installing {self.full_name}..."):
             self.command.os.chmod(download_path, 0o755)

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -46,7 +46,7 @@ class LinuxDeployBase:
         download_path = self.command.download_file(
             url=self.download_url,
             download_path=self.file_path,
-            error_fragment=f"download {self.full_name}",
+            role=self.full_name,
         )
 
         with self.command.input.wait_bar(f"Installing {self.full_name}..."):

--- a/src/briefcase/integrations/rcedit.py
+++ b/src/briefcase/integrations/rcedit.py
@@ -1,6 +1,4 @@
-from requests import exceptions as requests_exceptions
-
-from briefcase.exceptions import MissingToolError, NetworkFailure
+from briefcase.exceptions import MissingToolError
 
 
 class RCEdit:
@@ -51,12 +49,11 @@ class RCEdit:
 
     def install(self):
         """Download and install RCEdit."""
-        try:
-            self.command.download_url(
-                url=self.download_url, download_path=self.command.tools_path
-            )
-        except requests_exceptions.ConnectionError as e:
-            raise NetworkFailure("downloading RCEdit") from e
+        self.command.download_file(
+            url=self.download_url,
+            download_path=self.command.tools_path,
+            error_fragment="download RCEdit",
+        )
 
     def uninstall(self):
         """Uninstall RCEdit."""

--- a/src/briefcase/integrations/rcedit.py
+++ b/src/briefcase/integrations/rcedit.py
@@ -52,7 +52,7 @@ class RCEdit:
         self.command.download_file(
             url=self.download_url,
             download_path=self.command.tools_path,
-            error_fragment="download RCEdit",
+            role="RCEdit",
         )
 
     def uninstall(self):

--- a/src/briefcase/integrations/wix.py
+++ b/src/briefcase/integrations/wix.py
@@ -126,7 +126,7 @@ WiX Toolset. Current value: {wix_home!r}
         wix_zip_path = self.command.download_file(
             url=WIX_DOWNLOAD_URL,
             download_path=self.command.tools_path,
-            error_fragment="download WiX",
+            role="WiX",
         )
 
         try:

--- a/src/briefcase/integrations/wix.py
+++ b/src/briefcase/integrations/wix.py
@@ -2,12 +2,9 @@ import os
 import shutil
 from pathlib import Path
 
-from requests import exceptions as requests_exceptions
-
 from briefcase.exceptions import (
     BriefcaseCommandError,
     MissingToolError,
-    NetworkFailure,
     NonManagedToolError,
 )
 
@@ -126,13 +123,11 @@ WiX Toolset. Current value: {wix_home!r}
 
     def install(self):
         """Download and install WiX."""
-        try:
-            wix_zip_path = self.command.download_url(
-                url=WIX_DOWNLOAD_URL,
-                download_path=self.command.tools_path,
-            )
-        except requests_exceptions.ConnectionError as e:
-            raise NetworkFailure("download WiX") from e
+        wix_zip_path = self.command.download_file(
+            url=WIX_DOWNLOAD_URL,
+            download_path=self.command.tools_path,
+            error_fragment="download WiX",
+        )
 
         try:
             with self.command.input.wait_bar("Installing WiX..."):

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -20,7 +20,7 @@ def test_install_app_support_package(
 ):
     """A support package can be downloaded and unpacked where it is needed."""
 
-    # Mock download_url to return a support package
+    # Mock download_file to return a support package
     create_command.download_file = mock.MagicMock(
         side_effect=mock_zip_download(
             "Python-3.X-OS-support.zip",
@@ -40,7 +40,7 @@ def test_install_app_support_package(
     create_command.download_file.assert_called_with(
         download_path=create_command.data_path / "support",
         url="https://briefcase-support.org/python?platform=tester&version=3.X&arch=gothic",
-        error_fragment="download support package",
+        role="support package",
     )
 
     # Confirm the right file was unpacked
@@ -66,7 +66,7 @@ def test_install_pinned_app_support_package(
     # Pin the support revision
     myapp.support_revision = "42"
 
-    # Mock download_url to return a support package
+    # Mock download_file to return a support package
     create_command.download_file = mock.MagicMock(
         side_effect=mock_zip_download(
             "Python-3.X-OS-support.zip",
@@ -86,7 +86,7 @@ def test_install_pinned_app_support_package(
     create_command.download_file.assert_called_with(
         download_path=create_command.data_path / "support",
         url="https://briefcase-support.org/python?platform=tester&version=3.X&arch=gothic&revision=42",
-        error_fragment="download support package",
+        role="support package",
     )
 
     # Confirm the right file was unpacked
@@ -117,7 +117,7 @@ def test_install_custom_app_support_package_file(
         [("internal/file.txt", "hello world")],
     )
 
-    # Modify download_url to return the temp zipfile
+    # Modify download_file to return the temp zipfile
     create_command.download_file = mock.MagicMock()
 
     # Mock shutil so we can confirm that unpack is called,
@@ -155,7 +155,7 @@ def test_support_package_url_with_invalid_custom_support_packge_url(
     url = "https://example.com/custom/support.zip"
     myapp.support_package = url
 
-    # Modify download_url to raise an exception
+    # Modify download_file to raise an exception
     create_command.download_file = mock.MagicMock(
         side_effect=MissingNetworkResourceError(url)
     )
@@ -172,7 +172,7 @@ def test_support_package_url_with_invalid_custom_support_packge_url(
             / "55441abbffa311f65622df45a943afc347a21ab40e8dcec79472c92ef467db24"
         ),
         url=url,
-        error_fragment="download support package",
+        role="support package",
     )
 
 
@@ -185,7 +185,7 @@ def test_support_package_url_with_unsupported_platform(
     # Set the host architecture to something unsupported
     create_command.host_arch = "unknown"
 
-    # Modify download_url to raise an exception due to missing support package
+    # Modify download_file to raise an exception due to missing support package
     create_command.download_file = mock.MagicMock(
         side_effect=MissingNetworkResourceError(
             "https://briefcase-support.org/python?platform=tester&version=3.X&arch=unknown"
@@ -200,7 +200,7 @@ def test_support_package_url_with_unsupported_platform(
     create_command.download_file.assert_called_with(
         download_path=create_command.data_path / "support",
         url="https://briefcase-support.org/python?platform=tester&version=3.X&arch=unknown",
-        error_fragment="download support package",
+        role="support package",
     )
 
 
@@ -215,7 +215,7 @@ def test_install_custom_app_support_package_url(
     # Provide an app-specific override of the package URL
     myapp.support_package = "https://example.com/custom/custom-support.zip"
 
-    # Mock download_url to return a support package
+    # Mock download_file to return a support package
     create_command.download_file = mock.MagicMock(
         side_effect=mock_zip_download(
             "custom-support.zip",
@@ -239,7 +239,7 @@ def test_install_custom_app_support_package_url(
             / "1d3ac0e09eb22abc63c4e7b699b6ab5d58e277015eeae61070e3f9f11512e6b3"
         ),
         url="https://example.com/custom/custom-support.zip",
-        error_fragment="download support package",
+        role="support package",
     )
 
     # Confirm the right file was unpacked into the hashed location
@@ -272,7 +272,7 @@ def test_install_pinned_custom_app_support_package_url(
     # Provide an app-specific override of the package URL
     myapp.support_package = "https://example.com/custom/custom-support.zip"
 
-    # Mock download_url to return a support package
+    # Mock download_file to return a support package
     create_command.download_file = mock.MagicMock(
         side_effect=mock_zip_download(
             "custom-support.zip",
@@ -296,7 +296,7 @@ def test_install_pinned_custom_app_support_package_url(
             / "6390bc0eb3eca03218604f6072094d44f44d82eacefc21975cc5b9b7b1720a0d"
         ),
         url="https://example.com/custom/custom-support.zip?revision=42",
-        error_fragment="download support package",
+        role="support package",
     )
 
     # Confirm the right file was unpacked
@@ -329,7 +329,7 @@ def test_install_pinned_custom_app_support_package_url_with_args(
     # Provide an app-specific override of the package URL
     myapp.support_package = "https://example.com/custom/custom-support.zip?cool=Yes"
 
-    # Mock download_url to return a support package
+    # Mock download_file to return a support package
     create_command.download_file = mock.MagicMock(
         side_effect=mock_zip_download(
             "custom-support.zip",
@@ -350,7 +350,7 @@ def test_install_pinned_custom_app_support_package_url_with_args(
         / "support"
         / "1a7054ce49ce29aeec90591be2d69cd655bd5414f4a9017425026760a375847b",
         url="https://example.com/custom/custom-support.zip?cool=Yes&revision=42",
-        error_fragment="download support package",
+        role="support package",
     )
 
     # Confirm the right file was unpacked
@@ -392,7 +392,7 @@ def test_invalid_support_package(
     app_requirements_path_index,
 ):
     """If the support package isn't a valid zipfile, an error is raised."""
-    # Mock download_url to return a non-zip file
+    # Mock download_file to return a non-zip file
     create_command.download_file = mock.MagicMock(
         side_effect=mock_file_download(
             "not-a.zip",

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -21,7 +21,7 @@ def test_install_app_support_package(
     """A support package can be downloaded and unpacked where it is needed."""
 
     # Mock download_url to return a support package
-    create_command.download_url = mock.MagicMock(
+    create_command.download_file = mock.MagicMock(
         side_effect=mock_zip_download(
             "Python-3.X-OS-support.zip",
             [("internal/file.txt", "hello world")],
@@ -37,9 +37,10 @@ def test_install_app_support_package(
     create_command.install_app_support_package(myapp)
 
     # Confirm the right URL was used
-    create_command.download_url.assert_called_with(
+    create_command.download_file.assert_called_with(
         download_path=create_command.data_path / "support",
         url="https://briefcase-support.org/python?platform=tester&version=3.X&arch=gothic",
+        error_fragment="download support package",
     )
 
     # Confirm the right file was unpacked
@@ -66,7 +67,7 @@ def test_install_pinned_app_support_package(
     myapp.support_revision = "42"
 
     # Mock download_url to return a support package
-    create_command.download_url = mock.MagicMock(
+    create_command.download_file = mock.MagicMock(
         side_effect=mock_zip_download(
             "Python-3.X-OS-support.zip",
             [("internal/file.txt", "hello world")],
@@ -82,9 +83,10 @@ def test_install_pinned_app_support_package(
     create_command.install_app_support_package(myapp)
 
     # Confirm the right URL was used
-    create_command.download_url.assert_called_with(
+    create_command.download_file.assert_called_with(
         download_path=create_command.data_path / "support",
         url="https://briefcase-support.org/python?platform=tester&version=3.X&arch=gothic&revision=42",
+        error_fragment="download support package",
     )
 
     # Confirm the right file was unpacked
@@ -116,7 +118,7 @@ def test_install_custom_app_support_package_file(
     )
 
     # Modify download_url to return the temp zipfile
-    create_command.download_url = mock.MagicMock()
+    create_command.download_file = mock.MagicMock()
 
     # Mock shutil so we can confirm that unpack is called,
     # but we still want the side effect of calling it
@@ -128,7 +130,7 @@ def test_install_custom_app_support_package_file(
 
     # There should have been no download attempt,
     # as the resource is local.
-    create_command.download_url.assert_not_called()
+    create_command.download_file.assert_not_called()
 
     # Confirm the right file was unpacked
     create_command.shutil.unpack_archive.assert_called_with(
@@ -154,7 +156,7 @@ def test_support_package_url_with_invalid_custom_support_packge_url(
     myapp.support_package = url
 
     # Modify download_url to raise an exception
-    create_command.download_url = mock.MagicMock(
+    create_command.download_file = mock.MagicMock(
         side_effect=MissingNetworkResourceError(url)
     )
 
@@ -163,13 +165,14 @@ def test_support_package_url_with_invalid_custom_support_packge_url(
         create_command.install_app_support_package(myapp)
 
     # However, there will have been a download attempt
-    create_command.download_url.assert_called_with(
+    create_command.download_file.assert_called_with(
         download_path=(
             create_command.data_path
             / "support"
             / "55441abbffa311f65622df45a943afc347a21ab40e8dcec79472c92ef467db24"
         ),
         url=url,
+        error_fragment="download support package",
     )
 
 
@@ -183,7 +186,7 @@ def test_support_package_url_with_unsupported_platform(
     create_command.host_arch = "unknown"
 
     # Modify download_url to raise an exception due to missing support package
-    create_command.download_url = mock.MagicMock(
+    create_command.download_file = mock.MagicMock(
         side_effect=MissingNetworkResourceError(
             "https://briefcase-support.org/python?platform=tester&version=3.X&arch=unknown"
         )
@@ -194,9 +197,10 @@ def test_support_package_url_with_unsupported_platform(
         create_command.install_app_support_package(myapp)
 
     # However, there will have been a download attempt
-    create_command.download_url.assert_called_with(
+    create_command.download_file.assert_called_with(
         download_path=create_command.data_path / "support",
         url="https://briefcase-support.org/python?platform=tester&version=3.X&arch=unknown",
+        error_fragment="download support package",
     )
 
 
@@ -212,7 +216,7 @@ def test_install_custom_app_support_package_url(
     myapp.support_package = "https://example.com/custom/custom-support.zip"
 
     # Mock download_url to return a support package
-    create_command.download_url = mock.MagicMock(
+    create_command.download_file = mock.MagicMock(
         side_effect=mock_zip_download(
             "custom-support.zip",
             [("internal/file.txt", "hello world")],
@@ -228,13 +232,14 @@ def test_install_custom_app_support_package_url(
     create_command.install_app_support_package(myapp)
 
     # Confirm the right URL and download path was used
-    create_command.download_url.assert_called_with(
+    create_command.download_file.assert_called_with(
         download_path=(
             create_command.data_path
             / "support"
             / "1d3ac0e09eb22abc63c4e7b699b6ab5d58e277015eeae61070e3f9f11512e6b3"
         ),
         url="https://example.com/custom/custom-support.zip",
+        error_fragment="download support package",
     )
 
     # Confirm the right file was unpacked into the hashed location
@@ -268,7 +273,7 @@ def test_install_pinned_custom_app_support_package_url(
     myapp.support_package = "https://example.com/custom/custom-support.zip"
 
     # Mock download_url to return a support package
-    create_command.download_url = mock.MagicMock(
+    create_command.download_file = mock.MagicMock(
         side_effect=mock_zip_download(
             "custom-support.zip",
             [("internal/file.txt", "hello world")],
@@ -284,13 +289,14 @@ def test_install_pinned_custom_app_support_package_url(
     create_command.install_app_support_package(myapp)
 
     # Confirm the right URL and download path was used
-    create_command.download_url.assert_called_with(
+    create_command.download_file.assert_called_with(
         download_path=(
             create_command.data_path
             / "support"
             / "6390bc0eb3eca03218604f6072094d44f44d82eacefc21975cc5b9b7b1720a0d"
         ),
         url="https://example.com/custom/custom-support.zip?revision=42",
+        error_fragment="download support package",
     )
 
     # Confirm the right file was unpacked
@@ -324,7 +330,7 @@ def test_install_pinned_custom_app_support_package_url_with_args(
     myapp.support_package = "https://example.com/custom/custom-support.zip?cool=Yes"
 
     # Mock download_url to return a support package
-    create_command.download_url = mock.MagicMock(
+    create_command.download_file = mock.MagicMock(
         side_effect=mock_zip_download(
             "custom-support.zip",
             [("internal/file.txt", "hello world")],
@@ -339,11 +345,12 @@ def test_install_pinned_custom_app_support_package_url_with_args(
     create_command.install_app_support_package(myapp)
 
     # Confirm the right URL was used
-    create_command.download_url.assert_called_with(
+    create_command.download_file.assert_called_with(
         download_path=create_command.data_path
         / "support"
         / "1a7054ce49ce29aeec90591be2d69cd655bd5414f4a9017425026760a375847b",
         url="https://example.com/custom/custom-support.zip?cool=Yes&revision=42",
+        error_fragment="download support package",
     )
 
     # Confirm the right file was unpacked
@@ -368,7 +375,7 @@ def test_offline_install(
     app_requirements_path_index,
 ):
     """If the computer is offline, an error is raised."""
-    create_command.download_url = mock.MagicMock(
+    create_command.requests.get = mock.MagicMock(
         side_effect=requests_exceptions.ConnectionError
     )
 
@@ -386,7 +393,7 @@ def test_invalid_support_package(
 ):
     """If the support package isn't a valid zipfile, an error is raised."""
     # Mock download_url to return a non-zip file
-    create_command.download_url = mock.MagicMock(
+    create_command.download_file = mock.MagicMock(
         side_effect=mock_file_download(
             "not-a.zip",
             "This isn't a zip file",
@@ -418,6 +425,6 @@ def test_missing_support_package(
 def test_no_support_path(create_command, myapp, no_support_path_index):
     """If support_path is not listed in briefcase.toml, a support package will
     not be downloaded."""
-    create_command.download_url = mock.MagicMock()
+    create_command.download_file = mock.MagicMock()
     create_command.install_app_support_package(myapp)
-    create_command.download_url.assert_not_called()
+    create_command.download_file.assert_not_called()

--- a/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
@@ -177,7 +177,7 @@ def test_default_name(mock_sdk, tmp_path):
     # MagicMock below py3.8 doesn't has __fspath__ attribute.
     if sys.version_info < (3, 8):
         skin_tgz_path = FsPathMock("")
-        mock_sdk.command.download_url.return_value = skin_tgz_path
+        mock_sdk.command.download_file.return_value = skin_tgz_path
 
     # Create the emulator
     avd = mock_sdk.create_emulator()
@@ -214,7 +214,7 @@ def test_default_name_with_collisions(mock_sdk, tmp_path):
     # MagicMock below py3.8 doesn't has __fspath__ attribute.
     if sys.version_info < (3, 8):
         skin_tgz_path = FsPathMock("")
-        mock_sdk.command.download_url.return_value = skin_tgz_path
+        mock_sdk.command.download_file.return_value = skin_tgz_path
 
     # Create the emulator
     avd = mock_sdk.create_emulator()

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -35,7 +35,7 @@ def mock_command(tmp_path):
         "Linux": "linux",
     }[command.host_os]
     # Override some other modules so we can test side-effects.
-    command.download_url = MagicMock()
+    command.download_file = MagicMock()
     command.subprocess = MagicMock()
     command.shutil = MagicMock()
     # Use the original module rmtree implementation
@@ -274,7 +274,7 @@ def test_download_sdk(mock_command, tmp_path):
     mock_command.download_file.assert_called_once_with(
         url=url,
         download_path=mock_command.tools_path,
-        error_fragment="download Android SDK Command-Line Tools",
+        role="Android SDK Command-Line Tools",
     )
 
     mock_command.shutil.unpack_archive.assert_called_once_with(
@@ -343,7 +343,7 @@ def test_download_sdk_legacy_install(mock_command, tmp_path):
     mock_command.download_file.assert_called_once_with(
         url=url,
         download_path=mock_command.tools_path,
-        error_fragment="download Android SDK Command-Line Tools",
+        role="Android SDK Command-Line Tools",
     )
 
     mock_command.shutil.unpack_archive.assert_called_once_with(
@@ -425,7 +425,7 @@ def test_download_sdk_if_sdkmanager_not_executable(mock_command, tmp_path):
     mock_command.download_file.assert_called_once_with(
         url=url,
         download_path=mock_command.tools_path,
-        error_fragment="download Android SDK Command-Line Tools",
+        role="Android SDK Command-Line Tools",
     )
 
     mock_command.shutil.unpack_archive.assert_called_once_with(
@@ -457,7 +457,7 @@ def test_raises_networkfailure_on_connectionerror(mock_command):
     mock_command.download_file.assert_called_once_with(
         url=url,
         download_path=mock_command.tools_path,
-        error_fragment="download Android SDK Command-Line Tools",
+        role="Android SDK Command-Line Tools",
     )
     # But no unpack occurred
     assert mock_command.shutil.unpack_archive.call_count == 0
@@ -484,7 +484,7 @@ def test_detects_bad_zipfile(mock_command, tmp_path):
     mock_command.download_file.assert_called_once_with(
         url=url,
         download_path=mock_command.tools_path,
-        error_fragment="download Android SDK Command-Line Tools",
+        role="Android SDK Command-Line Tools",
     )
     mock_command.shutil.unpack_archive.assert_called_once_with(
         cache_file, extract_dir=android_sdk_root_path / "cmdline-tools"

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -5,7 +5,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-from requests import exceptions as requests_exceptions
 
 from briefcase.console import Log
 from briefcase.exceptions import BriefcaseCommandError, MissingToolError, NetworkFailure
@@ -100,7 +99,7 @@ def test_succeeds_immediately_in_happy_path(mock_command, tmp_path, jdk):
     sdk = AndroidSDK.verify(mock_command, jdk=jdk)
 
     # No calls to download, run or unpack anything.
-    mock_command.download_url.assert_not_called()
+    mock_command.download_file.assert_not_called()
     mock_command.subprocess.run.assert_not_called()
     mock_command.shutil.unpack_archive.assert_not_called()
 
@@ -140,7 +139,7 @@ def test_succeeds_immediately_in_happy_path_with_debug(mock_command, tmp_path, j
     sdk = AndroidSDK.verify(mock_command, jdk=jdk)
 
     # No calls to download or unpack anything.
-    mock_command.download_url.assert_not_called()
+    mock_command.download_file.assert_not_called()
     mock_command.shutil.unpack_archive.assert_not_called()
 
     # The returned SDK has the expected root path.
@@ -175,7 +174,7 @@ def test_user_provided_sdk(mock_command, tmp_path, jdk):
     sdk = AndroidSDK.verify(mock_command, jdk=jdk)
 
     # No calls to download or unpack anything.
-    mock_command.download_url.assert_not_called()
+    mock_command.download_file.assert_not_called()
     mock_command.shutil.unpack_archive.assert_not_called()
 
     # The returned SDK has the expected root path.
@@ -208,7 +207,7 @@ def test_user_provided_sdk_with_debug(mock_command, tmp_path, jdk):
     sdk = AndroidSDK.verify(mock_command, jdk=jdk)
 
     # No calls to download, run or unpack anything.
-    mock_command.download_url.assert_not_called()
+    mock_command.download_file.assert_not_called()
     mock_command.subprocess.run.assert_not_called()
     mock_command.shutil.unpack_archive.assert_not_called()
 
@@ -241,7 +240,7 @@ def test_invalid_user_provided_sdk(mock_command, tmp_path, jdk):
     sdk = AndroidSDK.verify(mock_command, jdk=jdk)
 
     # No calls to download, run or unpack anything.
-    mock_command.download_url.assert_not_called()
+    mock_command.download_file.assert_not_called()
     mock_command.subprocess.run.assert_not_called()
     mock_command.shutil.unpack_archive.assert_not_called()
 
@@ -256,7 +255,7 @@ def test_download_sdk(mock_command, tmp_path):
 
     # The download will produce a cached file.
     cache_file = MagicMock()
-    mock_command.download_url.return_value = cache_file
+    mock_command.download_file.return_value = cache_file
 
     # Calling unpack will create files
     mock_command.shutil.unpack_archive.side_effect = mock_unpack
@@ -272,9 +271,10 @@ def test_download_sdk(mock_command, tmp_path):
         "https://dl.google.com/android/repository/"
         f"commandlinetools-{mock_command._test_download_tag}-8092744_latest.zip"
     )
-    mock_command.download_url.assert_called_once_with(
+    mock_command.download_file.assert_called_once_with(
         url=url,
         download_path=mock_command.tools_path,
+        error_fragment="download Android SDK Command-Line Tools",
     )
 
     mock_command.shutil.unpack_archive.assert_called_once_with(
@@ -324,7 +324,7 @@ def test_download_sdk_legacy_install(mock_command, tmp_path):
 
     # The download will produce a cached file.
     cache_file = MagicMock()
-    mock_command.download_url.return_value = cache_file
+    mock_command.download_file.return_value = cache_file
 
     # Calling unpack will create files
     mock_command.shutil.unpack_archive.side_effect = mock_unpack
@@ -340,9 +340,10 @@ def test_download_sdk_legacy_install(mock_command, tmp_path):
         "https://dl.google.com/android/repository/"
         f"commandlinetools-{mock_command._test_download_tag}-8092744_latest.zip"
     )
-    mock_command.download_url.assert_called_once_with(
+    mock_command.download_file.assert_called_once_with(
         url=url,
         download_path=mock_command.tools_path,
+        error_fragment="download Android SDK Command-Line Tools",
     )
 
     mock_command.shutil.unpack_archive.assert_called_once_with(
@@ -385,7 +386,7 @@ def test_no_install(mock_command, tmp_path):
     with pytest.raises(MissingToolError):
         AndroidSDK.verify(mock_command, jdk=MagicMock(), install=False)
 
-    assert mock_command.download_url.call_count == 0
+    assert mock_command.download_file.call_count == 0
 
 
 @pytest.mark.skipif(
@@ -405,7 +406,7 @@ def test_download_sdk_if_sdkmanager_not_executable(mock_command, tmp_path):
 
     # The download will produce a cached file
     cache_file = MagicMock()
-    mock_command.download_url.return_value = cache_file
+    mock_command.download_file.return_value = cache_file
 
     # Calling unpack will create files
     mock_command.shutil.unpack_archive.side_effect = mock_unpack
@@ -421,9 +422,10 @@ def test_download_sdk_if_sdkmanager_not_executable(mock_command, tmp_path):
         "https://dl.google.com/android/repository/"
         f"commandlinetools-{mock_command._test_download_tag}-8092744_latest.zip"
     )
-    mock_command.download_url.assert_called_once_with(
+    mock_command.download_file.assert_called_once_with(
         url=url,
         download_path=mock_command.tools_path,
+        error_fragment="download Android SDK Command-Line Tools",
     )
 
     mock_command.shutil.unpack_archive.assert_called_once_with(
@@ -442,9 +444,9 @@ def test_download_sdk_if_sdkmanager_not_executable(mock_command, tmp_path):
 
 def test_raises_networkfailure_on_connectionerror(mock_command):
     """If an error occurs downloading the ZIP file, and error is raised."""
-    mock_command.download_url.side_effect = requests_exceptions.ConnectionError()
+    mock_command.download_file.side_effect = NetworkFailure("mock")
 
-    with pytest.raises(NetworkFailure):
+    with pytest.raises(NetworkFailure, match="Unable to mock"):
         AndroidSDK.verify(mock_command, jdk=MagicMock())
 
     # The download was attempted
@@ -452,9 +454,10 @@ def test_raises_networkfailure_on_connectionerror(mock_command):
         "https://dl.google.com/android/repository/"
         f"commandlinetools-{mock_command._test_download_tag}-8092744_latest.zip"
     )
-    mock_command.download_url.assert_called_once_with(
+    mock_command.download_file.assert_called_once_with(
         url=url,
         download_path=mock_command.tools_path,
+        error_fragment="download Android SDK Command-Line Tools",
     )
     # But no unpack occurred
     assert mock_command.shutil.unpack_archive.call_count == 0
@@ -465,7 +468,7 @@ def test_detects_bad_zipfile(mock_command, tmp_path):
     android_sdk_root_path = tmp_path / "tools" / "android_sdk"
 
     cache_file = MagicMock()
-    mock_command.download_url.return_value = cache_file
+    mock_command.download_file.return_value = cache_file
 
     # But the unpack will fail.
     mock_command.shutil.unpack_archive.side_effect = shutil.ReadError
@@ -478,9 +481,10 @@ def test_detects_bad_zipfile(mock_command, tmp_path):
         "https://dl.google.com/android/repository/"
         f"commandlinetools-{mock_command._test_download_tag}-8092744_latest.zip"
     )
-    mock_command.download_url.assert_called_once_with(
+    mock_command.download_file.assert_called_once_with(
         url=url,
         download_path=mock_command.tools_path,
+        error_fragment="download Android SDK Command-Line Tools",
     )
     mock_command.shutil.unpack_archive.assert_called_once_with(
         cache_file, extract_dir=android_sdk_root_path / "cmdline-tools"

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
@@ -15,7 +15,7 @@ def test_existing_skin(mock_sdk):
     # Verify the system image that we already have
     mock_sdk.verify_emulator_skin("pixel_X")
 
-    # download_url was *not* called.
+    # download_file was *not* called.
     mock_sdk.command.download_file.assert_not_called()
 
 
@@ -39,7 +39,7 @@ def test_new_skin(mock_sdk):
         "+archive/refs/heads/mirror-goog-studio-main/"
         "artwork/resources/device-art-resources/pixel_X.tar.gz",
         download_path=mock_sdk.root_path,
-        error_fragment="download pixel_X device skin",
+        role="pixel_X device skin",
     )
 
     # Skin is unpacked.
@@ -75,7 +75,7 @@ def test_skin_download_failure(mock_sdk, tmp_path):
         "+archive/refs/heads/mirror-goog-studio-main/"
         "artwork/resources/device-art-resources/pixel_X.tar.gz",
         download_path=mock_sdk.root_path,
-        error_fragment="download pixel_X device skin",
+        role="pixel_X device skin",
     )
 
     # Skin wasn't downloaded, so it wasn't unpacked
@@ -110,7 +110,7 @@ def test_unpack_failure(mock_sdk, tmp_path):
         "+archive/refs/heads/mirror-goog-studio-main/"
         "artwork/resources/device-art-resources/pixel_X.tar.gz",
         download_path=mock_sdk.root_path,
-        error_fragment="download pixel_X device skin",
+        role="pixel_X device skin",
     )
 
     # An attempt to unpack the skin was made.

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
@@ -2,7 +2,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-from requests import exceptions as requests_exceptions
 
 from briefcase.exceptions import BriefcaseCommandError, NetworkFailure
 from tests.utils import FsPathMock
@@ -17,7 +16,7 @@ def test_existing_skin(mock_sdk):
     mock_sdk.verify_emulator_skin("pixel_X")
 
     # download_url was *not* called.
-    mock_sdk.command.download_url.assert_not_called()
+    mock_sdk.command.download_file.assert_not_called()
 
 
 def test_new_skin(mock_sdk):
@@ -29,17 +28,18 @@ def test_new_skin(mock_sdk):
     else:
         skin_tgz_path = MagicMock()
         skin_tgz_path.__fspath__.return_value = "/path/to/skin.tgz"
-    mock_sdk.command.download_url.return_value = skin_tgz_path
+    mock_sdk.command.download_file.return_value = skin_tgz_path
 
     # Verify the skin, triggering a download
     mock_sdk.verify_emulator_skin("pixel_X")
 
     # Skin was downloaded
-    mock_sdk.command.download_url.assert_called_once_with(
+    mock_sdk.command.download_file.assert_called_once_with(
         url="https://android.googlesource.com/platform/tools/adt/idea/"
         "+archive/refs/heads/mirror-goog-studio-main/"
         "artwork/resources/device-art-resources/pixel_X.tar.gz",
         download_path=mock_sdk.root_path,
+        error_fragment="download pixel_X device skin",
     )
 
     # Skin is unpacked.
@@ -60,21 +60,22 @@ def test_skin_download_failure(mock_sdk, tmp_path):
     else:
         skin_tgz_path = MagicMock()
         skin_tgz_path.__fspath__.return_value = "/path/to/skin.tgz"
-    mock_sdk.command.download_url.return_value = skin_tgz_path
+    mock_sdk.command.download_file.return_value = skin_tgz_path
 
     # Mock a failure downloading the skin
-    mock_sdk.command.download_url.side_effect = requests_exceptions.ConnectionError
+    mock_sdk.command.download_file.side_effect = NetworkFailure("mock")
 
     # Verify the skin, triggering a download
-    with pytest.raises(NetworkFailure):
+    with pytest.raises(NetworkFailure, match="Unable to mock"):
         mock_sdk.verify_emulator_skin("pixel_X")
 
     # An attempt was made to download the skin
-    mock_sdk.command.download_url.assert_called_once_with(
+    mock_sdk.command.download_file.assert_called_once_with(
         url="https://android.googlesource.com/platform/tools/adt/idea/"
         "+archive/refs/heads/mirror-goog-studio-main/"
         "artwork/resources/device-art-resources/pixel_X.tar.gz",
         download_path=mock_sdk.root_path,
+        error_fragment="download pixel_X device skin",
     )
 
     # Skin wasn't downloaded, so it wasn't unpacked
@@ -91,7 +92,7 @@ def test_unpack_failure(mock_sdk, tmp_path):
     else:
         skin_tgz_path = MagicMock()
         skin_tgz_path.__fspath__.return_value = "/path/to/skin.tgz"
-    mock_sdk.command.download_url.return_value = skin_tgz_path
+    mock_sdk.command.download_file.return_value = skin_tgz_path
 
     # Mock a failure unpacking the skin
     mock_sdk.command.shutil.unpack_archive.side_effect = EOFError
@@ -104,11 +105,12 @@ def test_unpack_failure(mock_sdk, tmp_path):
         mock_sdk.verify_emulator_skin("pixel_X")
 
     # Skin was downloaded
-    mock_sdk.command.download_url.assert_called_once_with(
+    mock_sdk.command.download_file.assert_called_once_with(
         url="https://android.googlesource.com/platform/tools/adt/idea/"
         "+archive/refs/heads/mirror-goog-studio-main/"
         "artwork/resources/device-art-resources/pixel_X.tar.gz",
         download_path=mock_sdk.root_path,
+        error_fragment="download pixel_X device skin",
     )
 
     # An attempt to unpack the skin was made.

--- a/tests/integrations/java/test_JDK__verify.py
+++ b/tests/integrations/java/test_JDK__verify.py
@@ -334,7 +334,7 @@ def test_successful_jdk_download(
     test_command.download_file.assert_called_with(
         url=jdk_url,
         download_path=tmp_path / "tools",
-        error_fragment="download Java 8 JDK",
+        role="Java 8 JDK",
     )
     # The archive was unpacked
     # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
@@ -376,7 +376,7 @@ def test_jdk_download_failure(test_command, tmp_path):
         url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
         "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
         download_path=tmp_path / "tools",
-        error_fragment="download Java 8 JDK",
+        role="Java 8 JDK",
     )
     # No attempt was made to unpack the archive
     assert test_command.shutil.unpack_archive.call_count == 0
@@ -408,7 +408,7 @@ def test_invalid_jdk_archive(test_command, tmp_path):
         url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
         "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
         download_path=tmp_path / "tools",
-        error_fragment="download Java 8 JDK",
+        role="Java 8 JDK",
     )
     # An attempt was made to unpack the archive.
     # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7

--- a/tests/integrations/java/test_JDK__verify.py
+++ b/tests/integrations/java/test_JDK__verify.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from requests import exceptions as requests_exceptions
 
 from briefcase.console import Log
 from briefcase.exceptions import BriefcaseCommandError, MissingToolError, NetworkFailure
@@ -316,7 +315,7 @@ def test_successful_jdk_download(
     else:
         archive = mock.MagicMock()
         archive.__fspath__.return_value = "/path/to/download.zip"
-    test_command.download_url.return_value = archive
+    test_command.download_file.return_value = archive
 
     # Create a directory to make it look like Java was downloaded and unpacked.
     (tmp_path / "tools" / "jdk8u242-b08").mkdir(parents=True)
@@ -332,9 +331,10 @@ def test_successful_jdk_download(
     assert "** WARNING: JAVA_HOME does not point to a Java 8 JDK" in output.out
 
     # Download was invoked
-    test_command.download_url.assert_called_with(
+    test_command.download_file.assert_called_with(
         url=jdk_url,
         download_path=tmp_path / "tools",
+        error_fragment="download Java 8 JDK",
     )
     # The archive was unpacked
     # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
@@ -356,7 +356,7 @@ def test_not_installed(test_command, tmp_path):
         JDK.verify(command=test_command, install=False)
 
     # Download was not invoked
-    assert test_command.download_url.call_count == 0
+    assert test_command.download_file.call_count == 0
 
 
 def test_jdk_download_failure(test_command, tmp_path):
@@ -365,17 +365,18 @@ def test_jdk_download_failure(test_command, tmp_path):
     test_command.host_os = "Linux"
 
     # Mock a failure on download
-    test_command.download_url.side_effect = requests_exceptions.ConnectionError
+    test_command.download_file.side_effect = NetworkFailure("mock")
 
     # Invoking verify_jdk causes a network failure.
-    with pytest.raises(NetworkFailure):
+    with pytest.raises(NetworkFailure, match="Unable to mock"):
         JDK.verify(command=test_command)
 
     # That download was attempted
-    test_command.download_url.assert_called_with(
+    test_command.download_file.assert_called_with(
         url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
         "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
         download_path=tmp_path / "tools",
+        error_fragment="download Java 8 JDK",
     )
     # No attempt was made to unpack the archive
     assert test_command.shutil.unpack_archive.call_count == 0
@@ -394,7 +395,7 @@ def test_invalid_jdk_archive(test_command, tmp_path):
     else:
         archive = mock.MagicMock()
         archive.__fspath__.return_value = "/path/to/download.zip"
-    test_command.download_url.return_value = archive
+    test_command.download_file.return_value = archive
 
     # Mock an unpack failure due to an invalid archive
     test_command.shutil.unpack_archive.side_effect = shutil.ReadError
@@ -403,10 +404,11 @@ def test_invalid_jdk_archive(test_command, tmp_path):
         JDK.verify(command=test_command)
 
     # The download occurred
-    test_command.download_url.assert_called_with(
+    test_command.download_file.assert_called_with(
         url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
         "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
         download_path=tmp_path / "tools",
+        error_fragment="download Java 8 JDK",
     )
     # An attempt was made to unpack the archive.
     # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7

--- a/tests/integrations/java/test_JDK_upgrade.py
+++ b/tests/integrations/java/test_JDK_upgrade.py
@@ -4,7 +4,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-from requests import exceptions as requests_exceptions
 
 from briefcase.exceptions import (
     BriefcaseCommandError,
@@ -37,7 +36,7 @@ def test_non_managed_install(test_command, tmp_path, capsys):
         jdk.upgrade()
 
     # No download was attempted
-    assert test_command.download_url.call_count == 0
+    assert test_command.download_file.call_count == 0
 
 
 def test_non_existing_install(test_command, tmp_path):
@@ -49,7 +48,7 @@ def test_non_existing_install(test_command, tmp_path):
         jdk.upgrade()
 
     # No download was attempted
-    assert test_command.download_url.call_count == 0
+    assert test_command.download_file.call_count == 0
 
 
 def test_existing_install(test_command, tmp_path):
@@ -73,7 +72,7 @@ def test_existing_install(test_command, tmp_path):
     else:
         archive = MagicMock()
         archive.__fspath__.return_value = "/path/to/download.zip"
-    test_command.download_url.return_value = archive
+    test_command.download_file.return_value = archive
 
     # Create a directory to make it look like Java was downloaded and unpacked.
     (tmp_path / "tools" / "jdk8u242-b08").mkdir(parents=True)
@@ -88,10 +87,11 @@ def test_existing_install(test_command, tmp_path):
     test_command.shutil.rmtree.assert_called_with(java_home)
 
     # A download was initiated
-    test_command.download_url.assert_called_with(
+    test_command.download_file.assert_called_with(
         url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
         "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
         download_path=tmp_path / "tools",
+        error_fragment="download Java 8 JDK",
     )
 
     # The archive was unpacked.
@@ -127,7 +127,7 @@ def test_macOS_existing_install(test_command, tmp_path):
     else:
         archive = MagicMock()
         archive.__fspath__.return_value = "/path/to/download.zip"
-    test_command.download_url.return_value = archive
+    test_command.download_file.return_value = archive
 
     # Create a directory to make it look like Java was downloaded and unpacked.
     (tmp_path / "tools" / "jdk8u242-b08").mkdir(parents=True)
@@ -142,10 +142,11 @@ def test_macOS_existing_install(test_command, tmp_path):
     test_command.shutil.rmtree.assert_called_with(tmp_path / "tools" / "java")
 
     # A download was initiated
-    test_command.download_url.assert_called_with(
+    test_command.download_file.assert_called_with(
         url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
         "jdk8u242-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u242b08.tar.gz",
         download_path=tmp_path / "tools",
+        error_fragment="download Java 8 JDK",
     )
 
     # The archive was unpacked.
@@ -171,23 +172,24 @@ def test_download_fail(test_command, tmp_path):
     test_command.shutil.rmtree.side_effect = rmtree
 
     # Mock a failure on download
-    test_command.download_url.side_effect = requests_exceptions.ConnectionError
+    test_command.download_file.side_effect = NetworkFailure("mock")
 
     # Create an SDK wrapper
     jdk = JDK(test_command, java_home=java_home)
 
     # Attempt an upgrade. This will fail along with the download
-    with pytest.raises(NetworkFailure):
+    with pytest.raises(NetworkFailure, match="Unable to mock"):
         jdk.upgrade()
 
     # The old version has been deleted
     test_command.shutil.rmtree.assert_called_with(java_home)
 
     # A download was initiated
-    test_command.download_url.assert_called_with(
+    test_command.download_file.assert_called_with(
         url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
         "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
         download_path=tmp_path / "tools",
+        error_fragment="download Java 8 JDK",
     )
 
     # No attempt was made to unpack the archive
@@ -215,7 +217,7 @@ def test_unpack_fail(test_command, tmp_path):
     else:
         archive = MagicMock()
         archive.__fspath__.return_value = "/path/to/download.zip"
-    test_command.download_url.return_value = archive
+    test_command.download_file.return_value = archive
 
     # Mock an unpack failure due to an invalid archive
     test_command.shutil.unpack_archive.side_effect = shutil.ReadError
@@ -231,10 +233,11 @@ def test_unpack_fail(test_command, tmp_path):
     test_command.shutil.rmtree.assert_called_with(java_home)
 
     # A download was initiated
-    test_command.download_url.assert_called_with(
+    test_command.download_file.assert_called_with(
         url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
         "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
         download_path=tmp_path / "tools",
+        error_fragment="download Java 8 JDK",
     )
 
     # The archive was unpacked.

--- a/tests/integrations/java/test_JDK_upgrade.py
+++ b/tests/integrations/java/test_JDK_upgrade.py
@@ -91,7 +91,7 @@ def test_existing_install(test_command, tmp_path):
         url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
         "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
         download_path=tmp_path / "tools",
-        error_fragment="download Java 8 JDK",
+        role="Java 8 JDK",
     )
 
     # The archive was unpacked.
@@ -146,7 +146,7 @@ def test_macOS_existing_install(test_command, tmp_path):
         url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
         "jdk8u242-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u242b08.tar.gz",
         download_path=tmp_path / "tools",
-        error_fragment="download Java 8 JDK",
+        role="Java 8 JDK",
     )
 
     # The archive was unpacked.
@@ -189,7 +189,7 @@ def test_download_fail(test_command, tmp_path):
         url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
         "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
         download_path=tmp_path / "tools",
-        error_fragment="download Java 8 JDK",
+        role="Java 8 JDK",
     )
 
     # No attempt was made to unpack the archive
@@ -237,7 +237,7 @@ def test_unpack_fail(test_command, tmp_path):
         url="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/"
         "jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
         download_path=tmp_path / "tools",
-        error_fragment="download Java 8 JDK",
+        role="Java 8 JDK",
     )
 
     # The archive was unpacked.

--- a/tests/integrations/linuxdeploy/test_LinuxDeployBase__upgrade.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployBase__upgrade.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-from requests import exceptions as requests_exceptions
 
 from briefcase.exceptions import MissingToolError, NetworkFailure
 from briefcase.integrations.linuxdeploy import LinuxDeployBase
@@ -48,7 +47,7 @@ def test_upgrade_exists(linuxdeploy, mock_command, tmp_path):
     appimage_path.touch()
 
     # Mock a successful download
-    mock_command.download_url.side_effect = side_effect_create_mock_appimage(
+    mock_command.download_file.side_effect = side_effect_create_mock_appimage(
         appimage_path
     )
 
@@ -59,9 +58,10 @@ def test_upgrade_exists(linuxdeploy, mock_command, tmp_path):
     assert appimage_path.exists()
 
     # A download is invoked
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy-wonky.AppImage",
         download_path=tmp_path / "plugin",
+        error_fragment="download Dummy plugin",
     )
     # The downloaded file will be made executable
     mock_command.os.chmod.assert_called_with("new-downloaded-file", 0o755)
@@ -74,7 +74,7 @@ def test_upgrade_does_not_exist(linuxdeploy, mock_command):
         linuxdeploy.upgrade()
 
     # The tool wasn't already installed, so an error is raised.
-    assert mock_command.download_url.call_count == 0
+    assert mock_command.download_file.call_count == 0
 
 
 def test_upgrade_linuxdeploy_download_failure(linuxdeploy, mock_command, tmp_path):
@@ -85,17 +85,18 @@ def test_upgrade_linuxdeploy_download_failure(linuxdeploy, mock_command, tmp_pat
     appimage_path.parent.mkdir(parents=True)
     appimage_path.touch()
 
-    mock_command.download_url.side_effect = requests_exceptions.ConnectionError
+    mock_command.download_file.side_effect = NetworkFailure("mock")
 
     # Updated the linuxdeploy wrapper; the upgrade will fail
-    with pytest.raises(NetworkFailure):
+    with pytest.raises(NetworkFailure, match="Unable to mock"):
         linuxdeploy.upgrade()
 
     # The mock file will be deleted
     assert not appimage_path.exists()
 
     # A download was invoked
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy-wonky.AppImage",
         download_path=tmp_path / "plugin",
+        error_fragment="download Dummy plugin",
     )

--- a/tests/integrations/linuxdeploy/test_LinuxDeployBase__upgrade.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployBase__upgrade.py
@@ -61,7 +61,7 @@ def test_upgrade_exists(linuxdeploy, mock_command, tmp_path):
     mock_command.download_file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy-wonky.AppImage",
         download_path=tmp_path / "plugin",
-        error_fragment="download Dummy plugin",
+        role="Dummy plugin",
     )
     # The downloaded file will be made executable
     mock_command.os.chmod.assert_called_with("new-downloaded-file", 0o755)
@@ -98,5 +98,5 @@ def test_upgrade_linuxdeploy_download_failure(linuxdeploy, mock_command, tmp_pat
     mock_command.download_file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy-wonky.AppImage",
         download_path=tmp_path / "plugin",
-        error_fragment="download Dummy plugin",
+        role="Dummy plugin",
     )

--- a/tests/integrations/linuxdeploy/test_LinuxDeployBase__verify.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployBase__verify.py
@@ -89,7 +89,7 @@ def test_verify_does_not_exist(mock_command, tmp_path):
     mock_command.download_file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy-wonky.AppImage",
         download_path=tmp_path / "tools" / "somewhere",
-        error_fragment="download Dummy plugin",
+        role="Dummy plugin",
     )
     # The downloaded file will be made executable
     mock_command.os.chmod.assert_called_with("new-downloaded-file", 0o755)
@@ -113,7 +113,7 @@ def test_verify_does_not_exist_non_appimage(mock_command, tmp_path):
     mock_command.download_file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy.sh",
         download_path=tmp_path / "tools" / "somewhere",
-        error_fragment="download Dummy plugin",
+        role="Dummy plugin",
     )
     # The downloaded file will be made executable
     mock_command.os.chmod.assert_called_with("new-downloaded-file", 0o755)
@@ -138,5 +138,5 @@ def test_verify_linuxdeploy_download_failure(mock_command, tmp_path):
     mock_command.download_file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy-wonky.AppImage",
         download_path=tmp_path / "tools" / "somewhere",
-        error_fragment="download Dummy plugin",
+        role="Dummy plugin",
     )

--- a/tests/integrations/linuxdeploy/test_LinuxDeployBase__verify.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployBase__verify.py
@@ -1,5 +1,4 @@
 import pytest
-from requests import exceptions as requests_exceptions
 
 from briefcase.exceptions import MissingToolError, NetworkFailure
 from briefcase.integrations.linuxdeploy import LinuxDeployBase
@@ -46,7 +45,7 @@ def test_verify_exists(mock_command, tmp_path):
     linuxdeploy = LinuxDeployDummy.verify(mock_command)
 
     # No download occured
-    assert mock_command.download_url.call_count == 0
+    assert mock_command.download_file.call_count == 0
     assert mock_command.os.chmod.call_count == 0
 
     # The build command retains the path to the downloaded file.
@@ -62,7 +61,7 @@ def test_verify_does_not_exist_dont_install(mock_command):
         LinuxDeployDummy.verify(mock_command, install=False)
 
     # No download occured
-    assert mock_command.download_url.call_count == 0
+    assert mock_command.download_file.call_count == 0
     assert mock_command.os.chmod.call_count == 0
 
 
@@ -73,7 +72,7 @@ def test_verify_does_not_exist(mock_command, tmp_path):
     )
 
     # Mock a successful download
-    mock_command.download_url.side_effect = side_effect_create_mock_appimage(
+    mock_command.download_file.side_effect = side_effect_create_mock_appimage(
         appimage_path
     )
 
@@ -87,9 +86,10 @@ def test_verify_does_not_exist(mock_command, tmp_path):
     }
 
     # A download is invoked
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy-wonky.AppImage",
         download_path=tmp_path / "tools" / "somewhere",
+        error_fragment="download Dummy plugin",
     )
     # The downloaded file will be made executable
     mock_command.os.chmod.assert_called_with("new-downloaded-file", 0o755)
@@ -104,15 +104,16 @@ def test_verify_does_not_exist_non_appimage(mock_command, tmp_path):
     tool_path = tmp_path / "tools" / "somewhere" / "linuxdeploy-dummy.sh"
 
     # Mock a successful download
-    mock_command.download_url.side_effect = side_effect_create_mock_tool(tool_path)
+    mock_command.download_file.side_effect = side_effect_create_mock_tool(tool_path)
 
     # Create a linuxdeploy wrapper by verification
     linuxdeploy = LinuxDeployDummy.verify(mock_command, file_name=tool_path.name)
 
     # A download is invoked
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy.sh",
         download_path=tmp_path / "tools" / "somewhere",
+        error_fragment="download Dummy plugin",
     )
     # The downloaded file will be made executable
     mock_command.os.chmod.assert_called_with("new-downloaded-file", 0o755)
@@ -128,13 +129,14 @@ def test_verify_does_not_exist_non_appimage(mock_command, tmp_path):
 def test_verify_linuxdeploy_download_failure(mock_command, tmp_path):
     """If a tool/plugin doesn't exist, and a download failure occurs, an error
     is raised."""
-    mock_command.download_url.side_effect = requests_exceptions.ConnectionError
+    mock_command.download_file.side_effect = NetworkFailure("mock")
 
-    with pytest.raises(NetworkFailure):
+    with pytest.raises(NetworkFailure, match="Unable to mock"):
         LinuxDeployDummy.verify(mock_command)
 
     # A download was invoked
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy-wonky.AppImage",
         download_path=tmp_path / "tools" / "somewhere",
+        error_fragment="download Dummy plugin",
     )

--- a/tests/integrations/linuxdeploy/test_LinuxDeployURLPlugin__verify.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployURLPlugin__verify.py
@@ -30,7 +30,7 @@ def test_verify(mock_command, tmp_path):
         / "linuxdeploy_plugins"
         / "sometool"
         / "f3355f8e631ffc1abbb7afd37b36315f7846182ca2276c481fb9a43a7f4d239f",
-        error_fragment="download user-provided linuxdeploy plugin from URL",
+        role="user-provided linuxdeploy plugin from URL",
     )
 
 
@@ -52,7 +52,7 @@ def test_download_failure(mock_command, tmp_path):
         / "linuxdeploy_plugins"
         / "sometool"
         / "f3355f8e631ffc1abbb7afd37b36315f7846182ca2276c481fb9a43a7f4d239f",
-        error_fragment="download user-provided linuxdeploy plugin from URL",
+        role="user-provided linuxdeploy plugin from URL",
     )
 
 

--- a/tests/integrations/linuxdeploy/test_LinuxDeployURLPlugin__verify.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployURLPlugin__verify.py
@@ -1,5 +1,4 @@
 import pytest
-from requests import exceptions as requests_exceptions
 
 from briefcase.exceptions import BriefcaseCommandError, NetworkFailure
 from briefcase.integrations.linuxdeploy import LinuxDeployURLPlugin
@@ -10,7 +9,7 @@ from .utils import side_effect_create_mock_appimage
 def test_verify(mock_command, tmp_path):
     """URL plugins will be downloaded."""
     # Mock a successful download
-    mock_command.download_url.side_effect = side_effect_create_mock_appimage(
+    mock_command.download_file.side_effect = side_effect_create_mock_appimage(
         tmp_path
         / "tools"
         / "linuxdeploy_plugins"
@@ -24,13 +23,14 @@ def test_verify(mock_command, tmp_path):
         url="https://example.com/path/to/linuxdeploy-plugin-sometool-wonky.AppImage",
     )
 
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-plugin-sometool-wonky.AppImage",
         download_path=tmp_path
         / "tools"
         / "linuxdeploy_plugins"
         / "sometool"
         / "f3355f8e631ffc1abbb7afd37b36315f7846182ca2276c481fb9a43a7f4d239f",
+        error_fragment="download user-provided linuxdeploy plugin from URL",
     )
 
 
@@ -38,13 +38,22 @@ def test_download_failure(mock_command, tmp_path):
     """A failure downloading a custom URL plugin raises an error."""
 
     # Mock a successful download
-    mock_command.download_url.side_effect = requests_exceptions.ConnectionError
+    mock_command.download_file.side_effect = NetworkFailure("mock")
 
-    with pytest.raises(NetworkFailure):
-        LinuxDeployURLPlugin.verify(
-            mock_command,
-            url="https://example.com/path/to/linuxdeploy-plugin-sometool-wonky.AppImage",
-        )
+    url = "https://example.com/path/to/linuxdeploy-plugin-sometool-wonky.AppImage"
+
+    with pytest.raises(NetworkFailure, match="Unable to mock"):
+        LinuxDeployURLPlugin.verify(mock_command, url=url)
+
+    # A download was invoked
+    mock_command.download_file.assert_called_with(
+        url=url,
+        download_path=mock_command.tools_path
+        / "linuxdeploy_plugins"
+        / "sometool"
+        / "f3355f8e631ffc1abbb7afd37b36315f7846182ca2276c481fb9a43a7f4d239f",
+        error_fragment="download user-provided linuxdeploy plugin from URL",
+    )
 
 
 def test_invalid_plugin_name(mock_command, tmp_path):

--- a/tests/integrations/linuxdeploy/test_LinuxDeploy__verify_plugins.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeploy__verify_plugins.py
@@ -49,7 +49,7 @@ def test_gtk_plugin(linuxdeploy, mock_command, tmp_path):
     mock_command.download_file.assert_called_with(
         url="https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh",
         download_path=tmp_path / "tools" / "linuxdeploy_plugins" / "gtk",
-        error_fragment="download linuxdeploy GTK plugin",
+        role="linuxdeploy GTK plugin",
     )
 
 
@@ -76,7 +76,7 @@ def test_qt_plugin(linuxdeploy, mock_command, tmp_path):
             "releases/download/continuous/linuxdeploy-plugin-qt-wonky.AppImage"
         ),
         download_path=tmp_path / "tools" / "linuxdeploy_plugins" / "qt",
-        error_fragment="download linuxdeploy Qt plugin",
+        role="linuxdeploy Qt plugin",
     )
 
 
@@ -108,7 +108,7 @@ def test_custom_url_plugin(linuxdeploy, mock_command, tmp_path):
         / "linuxdeploy_plugins"
         / "sometool"
         / "f3355f8e631ffc1abbb7afd37b36315f7846182ca2276c481fb9a43a7f4d239f",
-        error_fragment="download user-provided linuxdeploy plugin from URL",
+        role="user-provided linuxdeploy plugin from URL",
     )
 
 
@@ -203,7 +203,7 @@ def test_complex_plugin_config(linuxdeploy, mock_command, tmp_path):
     # Three tools are obtained by downloading.
     # We don't want the side effects to occur until the function is invoked;
     # so we need to wrap the side effect callables in another callable.
-    def mock_downloads(url, download_path, error_fragment):
+    def mock_downloads(url, download_path, role):
         if "linuxdeploy_plugins/gtk" in str(download_path):
             return side_effect_create_mock_tool(
                 tmp_path
@@ -211,7 +211,7 @@ def test_complex_plugin_config(linuxdeploy, mock_command, tmp_path):
                 / "linuxdeploy_plugins"
                 / "gtk"
                 / "linuxdeploy-plugin-gtk.sh"
-            )(url, download_path, error_fragment)
+            )(url, download_path, role)
         elif "linuxdeploy_plugins/qt" in str(download_path):
             return side_effect_create_mock_appimage(
                 tmp_path
@@ -219,7 +219,7 @@ def test_complex_plugin_config(linuxdeploy, mock_command, tmp_path):
                 / "linuxdeploy_plugins"
                 / "qt"
                 / "linuxdeploy-plugin-qt-wonky.AppImage"
-            )(url, download_path, error_fragment)
+            )(url, download_path, role)
         elif "linuxdeploy_plugins/network" in str(download_path):
             return side_effect_create_mock_tool(
                 tmp_path
@@ -228,7 +228,7 @@ def test_complex_plugin_config(linuxdeploy, mock_command, tmp_path):
                 / "sometool"
                 / "f3355f8e631ffc1abbb7afd37b36315f7846182ca2276c481fb9a43a7f4d239f"
                 / "linuxdeploy-plugin-network.sh"
-            )(url, download_path, error_fragment)
+            )(url, download_path, role)
         else:
             raise Exception("Unexpected download")
 

--- a/tests/integrations/rcedit/test_RCEdit__upgrade.py
+++ b/tests/integrations/rcedit/test_RCEdit__upgrade.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-from requests import exceptions as requests_exceptions
 
 from briefcase.exceptions import MissingToolError, NetworkFailure
 from briefcase.integrations.rcedit import RCEdit
@@ -29,7 +28,7 @@ def test_upgrade_exists(mock_command, tmp_path):
         rcedit_path.touch()
         return "new-downloaded-file"
 
-    mock_command.download_url.side_effect = side_effect_create_mock_appimage
+    mock_command.download_file.side_effect = side_effect_create_mock_appimage
 
     # Create a rcedit wrapper, then upgrade it
     rcedit = RCEdit(mock_command)
@@ -39,10 +38,11 @@ def test_upgrade_exists(mock_command, tmp_path):
     assert rcedit_path.exists()
 
     # A download is invoked
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url="https://github.com/electron/rcedit/"
         "releases/download/v1.1.1/rcedit-x64.exe",
         download_path=tmp_path / "tools",
+        error_fragment="download RCEdit",
     )
 
 
@@ -54,7 +54,7 @@ def test_upgrade_does_not_exist(mock_command, tmp_path):
         rcedit.upgrade()
 
     # The tool wasn't already installed, so an error is raised.
-    assert mock_command.download_url.call_count == 0
+    assert mock_command.download_file.call_count == 0
 
 
 def test_upgrade_rcedit_download_failure(mock_command, tmp_path):
@@ -64,20 +64,21 @@ def test_upgrade_rcedit_download_failure(mock_command, tmp_path):
     rcedit_path = tmp_path / "tools" / "rcedit-x64.exe"
     rcedit_path.touch()
 
-    mock_command.download_url.side_effect = requests_exceptions.ConnectionError
+    mock_command.download_file.side_effect = NetworkFailure("mock")
 
     # Create a rcedit wrapper, then upgrade it.
     # The upgrade will fail
     rcedit = RCEdit(mock_command)
-    with pytest.raises(NetworkFailure):
+    with pytest.raises(NetworkFailure, match="Unable to mock"):
         rcedit.upgrade()
 
     # The mock file will be deleted
     assert not rcedit_path.exists()
 
     # A download was invoked
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url="https://github.com/electron/rcedit/"
         "releases/download/v1.1.1/rcedit-x64.exe",
         download_path=tmp_path / "tools",
+        error_fragment="download RCEdit",
     )

--- a/tests/integrations/rcedit/test_RCEdit__upgrade.py
+++ b/tests/integrations/rcedit/test_RCEdit__upgrade.py
@@ -42,7 +42,7 @@ def test_upgrade_exists(mock_command, tmp_path):
         url="https://github.com/electron/rcedit/"
         "releases/download/v1.1.1/rcedit-x64.exe",
         download_path=tmp_path / "tools",
-        error_fragment="download RCEdit",
+        role="RCEdit",
     )
 
 
@@ -80,5 +80,5 @@ def test_upgrade_rcedit_download_failure(mock_command, tmp_path):
         url="https://github.com/electron/rcedit/"
         "releases/download/v1.1.1/rcedit-x64.exe",
         download_path=tmp_path / "tools",
-        error_fragment="download RCEdit",
+        role="RCEdit",
     )

--- a/tests/integrations/rcedit/test_RCEdit__verify.py
+++ b/tests/integrations/rcedit/test_RCEdit__verify.py
@@ -68,7 +68,7 @@ def test_verify_does_not_exist(mock_command, tmp_path):
         url="https://github.com/electron/rcedit/"
         "releases/download/v1.1.1/rcedit-x64.exe",
         download_path=tmp_path / "tools",
-        error_fragment="download RCEdit",
+        role="RCEdit",
     )
 
     # The build command retains the path to the downloaded file.
@@ -88,5 +88,5 @@ def test_verify_rcedit_download_failure(mock_command, tmp_path):
         url="https://github.com/electron/rcedit/"
         "releases/download/v1.1.1/rcedit-x64.exe",
         download_path=tmp_path / "tools",
-        error_fragment="download RCEdit",
+        role="RCEdit",
     )

--- a/tests/integrations/rcedit/test_RCEdit__verify.py
+++ b/tests/integrations/rcedit/test_RCEdit__verify.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-from requests import exceptions as requests_exceptions
 
 from briefcase.exceptions import MissingToolError, NetworkFailure
 from briefcase.integrations.rcedit import RCEdit
@@ -27,8 +26,8 @@ def test_verify_exists(mock_command, tmp_path):
     # Create a rcedit wrapper by verification
     rcedit = RCEdit.verify(mock_command)
 
-    # No download occured
-    assert mock_command.download_url.call_count == 0
+    # No download occurred
+    assert mock_command.download_file.call_count == 0
     assert mock_command.os.chmod.call_count == 0
 
     # The build command retains the path to the downloaded file.
@@ -38,15 +37,15 @@ def test_verify_exists(mock_command, tmp_path):
 def test_verify_does_not_exist_dont_install(mock_command, tmp_path):
     """If RCEdit doesn't exist, and install=False, it is *not* downloaded."""
     # Mock a successful download
-    mock_command.download_url.return_value = "new-downloaded-file"
+    mock_command.download_file.return_value = "new-downloaded-file"
 
     # True to create a rcedit wrapper by verification.
     # This will fail because it doesn't exist, but installation was disabled.
     with pytest.raises(MissingToolError):
         RCEdit.verify(mock_command, install=False)
 
-    # No download occured
-    assert mock_command.download_url.call_count == 0
+    # No download occurred
+    assert mock_command.download_file.call_count == 0
     assert mock_command.os.chmod.call_count == 0
 
 
@@ -59,16 +58,17 @@ def test_verify_does_not_exist(mock_command, tmp_path):
         rcedit_path.touch()
         return "new-downloaded-file"
 
-    mock_command.download_url.side_effect = side_effect_create_mock_appimage
+    mock_command.download_file.side_effect = side_effect_create_mock_appimage
 
     # Create a rcedit wrapper by verification
     rcedit = RCEdit.verify(mock_command)
 
     # A download is invoked
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url="https://github.com/electron/rcedit/"
         "releases/download/v1.1.1/rcedit-x64.exe",
         download_path=tmp_path / "tools",
+        error_fragment="download RCEdit",
     )
 
     # The build command retains the path to the downloaded file.
@@ -78,14 +78,15 @@ def test_verify_does_not_exist(mock_command, tmp_path):
 def test_verify_rcedit_download_failure(mock_command, tmp_path):
     """If RCEdit doesn't exist, but a download failure occurs, an error is
     raised."""
-    mock_command.download_url.side_effect = requests_exceptions.ConnectionError
+    mock_command.download_file.side_effect = NetworkFailure("mock")
 
-    with pytest.raises(NetworkFailure):
+    with pytest.raises(NetworkFailure, match="Unable to mock"):
         RCEdit.verify(mock_command)
 
     # A download was invoked
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url="https://github.com/electron/rcedit/"
         "releases/download/v1.1.1/rcedit-x64.exe",
         download_path=tmp_path / "tools",
+        error_fragment="download RCEdit",
     )

--- a/tests/integrations/wix/test_WiX__upgrade.py
+++ b/tests/integrations/wix/test_WiX__upgrade.py
@@ -35,7 +35,7 @@ def test_non_managed_install(mock_command, tmp_path, capsys):
         wix.upgrade()
 
     # No download was attempted
-    assert mock_command.download_url.call_count == 0
+    assert mock_command.download_file.call_count == 0
 
 
 def test_non_existing_wix_install(mock_command, tmp_path):
@@ -47,7 +47,7 @@ def test_non_existing_wix_install(mock_command, tmp_path):
         wix.upgrade()
 
     # No download was attempted
-    assert mock_command.download_url.call_count == 0
+    assert mock_command.download_file.call_count == 0
 
 
 def test_existing_wix_install(mock_command, tmp_path):
@@ -87,7 +87,7 @@ def test_existing_wix_install(mock_command, tmp_path):
     mock_command.download_file.assert_called_with(
         url=WIX_DOWNLOAD_URL,
         download_path=tmp_path / "tools",
-        error_fragment="download WiX",
+        role="WiX",
     )
 
     # The download was unpacked
@@ -123,7 +123,7 @@ def test_download_fail(mock_command, tmp_path):
     mock_command.download_file.assert_called_with(
         url=WIX_DOWNLOAD_URL,
         download_path=tmp_path / "tools",
-        error_fragment="download WiX",
+        role="WiX",
     )
 
     # ... but the unpack didn't happen
@@ -166,7 +166,7 @@ def test_unpack_fail(mock_command, tmp_path):
     mock_command.download_file.assert_called_with(
         url=WIX_DOWNLOAD_URL,
         download_path=tmp_path / "tools",
-        error_fragment="download WiX",
+        role="WiX",
     )
 
     # The download was unpacked.

--- a/tests/integrations/wix/test_WiX__upgrade.py
+++ b/tests/integrations/wix/test_WiX__upgrade.py
@@ -3,7 +3,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-from requests import exceptions as requests_exceptions
 
 from briefcase.exceptions import (
     BriefcaseCommandError,
@@ -73,7 +72,7 @@ def test_existing_wix_install(mock_command, tmp_path):
         wix_zip = MagicMock()
         wix_zip.__fspath__.return_value = wix_zip_path
 
-    mock_command.download_url.return_value = wix_zip
+    mock_command.download_file.return_value = wix_zip
 
     # Create an SDK wrapper
     wix = WiX(mock_command, wix_home=wix_path, bin_install=True)
@@ -85,9 +84,10 @@ def test_existing_wix_install(mock_command, tmp_path):
     mock_command.shutil.rmtree.assert_called_with(wix_path)
 
     # A download was initiated
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url=WIX_DOWNLOAD_URL,
         download_path=tmp_path / "tools",
+        error_fragment="download WiX",
     )
 
     # The download was unpacked
@@ -110,19 +110,20 @@ def test_download_fail(mock_command, tmp_path):
     (wix_path / "candle.exe").touch()
 
     # Mock the download failure
-    mock_command.download_url.side_effect = requests_exceptions.ConnectionError
+    mock_command.download_file.side_effect = NetworkFailure("mock")
 
     # Create an SDK wrapper
     wix = WiX(mock_command, wix_home=wix_path, bin_install=True)
 
     # Upgrade the install. This will trigger a download that will fail
-    with pytest.raises(NetworkFailure):
+    with pytest.raises(NetworkFailure, match="Unable to mock"):
         wix.upgrade()
 
     # A download was initiated
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url=WIX_DOWNLOAD_URL,
         download_path=tmp_path / "tools",
+        error_fragment="download WiX",
     )
 
     # ... but the unpack didn't happen
@@ -148,7 +149,7 @@ def test_unpack_fail(mock_command, tmp_path):
         wix_zip = MagicMock()
         wix_zip.__fspath__.return_value = wix_zip_path
 
-    mock_command.download_url.return_value = wix_zip
+    mock_command.download_file.return_value = wix_zip
 
     # Mock an unpack failure
     mock_command.shutil.unpack_archive.side_effect = EOFError
@@ -162,9 +163,10 @@ def test_unpack_fail(mock_command, tmp_path):
         wix.upgrade()
 
     # A download was initiated
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url=WIX_DOWNLOAD_URL,
         download_path=tmp_path / "tools",
+        error_fragment="download WiX",
     )
 
     # The download was unpacked.

--- a/tests/integrations/wix/test_WiX__verify.py
+++ b/tests/integrations/wix/test_WiX__verify.py
@@ -3,7 +3,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-from requests import exceptions as requests_exceptions
 
 from briefcase.exceptions import BriefcaseCommandError, MissingToolError, NetworkFailure
 from briefcase.integrations.wix import WIX_DOWNLOAD_URL, WiX
@@ -84,7 +83,7 @@ def test_existing_wix_install(mock_command, tmp_path):
     mock_command.os.environ.get.assert_called_with("WIX")
 
     # No download was attempted
-    assert mock_command.download_url.call_count == 0
+    assert mock_command.download_file.call_count == 0
 
     # The returned paths are as expected
     assert wix.heat_exe == tmp_path / "tools" / "wix" / "heat.exe"
@@ -110,7 +109,7 @@ def test_download_wix(mock_command, tmp_path):
         wix_zip = MagicMock()
         wix_zip.__fspath__.return_value = wix_zip_path
 
-    mock_command.download_url.return_value = wix_zip
+    mock_command.download_file.return_value = wix_zip
 
     # Verify the install. This will trigger a download
     wix = WiX.verify(mock_command)
@@ -119,9 +118,10 @@ def test_download_wix(mock_command, tmp_path):
     mock_command.os.environ.get.assert_called_with("WIX")
 
     # A download was initiated
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url=WIX_DOWNLOAD_URL,
         download_path=tmp_path / "tools",
+        error_fragment="download WiX",
     )
 
     # The download was unpacked.
@@ -153,7 +153,7 @@ def test_dont_install(mock_command, tmp_path):
     mock_command.os.environ.get.assert_called_with("WIX")
 
     # No download was initiated
-    mock_command.download_url.assert_not_called()
+    mock_command.download_file.assert_not_called()
 
 
 def test_download_fail(mock_command, tmp_path):
@@ -162,19 +162,20 @@ def test_download_fail(mock_command, tmp_path):
     mock_command.os.environ.get.return_value = None
 
     # Mock the download failure
-    mock_command.download_url.side_effect = requests_exceptions.ConnectionError
+    mock_command.download_file.side_effect = NetworkFailure("mock")
 
     # Verify the install. This will trigger a download
-    with pytest.raises(NetworkFailure):
+    with pytest.raises(NetworkFailure, match="Unable to mock"):
         WiX.verify(mock_command)
 
     # The environment was queried.
     mock_command.os.environ.get.assert_called_with("WIX")
 
     # A download was initiated
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url=WIX_DOWNLOAD_URL,
         download_path=tmp_path / "tools",
+        error_fragment="download WiX",
     )
 
     # ... but the unpack didn't happen
@@ -198,7 +199,7 @@ def test_unpack_fail(mock_command, tmp_path):
         wix_zip = MagicMock()
         wix_zip.__fspath__.return_value = wix_zip_path
 
-    mock_command.download_url.return_value = wix_zip
+    mock_command.download_file.return_value = wix_zip
 
     # Mock an unpack failure
     mock_command.shutil.unpack_archive.side_effect = EOFError
@@ -212,9 +213,10 @@ def test_unpack_fail(mock_command, tmp_path):
     mock_command.os.environ.get.assert_called_with("WIX")
 
     # A download was initiated
-    mock_command.download_url.assert_called_with(
+    mock_command.download_file.assert_called_with(
         url=WIX_DOWNLOAD_URL,
         download_path=tmp_path / "tools",
+        error_fragment="download WiX",
     )
 
     # The download was unpacked.

--- a/tests/integrations/wix/test_WiX__verify.py
+++ b/tests/integrations/wix/test_WiX__verify.py
@@ -121,7 +121,7 @@ def test_download_wix(mock_command, tmp_path):
     mock_command.download_file.assert_called_with(
         url=WIX_DOWNLOAD_URL,
         download_path=tmp_path / "tools",
-        error_fragment="download WiX",
+        role="WiX",
     )
 
     # The download was unpacked.
@@ -175,7 +175,7 @@ def test_download_fail(mock_command, tmp_path):
     mock_command.download_file.assert_called_with(
         url=WIX_DOWNLOAD_URL,
         download_path=tmp_path / "tools",
-        error_fragment="download WiX",
+        role="WiX",
     )
 
     # ... but the unpack didn't happen
@@ -216,7 +216,7 @@ def test_unpack_fail(mock_command, tmp_path):
     mock_command.download_file.assert_called_with(
         url=WIX_DOWNLOAD_URL,
         download_path=tmp_path / "tools",
-        error_fragment="download WiX",
+        role="WiX",
     )
 
     # The download was unpacked.

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -110,7 +110,7 @@ def test_verify_tools_download_failure(build_command):
     build_command.download_file.assert_called_with(
         url="https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-wonky.AppImage",
         download_path=build_command.tools_path,
-        error_fragment="download linuxdeploy",
+        role="linuxdeploy",
     )
 
     # But it failed, so the file won't be made executable...

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -4,9 +4,8 @@ import sys
 from unittest import mock
 
 import pytest
-from requests import exceptions as requests_exceptions
 
-from briefcase.exceptions import BriefcaseCommandError
+from briefcase.exceptions import BriefcaseCommandError, NetworkFailure
 from briefcase.integrations.docker import Docker
 from briefcase.integrations.linuxdeploy import LinuxDeploy
 from briefcase.platforms.linux.appimage import LinuxAppImageBuildCommand
@@ -82,14 +81,14 @@ def test_verify_tools_wrong_platform(build_command):
 
     build_command.host_os = "TestOS"
     build_command.build_app = mock.MagicMock()
-    build_command.download_url = mock.MagicMock()
+    build_command.download_file = mock.MagicMock()
 
     # Try to invoke the build
     with pytest.raises(BriefcaseCommandError):
         build_command()
 
     # The download was not attempted
-    assert build_command.download_url.call_count == 0
+    assert build_command.download_file.call_count == 0
 
     # But it failed, so the file won't be made executable...
     assert build_command.os.chmod.call_count == 0
@@ -101,18 +100,17 @@ def test_verify_tools_wrong_platform(build_command):
 def test_verify_tools_download_failure(build_command):
     """If the build tools can't be retrieved, the build fails."""
     build_command.build_app = mock.MagicMock()
-    build_command.download_url = mock.MagicMock(
-        side_effect=requests_exceptions.ConnectionError
-    )
+    build_command.download_file = mock.MagicMock(side_effect=NetworkFailure("mock"))
 
     # Try to invoke the build
     with pytest.raises(BriefcaseCommandError):
         build_command()
 
     # The download was attempted
-    build_command.download_url.assert_called_with(
+    build_command.download_file.assert_called_with(
         url="https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-wonky.AppImage",
         download_path=build_command.tools_path,
+        error_fragment="download linuxdeploy",
     )
 
     # But it failed, so the file won't be made executable...

--- a/tests/platforms/linux/flatpak/test_create.py
+++ b/tests/platforms/linux/flatpak/test_create.py
@@ -53,7 +53,7 @@ def test_install_support_package(first_app_config, tmp_path):
     """Support files are copied into place, rather than being unpacked."""
     command = LinuxFlatpakCreateCommand(base_path=tmp_path)
     command.shutil = mock.MagicMock()
-    command.download_url = mock.MagicMock(
+    command.download_file = mock.MagicMock(
         return_value=tmp_path / "support" / "Python-3.X.Y.tgz"
     )
 

--- a/tests/platforms/macOS/app/test_create.py
+++ b/tests/platforms/macOS/app/test_create.py
@@ -21,7 +21,7 @@ def test_install_app_support_package(first_app_config, tmp_path):
     create_command = macOSAppCreateCommand(base_path=tmp_path)
 
     # Modify download_url to return the temp zipfile
-    create_command.download_url = mock.MagicMock(return_value=support_file)
+    create_command.download_file = mock.MagicMock(return_value=support_file)
 
     # Mock support package path
     create_command.support_path = mock.MagicMock(return_value=support_path)

--- a/tests/platforms/macOS/app/test_create.py
+++ b/tests/platforms/macOS/app/test_create.py
@@ -20,7 +20,7 @@ def test_install_app_support_package(first_app_config, tmp_path):
 
     create_command = macOSAppCreateCommand(base_path=tmp_path)
 
-    # Modify download_url to return the temp zipfile
+    # Modify download_file to return the temp zipfile
     create_command.download_file = mock.MagicMock(return_value=support_file)
 
     # Mock support package path

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -70,7 +70,7 @@ def create_zip_file(zippath, content):
     return zippath
 
 
-def mock_file_download(filename, content, mode="w"):
+def mock_file_download(filename, content, mode="w", error_fragment=""):
     """Create a side effect function that mocks the download of a zip file.
 
     :param filename: The file name (*not* the path - just the file name) to
@@ -82,20 +82,20 @@ def mock_file_download(filename, content, mode="w"):
     :returns: a function that can act as a mock side effect for `download_url()`
     """
 
-    def _download_url(url, download_path):
+    def _download_url(url, download_path, error_fragment=""):
         return create_file(download_path / filename, content, mode=mode)
 
     return _download_url
 
 
-def mock_zip_download(filename, content):
+def mock_zip_download(filename, content, error_fragment=""):
     """Create a side effect function that mocks the download of a zip file.
 
     :param content: A string containing the content to write.
     :returns: a function that can act as a mock side effect for `download_url()`
     """
 
-    def _download_url(url, download_path):
+    def _download_url(url, download_path, error_fragment):
         return create_zip_file(download_path / filename, content)
 
     return _download_url

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -70,7 +70,7 @@ def create_zip_file(zippath, content):
     return zippath
 
 
-def mock_file_download(filename, content, mode="w", error_fragment=""):
+def mock_file_download(filename, content, mode="w", role=None):
     """Create a side effect function that mocks the download of a zip file.
 
     :param filename: The file name (*not* the path - just the file name) to
@@ -79,23 +79,24 @@ def mock_file_download(filename, content, mode="w", error_fragment=""):
     :param mode: The mode to open the file. This is `w` by default;
         use `wb` and provide content as a bitstring if you need to
         write a binary file.
-    :returns: a function that can act as a mock side effect for `download_url()`
+    :param role: The role played by the content being downloaded
+    :returns: a function that can act as a mock side effect for `download_file()`
     """
 
-    def _download_url(url, download_path, error_fragment=""):
+    def _download_file(url, download_path, role):
         return create_file(download_path / filename, content, mode=mode)
 
-    return _download_url
+    return _download_file
 
 
-def mock_zip_download(filename, content, error_fragment=""):
+def mock_zip_download(filename, content, role=None):
     """Create a side effect function that mocks the download of a zip file.
 
     :param content: A string containing the content to write.
-    :returns: a function that can act as a mock side effect for `download_url()`
+    :returns: a function that can act as a mock side effect for `download_file()`
     """
 
-    def _download_url(url, download_path, error_fragment):
+    def _download_file(url, download_path, role):
         return create_zip_file(download_path / filename, content)
 
-    return _download_url
+    return _download_file


### PR DESCRIPTION
## Summary
 - Move boilerplate code to raise `NetworkFailure` from `ConnectionError` into core download method.
 - Rename base method `download_url()` to `download_file()` to remove confusion around tool property `download_url` for tool URLs.

## Changes
Everywhere a file is downloaded, we have this boilerplate code to raise `NetworkFailure` from Requests' `ConnectionError`.

```
❯ grep -nrF "command.download_url" -A5 src/briefcase/
src/briefcase/integrations/android_sdk.py:257:            cmdline_tools_zip_path = self.command.download_url(
src/briefcase/integrations/android_sdk.py-258-                url=self.cmdline_tools_url,
src/briefcase/integrations/android_sdk.py-259-                download_path=self.command.tools_path,
src/briefcase/integrations/android_sdk.py-260-            )
src/briefcase/integrations/android_sdk.py-261-        except requests_exceptions.ConnectionError as e:
src/briefcase/integrations/android_sdk.py-262-            raise NetworkFailure("download Android SDK Command-Line Tools") from e
--
src/briefcase/integrations/android_sdk.py:596:            skin_tgz_path = self.command.download_url(
src/briefcase/integrations/android_sdk.py-597-                url=skin_url,
src/briefcase/integrations/android_sdk.py-598-                download_path=self.root_path,
src/briefcase/integrations/android_sdk.py-599-            )
src/briefcase/integrations/android_sdk.py-600-        except requests_exceptions.ConnectionError as e:
src/briefcase/integrations/android_sdk.py-601-            raise NetworkFailure(f"download {skin} device skin") from e
--
src/briefcase/integrations/linuxdeploy.py:51:            self.command.download_url(
src/briefcase/integrations/linuxdeploy.py-52-                url=self.download_url,
src/briefcase/integrations/linuxdeploy.py-53-                download_path=self.file_path,
src/briefcase/integrations/linuxdeploy.py-54-            )
src/briefcase/integrations/linuxdeploy.py-55-        except requests_exceptions.ConnectionError as e:
src/briefcase/integrations/linuxdeploy.py-56-            raise NetworkFailure(f"download {self.full_name}") from e
--
src/briefcase/integrations/java.py:237:            jdk_zip_path = self.command.download_url(
src/briefcase/integrations/java.py-238-                url=self.adoptOpenJDK_download_url,
src/briefcase/integrations/java.py-239-                download_path=self.command.tools_path,
src/briefcase/integrations/java.py-240-            )
src/briefcase/integrations/java.py-241-        except requests_exceptions.ConnectionError as e:
src/briefcase/integrations/java.py-242-            raise NetworkFailure("download Java 8 JDK") from e
--
src/briefcase/integrations/rcedit.py:55:            self.command.download_url(
src/briefcase/integrations/rcedit.py-56-                url=self.download_url, download_path=self.command.tools_path
src/briefcase/integrations/rcedit.py-57-            )
src/briefcase/integrations/rcedit.py-58-        except requests_exceptions.ConnectionError as e:
src/briefcase/integrations/rcedit.py-59-            raise NetworkFailure("downloading RCEdit") from e
--
src/briefcase/integrations/wix.py:130:            wix_zip_path = self.command.download_url(
src/briefcase/integrations/wix.py-131-                url=WIX_DOWNLOAD_URL,
src/briefcase/integrations/wix.py-132-                download_path=self.command.tools_path,
src/briefcase/integrations/wix.py-133-            )
src/briefcase/integrations/wix.py-134-        except requests_exceptions.ConnectionError as e:
src/briefcase/integrations/wix.py-135-            raise NetworkFailure("download WiX") from e
```

This code is quite distracting (IMO) inline with the business logic and it seems more appropriate for the download method to just raise a native error that Briefcase already expects.

Incorporating this catch in to `BaseCommand.download_url()` was relatively trivial. Unfortunately, it led to a lot of changes for tests. In some ways, it trivializes some of the download failure tests but they still seem valuable to ensure download failures do what we want within the code for the tools.

Additionally, the shared name `download_url` between the command action to download and the tools' property for their URLs was a little confusing. I renamed the method that actually downloads from `download_url()` to `download_file()`.

So, a lot of churn for tests....but Briefcase's impact is relatively small.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
