### PR TITLE
Fixes #841 - Look for the Android emulator binary, not just the folder.

### DIFF
--- a/changes/841.bugfix.rst
+++ b/changes/841.bugfix.rst
@@ -1,0 +1,1 @@
+When verifying the existence of the Android emulator, Briefcase now looks for the actual binary, not the folder that contains the binary. This was causing false positives on some Android SDK setups.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -406,7 +406,7 @@ connection.
         # might be missing.
         (self.root_path / "platforms").mkdir(exist_ok=True)
 
-        if (self.root_path / "emulator").exists():
+        if (self.emulator_path).exists():
             self.command.logger.debug("Android emulator is already installed.")
             return
 

--- a/tests/integrations/android_sdk/ADB/test_command.py
+++ b/tests/integrations/android_sdk/ADB/test_command.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -18,7 +19,12 @@ def test_simple_command(mock_sdk, tmp_path):
     # Check that adb was invoked with the expected commands
     mock_sdk.command.subprocess.check_output.assert_called_once_with(
         [
-            os.fsdecode(tmp_path / "sdk" / "platform-tools" / "adb"),
+            os.fsdecode(
+                tmp_path
+                / "sdk"
+                / "platform-tools"
+                / f"adb{'.exe' if sys.platform == 'win32' else ''}"
+            ),
             "-s",
             "exampleDevice",
             "example",
@@ -63,7 +69,12 @@ def test_error_handling(mock_sdk, tmp_path, name, exception):
     # Check that adb was invoked as expected
     mock_sdk.command.subprocess.check_output.assert_called_once_with(
         [
-            os.fsdecode(tmp_path / "sdk" / "platform-tools" / "adb"),
+            os.fsdecode(
+                tmp_path
+                / "sdk"
+                / "platform-tools"
+                / f"adb{'.exe' if sys.platform == 'win32' else ''}"
+            ),
             "-s",
             "exampleDevice",
             "example",

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
@@ -12,11 +12,11 @@ from ....utils import create_file
 def create_emulator(root_path):
     # Create `emulator` within `root_path`.
     if sys.platform == "win32":
-        create_file(
-            root_path / "emulator" / "emulator.exe", "The Emulator", chmod=0o755
-        )
+        emulator_bin = "emulator.exe"
     else:
-        create_file(root_path / "emulator" / "emulator", "The Emulator", chmod=0o755)
+        emulator_bin = "emulator"
+
+    create_file(root_path / "emulator" / emulator_bin, "The Emulator", chmod=0o755)
 
 
 def test_succeeds_immediately_if_emulator_installed(mock_sdk):

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
@@ -13,7 +13,7 @@ def create_emulator(root_path):
     # Create `emulator` within `root_path`.
     if sys.platform == "win32":
         create_file(
-            root_path / "emulator" / "emulator.bat", "The Emulator", chmod=0o755
+            root_path / "emulator" / "emulator.exe", "The Emulator", chmod=0o755
         )
     else:
         create_file(root_path / "emulator" / "emulator", "The Emulator", chmod=0o755)

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
@@ -1,16 +1,29 @@
 import os
 import subprocess
+import sys
 
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
+
+from ....utils import create_file
+
+
+def create_emulator(root_path):
+    # Create `emulator` within `root_path`.
+    if sys.platform == "win32":
+        create_file(
+            root_path / "emulator" / "emulator.bat", "The Emulator", chmod=0o755
+        )
+    else:
+        create_file(root_path / "emulator" / "emulator", "The Emulator", chmod=0o755)
 
 
 def test_succeeds_immediately_if_emulator_installed(mock_sdk):
     """`verify_emulator()` exits early if the emulator exists in its
     root_path."""
     # Create `emulator` within `root_path`.
-    (mock_sdk.root_path / "emulator").mkdir(parents=True)
+    create_emulator(mock_sdk.root_path)
 
     # Also create the platforms folder
     (mock_sdk.root_path / "platforms").mkdir(parents=True)
@@ -28,7 +41,7 @@ def test_succeeds_immediately_if_emulator_installed(mock_sdk):
 def test_creates_platforms_folder(mock_sdk):
     """If the platforms folder doesn't exist, it is created."""
     # Create `emulator` within `root_path`.
-    (mock_sdk.root_path / "emulator").mkdir(parents=True)
+    create_emulator(mock_sdk.root_path)
 
     # Verify the emulator. This should create the missing platforms folder.
     mock_sdk.verify_emulator()
@@ -43,6 +56,28 @@ def test_creates_platforms_folder(mock_sdk):
 
 def test_installs_android_emulator(mock_sdk):
     """The emulator tools will be installed if needed."""
+    mock_sdk.verify_emulator()
+
+    # Platforms folder now exists
+    assert (mock_sdk.root_path / "platforms").exists()
+
+    mock_sdk.command.subprocess.run.assert_called_once_with(
+        [
+            os.fsdecode(mock_sdk.sdkmanager_path),
+            "platform-tools",
+            "emulator",
+        ],
+        env=mock_sdk.env,
+        check=True,
+    )
+
+
+def test_partial_android_emulator_install(mock_sdk):
+    """If the Android emulator is only partially installed, it's not
+    detected."""
+    # Create the emulator *directory*, but not the actual binary.
+    (mock_sdk.root_path / "emulator").mkdir(parents=True)
+
     mock_sdk.verify_emulator()
 
     # Platforms folder now exists

--- a/tests/integrations/android_sdk/conftest.py
+++ b/tests/integrations/android_sdk/conftest.py
@@ -1,3 +1,4 @@
+import platform
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -17,9 +18,8 @@ def mock_sdk(tmp_path):
     command.input = DummyConsole()
     command.logger = Log(verbosity=1)
 
-    # For default test purposes, assume we're on macOS x86_64
-    command.host_os = "Darwin"
-    command.host_arch = "x86_64"
+    command.host_arch = platform.machine()
+    command.host_os = platform.system()
 
     # Mock an empty environment
     command.os.environ = {}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+import os
 import zipfile
 from unittest.mock import MagicMock
 
@@ -31,7 +32,7 @@ class FsPathMock(MagicMock):
         return MagicMock(**kw)
 
 
-def create_file(filepath, content, mode="w"):
+def create_file(filepath, content, mode="w", chmod=None):
     """A test utility to create a file with known content.
 
     Ensures that the directory for the file exists, and writes a file with
@@ -47,6 +48,9 @@ def create_file(filepath, content, mode="w"):
     filepath.parent.mkdir(parents=True, exist_ok=True)
     with filepath.open(mode) as f:
         f.write(content)
+
+    if chmod:
+        os.chmod(filepath, chmod)
 
     return filepath
 


### PR DESCRIPTION
In some configurations, the Android SDK would have an empty (or near empty) emulator directory, and *not* have the emulator binary. This led to a false positive detection of the emulator, and any emulator-related activity (such as listing the AVDs would fail).

This PR checks for the actual binary, not just the folder that contains the binary.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
