### PR TITLE
Support multiple Rich renderables in console

### DIFF
--- a/changes/836.misc.rst
+++ b/changes/836.misc.rst
@@ -1,0 +1,1 @@
+Support multiple dynamic elements in the console simultaneously.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -663,9 +663,8 @@ or delete the old data directory, and re-run Briefcase.
                 if total is None:
                     f.write(response.content)
                 else:
-                    progress_bar = self.input.progress_bar()
-                    task_id = progress_bar.add_task("Downloader", total=int(total))
-                    with progress_bar:
+                    with self.input.progress_bar() as progress_bar:
+                        task_id = progress_bar.add_task("Downloader", total=int(total))
                         for data in response.iter_content(chunk_size=1024 * 1024):
                             f.write(data)
                             progress_bar.update(task_id, advance=len(data))

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -280,9 +280,8 @@ or
 
         # Signs code objects in reversed lexicographic order to ensure nesting order is respected
         # (objects must be signed from the inside out)
-        progress_bar = self.input.progress_bar()
-        task_id = progress_bar.add_task("Signing App", total=len(sign_targets))
-        with progress_bar:
+        with self.input.progress_bar() as progress_bar:
+            task_id = progress_bar.add_task("Signing App", total=len(sign_targets))
             for path in sorted(sign_targets, reverse=True):
                 self.sign_file(
                     path,

--- a/tests/commands/create/test_install_image.py
+++ b/tests/commands/create/test_install_image.py
@@ -51,7 +51,7 @@ def test_no_requested_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "Installing input/original.png as sample image... done\n\n"
+    expected = "Installing input/original.png as sample image... done\n"
     assert capsys.readouterr().out == expected
 
     # The file was copied into position
@@ -86,7 +86,7 @@ def test_no_requested_size_invalid_path(create_command, tmp_path, capsys):
 
 
 def test_requested_size(create_command, tmp_path, capsys):
-    """If the app specifies a sized image, an anoated image filename is
+    """If the app specifies a sized image, an annotated image filename is
     used."""
     create_command.shutil = mock.MagicMock()
 
@@ -107,7 +107,7 @@ def test_requested_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "Installing input/original-3742.png as 3742px sample image... done\n\n"
+    expected = "Installing input/original-3742.png as 3742px sample image... done\n"
     assert capsys.readouterr().out == expected
 
     # The file was copied into position
@@ -165,7 +165,7 @@ def test_variant_with_no_requested_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "Installing input/original.png as round sample image... done\n\n"
+    expected = "Installing input/original.png as round sample image... done\n"
     assert capsys.readouterr().out == expected
 
     # The file was copied into position
@@ -261,7 +261,7 @@ def test_variant_with_size(create_command, tmp_path, capsys):
 
     # The right message was written to output
     expected = (
-        "Installing input/original-3742.png as 3742px round sample image... done\n\n"
+        "Installing input/original-3742.png as 3742px round sample image... done\n"
     )
     assert capsys.readouterr().out == expected
 
@@ -326,7 +326,7 @@ def test_unsized_variant(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "Installing input/original.png as round sample image... done\n\n"
+    expected = "Installing input/original.png as round sample image... done\n"
     assert capsys.readouterr().out == expected
 
     # The file was copied into position

--- a/tests/console/Console/test_live_display.py
+++ b/tests/console/Console/test_live_display.py
@@ -1,0 +1,175 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+import briefcase.console
+
+
+@pytest.fixture
+def renderable():
+    mock_renderable = MagicMock()
+    mock_renderable.live = MagicMock()
+    mock_renderable.live.transient = False
+    return mock_renderable
+
+
+@pytest.fixture
+def monkeypatched_live_display(monkeypatch):
+    """Monkeypatch the instantiation of the Live Display."""
+    live_display = MagicMock()
+    live_display.return_value = live_display
+    monkeypatch.setattr(briefcase.console, "Live", live_display)
+    return live_display
+
+
+def test_live_display_add_new(console, renderable):
+    """New renderable is added to Live Display."""
+    assert console._live_display_stack.count(renderable) == 0
+
+    console._live_display_add(renderable)
+
+    assert len(console._live_display_stack) == 1
+    assert console.is_output_controlled is True
+    console._live_display.update.assert_called_once()
+    console._live_display.start.assert_called_once()
+
+
+def test_live_display_add_existing(console, renderable):
+    """Existing renderable is not added to Live Display."""
+    assert console._live_display_stack.count(renderable) == 0
+    console._live_display_add(renderable)
+
+    console._live_display = MagicMock()
+    console._live_display_add(renderable)
+
+    assert console._live_display_stack.count(renderable) == 1
+    assert len(console._live_display_stack) == 1
+    assert console.is_output_controlled is True
+    console._live_display.update.assert_not_called()
+    console._live_display.start.assert_not_called()
+
+
+def test_live_display_remove_only_existing(console, renderable):
+    """Only existing renderable is removed from Live Display."""
+    assert console._live_display_stack.count(renderable) == 0
+    console._live_display_add(renderable)
+
+    console._live_display = MagicMock()
+    console._live_display_remove(renderable)
+
+    assert len(console._live_display_stack) == 0
+    assert console.is_output_controlled is False
+    console._live_display.stop.assert_called_once()
+
+
+def test_live_display_remove_existing(console, renderable):
+    """Existing renderable is removed from Live Display."""
+    assert console._live_display_stack.count(renderable) == 0
+    console._live_display_add(renderable)
+    console._live_display_add("asdf")
+
+    console._live_display = MagicMock()
+    console._live_display_remove(renderable)
+
+    assert len(console._live_display_stack) == 1
+    assert console.is_output_controlled is True
+    console._live_display.update.assert_called_once()
+    console._live_display.start.assert_called_once()
+
+
+def test_live_display_remove_nonexistent(console, renderable):
+    """Nonexistent renderable is effectively removed from Live Display
+    stack."""
+    assert console._live_display_stack.count(renderable) == 0
+    console._live_display_add("asdf")
+
+    console._live_display = MagicMock()
+    console._live_display_remove(renderable)
+
+    assert len(console._live_display_stack) == 1
+    assert console.is_output_controlled is True
+    console._live_display.update.assert_called_once()
+    console._live_display.start.assert_called_once()
+
+
+def test_live_display_update_new(console, renderable, monkeypatched_live_display):
+    """Live Display is created and updated for fresh renderable."""
+    console._live_display = None
+
+    console._live_display_add(renderable)
+
+    assert console._live_display is monkeypatched_live_display
+    assert console.is_output_controlled is True
+    monkeypatched_live_display.update.assert_called_once()
+    monkeypatched_live_display.start.assert_called_once()
+
+
+def test_live_display_remove_dynamic_elements_active(console):
+    """Live Display is stopped when removing active dynamic elements."""
+    initial_live_display = console._live_display
+    console.is_output_controlled = True
+
+    console.remove_dynamic_elements()
+
+    initial_live_display.stop.assert_called_once()
+    assert console._live_display is None
+    assert console.is_output_controlled is False
+
+
+def test_live_display_remove_dynamic_elements_not_active(console):
+    """Live Display is not stopped when there are no dynamic elements
+    active."""
+    console._live_display = None
+    assert console.is_output_controlled is False
+
+    console.remove_dynamic_elements()
+
+    assert console._live_display is None
+    assert console.is_output_controlled is False
+
+
+def test_live_display_restore_dynamic_elements(console, monkeypatched_live_display):
+    """Live Display is updated when restoring any dynamic elements."""
+    console._live_display_stack = ["asdf"]
+    console._live_display = None
+    assert console.is_output_controlled is False
+
+    console.restore_dynamic_elements()
+
+    monkeypatched_live_display.update.assert_called_once()
+    monkeypatched_live_display.start.assert_called_once()
+    assert console.is_output_controlled is True
+
+
+def test_live_display_restore_dynamic_elements_no_active(
+    console,
+    monkeypatched_live_display,
+):
+    """Live Display is not updated when no dynamic elements to restore."""
+    console._live_display = None
+    assert console.is_output_controlled is False
+
+    console.restore_dynamic_elements()
+
+    monkeypatched_live_display.update.assert_not_called()
+    monkeypatched_live_display.start.assert_not_called()
+    monkeypatched_live_display.stop.assert_called_once()
+    assert console.is_output_controlled is False
+
+
+def test_live_display_restore_dynamic_elements_with_existing_live_display(
+    console,
+    monkeypatched_live_display,
+):
+    """Live Display is updated when restoring any dynamic elements."""
+    # this shouldn't happen in practice since "remove" sets live display to None
+    console._live_display_stack = ["asdf"]
+    assert console.is_output_controlled is False
+
+    console.restore_dynamic_elements()
+
+    console._live_display.update.assert_called_once()
+    console._live_display.start.assert_called_once()
+    monkeypatched_live_display.update.assert_not_called()
+    monkeypatched_live_display.start.assert_not_called()
+    assert console.is_output_controlled is True

--- a/tests/console/Console/test_wait_bar.py
+++ b/tests/console/Console/test_wait_bar.py
@@ -6,7 +6,7 @@ def test_wait_bar_done_message(console, capsys):
     with console.wait_bar("Wait message...", done_message="finished"):
         pass
 
-    assert capsys.readouterr().out == "Wait message... finished\n\n"
+    assert capsys.readouterr().out == "Wait message... finished\n"
 
 
 def test_wait_bar_done_message_nested(console, capsys):
@@ -15,17 +15,21 @@ def test_wait_bar_done_message_nested(console, capsys):
         with console.wait_bar("Wait message 2...", done_message="finished"):
             pass
 
-    expected = "Wait message 2... finished\nWait message 1... finished\n\n"
-    assert capsys.readouterr().out == expected
+    # fmt: off
+    assert capsys.readouterr().out == (
+        "Wait message 2... finished\n"
+        "Wait message 1... finished\n"
+    )
+    # fmt: on
 
 
 @pytest.mark.parametrize(
     ("message", "transient", "output"),
     (
-        ("Wait message...", False, "Wait message... done\n\n"),
-        ("", False, "\n"),
-        ("Wait Message...", True, "\n"),
-        ("", True, "\n"),
+        ("Wait message...", False, "Wait message... done\n"),
+        ("", False, ""),
+        ("Wait Message...", True, ""),
+        ("", True, ""),
     ),
 )
 def test_wait_bar_transient(console, message, transient, output, capsys):
@@ -44,11 +48,11 @@ def test_wait_bar_transient(console, message, transient, output, capsys):
             "Wait message 1...",
             "Wait message 2...",
             False,
-            "Wait message 2... done\nWait message 1... done\n\n",
+            "Wait message 2... done\n" "Wait message 1... done\n",
         ),
-        ("", "", False, "\n"),
-        ("Wait message 1...", "Wait message 2...", True, "\n"),
-        ("", "", True, "\n"),
+        ("", "", False, ""),
+        ("Wait message 1...", "Wait message 2...", True, ""),
+        ("", "", True, ""),
     ),
 )
 def test_wait_bar_transient_nested(
@@ -71,10 +75,10 @@ def test_wait_bar_transient_nested(
 @pytest.mark.parametrize(
     ("message", "transient", "output"),
     (
-        ("Wait message...", False, "Wait message...\n\n"),
-        ("", False, "\n"),
-        ("Wait Message...", True, "\n"),
-        ("", True, "\n"),
+        ("Wait message...", False, "Wait message...\n"),
+        ("", False, ""),
+        ("Wait Message...", True, ""),
+        ("", True, ""),
     ),
 )
 def test_wait_bar_keyboard_interrupt(console, message, transient, output, capsys):
@@ -94,11 +98,11 @@ def test_wait_bar_keyboard_interrupt(console, message, transient, output, capsys
             "Wait message 1...",
             "Wait message 2...",
             False,
-            "Wait message 2...\nWait message 1...\n\n",
+            "Wait message 2...\nWait message 1...\n",
         ),
-        ("", "", False, "\n"),
-        ("Wait message 1...", "Wait message 2...", True, "\n"),
-        ("", "", True, "\n"),
+        ("", "", False, ""),
+        ("Wait message 1...", "Wait message 2...", True, ""),
+        ("", "", True, ""),
     ),
 )
 def test_wait_bar_keyboard_interrupt_nested(

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -9,6 +9,7 @@ from briefcase.console import Console
 def console():
     console = Console()
     console.input = mock.MagicMock()
+    console._live_display = mock.MagicMock()
     return console
 
 
@@ -16,4 +17,5 @@ def console():
 def disabled_console():
     console = Console(enabled=False)
     console.input = mock.MagicMock()
+    console._live_display = mock.MagicMock()
     return console

--- a/tests/integrations/subprocess/test_Subprocess__run_in_wait_bar.py
+++ b/tests/integrations/subprocess/test_Subprocess__run_in_wait_bar.py
@@ -29,8 +29,13 @@ def test_call(mock_sub, capsys):
         text=True,
         encoding=ANY,
     )
-    expected_output = "output line 1\n" "\n" "output line 3\n" "\n"
-    assert capsys.readouterr().out == expected_output
+    # fmt: off
+    assert capsys.readouterr().out == (
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+    )
+    # fmt: on
 
 
 def test_call_with_arg(mock_sub, capsys):
@@ -47,8 +52,13 @@ def test_call_with_arg(mock_sub, capsys):
         universal_newlines=True,
         encoding=ANY,
     )
-    expected_output = "output line 1\n" "\n" "output line 3\n" "\n"
-    assert capsys.readouterr().out == expected_output
+    # fmt: off
+    assert capsys.readouterr().out == (
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+    )
+    # fmt: on
 
 
 def test_debug_call(mock_sub, capsys):
@@ -66,7 +76,7 @@ def test_debug_call(mock_sub, capsys):
         text=True,
         encoding=ANY,
     )
-    expected_output = (
+    assert capsys.readouterr().out == (
         "\n"
         ">>> Running Command:\n"
         ">>>     hello world\n"
@@ -76,9 +86,7 @@ def test_debug_call(mock_sub, capsys):
         "\n"
         "output line 3\n"
         ">>> Return code: -3\n"
-        "\n"
     )
-    assert capsys.readouterr().out == expected_output
 
 
 def test_debug_call_with_env(mock_sub, capsys, tmp_path):
@@ -103,7 +111,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path):
         text=True,
         encoding=ANY,
     )
-    expected_output = (
+    assert capsys.readouterr().out == (
         "\n"
         ">>> Running Command:\n"
         ">>>     hello world\n"
@@ -115,9 +123,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path):
         "\n"
         "output line 3\n"
         ">>> Return code: -3\n"
-        "\n"
     )
-    assert capsys.readouterr().out == expected_output
 
 
 @pytest.mark.parametrize(
@@ -163,9 +169,13 @@ def test_stderr_is_redirected(mock_sub, popen_process, capsys):
         text=True,
         encoding=ANY,
     )
-
-    expected_output = "output line 1\n" "\n" "output line 3\n" "\n"
-    assert capsys.readouterr().out == expected_output
+    # fmt: off
+    assert capsys.readouterr().out == (
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+    )
+    # fmt: on
     assert run_result.stderr == stderr_output
 
 
@@ -185,8 +195,13 @@ def test_stderr_dev_null(mock_sub, popen_process, capsys):
         encoding=ANY,
     )
 
-    expected_output = "output line 1\n" "\n" "output line 3\n" "\n"
-    assert capsys.readouterr().out == expected_output
+    # fmt: off
+    assert capsys.readouterr().out == (
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+    )
+    # fmt: on
     assert run_result.stderr is None
 
 
@@ -200,8 +215,13 @@ def test_calledprocesserror(mock_sub, popen_process, capsys):
         with mock_sub.command.input.wait_bar():
             mock_sub.run(["hello", "world"], check=True, stderr=subprocess.PIPE)
 
-    expected_output = "output line 1\n" "\n" "output line 3\n" "\n"
-    assert capsys.readouterr().out == expected_output
+    # fmt: off
+    assert capsys.readouterr().out == (
+        "output line 1\n"
+        "\n"
+        "output line 3\n"
+    )
+    # fmt: on
     assert exc.value.returncode == -3
     assert exc.value.cmd == ["hello", "world"]
     assert exc.value.stderr == stderr_output


### PR DESCRIPTION
## Summary
While our discussions during the initial implementation of Rich largely decided that displaying multiple Rich renderables in the console at once was not necessary, I have found exceptions.

The primary use-case for this functionality is downloading a file while the Wait Bar is running. Right now, all the tools' installations are carefully crafted to start the Wait Bar after the tool has been downloaded.....but we're only doing this because the download progress bar could not be displayed while the Wait Bar was running.

This PR allows arbitrary use of `Console.progress_bar` and `Console.wait_bar` (as well as arbitrary Rich renderables if they are implemented).

<details>
<summary> Example Demo (paste in to REPL)</summary>

```python
from time import sleep
from briefcase.console import Console, Log

logger = Log()
console = Console()
sleep_time = 1

def pause(loop_count=5):
    for idx in range(loop_count):
        logger.info(f"{idx}")
        sleep(sleep_time)

def main():
    with console.wait_bar("Building..."):
        pause(3)
        with console.wait_bar("Installing..."):
            logger.info("Changed wait bar message")
            pause(3)
            logger.info("Starting progress bar with multiple tasks")
            with console.progress_bar() as bar:
                task_1_id = bar.add_task("", total=100)
                task_2_id = bar.add_task("", total=100)
                for idx in range(10):
                    if idx == 4:
                        logger.warning("warning for initial progress bar")
                    if idx == 6:
                        with console.progress_bar() as bar_new:
                            logger.info("Starting a new progress bar inside existing one")
                            new_task_id = bar_new.add_task("", total=100)
                            for _ in range(4):
                                bar_new.update(new_task_id, advance=25)
                                sleep(sleep_time)
                        logger.info("Finished nested progress bar")
                    bar.update(task_1_id, advance=20)
                    bar.update(task_2_id, advance=10)
                    sleep(sleep_time / 2)
            logger.info("Finished initial progress bar with multiple tasks")
            logger.info("removing dynamic elements", prefix='asdf')
            pause(2)
            console.remove_dynamic_elements()
            logger.info("Dynamic elements removed")
            pause(3)
            console.restore_dynamic_elements()
            logger.info("Restored dynamic elements", prefix='asdf')
            pause(3)
            logger.info("Wrapping up install")
        logger.info("Back to 'Building...' wait bar message")
        pause()
    logger.info("All dynamic elements wrapped up; exiting.", prefix="asdf")

main()

```

</details>

## Design
This started out as a curiosity and I ultimately nerd sniped myself...but it was nice getting to know Rich better because it really is so well done.

When a Rich renderable is started in isolation, it will use a Live Display that is reserved just for it. This prevents starting another Rich renderable the same way because Rich limits the [number of active Live Displays to one](https://rich.readthedocs.io/en/latest/live.html#nesting-lives). Therefore, the basis of this approach here is externalizing the Live Display that any renderable will use and managing it alongside the renderables.

Next, the content for the Live Display needs to be managed independently of the Live Display itself. I initially tried to introspect the Live Display to determine what's currently being displayed when I wanted to add or remove renderables. However, Will has said (in an issue/discussion I can no longer find) that the Display and its renderables should be treated more like HTML. Once it is displayed, that's it; if you want to change it, you don't introspect the HTML or modify it directly (unless youre sneaky js i guess). You build a new HTML document using externally managed data. So, I created (more or less) a stack of renderables that can be displayed. You can only add renderables on top of what's already being displayed; so, this isn't entirely generalized to allow doing whatever you want...but this limitation seems reasonable given our use-case.

Finally, I exposed methods to stop and start the Live Display from anywhere in Briefcase. These will be necessary to accommodate cmd.exe's `Terminate batch job` message. I can imagine exposing a context manager that allows you to wrap certain calls while ensuring dynamic elements are turned off....but given I'm imagining the cmd issue to be resolved directly in `subprocess.py`, I wouldn't use such a manager there. But it would be simple enough to create if needed later. (Although, thinking more about this...such a context manager would allow easily prompting the user inside a Wait Bar....as a thought.)

On a sidenote, these changes got rid of the mysterious extra new line that was showing up in wait bar tests...

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
