### PR TITLE
Ensure the RCEdit plugin has a full name.

### DIFF
--- a/changes/837.bugfix.rst
+++ b/changes/837.bugfix.rst
@@ -1,0 +1,1 @@
+The RCEdit plugin can now be upgraded.

--- a/src/briefcase/integrations/rcedit.py
+++ b/src/briefcase/integrations/rcedit.py
@@ -3,6 +3,7 @@ from briefcase.exceptions import MissingToolError
 
 class RCEdit:
     name = "rcedit"
+    full_name = "RCEdit"
 
     def __init__(self, command):
         self.command = command


### PR DESCRIPTION
The contract for the Upgrade command requires that every managed tool integration has a `full_name`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
