### PR TITLE
Add iOS log filter for messages coming from extension modules.

### DIFF
--- a/changes/842.feature.rst
+++ b/changes/842.feature.rst
@@ -1,0 +1,1 @@
+Log messages can now be captured on iOS if they originate from a dynamically loaded module.

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -353,13 +353,17 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         # Start log stream for the app.
         # The following sets up a log stream filter that looks for:
         #  1. a log sender that matches that app binary; or,
-        #  2. a log sender of that is a Python exception module,
+        #  2. a log sender of that is a Python extension module,
         #     and a process that matches the app binary.
         # Case (1) works when the standard libary is statically linked,
         #   and for native NSLog() calls in the bootstrap binary
         # Case (2) works when the standard library is dynamically linked,
         #   and ctypes (which handles the NSLog integration) is an
         #   extension module.
+        # It's not enough to filter on *just* the processImagePath,
+        # as the process will generate lots of system-level messages.
+        # We can't filter on *just* the senderImagePath, because other
+        # apps will generate log messages that would be caught by the filter.
         simulator_log_popen = self.subprocess.Popen(
             [
                 "xcrun",

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -47,6 +47,10 @@ class macOSRunMixin:
         #  2. a log sender of libffi, and a process that matches the app binary.
         # Case (1) works for pre-Python 3.9 static linked binaries.
         # Case (2) works for Python 3.9+ dynamic linked binaries.
+        # It's not enough to filter on *just* the processImagePath,
+        # as the process will generate lots of system-level messages.
+        # We can't filter on *just* the senderImagePath, because other
+        # apps will generate log messages that would be caught by the filter.
         sender = os.fsdecode(
             self.binary_path(app) / "Contents" / "MacOS" / app.formal_name
         )

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -95,7 +95,9 @@ def test_run_app_simulator_booted(first_app_config, tmp_path):
             "--style",
             "compact",
             "--predicate",
-            'senderImagePath ENDSWITH "/First App"',
+            'senderImagePath ENDSWITH "/First App"'
+            ' OR (processImagePath ENDSWITH "/First App"'
+            ' AND senderImagePath ENDSWITH "-iphonesimulator.so")',
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -199,7 +201,9 @@ def test_run_app_simulator_shut_down(first_app_config, tmp_path):
             "--style",
             "compact",
             "--predicate",
-            'senderImagePath ENDSWITH "/First App"',
+            'senderImagePath ENDSWITH "/First App"'
+            ' OR (processImagePath ENDSWITH "/First App"'
+            ' AND senderImagePath ENDSWITH "-iphonesimulator.so")',
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -316,7 +320,9 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
             "--style",
             "compact",
             "--predicate",
-            'senderImagePath ENDSWITH "/First App"',
+            'senderImagePath ENDSWITH "/First App"'
+            ' OR (processImagePath ENDSWITH "/First App"'
+            ' AND senderImagePath ENDSWITH "-iphonesimulator.so")',
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -669,7 +675,9 @@ def test_run_app_simulator_launch_failure(first_app_config, tmp_path):
             "--style",
             "compact",
             "--predicate",
-            'senderImagePath ENDSWITH "/First App"',
+            'senderImagePath ENDSWITH "/First App"'
+            ' OR (processImagePath ENDSWITH "/First App"'
+            ' AND senderImagePath ENDSWITH "-iphonesimulator.so")',
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
When the ctypes module is dynamically loaded, the source of log messages written to NSLog by Python is reported as the extension module, rather than the name of the app binary. 

This mirrors the filter that is required for macOS apps, where libFFI is dynamically linked; on macOS, libffi is the source of NSLog messages.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
