### PR TITLE
Add support for cross-platform binary package installation

### DIFF
--- a/changes/471.feature.rst
+++ b/changes/471.feature.rst
@@ -1,0 +1,1 @@
+iOS now supports the installation of binary packages.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -419,6 +419,15 @@ class CreateCommand(BaseCommand):
                             requirement = os.path.abspath(self.base_path / requirement)
                         f.write(f"{requirement}\n")
 
+    def _extra_pip_args(self, app: BaseConfig):
+        """Any additional arguments that must be passed to pip when installing
+        packages.
+
+        :param app: The app configuration
+        :returns: A list of additional arguments
+        """
+        return []
+
     def _install_app_dependencies(self, app: BaseConfig, app_packages_path):
         """Install dependencies for the app with pip.
 
@@ -457,6 +466,7 @@ class CreateCommand(BaseCommand):
                             "--no-user",
                             f"--target={app_packages_path}",
                         ]
+                        + self._extra_pip_args(app)
                         + app.requires,
                         check=True,
                         **pip_kwargs,

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -124,7 +124,7 @@ class GradleCreateCommand(GradleMixin, CreateCommand):
         }
 
 
-class GradleUpdateCommand(GradleMixin, UpdateCommand):
+class GradleUpdateCommand(GradleCreateCommand, UpdateCommand):
     description = "Update an existing Android Gradle project."
 
 

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -209,7 +209,7 @@ class iOSXcodeCreateCommand(iOSXcodePassiveMixin, CreateCommand):
     description = "Create and populate a iOS Xcode project."
 
 
-class iOSXcodeUpdateCommand(iOSXcodePassiveMixin, UpdateCommand):
+class iOSXcodeUpdateCommand(iOSXcodeCreateCommand, UpdateCommand):
     description = "Update an existing iOS Xcode project."
 
 

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -208,6 +208,17 @@ or:
 class iOSXcodeCreateCommand(iOSXcodePassiveMixin, CreateCommand):
     description = "Create and populate a iOS Xcode project."
 
+    def _extra_pip_args(self, app: BaseConfig):
+        """Any additional arguments that must be passed to pip when installing
+        packages.
+
+        :param app: The app configuration
+        :returns: A list of additional arguments
+        """
+        # TODO: Add the repo for BeeWare-provided binaries,
+        # by adding --extra-index-url https://briefcase-support.org/pypi
+        return []
+
 
 class iOSXcodeUpdateCommand(iOSXcodeCreateCommand, UpdateCommand):
     description = "Update an existing iOS Xcode project."

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -215,9 +215,10 @@ class iOSXcodeCreateCommand(iOSXcodePassiveMixin, CreateCommand):
         :param app: The app configuration
         :returns: A list of additional arguments
         """
-        # TODO: Add the repo for BeeWare-provided binaries,
-        # by adding --extra-index-url https://briefcase-support.org/pypi
-        return []
+        return [
+            "--extra-index-url",
+            "https://pypi.anaconda.org/beeware/simple",
+        ]
 
 
 class iOSXcodeUpdateCommand(iOSXcodeCreateCommand, UpdateCommand):

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -143,7 +143,7 @@ class LinuxAppImageCreateCommand(LinuxAppImageMixin, CreateCommand):
             super().install_app_dependencies(app=app)
 
 
-class LinuxAppImageUpdateCommand(LinuxAppImageMixin, UpdateCommand):
+class LinuxAppImageUpdateCommand(LinuxAppImageCreateCommand, UpdateCommand):
     description = "Update an existing Linux AppImage."
 
 

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -125,7 +125,7 @@ class LinuxFlatpakCreateCommand(LinuxFlatpakMixin, CreateCommand):
             )
 
 
-class LinuxFlatpakUpdateCommand(LinuxFlatpakMixin, UpdateCommand):
+class LinuxFlatpakUpdateCommand(LinuxFlatpakCreateCommand, UpdateCommand):
     description = "Update an existing Linux Flatpak."
 
 

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -64,7 +64,7 @@ class macOSAppCreateCommand(macOSAppMixin, CreateCommand):
             self.shutil.move(os.fsdecode(Path(tmpdir) / "lib"), os.fsdecode(lib_path))
 
 
-class macOSAppUpdateCommand(macOSAppMixin, UpdateCommand):
+class macOSAppUpdateCommand(macOSAppCreateCommand, UpdateCommand):
     description = "Update an existing macOS app."
 
 

--- a/src/briefcase/platforms/macOS/xcode.py
+++ b/src/briefcase/platforms/macOS/xcode.py
@@ -68,7 +68,7 @@ class macOSXcodeOpenCommand(macOSXcodeMixin, OpenCommand):
     description = "Open a macOS Xcode project."
 
 
-class macOSXcodeUpdateCommand(macOSXcodeMixin, UpdateCommand):
+class macOSXcodeUpdateCommand(macOSXcodeCreateCommand, UpdateCommand):
     description = "Update an existing macOS Xcode project."
 
 

