### PR TITLE
Add an "open" command.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,13 @@ jobs:
     - name: Test
       run: |
         tox -e py
+    - name: Check coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: unittests
+        fail_ci_if_error: true
 
   platform-compat:
     name: Platform compatibility test
@@ -130,6 +137,13 @@ jobs:
     - name: Test
       run: |
         tox -e py
+    - name: Check coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: unittests
+        fail_ci_if_error: true
 
   verify-desktop:
     name: Desktop app verification

--- a/changes/846.feature.rst
+++ b/changes/846.feature.rst
@@ -1,0 +1,1 @@
+Added an "open" command that can be used to open projects in IDEs.

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -47,6 +47,7 @@ def parse_cmdline(args):
             "upgrade",
             "create",
             "update",
+            "open",
             "build",
             "run",
             "package",

--- a/src/briefcase/commands/__init__.py
+++ b/src/briefcase/commands/__init__.py
@@ -2,6 +2,7 @@ from .build import BuildCommand  # noqa
 from .create import CreateCommand  # noqa
 from .dev import DevCommand  # noqa
 from .new import NewCommand  # noqa
+from .open import OpenCommand  # noqa
 from .package import PackageCommand  # noqa
 from .publish import PublishCommand  # noqa
 from .run import RunCommand  # noqa

--- a/src/briefcase/commands/open.py
+++ b/src/briefcase/commands/open.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+from briefcase.config import BaseConfig
+
+from .base import BaseCommand, full_options
+
+
+class OpenCommand(BaseCommand):
+    command = "open"
+
+    def open_project(self, project_path):
+        if self.host_os == "Windows":
+            self.os.startfile(project_path)
+        elif self.host_os == "Darwin":
+            self.subprocess.Popen(["open", project_path])
+        else:
+            self.subprocess.Popen(["xdg-open", project_path])
+
+    def open_app(self, app: BaseConfig, **options):
+        """Open the project for an app.
+
+        :param app: The application to open
+        """
+        project_path = self.project_path(app)
+        if not project_path.exists():
+            state = self.create_command(app, **options)
+        else:
+            state = None
+
+        self.logger.info(
+            f"Opening {self.project_path(app).relative_to(self.base_path)}...",
+            prefix=app.app_name,
+        )
+        self.open_project(project_path)
+
+        return state
+
+    def __call__(self, app: Optional[BaseConfig] = None, **options):
+        # Confirm all required tools are available
+        self.verify_tools()
+
+        if app:
+            state = self.open_app(app, **options)
+        else:
+            state = None
+            for app_name, app in sorted(self.apps.items()):
+                state = self.open_app(app, **full_options(state, options))
+
+        return state

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -5,6 +5,7 @@ import time
 from briefcase.commands import (
     BuildCommand,
     CreateCommand,
+    OpenCommand,
     PackageCommand,
     PublishCommand,
     RunCommand,
@@ -59,6 +60,9 @@ class GradleMixin:
             self.platform_path / self.output_format / safe_formal_name(app.formal_name)
         )
 
