### PR TITLE
Improve CI testing configurations of build products

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        platform: ['macos-latest', 'windows-latest', 'ubuntu-18.04']
+        platform: ['macos-latest', 'windows-latest', 'ubuntu-latest']
         framework: ['toga', 'pyside2', 'pyside6', 'ppb']
         include:
         - platform: macos-latest
@@ -148,10 +148,9 @@ jobs:
           briefcase-data-dir: ~\AppData\Local\BeeWare\briefcase\Cache
           pip-cache-dir: ~\AppData\Local\pip\Cache
           docker-cache-dir: C:\ProgramData\DockerDesktop
-        - platform: ubuntu-18.04
+        - platform: ubuntu-latest
           briefcase-data-dir: ~/.cache/briefcase
           pip-cache-dir: ~/.cache/pip
-          briefcase-args: --no-docker
           # cache action cannot cache docker images (actions/cache#31)
           # docker-cache-dir: /var/lib/docker
     runs-on: ${{ matrix.platform }}
@@ -171,7 +170,7 @@ jobs:
       with:
         python-version: ${{ env.python_version }}
     - name: Install dependencies
-      if: matrix.platform == 'ubuntu-18.04'
+      if: matrix.platform == 'ubuntu-latest'
       run: |
         sudo apt-get update -y
         sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-dev libgirepository1.0-dev libcairo2-dev pkg-config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,24 +131,28 @@ jobs:
       run: |
         tox -e py
 
-  verify-desktop:
-    name: Desktop app verification
-    needs: smoke
+  verify-apps:
+    name: App verification
+    needs: platform-compat
     strategy:
       max-parallel: 4
       matrix:
-        platform: ['macos-latest', 'windows-latest', 'ubuntu-latest']
+        os_name: ['macOS', 'windows', 'linux']
         framework: ['toga', 'pyside2', 'pyside6', 'ppb']
         include:
-        - platform: macos-latest
+        - os_name: macOS
+          platform: macos-latest
           briefcase-data-dir: ~/Library/Caches/org.beeware.briefcase
           pip-cache-dir: ~/Library/Caches/pip
           docker-cache-dir: ~/Library/Containers/com.docker.docker/Data/vms/0/
-        - platform: windows-latest
+        - os_name: windows
+          platform: windows-latest
           briefcase-data-dir: ~\AppData\Local\BeeWare\briefcase\Cache
           pip-cache-dir: ~\AppData\Local\pip\Cache
           docker-cache-dir: C:\ProgramData\DockerDesktop
-        - platform: ubuntu-latest
+        - os_name: linux
+          # Need to use at least 22.04 to get the bugfix in flatpak for handling spaces in filenames.
+          platform: ubuntu-22.04
           briefcase-data-dir: ~/.cache/briefcase
           pip-cache-dir: ~/.cache/pip
           # cache action cannot cache docker images (actions/cache#31)
@@ -169,16 +173,57 @@ jobs:
       uses: actions/setup-python@v3.1.2
       with:
         python-version: ${{ env.python_version }}
-    - name: Install dependencies
-      if: matrix.platform == 'ubuntu-latest'
+    - name: Install system dependencies
+      if: matrix.platform == 'ubuntu-22.04'
       run: |
-        sudo apt-get update -y
-        sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-dev libgirepository1.0-dev libcairo2-dev pkg-config
+        sudo apt-get install -y flatpak flatpak-builder
     - name: Install dependencies
       run: |
         pip install --upgrade pip
         pip install --upgrade setuptools
-        pip install tox
-    - name: Test
+        pip install .
+    - name: Create App
       run: |
-        tox -e verify-${{ matrix.framework }} -- ${{ matrix.briefcase-args }}
+        cd tests/apps
+        cat verify-${{ matrix.framework }}.config | briefcase new
+    - name: Build App
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create
+        briefcase build
+        briefcase package --adhoc-sign
+    - name: Build Xcode project
+      if: matrix.os_name == 'macOS'
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create ${{ matrix.os_name }} Xcode
+        briefcase build ${{ matrix.os_name }} Xcode
+        briefcase package ${{ matrix.os_name }} Xcode --adhoc-sign
+    - name: Build Visual Studio project
+      if: matrix.os_name == 'windows'
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create ${{ matrix.os_name }} VisualStudio
+        briefcase build ${{ matrix.os_name }} VisualStudio
+        briefcase package ${{ matrix.os_name }} VisualStudio --adhoc-sign
+    - name: Build Flatpak project
+      if: matrix.os_name == 'linux' && matrix.framework == 'toga'
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create ${{ matrix.os_name }} flatpak
+        briefcase build ${{ matrix.os_name }} flatpak
+        briefcase package ${{ matrix.os_name }} flatpak --adhoc-sign
+    - name: Build Android App
+      if: matrix.framework == 'toga'
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create android
+        briefcase build android
+        briefcase package android --adhoc-sign
+    - name: Build iOS App
+      if: matrix.platform == 'macos-latest' && matrix.framework == 'toga'
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create iOS
+        briefcase build iOS -d "iPhone SE (2nd generation)"
+        briefcase package iOS --adhoc-sign

--- a/changes/844.misc.rst
+++ b/changes/844.misc.rst
@@ -1,1 +1,1 @@
-Linux tests are now run in Docker on CI.
+Linux tests are now run in Docker on CI; iOS, Android, Linux Flatpak, macOS Xcode, and Windows VisualStudio are tested.

--- a/changes/844.misc.rst
+++ b/changes/844.misc.rst
@@ -1,0 +1,1 @@
+Linux tests are now run in Docker on CI.

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = towncrier-check,docs,package,py{37,38,39,310,311},verify-{toga,pyside2,pyside6,ppb}
+envlist = towncrier-check,docs,package,py{37,38,39,310,311}
 skip_missing_interpreters = true
 
 [testenv]
@@ -55,17 +55,3 @@ passenv =
     TWINE_PASSWORD
 commands =
     python -m twine upload dist/*
-
-[testenv:verify-{toga,pyside2,pyside6,ppb}]
-setenv = PYTHONPATH = {toxinidir}/src
-changedir = {toxinidir}/tests/apps
-deps =
-allowlist_externals =
-    sh
-    rm
-commands =
-    rm -rf {envname}
-    sh -c 'cat {envname}.config | briefcase new'
-    sh -c 'cd {envname} && briefcase create {posargs}'
-    sh -c 'cd {envname} && briefcase build {posargs}'
-    sh -c 'cd {envname} && briefcase package --adhoc-sign {posargs}'


### PR DESCRIPTION
Github Actions is scheduled to deprecate the ubuntu-18.04 test runner; this means we'll no longer be able to use `--no-docker` in CI. The use of `--no-docker` in CI has also led to some edge cases slipping through our testing, so this is probably desirable anyway.

Since we need to revisit our CI config anyway, this is also an opportune time to improve CI coverage of other testing platforms. This config change adds iOS, Android, Linux Flatpak, macOS Xcode and Windows VisualStudio tests.

It *doesn't* include a full execution of the final product, so it's not a complete solution to #699.

Fixes #839 
Refs #699

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