--- a/src/briefcase/platforms/windows/app.py
+++ b/src/briefcase/platforms/windows/app.py
@@ -25,7 +25,7 @@ class WindowsAppCreateCommand(WindowsAppMixin, WindowsCreateCommand):
     description = "Create and populate a Windows app."
 
 
-class WindowsAppUpdateCommand(WindowsAppMixin, UpdateCommand):
+class WindowsAppUpdateCommand(WindowsAppCreateCommand, UpdateCommand):
     description = "Update an existing Windows app."
 
 

--- a/src/briefcase/platforms/windows/visualstudio.py
+++ b/src/briefcase/platforms/windows/visualstudio.py
@@ -25,7 +25,7 @@ class WindowsVisualStudioCreateCommand(WindowsVisualStudioMixin, WindowsCreateCo
     description = "Create and populate a Visual Studio project."
 
 
-class WindowsVisualStudioUpdateCommand(WindowsVisualStudioMixin, UpdateCommand):
+class WindowsVisualStudioUpdateCommand(WindowsVisualStudioCreateCommand, UpdateCommand):
     description = "Update an existing Visual Studio project."
 
 

--- a/tests/commands/create/test_install_app_dependencies.py
+++ b/tests/commands/create/test_install_app_dependencies.py
@@ -125,7 +125,7 @@ def test_app_packages_valid_requires(
                 / "path"
                 / "to"
                 / "support"
-                / "cross-platform"
+                / "platform-site"
             )
         },
     )
@@ -202,7 +202,7 @@ def test_app_packages_invalid_requires(
                 / "path"
                 / "to"
                 / "support"
-                / "cross-platform"
+                / "platform-site"
             )
         },
     )
@@ -248,7 +248,7 @@ def test_app_packages_offline(
                 / "path"
                 / "to"
                 / "support"
-                / "cross-platform"
+                / "platform-site"
             )
         },
     )
@@ -294,7 +294,7 @@ def test_app_packages_install_dependencies(
                 / "path"
                 / "to"
                 / "support"
-                / "cross-platform"
+                / "platform-site"
             )
         },
     )
@@ -351,7 +351,7 @@ def test_app_packages_replace_existing_dependencies(
                 / "path"
                 / "to"
                 / "support"
-                / "cross-platform"
+                / "platform-site"
             )
         },
     )

--- a/tests/commands/create/test_install_app_dependencies.py
+++ b/tests/commands/create/test_install_app_dependencies.py
@@ -119,6 +119,48 @@ def test_app_packages_valid_requires(
             "third>=3.2.1",
         ],
         check=True,
+        env={
+            "PYTHONPATH": str(
+                create_command.bundle_path(myapp)
+                / "path"
+                / "to"
+                / "support"
+                / "cross-platform"
+            )
+        },
+    )
+
+
+def test_app_packages_valid_requires_no_support_package(
+    create_command,
+    myapp,
+    app_packages_path,
+    app_packages_path_index,
+):
+    """If the template doesn't specify a support package, the cross-platform
+    site isn't specified."""
+    myapp.requires = ["first", "second==1.2.3", "third>=3.2.1"]
+
+    # Override the cache of paths to specify an app packages path, but no support package path
+    create_command._path_index = {myapp: {"app_packages_path": "path/to/app_packages"}}
+
+    create_command.install_app_dependencies(myapp)
+
+    # A request was made to install dependencies
+    create_command.subprocess.run.assert_called_with(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "--no-user",
+            f"--target={app_packages_path}",
+            "first",
+            "second==1.2.3",
+            "third>=3.2.1",
+        ],
+        check=True,
     )
 
 
@@ -154,6 +196,15 @@ def test_app_packages_invalid_requires(
             "does-not-exist",
         ],
         check=True,
+        env={
+            "PYTHONPATH": str(
+                create_command.bundle_path(myapp)
+                / "path"
+                / "to"
+                / "support"
+                / "cross-platform"
+            )
+        },
     )
 
 
@@ -191,6 +242,15 @@ def test_app_packages_offline(
             "third",
         ],
         check=True,
+        env={
+            "PYTHONPATH": str(
+                create_command.bundle_path(myapp)
+                / "path"
+                / "to"
+                / "support"
+                / "cross-platform"
+            )
+        },
     )
 
 
@@ -228,6 +288,15 @@ def test_app_packages_install_dependencies(
             "third",
         ],
         check=True,
+        env={
+            "PYTHONPATH": str(
+                create_command.bundle_path(myapp)
+                / "path"
+                / "to"
+                / "support"
+                / "cross-platform"
+            )
+        },
     )
 
     # The new app packages have installation artefacts created
@@ -276,6 +345,15 @@ def test_app_packages_replace_existing_dependencies(
             "third",
         ],
         check=True,
+        env={
+            "PYTHONPATH": str(
+                create_command.bundle_path(myapp)
+                / "path"
+                / "to"
+                / "support"
+                / "cross-platform"
+            )
+        },
     )
 
     # The new app packages have installation artefacts created