+    def project_path(self, app):
+        return self.bundle_path(app)
+
     def binary_path(self, app):
         return (
             self.bundle_path(app)
@@ -95,7 +99,7 @@ class GradleMixin:
 
 
 class GradleCreateCommand(GradleMixin, CreateCommand):
-    description = "Create and populate an Android APK."
+    description = "Create and populate an Android Gradle project."
 
     def output_format_template_context(self, app: BaseConfig):
         """Additional template context required by the output format.
@@ -121,7 +125,11 @@ class GradleCreateCommand(GradleMixin, CreateCommand):
 
 
 class GradleUpdateCommand(GradleMixin, UpdateCommand):
-    description = "Update an existing Android debug APK."
+    description = "Update an existing Android Gradle project."
+
+
+class GradleOpenCommand(GradleMixin, OpenCommand):
+    description = "Open the folder for an Android Gradle project."
 
 
 class GradleBuildCommand(GradleMixin, BuildCommand):
@@ -269,6 +277,7 @@ class GradlePublishCommand(GradleMixin, PublishCommand):
 
 # Declare the briefcase command bindings
 create = GradleCreateCommand  # noqa
+open = GradleOpenCommand  # noqa
 update = GradleUpdateCommand  # noqa
 build = GradleBuildCommand  # noqa
 run = GradleRunCommand  # noqa

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from briefcase.commands import (
     BuildCommand,
     CreateCommand,
+    OpenCommand,
     PackageCommand,
     PublishCommand,
     RunCommand,
@@ -27,6 +28,9 @@ class iOSXcodePassiveMixin(iOSMixin):
     @property
     def default_packaging_format(self):
         return "ipa"
+
+    def project_path(self, app):
+        return self.bundle_path(app) / f"{app.formal_name}.xcodeproj"
 
     def binary_path(self, app):
         return (
@@ -209,6 +213,10 @@ class iOSXcodeUpdateCommand(iOSXcodePassiveMixin, UpdateCommand):
     description = "Update an existing iOS Xcode project."
 
 
+class iOSXcodeOpenCommand(iOSXcodePassiveMixin, OpenCommand):
+    description = "Open an existing iOS Xcode project."
+
+
 class iOSXcodeBuildCommand(iOSXcodeMixin, BuildCommand):
     description = "Build an iOS Xcode project."
 
@@ -238,7 +246,7 @@ class iOSXcodeBuildCommand(iOSXcodeMixin, BuildCommand):
                     [
                         "xcodebuild",
                         "-project",
-                        self.bundle_path(app) / f"{app.formal_name}.xcodeproj",
+                        self.project_path(app),
                         "-destination",
                         f'platform="iOS Simulator,name={device},OS={iOS_version}"',
                         "-quiet",
@@ -407,6 +415,7 @@ class iOSXcodePublishCommand(iOSXcodeMixin, PublishCommand):
 # Declare the briefcase command bindings
 create = iOSXcodeCreateCommand  # noqa
 update = iOSXcodeUpdateCommand  # noqa
+open = iOSXcodeOpenCommand  # noqa
 build = iOSXcodeBuildCommand  # noqa
 run = iOSXcodeRunCommand  # noqa
 package = iOSXcodePackageCommand  # noqa

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from briefcase.commands import (
     BuildCommand,
     CreateCommand,
+    OpenCommand,
     PackageCommand,
     PublishCommand,
     RunCommand,
@@ -22,6 +23,9 @@ class LinuxAppImageMixin(LinuxMixin):
 
     def appdir_path(self, app):
         return self.bundle_path(app) / f"{app.formal_name}.AppDir"
+
+    def project_path(self, app):
+        return self.bundle_path(app)
 
     def binary_path(self, app):
         binary_name = app.formal_name.replace(" ", "_")
@@ -136,6 +140,10 @@ class LinuxAppImageCreateCommand(LinuxAppImageMixin, CreateCommand):
 
 class LinuxAppImageUpdateCommand(LinuxAppImageMixin, UpdateCommand):
     description = "Update an existing Linux AppImage."
+
+
+class LinuxAppImageOpenCommand(LinuxAppImageMixin, OpenCommand):
+    description = "Open the folder containing an existing Linux AppImage project."
 
 
 class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
@@ -290,6 +298,7 @@ class LinuxAppImagePublishCommand(LinuxAppImageMixin, PublishCommand):
 # Declare the briefcase command bindings
 create = LinuxAppImageCreateCommand  # noqa
 update = LinuxAppImageUpdateCommand  # noqa
+open = LinuxAppImageOpenCommand  # noqa
 build = LinuxAppImageBuildCommand  # noqa
 run = LinuxAppImageRunCommand  # noqa
 package = LinuxAppImagePackageCommand  # noqa

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -18,7 +18,10 @@ from briefcase.integrations.linuxdeploy import LinuxDeploy
 from briefcase.platforms.linux import LinuxMixin
 
 
-class LinuxAppImageMixin(LinuxMixin):
+class LinuxAppImagePassiveMixin(LinuxMixin):
+    # The Passive mixin honors the docker options, but doesn't try to verify
+    # docker exists. It is used by commands that are "passive" from the
+    # perspective of the build system, like open and run.
     output_format = "appimage"
 
     def appdir_path(self, app):
@@ -60,6 +63,8 @@ class LinuxAppImageMixin(LinuxMixin):
         super().clone_options(command)
         self.use_docker = command.use_docker
 
+
+class LinuxAppImageMixin(LinuxAppImagePassiveMixin):
     def docker_image_tag(self, app):
         """The Docker image tag for an app."""
         return (
@@ -142,7 +147,7 @@ class LinuxAppImageUpdateCommand(LinuxAppImageMixin, UpdateCommand):
     description = "Update an existing Linux AppImage."
 
 
-class LinuxAppImageOpenCommand(LinuxAppImageMixin, OpenCommand):
+class LinuxAppImageOpenCommand(LinuxAppImagePassiveMixin, OpenCommand):
     description = "Open the folder containing an existing Linux AppImage project."
 
 
@@ -260,7 +265,7 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
                 ) from e
 
 
-class LinuxAppImageRunCommand(LinuxAppImageMixin, RunCommand):
+class LinuxAppImageRunCommand(LinuxAppImagePassiveMixin, RunCommand):
     description = "Run a Linux AppImage."
 
     def verify_tools(self):

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -1,6 +1,7 @@
 from briefcase.commands import (
     BuildCommand,
     CreateCommand,
+    OpenCommand,
     PackageCommand,
     PublishCommand,
     RunCommand,
@@ -21,6 +22,9 @@ class LinuxFlatpakMixin(LinuxMixin):
         # if run has been invoked. As a neat side effect, it's also a shell script
         # that can invoke the flatpak.
         return self.bundle_path(app) / f"{app.bundle}.{app.app_name}"
+
+    def project_path(self, app):
+        return self.bundle_path(app)
 
     def distribution_path(self, app, packaging_format):
         binary_name = app.formal_name.replace(" ", "_")
@@ -125,6 +129,10 @@ class LinuxFlatpakUpdateCommand(LinuxFlatpakMixin, UpdateCommand):
     description = "Update an existing Linux Flatpak."
 
 
+class LinuxFlatpakOpenCommand(LinuxFlatpakMixin, OpenCommand):
+    description = "Open the folder containing an existing Linux Flatpak project."
+
+
 class LinuxFlatpakBuildCommand(LinuxFlatpakMixin, BuildCommand):
     description = "Build a Linux Flatpak."
 
@@ -207,6 +215,7 @@ class LinuxFlatpakPublishCommand(LinuxFlatpakMixin, PublishCommand):
 # Declare the briefcase command bindings
 create = LinuxFlatpakCreateCommand  # noqa
 update = LinuxFlatpakUpdateCommand  # noqa
+open = LinuxFlatpakOpenCommand  # noqa
 build = LinuxFlatpakBuildCommand  # noqa
 run = LinuxFlatpakRunCommand  # noqa
 package = LinuxFlatpakPackageCommand  # noqa

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from briefcase.commands import (
     BuildCommand,
     CreateCommand,
+    OpenCommand,
     PackageCommand,
     PublishCommand,
     RunCommand,
@@ -21,6 +22,9 @@ from briefcase.platforms.macOS import (
 
 class macOSAppMixin(macOSMixin):
     output_format = "app"
+
+    def project_path(self, app):
+        return self.binary_path(app) / "Contents"
 
     def binary_path(self, app):
         return self.bundle_path(app) / f"{app.formal_name}.app"
@@ -64,6 +68,10 @@ class macOSAppUpdateCommand(macOSAppMixin, UpdateCommand):
     description = "Update an existing macOS app."
 
 
+class macOSAppOpenCommand(macOSAppMixin, OpenCommand):
+    description = "Open the app bundle folder for a macOS app."
+
+
 class macOSAppBuildCommand(macOSAppMixin, macOSSigningMixin, BuildCommand):
     description = "Build a macOS app."
 
@@ -95,6 +103,7 @@ class macOSAppPublishCommand(macOSAppMixin, PublishCommand):
 # Declare the briefcase command bindings
 create = macOSAppCreateCommand  # noqa
 update = macOSAppUpdateCommand  # noqa
+open = macOSAppOpenCommand  # noqa
 build = macOSAppBuildCommand  # noqa
 run = macOSAppRunCommand  # noqa
 package = macOSAppPackageCommand  # noqa

--- a/src/briefcase/platforms/macOS/xcode.py
+++ b/src/briefcase/platforms/macOS/xcode.py
@@ -3,6 +3,7 @@ import subprocess
 from briefcase.commands import (
     BuildCommand,
     CreateCommand,
+    OpenCommand,
     PackageCommand,
     PublishCommand,
     RunCommand,
@@ -32,6 +33,9 @@ class macOSXcodeMixin(macOSMixin):
         # git check *after* the xcode check.
         super().verify_tools()
 
+    def project_path(self, app):
+        return self.bundle_path(app) / f"{app.formal_name}.xcodeproj"
+
     def binary_path(self, app):
         return (
             self.platform_path
@@ -60,6 +64,10 @@ class macOSXcodeCreateCommand(macOSXcodeMixin, CreateCommand):
     description = "Create and populate a macOS Xcode project."
 
 
+class macOSXcodeOpenCommand(macOSXcodeMixin, OpenCommand):
+    description = "Open a macOS Xcode project."
+
+
 class macOSXcodeUpdateCommand(macOSXcodeMixin, UpdateCommand):
     description = "Update an existing macOS Xcode project."
 
@@ -80,7 +88,7 @@ class macOSXcodeBuildCommand(macOSXcodeMixin, BuildCommand):
                     [
                         "xcodebuild",
                         "-project",
-                        self.bundle_path(app) / f"{app.formal_name}.xcodeproj",
+                        self.project_path(app),
                         "-quiet",
                         "-configuration",
                         "Release",
@@ -110,6 +118,7 @@ class macOSXcodePublishCommand(macOSXcodeMixin, PublishCommand):
 # Declare the briefcase command bindings
 create = macOSXcodeCreateCommand  # noqa
 update = macOSXcodeUpdateCommand  # noqa
+open = macOSXcodeOpenCommand  # noqa
 build = macOSXcodeBuildCommand  # noqa
 run = macOSXcodeRunCommand  # noqa
 package = macOSXcodePackageCommand  # noqa

--- a/src/briefcase/platforms/windows/app.py
+++ b/src/briefcase/platforms/windows/app.py
@@ -1,7 +1,7 @@
 import subprocess
 from pathlib import Path
 
-from briefcase.commands import BuildCommand, PublishCommand, UpdateCommand
+from briefcase.commands import BuildCommand, OpenCommand, PublishCommand, UpdateCommand
 from briefcase.config import BaseConfig
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.rcedit import RCEdit
@@ -17,6 +17,9 @@ class WindowsAppMixin(WindowsMixin):
     output_format = "app"
     packaging_root = Path("src")
 
+    def project_path(self, app):
+        return self.bundle_path(app)
+
 
 class WindowsAppCreateCommand(WindowsAppMixin, WindowsCreateCommand):
     description = "Create and populate a Windows app."
@@ -24,6 +27,10 @@ class WindowsAppCreateCommand(WindowsAppMixin, WindowsCreateCommand):
 
 class WindowsAppUpdateCommand(WindowsAppMixin, UpdateCommand):
     description = "Update an existing Windows app."
+
+
+class WindowsAppOpenCommand(WindowsAppMixin, OpenCommand):
+    description = "Open the folder containing an existing Windows app."
 
 
 class WindowsAppBuildCommand(WindowsAppMixin, BuildCommand):
@@ -97,6 +104,7 @@ class WindowsAppPublishCommand(WindowsAppMixin, PublishCommand):
 # Declare the briefcase command bindings
 create = WindowsAppCreateCommand  # noqa
 update = WindowsAppUpdateCommand  # noqa
+open = WindowsAppOpenCommand  # noqa
 build = WindowsAppBuildCommand  # noqa
 run = WindowsAppRunCommand  # noqa
 package = WindowsAppPackageCommand  # noqa

--- a/src/briefcase/platforms/windows/visualstudio.py
+++ b/src/briefcase/platforms/windows/visualstudio.py
@@ -1,7 +1,7 @@
 import subprocess
 from pathlib import Path
 
-from briefcase.commands import BuildCommand, PublishCommand, UpdateCommand
+from briefcase.commands import BuildCommand, OpenCommand, PublishCommand, UpdateCommand
 from briefcase.config import BaseConfig
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.visualstudio import VisualStudio
@@ -17,17 +17,24 @@ class WindowsVisualStudioMixin(WindowsMixin):
     output_format = "VisualStudio"
     packaging_root = Path("x64") / "Release"
 
+    def project_path(self, app):
+        return self.bundle_path(app) / f"{app.formal_name}.sln"
+
 
 class WindowsVisualStudioCreateCommand(WindowsVisualStudioMixin, WindowsCreateCommand):
-    description = "Create and populate a Visual Studio app project."
+    description = "Create and populate a Visual Studio project."
 
 
 class WindowsVisualStudioUpdateCommand(WindowsVisualStudioMixin, UpdateCommand):
-    description = "Update an existing Visual Studio app project."
+    description = "Update an existing Visual Studio project."
+
+
+class WindowsVisualStudioOpenCommand(WindowsVisualStudioMixin, OpenCommand):
+    description = "Open an existing Visual Studio project."
 
 
 class WindowsVisualStudioBuildCommand(WindowsVisualStudioMixin, BuildCommand):
-    description = "Build a Visual Studio app project."
+    description = "Build a Visual Studio project."
 
     def verify_tools(self):
         super().verify_tools()
@@ -61,23 +68,24 @@ class WindowsVisualStudioBuildCommand(WindowsVisualStudioMixin, BuildCommand):
 
 
 class WindowsVisualStudioRunCommand(WindowsVisualStudioMixin, WindowsRunCommand):
-    description = "Run a Visual Studio app project."
+    description = "Run a Visual Studio project."
 
 
 class WindowsVisualStudioPackageCommand(
     WindowsVisualStudioMixin,
     WindowsPackageCommand,
 ):
-    description = "Package a Visual Studio app project as an MSI."
+    description = "Package a Visual Studio project as an MSI."
 
 
 class WindowsVisualStudioPublishCommand(WindowsVisualStudioMixin, PublishCommand):
-    description = "Publish a Visual Studio app project."
+    description = "Publish a Visual Studio project."
 
 
 # Declare the briefcase command bindings
 create = WindowsVisualStudioCreateCommand  # noqa
 update = WindowsVisualStudioUpdateCommand  # noqa
+open = WindowsVisualStudioOpenCommand  # noqa
 build = WindowsVisualStudioBuildCommand  # noqa
 run = WindowsVisualStudioRunCommand  # noqa
 package = WindowsVisualStudioPackageCommand  # noqa

--- a/tests/commands/open/conftest.py
+++ b/tests/commands/open/conftest.py
@@ -1,0 +1,96 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.commands import OpenCommand
+from briefcase.commands.base import full_options
+from briefcase.config import AppConfig
+
+from ...utils import create_file
+
+
+class DummyOpenCommand(OpenCommand):
+    """A dummy open command that doesn't actually do anything.
+
+    It only serves to track which actions would be performend.
+    """
+
+    platform = "tester"
+    output_format = "dummy"
+    description = "Dummy Open command"
+
+    def __init__(self, *args, apps, **kwargs):
+        super().__init__(*args, apps=apps, **kwargs)
+
+        # Override the OS services that are used when opening
+        self.os = MagicMock()
+        self.subprocess = MagicMock()
+
+        self.actions = []
+
+    def binary_path(self, app):
+        raise NotImplementedError(
+            "Required by interface contract, but should not be used"
+        )
+
+    def project_path(self, app):
+        return self.bundle_path(app) / f"{app.formal_name}.project"
+
+    def distribution_path(self, app, packaging_format):
+        raise NotImplementedError(
+            "Required by interface contract, but should not be used"
+        )
+
+    def verify_tools(self):
+        super().verify_tools()
+        self.actions.append(("verify",))
+
+    def open_project(self, project_path):
+        super().open_project(project_path)
+        self.actions.append(("open", project_path))
+
+    # These commands override the default behavior, simply tracking that
+    # they were invoked, rather than instantiating a Create command.
+    # This is for testing purposes.
+    def create_command(self, app, **kwargs):
+        self.actions.append(("create", app.app_name, kwargs))
+        return full_options({"create_state": app.app_name}, kwargs)
+
+
+@pytest.fixture
+def open_command(tmp_path):
+    return DummyOpenCommand(
+        base_path=tmp_path,
+        apps={
+            "first": AppConfig(
+                app_name="first",
+                bundle="com.example",
+                version="0.0.1",
+                description="The first simple app",
+                sources=["src/first"],
+            ),
+            "second": AppConfig(
+                app_name="second",
+                bundle="com.example",
+                version="0.0.2",
+                description="The second simple app",
+                sources=["src/second"],
+            ),
+        },
+    )
+
+
+@pytest.fixture
+def first_app(tmp_path):
+    """Populate skeleton app content for the first app."""
+    project_file = tmp_path / "tester" / "dummy" / "first" / "first.project"
+    create_file(project_file, "first project")
+    return project_file
+
+
+@pytest.fixture
+def second_app(tmp_path):
+    """Populate skeleton app content for the second app."""
+    project_file = tmp_path / "tester" / "dummy" / "second" / "second.project"
+    create_file(project_file, "second project")
+    return project_file

--- a/tests/commands/open/test_call.py
+++ b/tests/commands/open/test_call.py
@@ -1,0 +1,46 @@
+def test_open(open_command, first_app, second_app):
+    """The open command can be called."""
+    # Configure no command line options
+    options = open_command.parse_options([])
+
+    open_command(**options)
+
+    # The right sequence of things will be done
+    assert open_command.actions == [
+        ("verify",),
+        # open the first app
+        ("open", first_app),
+        # open the second app
+        ("open", second_app),
+    ]
+
+
+def test_open_single(open_command, first_app):
+    """The open command can be called to open a single app from the config."""
+    # Configure no command line options
+    options = open_command.parse_options([])
+
+    open_command(app=open_command.apps["first"], **options)
+
+    # The right sequence of things will be done
+    assert open_command.actions == [
+        ("verify",),
+        # open the first app
+        ("open", first_app),
+    ]
+
+
+def test_create_before_open(open_command, tmp_path):
+    """If the app doesn't exist, it will be created before opening."""
+    # Configure no command line options
+    options = open_command.parse_options([])
+
+    open_command(app=open_command.apps["first"], **options)
+
+    # The right sequence of things will be done
+    assert open_command.actions == [
+        ("verify",),
+        # create, then open the first app
+        ("create", "first", {}),
+        ("open", tmp_path / "tester" / "dummy" / "first" / "first.project"),
+    ]

--- a/tests/commands/open/test_open_project.py
+++ b/tests/commands/open/test_open_project.py
@@ -1,0 +1,33 @@
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="Windows specific test")
+def test_open_macOS(open_command, tmp_path):
+    """On macOS, open invokes `open`"""
+    open_command(app=open_command.apps["first"])
+
+    open_command.subprocess.Popen.assert_called_once_with(
+        ["open", tmp_path / "tester" / "dummy" / "first" / "first.project"]
+    )
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Windows specific test")
+def test_open_linux(open_command, tmp_path):
+    """On linux, open invokes `xdg-open`"""
+    open_command(app=open_command.apps["first"])
+
+    open_command.subprocess.Popen.assert_called_once_with(
+        ["xdg-open", tmp_path / "tester" / "dummy" / "first" / "first.project"]
+    )
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows specific test")
+def test_open_windows(open_command, tmp_path):
+    """On Windows, open invokes `startfile`"""
+    open_command(app=open_command.apps["first"])
+
+    assert open_command.os.startfile.assert_called_once_with(
+        tmp_path / "tester" / "dummy" / "first" / "first.project"
+    )

