### PR TITLE
Replace use of `pkg_resources` with `importlib.metadata`

### DIFF
--- a/changes/840.misc.rst
+++ b/changes/840.misc.rst
@@ -1,0 +1,1 @@
+Replace usage of ``pkg_resources`` with ``importlib.metadata``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ install_requires =
     wheel >= 0.34
     cookiecutter >= 1.0
     tomli >= 2.0.0; python_version <= "3.10"
+    importlib_metadata>=4.4.0; python_version <= "3.9"
     requests >= 2.22.0
     GitPython >= 3.0.8
     dmgbuild >= 1.3.3; sys_platform == "darwin"

--- a/src/briefcase/platforms/__init__.py
+++ b/src/briefcase/platforms/__init__.py
@@ -1,10 +1,18 @@
-import pkg_resources
+try:
+    # Usually, the pattern is "import module; if it doesn't exist,
+    # import the shim". However, we need the 3.10 API for entry_points,
+    # as the 3.8 didn't support the `groups` argument to entry_points.
+    # Therefore, we try to import the compatibility shim first; and fall
+    # back to the stdlib module if the shim isn't there.
+    from importlib_metadata import entry_points
+except ImportError:
+    from importlib.metadata import entry_points
 
 
 def get_platforms():
     return {
         entry_point.name: entry_point.load()
-        for entry_point in pkg_resources.iter_entry_points("briefcase.platforms")
+        for entry_point in entry_points(group="briefcase.platforms")
     }
 
 
@@ -14,7 +22,5 @@ def get_output_formats(platform):
     # actual entry point names preserve case.
     return {
         entry_point.name: entry_point.load()
-        for entry_point in pkg_resources.iter_entry_points(
-            f"briefcase.formats.{platform.lower()}"
-        )
+        for entry_point in entry_points(group=f"briefcase.formats.{platform.lower()}")
     }


### PR DESCRIPTION
Python recommends the use of `importlib.metadata` instead of the older `pkg_resources` module. However, the API to do this wasn't really viable until Python 3.10. We now 3.10, and the backwards compatibility shim exists for earlier Python versions that we support.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