--- a/tests/platforms/iOS/xcode/conftest.py
+++ b/tests/platforms/iOS/xcode/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+from ....utils import create_file
+
+
+@pytest.fixture
+def first_app_generated(first_app_config, tmp_path):
+    # Create the briefcase.toml file
+    create_file(
+        tmp_path / "iOS" / "Xcode" / "First App" / "briefcase.toml",
+        """
+[paths]
+app_packages_path="app_packages"
+support_path="support"
+""",
+    )
+    return first_app_config

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -22,7 +22,8 @@ def test_extra_pip_args(first_app_generated, tmp_path):
             "--upgrade",
             "--no-user",
             f"--target={tmp_path / 'iOS' / 'Xcode' / 'First App' / 'app_packages'}",
-            # TODO: Add the repo for BeeWare-provided binaries
+            "--extra-index-url",
+            "https://pypi.anaconda.org/beeware/simple",
             "something==1.2.3",
             "other>=2.3.4",
         ],

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -1,0 +1,35 @@
+import sys
+from unittest import mock
+
+from briefcase.platforms.iOS.xcode import iOSXcodeCreateCommand
+
+
+def test_extra_pip_args(first_app_generated, tmp_path):
+    """Extra iOS-specific args are included in calls to pip during update."""
+    command = iOSXcodeCreateCommand(base_path=tmp_path)
+    first_app_generated.requires = ["something==1.2.3", "other>=2.3.4"]
+
+    command.subprocess = mock.MagicMock()
+
+    command.install_app_dependencies(first_app_generated)
+
+    command.subprocess.run.assert_called_once_with(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "--no-user",
+            f"--target={tmp_path / 'iOS' / 'Xcode' / 'First App' / 'app_packages'}",
+            # TODO: Add the repo for BeeWare-provided binaries
+            "something==1.2.3",
+            "other>=2.3.4",
+        ],
+        check=True,
+        env={
+            "PYTHONPATH": str(
+                tmp_path / "iOS" / "Xcode" / "First App" / "support" / "platform-site"
+            )
+        },
+    )

--- a/tests/platforms/iOS/xcode/test_update.py
+++ b/tests/platforms/iOS/xcode/test_update.py
@@ -22,7 +22,8 @@ def test_extra_pip_args(first_app_generated, tmp_path):
             "--upgrade",
             "--no-user",
             f"--target={tmp_path / 'iOS' / 'Xcode' / 'First App' / 'app_packages'}",
-            # TODO: Add the repo for BeeWare-provided binaries noqa:
+            "--extra-index-url",
+            "https://pypi.anaconda.org/beeware/simple",
             "something==1.2.3",
             "other>=2.3.4",
         ],

--- a/tests/platforms/iOS/xcode/test_update.py
+++ b/tests/platforms/iOS/xcode/test_update.py
@@ -1,0 +1,35 @@
+import sys
+from unittest import mock
+
+from briefcase.platforms.iOS.xcode import iOSXcodeUpdateCommand
+
+
+def test_extra_pip_args(first_app_generated, tmp_path):
+    """Extra iOS-specific args are included in calls to pip during update."""
+    command = iOSXcodeUpdateCommand(base_path=tmp_path)
+    first_app_generated.requires = ["something==1.2.3", "other>=2.3.4"]
+
+    command.subprocess = mock.MagicMock()
+
+    command.install_app_dependencies(first_app_generated)
+
+    command.subprocess.run.assert_called_once_with(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "--no-user",
+            f"--target={tmp_path / 'iOS' / 'Xcode' / 'First App' / 'app_packages'}",
+            # TODO: Add the repo for BeeWare-provided binaries noqa:
+            "something==1.2.3",
+            "other>=2.3.4",
+        ],
+        check=True,
+        env={
+            "PYTHONPATH": str(
+                tmp_path / "iOS" / "Xcode" / "First App" / "support" / "platform-site"
+            )
+        },
+    )


### PR DESCRIPTION
By default, pip assumes that it is being run with the interpreter that will be used to execute the code being installed. This doesn't work for mobile platforms, because we can't run pip on the device.

For macOS, Windows and Linux, the interpreter running `pip` is broadly compatible with the one that will be used at runtime, so there's no issue.

On Android, the Chaquopy Gradle plugin manages pip installs.

For iOS, we need to trick pip into thinking the current platform is iOS so that it will install iOS binary wheels, from a custom (BeeWare provided) package repository.

We do this by modifying the invocation of pip with 2 extension points:
1. An `_extra_pip_args()` API that backends can override to add additional flags (in this case, `--extra-index-url`) 
2. When invoking pip, if the project provides a support package, it will assume that support package provides a `platform-site` folder that contains `sitecustomize.py`. That script can be used to monkeypatch the `sysconfig` and `platform` modules to make the interpreter look like iOS. If the support package doesn't have a platform-site folder, this addition will be a no-op. 

Also addresses a cluster of potential bugs with `update` commands. Update needs to be a subclass of Create so that any platform overrides of Create (such as modifying app requirements) also apply to Update.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