--- a/tests/commands/open/test_open_project.py
+++ b/tests/commands/open/test_open_project.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 
-@pytest.mark.skipif(sys.platform != "darwin", reason="Windows specific test")
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS specific test")
 def test_open_macOS(open_command, tmp_path):
     """On macOS, open invokes `open`"""
     open_command(app=open_command.apps["first"])
@@ -13,7 +13,7 @@ def test_open_macOS(open_command, tmp_path):
     )
 
 
-@pytest.mark.skipif(sys.platform != "linux", reason="Windows specific test")
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux specific test")
 def test_open_linux(open_command, tmp_path):
     """On linux, open invokes `xdg-open`"""
     open_command(app=open_command.apps["first"])

--- a/tests/commands/open/test_open_project.py
+++ b/tests/commands/open/test_open_project.py
@@ -28,6 +28,6 @@ def test_open_windows(open_command, tmp_path):
     """On Windows, open invokes `startfile`"""
     open_command(app=open_command.apps["first"])
 
-    assert open_command.os.startfile.assert_called_once_with(
+    open_command.os.startfile.assert_called_once_with(
         tmp_path / "tester" / "dummy" / "first" / "first.project"
     )

--- a/tests/platforms/android/gradle/test_open.py
+++ b/tests/platforms/android/gradle/test_open.py
@@ -8,6 +8,20 @@ from briefcase.platforms.android.gradle import GradleOpenCommand
 from ....utils import create_file
 
 
+def create_sdk_manager(tmp_path, extension=""):
+    create_file(
+        tmp_path
+        / "data"
+        / "tools"
+        / "android_sdk"
+        / "cmdline-tools"
+        / "latest"
+        / "bin"
+        / f"sdkmanager{extension}",
+        "Android SDK manager",
+    )
+
+
 @pytest.fixture
 def open_command(tmp_path, first_app_config):
     command = GradleOpenCommand(
@@ -45,17 +59,7 @@ def test_open_macOS(open_command, first_app_config, tmp_path):
     open_command.project_path(first_app_config).mkdir(parents=True)
 
     # Create a stub sdkmanager
-    create_file(
-        tmp_path
-        / "data"
-        / "tools"
-        / "android_sdk"
-        / "cmdline-tools"
-        / "latest"
-        / "bin"
-        / "sdkmanager",
-        "Android SDK manager",
-    )
+    create_sdk_manager(tmp_path)
 
     open_command(first_app_config)
 
@@ -74,17 +78,7 @@ def test_open_linux(open_command, first_app_config, tmp_path):
     create_file(tmp_path / "data" / "tools" / "java" / "bin" / "java", "java")
 
     # Create a stub sdkmanager
-    create_file(
-        tmp_path
-        / "data"
-        / "tools"
-        / "android_sdk"
-        / "cmdline-tools"
-        / "latest"
-        / "bin"
-        / "sdkmanager",
-        "Android SDK manager",
-    )
+    create_sdk_manager(tmp_path)
 
     open_command(first_app_config)
 
@@ -103,17 +97,7 @@ def test_open_windows(open_command, first_app_config, tmp_path):
     create_file(tmp_path / "data" / "tools" / "java" / "bin" / "java", "java")
 
     # Create a stub sdkmanager
-    create_file(
-        tmp_path
-        / "data"
-        / "tools"
-        / "android_sdk"
-        / "cmdline-tools"
-        / "latest"
-        / "bin"
-        / "sdkmanager.bat",
-        "Android SDK manager",
-    )
+    create_sdk_manager(tmp_path, extension=".bat")
 
     open_command(first_app_config)
 

--- a/tests/platforms/android/gradle/test_open.py
+++ b/tests/platforms/android/gradle/test_open.py
@@ -1,0 +1,122 @@
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.platforms.android.gradle import GradleOpenCommand
+
+from ....utils import create_file
+
+
+@pytest.fixture
+def open_command(tmp_path, first_app_config):
+    command = GradleOpenCommand(
+        base_path=tmp_path / "base_path",
+        data_path=tmp_path / "data",
+    )
+    command.os = MagicMock()
+    command.subprocess = MagicMock()
+
+    # Mock some OS calls needed to make the tools appear to exist
+    command.os.environ = {}
+    command.os.access.return_value = True
+
+    # Mock the file marking licenses as accepted
+    create_file(
+        tmp_path
+        / "data"
+        / "tools"
+        / "android_sdk"
+        / "licenses"
+        / "android-sdk-license",
+        "license accepted",
+    )
+
+    return command
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS specific test")
+def test_open_macOS(open_command, first_app_config, tmp_path):
+    """On macOS, open uses Finder to open the project folder."""
+    # Mock the call to verify the existence of java
+    open_command.subprocess.check_output.return_value = "javac 1.8.0_144\n"
+
+    # Create the project folder to mock a created project.
+    open_command.project_path(first_app_config).mkdir(parents=True)
+
+    # Create a stub sdkmanager
+    create_file(
+        tmp_path
+        / "data"
+        / "tools"
+        / "android_sdk"
+        / "cmdline-tools"
+        / "latest"
+        / "bin"
+        / "sdkmanager",
+        "Android SDK manager",
+    )
+
+    open_command(first_app_config)
+
+    open_command.subprocess.Popen.assert_called_once_with(
+        ["open", tmp_path / "base_path" / "android" / "gradle" / "First App"]
+    )
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux specific test")
+def test_open_linux(open_command, first_app_config, tmp_path):
+    """On linux, open invokes `xdg-open` on the project folder."""
+    # Create the project folder to mock a created project.
+    open_command.project_path(first_app_config).mkdir(parents=True)
+
+    # Create a stub java binary
+    create_file(tmp_path / "data" / "tools" / "java" / "bin" / "java", "java")
+
+    # Create a stub sdkmanager
+    create_file(
+        tmp_path
+        / "data"
+        / "tools"
+        / "android_sdk"
+        / "cmdline-tools"
+        / "latest"
+        / "bin"
+        / "sdkmanager",
+        "Android SDK manager",
+    )
+
+    open_command(first_app_config)
+
+    open_command.subprocess.Popen.assert_called_once_with(
+        ["xdg-open", tmp_path / "base_path" / "android" / "gradle" / "First App"]
+    )
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows specific test")
+def test_open_windows(open_command, first_app_config, tmp_path):
+    """On Windows, open invokes `startfile` on the project folder."""
+    # Create the project folder to mock a created project.
+    open_command.project_path(first_app_config).mkdir(parents=True)
+
+    # Create a stub java binary
+    create_file(tmp_path / "data" / "tools" / "java" / "bin" / "java", "java")
+
+    # Create a stub sdkmanager
+    create_file(
+        tmp_path
+        / "data"
+        / "tools"
+        / "android_sdk"
+        / "cmdline-tools"
+        / "latest"
+        / "bin"
+        / "sdkmanager.bat",
+        "Android SDK manager",
+    )
+
+    open_command(first_app_config)
+
+    open_command.os.startfile.assert_called_once_with(
+        tmp_path / "base_path" / "android" / "gradle" / "First App"
+    )

--- a/tests/platforms/iOS/xcode/test_open.py
+++ b/tests/platforms/iOS/xcode/test_open.py
@@ -1,0 +1,53 @@
+import subprocess
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.platforms.iOS.xcode import iOSXcodeOpenCommand
+
+from ....utils import create_file
+
+
+@pytest.fixture
+def open_command(tmp_path, first_app_config):
+    command = iOSXcodeOpenCommand(base_path=tmp_path / "base_path")
+    command.os = MagicMock()
+    command.subprocess = MagicMock()
+
+    # Mock the call to verify the existence of the cmdline tools
+    command.subprocess.check_output.side_effect = [
+        # xcode-select -p
+        "/Applications/Xcode.app/Contents/Developer",
+        # xcodebuild -version
+        "Xcode 13.0.0",
+        # xcode-select  --install
+        subprocess.CalledProcessError(cmd=["xcode-select", "--install"], returncode=1),
+        # /usr/bin/clang --version
+        "Apple clang version 13.1.6 (clang-1316.0.21.2.5)\n...",
+    ]
+    return command
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS specific test")
+def test_open(open_command, first_app_config, tmp_path):
+    """On iOS, Open starts Xcode on the project."""
+    # Create the project file to mock a created project.
+    create_file(
+        open_command.project_path(first_app_config) / "project.pbxproj",
+        "Xcode project",
+    )
+
+    open_command(first_app_config)
+
+    open_command.subprocess.Popen.assert_called_once_with(
+        [
+            "open",
+            tmp_path
+            / "base_path"
+            / "iOS"
+            / "Xcode"
+            / "First App"
+            / "First App.xcodeproj",
+        ]
+    )

--- a/tests/platforms/linux/appimage/test_open.py
+++ b/tests/platforms/linux/appimage/test_open.py
@@ -14,9 +14,6 @@ def open_command(tmp_path, first_app_config):
     command.os = MagicMock()
     command.subprocess = MagicMock()
 
-    # Mock the fact that we don't need docker.
-    command.use_docker = False
-
     return command
 
 

--- a/tests/platforms/linux/appimage/test_open.py
+++ b/tests/platforms/linux/appimage/test_open.py
@@ -1,0 +1,41 @@
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.platforms.linux.appimage import LinuxAppImageOpenCommand
+
+from ....utils import create_file
+
+
+@pytest.fixture
+def open_command(tmp_path, first_app_config):
+    command = LinuxAppImageOpenCommand(base_path=tmp_path / "base_path")
+    command.os = MagicMock()
+    command.subprocess = MagicMock()
+
+    # Mock the fact that we don't need docker.
+    command.use_docker = False
+
+    return command
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux specific test")
+def test_open(open_command, first_app_config, tmp_path):
+    """On Linux, Open runs `xdg-open` on the project folder."""
+    # Create the desktop file that would be in the project folder.
+    create_file(
+        open_command.project_path(first_app_config)
+        / "First App.AppDir"
+        / "com.example.firstapp.desktop",
+        "FreeDesktop file",
+    )
+
+    open_command(first_app_config)
+
+    open_command.subprocess.Popen.assert_called_once_with(
+        [
+            "xdg-open",
+            tmp_path / "base_path" / "linux" / "appimage" / "First App",
+        ]
+    )

--- a/tests/platforms/linux/flatpak/test_open.py
+++ b/tests/platforms/linux/flatpak/test_open.py
@@ -1,0 +1,44 @@
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.platforms.linux.flatpak import LinuxFlatpakOpenCommand
+
+from ....utils import create_file
+
+
+@pytest.fixture
+def open_command(tmp_path, first_app_config):
+    command = LinuxFlatpakOpenCommand(base_path=tmp_path / "base_path")
+    command.os = MagicMock()
+    command.subprocess = MagicMock()
+
+    # Mock the call to verify the existence of the flatpak tools
+    command.subprocess.check_output.side_effect = [
+        # flatpak --version
+        "1.2.3",
+        # flatpak-builder --version
+        "1.2.3",
+    ]
+
+    return command
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux specific test")
+def test_open(open_command, first_app_config, tmp_path):
+    """On Linux, Open run `xdg-open` on the Content folder."""
+    # Create the flatpak manifest file that would be in the project bundle.
+    create_file(
+        open_command.project_path(first_app_config) / "manifest.yml",
+        "Flatpak manifest",
+    )
+
+    open_command(first_app_config)
+
+    open_command.subprocess.Popen.assert_called_once_with(
+        [
+            "xdg-open",
+            tmp_path / "base_path" / "linux" / "flatpak" / "First App",
+        ]
+    )

--- a/tests/platforms/macOS/app/test_open.py
+++ b/tests/platforms/macOS/app/test_open.py
@@ -1,0 +1,42 @@
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.platforms.macOS.app import macOSAppOpenCommand
+
+from ....utils import create_file
+
+
+@pytest.fixture
+def open_command(tmp_path, first_app_config):
+    command = macOSAppOpenCommand(base_path=tmp_path / "base_path")
+    command.os = MagicMock()
+    command.subprocess = MagicMock()
+
+    return command
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS specific test")
+def test_open(open_command, first_app_config, tmp_path):
+    """On macOS, Open starts the finder on the Content folder."""
+    # Create the binary that would be in the project bundle.
+    create_file(
+        open_command.project_path(first_app_config) / "MacOS" / "First App",
+        "binary",
+    )
+
+    open_command(first_app_config)
+
+    open_command.subprocess.Popen.assert_called_once_with(
+        [
+            "open",
+            tmp_path
+            / "base_path"
+            / "macOS"
+            / "app"
+            / "First App"
+            / "First App.app"
+            / "Contents",
+        ]
+    )

--- a/tests/platforms/macOS/xcode/test_open.py
+++ b/tests/platforms/macOS/xcode/test_open.py
@@ -1,0 +1,53 @@
+import subprocess
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.platforms.macOS.xcode import macOSXcodeOpenCommand
+
+from ....utils import create_file
+
+
+@pytest.fixture
+def open_command(tmp_path, first_app_config):
+    command = macOSXcodeOpenCommand(base_path=tmp_path / "base_path")
+    command.os = MagicMock()
+    command.subprocess = MagicMock()
+
+    # Mock the call to verify the existence of the cmdline tools
+    command.subprocess.check_output.side_effect = [
+        # xcode-select -p
+        "/Applications/Xcode.app/Contents/Developer",
+        # xcodebuild -version
+        "Xcode 13.0.0",
+        # xcode-select  --install
+        subprocess.CalledProcessError(cmd=["xcode-select", "--install"], returncode=1),
+        # /usr/bin/clang --version
+        "Apple clang version 13.1.6 (clang-1316.0.21.2.5)\n...",
+    ]
+    return command
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS specific test")
+def test_open(open_command, first_app_config, tmp_path):
+    """On macOS, Open starts Xcode on the project."""
+    # Create the project file to mock a created project.
+    create_file(
+        open_command.project_path(first_app_config) / "project.pbxproj",
+        "Xcode project",
+    )
+
+    open_command(first_app_config)
+
+    open_command.subprocess.Popen.assert_called_once_with(
+        [
+            "open",
+            tmp_path
+            / "base_path"
+            / "macOS"
+            / "Xcode"
+            / "First App"
+            / "First App.xcodeproj",
+        ]
+    )

--- a/tests/platforms/windows/app/test_open.py
+++ b/tests/platforms/windows/app/test_open.py
@@ -1,0 +1,27 @@
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.platforms.windows.app import WindowsAppOpenCommand
+
+
+@pytest.fixture
+def open_command(tmp_path, first_app_config):
+    command = WindowsAppOpenCommand(base_path=tmp_path / "base_path")
+    command.os = MagicMock()
+    command.subprocess = MagicMock()
+    return command
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows specific test")
+def test_open_windows(open_command, first_app_config, tmp_path):
+    """On Windows, open invokes `startfile` on the project folder."""
+    # Create the project folder to mock a created project.
+    open_command.project_path(first_app_config).mkdir(parents=True)
+
+    open_command(first_app_config)
+
+    open_command.os.startfile.assert_called_once_with(
+        tmp_path / "base_path" / "windows" / "app" / "First App"
+    )

--- a/tests/platforms/windows/visualstudio/test_open.py
+++ b/tests/platforms/windows/visualstudio/test_open.py
@@ -1,0 +1,34 @@
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.platforms.windows.visualstudio import WindowsVisualStudioOpenCommand
+
+from ....utils import create_file
+
+
+@pytest.fixture
+def open_command(tmp_path, first_app_config):
+    command = WindowsVisualStudioOpenCommand(base_path=tmp_path / "base_path")
+    command.os = MagicMock()
+    command.subprocess = MagicMock()
+    return command
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows specific test")
+def test_open(open_command, first_app_config, tmp_path):
+    """Open command opens visual studio project file."""
+    # Create the solution file that would be in the created project.
+    create_file(open_command.project_path(first_app_config), "Visual Studio Solution")
+
+    open_command(first_app_config)
+
+    open_command.os.startfile.assert_called_once_with(
+        tmp_path
+        / "base_path"
+        / "windows"
+        / "VisualStudio"
+        / "First App"
+        / "First App.sln"
+    )


### PR DESCRIPTION
In the process of developing the Xcode templates for iOS dynamic loading, it occurred to me that it is unnecessarily complex to open the Xcode project associated with an app. 

This PR adds a `briefcase open` command that will open the "project" for the app. For backends like macOS/iOS Xcode, that will open Xcode; for Windows VisualStudio, it will open Visual Studio; for all others it will open the file manager in an appropriate folder. In most cases, that's the root of the generated template; however, for macOS, it will open the `Contents` folder *inside* the app bundle (as this location is fiddly to open).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
