### PR TITLE
Propagate `KeyboardInterrupt` out of output streamer

### DIFF
--- a/changes/851.bugfix.rst
+++ b/changes/851.bugfix.rst
@@ -1,0 +1,1 @@
+When CTRL+C is entered while an external program is running, ``briefcase`` will properly abort and exit.

--- a/src/briefcase/__main__.py
+++ b/src/briefcase/__main__.py
@@ -1,4 +1,5 @@
 import sys
+from contextlib import suppress
 
 from .cmdline import parse_cmdline
 from .console import Log
@@ -37,7 +38,8 @@ def main():
         if getattr(command, "save_log", False):
             log.capture_stacktrace()
     finally:
-        log.save_log_to_file(command)
+        with suppress(KeyboardInterrupt):
+            log.save_log_to_file(command)
 
     sys.exit(result)
 

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -1,10 +1,10 @@
-import contextlib
 import operator
 import os
 import platform
 import re
 import sys
 import traceback
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
@@ -255,8 +255,6 @@ class Log:
                 for func in self.log_file_extras:
                     try:
                         func()
-                    except KeyboardInterrupt:
-                        raise
                     except Exception:
                         self.error(traceback.format_exc())
 
@@ -329,7 +327,7 @@ class Console:
             console=self.print.console,
         )
 
-    @contextlib.contextmanager
+    @contextmanager
     def wait_bar(
         self,
         message="",

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import threading
 import time
+from contextlib import suppress
 from pathlib import Path
 
 import psutil
@@ -276,7 +277,7 @@ class Subprocess:
             self.stream_output(args[0], process)
             if process.stderr and kwargs["stderr"] != subprocess.STDOUT:
                 stderr = process.stderr.read()
-            return_code = process.poll()
+        return_code = process.poll()
         self._log_return_code(return_code)
 
         if check and return_code:
@@ -398,6 +399,8 @@ class Subprocess:
             self.command.logger.info("Stopping...")
             # allow time for CTRL+C to propagate to the child process
             time.sleep(0.25)
+            # re-raise to exit as "Aborted by user"
+            raise
         finally:
             self.cleanup(label, popen_process)
             streamer_deadline = time.time() + 3
@@ -413,14 +416,18 @@ class Subprocess:
 
         :param popen_process: popen process to stream stdout
         """
-        while True:
-            # readline should always return at least a newline (ie \n)
-            # UNLESS the underlying process is exiting/gone; then "" is returned
-            output_line = ensure_str(popen_process.stdout.readline())
-            if output_line:
-                self.command.logger.info(output_line)
-            elif output_line == "":
-                return
+        # ValueError is raised if stdout is unexpectedly closed.
+        # This can happen if the user starts spamming CTRL+C, for instance.
+        # Silently exit to avoid Python printing the exception to the console.
+        with suppress(ValueError):
+            while True:
+                # readline should always return at least a newline (ie \n)
+                # UNLESS the underlying process is exiting/gone; then "" is returned
+                output_line = ensure_str(popen_process.stdout.readline())
+                if output_line:
+                    self.command.logger.info(output_line)
+                elif output_line == "":
+                    return
 
     def cleanup(self, label, popen_process):
         """Clean up after a Popen process, gracefully terminating if possible;

--- a/tests/integrations/subprocess/conftest.py
+++ b/tests/integrations/subprocess/conftest.py
@@ -46,7 +46,7 @@ def popen_process():
     # Mock the readline values of an actual process. The final return value is "",
     # indicating that the process has exited; however, we insert a short sleep
     # to ensure that any other threads will have a chance to run before this
-    # thread acutally terminates.
+    # thread actually terminates.
     def mock_readline():
         yield from [
             "output line 1\n",

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -53,7 +53,8 @@ def test_keyboard_interrupt(mock_sub, popen_process, capsys):
     send_ctrl_c = mock.MagicMock()
     send_ctrl_c.side_effect = [False, KeyboardInterrupt]
 
-    mock_sub.stream_output("testing", popen_process, stop_func=send_ctrl_c)
+    with pytest.raises(KeyboardInterrupt):
+        mock_sub.stream_output("testing", popen_process, stop_func=send_ctrl_c)
 
     assert (
         capsys.readouterr().out == "output line 1\n"
@@ -124,7 +125,8 @@ def test_stuck_streamer(mock_sub, popen_process, monkeypatch, capsys):
 
     send_ctrl_c = mock.MagicMock()
     send_ctrl_c.side_effect = [False, KeyboardInterrupt]
-    mock_sub.stream_output("testing", popen_process, stop_func=send_ctrl_c)
+    with pytest.raises(KeyboardInterrupt):
+        mock_sub.stream_output("testing", popen_process, stop_func=send_ctrl_c)
 
     # fmt: off
     assert capsys.readouterr().out == (

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -106,7 +106,7 @@ def test_run_app_simulator_booted(first_app_config, tmp_path):
     command.subprocess.stream_output.assert_called_with(
         "log stream", log_stream_process
     )
-    command.subprocess.cleanup.assert_not_called()
+    command.subprocess.cleanup.assert_called_with("log stream", log_stream_process)
 
 
 def test_run_app_simulator_shut_down(first_app_config, tmp_path):
@@ -212,7 +212,7 @@ def test_run_app_simulator_shut_down(first_app_config, tmp_path):
     command.subprocess.stream_output.assert_called_with(
         "log stream", log_stream_process
     )
-    command.subprocess.cleanup.assert_not_called()
+    command.subprocess.cleanup.assert_called_with("log stream", log_stream_process)
 
 
 def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
@@ -331,7 +331,7 @@ def test_run_app_simulator_shutting_down(first_app_config, tmp_path):
     command.subprocess.stream_output.assert_called_with(
         "log stream", log_stream_process
     )
-    command.subprocess.cleanup.assert_not_called()
+    command.subprocess.cleanup.assert_called_with("log stream", log_stream_process)
 
 
 def test_run_app_simulator_boot_failure(first_app_config, tmp_path):


### PR DESCRIPTION
When the output streamer is interrupted, it should (relatively quickly) stop streaming and `briefcase` should exit with the `Aborted by user` message. Currently, the streamer swallows the `KeyboardInterrupt` signal; consequently, upstream code usually detects this as a failure, raises `BriefcaseCommandError`, and creates a log file.

This change propagates the `KeyboardInterrupt` into upstream code to ensure "user abort" codeflows are followed.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
