### PR TITLE
Only Instantiate `Log` and `Console` Once

### DIFF
--- a/changes/852.misc.rst
+++ b/changes/852.misc.rst
@@ -1,0 +1,1 @@
+All Commands use the single instances of ``Log`` and ``Console`` instead of individual instances.

--- a/src/briefcase/__main__.py
+++ b/src/briefcase/__main__.py
@@ -6,38 +6,35 @@ from .exceptions import BriefcaseError, HelpText
 
 
 def main():
-    log = Log()
+    logger = Log()
     command = None
     try:
-        command, options = parse_cmdline(sys.argv[1:])
-        # Replace the top-level logger with the one used by the command.
-        # This is needed to preserve extra logging detail.
-        log = command.logger
+        command, options = parse_cmdline(sys.argv[1:], logger=logger)
         command.check_obsolete_data_dir()
         command.parse_config("pyproject.toml")
         command(**options)
         result = 0
     except HelpText as e:
-        log.info()
-        log.info(str(e))
+        logger.info()
+        logger.info(str(e))
         result = e.error_code
     except BriefcaseError as e:
-        log.error()
-        log.error(str(e))
+        logger.error()
+        logger.error(str(e))
         result = e.error_code
-        log.capture_stacktrace()
+        logger.capture_stacktrace()
     except Exception:
-        log.capture_stacktrace()
+        logger.capture_stacktrace()
         raise
     except KeyboardInterrupt:
-        log.warning()
-        log.warning("Aborted by user.")
-        log.warning()
+        logger.warning()
+        logger.warning("Aborted by user.")
+        logger.warning()
         result = -42
         if getattr(command, "save_log", False):
-            log.capture_stacktrace()
+            logger.capture_stacktrace()
     finally:
-        log.save_log_to_file(command)
+        logger.save_log_to_file(command)
 
     sys.exit(result)
 

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -14,7 +14,7 @@ from .exceptions import (
 )
 
 
-def parse_cmdline(args):
+def parse_cmdline(args, logger=None):
     parser = argparse.ArgumentParser(
         prog="briefcase",
         description="Package Python code for distribution.",
@@ -78,15 +78,15 @@ def parse_cmdline(args):
     if options.command is None:
         raise NoCommandError(parser.format_help())
     elif options.command == "new":
-        command = NewCommand(base_path=Path.cwd())
+        command = NewCommand(base_path=Path.cwd(), logger=logger)
         options = command.parse_options(extra=extra)
         return command, options
     elif options.command == "dev":
-        command = DevCommand(base_path=Path.cwd())
+        command = DevCommand(base_path=Path.cwd(), logger=logger)
         options = command.parse_options(extra=extra)
         return command, options
     elif options.command == "upgrade":
-        command = UpgradeCommand(base_path=Path.cwd())
+        command = UpgradeCommand(base_path=Path.cwd(), logger=logger)
         options = command.parse_options(extra=extra)
         return command, options
 
@@ -160,6 +160,6 @@ def parse_cmdline(args):
         )
 
     # Construct a command, and parse the remaining arguments.
-    command = Command(base_path=Path.cwd())
+    command = Command(base_path=Path.cwd(), logger=logger)
     options = command.parse_options(extra=extra)
     return command, options

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -77,87 +77,85 @@ def parse_cmdline(args, logger=None):
     # If no command has been provided, display top-level help.
     if options.command is None:
         raise NoCommandError(parser.format_help())
-    elif options.command == "new":
-        command = NewCommand(base_path=Path.cwd(), logger=logger)
-        options = command.parse_options(extra=extra)
-        return command, options
+
+    # Commands agnostic to the platform and format
+    if options.command == "new":
+        Command = NewCommand
     elif options.command == "dev":
-        command = DevCommand(base_path=Path.cwd(), logger=logger)
-        options = command.parse_options(extra=extra)
-        return command, options
+        Command = DevCommand
     elif options.command == "upgrade":
-        command = UpgradeCommand(base_path=Path.cwd(), logger=logger)
-        options = command.parse_options(extra=extra)
-        return command, options
+        Command = UpgradeCommand
 
-    parser.add_argument(
-        "platform",
-        choices=list(platforms.keys()),
-        default={
-            "darwin": "macOS",
-            "linux": "linux",
-            "win32": "windows",
-        }[sys.platform],
-        metavar="platform",
-        nargs="?",
-        type=normalize,
-        help="The platform to target (one of %(choices)s; default: %(default)s",
-    )
-
-    # <format> is also optional, with the default being platform dependent.
-    # There's no way to encode option-dependent choices, so allow *any*
-    # input, and we'll manually validate.
-    parser.add_argument(
-        "output_format",
-        metavar="format",
-        nargs="?",
-        help="The output format to use (the available output formats are platform dependent)",
-    )
-
-    # Re-parse the arguments, now that we know it is a command that makes use
-    # of platform/output_format.
-    options, extra = parser.parse_known_args(args)
-
-    # Import the platform module
-    platform_module = platforms[options.platform]
-
-    output_formats = get_output_formats(options.platform)
-    # If the user requested a list of available output formats, output them.
-    if options.show_output_formats:
-        raise ShowOutputFormats(
-            platform=options.platform,
-            default=platform_module.DEFAULT_OUTPUT_FORMAT,
-            choices=list(output_formats.keys()),
-        )
-
-    # If the output format wasn't explicitly specified, check to see
-    # Otherwise, extract and use the default output_format for the platform.
-    if options.output_format is None:
-        output_format = platform_module.DEFAULT_OUTPUT_FORMAT
+    # Commands dependent on the platform and format
     else:
-        output_format = options.output_format
-
-    # Normalise casing of output_format to be more forgiving.
-    output_format = {n.lower(): n for n in output_formats}.get(
-        output_format.lower(), output_format
-    )
-
-    # We now know the command, platform, and format.
-    # Get the command class that corresponds to that definition.
-    try:
-        format_module = output_formats[output_format]
-        Command = getattr(format_module, options.command)
-    except KeyError:
-        raise InvalidFormatError(
-            requested=output_format,
-            choices=list(output_formats.keys()),
+        parser.add_argument(
+            "platform",
+            choices=list(platforms.keys()),
+            default={
+                "darwin": "macOS",
+                "linux": "linux",
+                "win32": "windows",
+            }[sys.platform],
+            metavar="platform",
+            nargs="?",
+            type=normalize,
+            help="The platform to target (one of %(choices)s; default: %(default)s",
         )
-    except AttributeError:
-        raise UnsupportedCommandError(
-            platform=options.platform,
-            output_format=output_format,
-            command=options.command,
+
+        # <format> is also optional, with the default being platform dependent.
+        # There's no way to encode option-dependent choices, so allow *any*
+        # input, and we'll manually validate.
+        parser.add_argument(
+            "output_format",
+            metavar="format",
+            nargs="?",
+            help="The output format to use (the available output formats are platform dependent)",
         )
+
+        # Re-parse the arguments, now that we know it is a command that makes use
+        # of platform/output_format.
+        options, extra = parser.parse_known_args(args)
+
+        # Import the platform module
+        platform_module = platforms[options.platform]
+
+        output_formats = get_output_formats(options.platform)
+        # If the user requested a list of available output formats, output them.
+        if options.show_output_formats:
+            raise ShowOutputFormats(
+                platform=options.platform,
+                default=platform_module.DEFAULT_OUTPUT_FORMAT,
+                choices=list(output_formats.keys()),
+            )
+
+        # If the output format wasn't explicitly specified, check to see
+        # Otherwise, extract and use the default output_format for the platform.
+        if options.output_format is None:
+            output_format = platform_module.DEFAULT_OUTPUT_FORMAT
+        else:
+            output_format = options.output_format
+
+        # Normalise casing of output_format to be more forgiving.
+        output_format = {n.lower(): n for n in output_formats}.get(
+            output_format.lower(), output_format
+        )
+
+        # We now know the command, platform, and format.
+        # Get the command class that corresponds to that definition.
+        try:
+            format_module = output_formats[output_format]
+            Command = getattr(format_module, options.command)
+        except KeyError:
+            raise InvalidFormatError(
+                requested=output_format,
+                choices=list(output_formats.keys()),
+            )
+        except AttributeError:
+            raise UnsupportedCommandError(
+                platform=options.platform,
+                output_format=output_format,
+                command=options.command,
+            )
 
     # Construct a command, and parse the remaining arguments.
     command = Command(base_path=Path.cwd(), logger=logger)

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -288,12 +288,14 @@ or delete the old data directory, and re-run Briefcase.
             # Create data directory to prevent full notice showing again.
             self.data_path.mkdir(parents=True, exist_ok=True)
 
-    @property
-    def create_command(self):
-        """Factory property; return an instance of a create command for the
-        same format."""
+    def _command_factory(self, command_name: str):
+        """Command factory for the current platform and format.
+
+        :param command_name: name of Command (e.g. 'create', 'build', 'run', etc.)
+        :return: instantiated Command
+        """
         format_module = importlib.import_module(self.__module__)
-        command = format_module.create(
+        command = getattr(format_module, command_name)(
             base_path=self.base_path,
             apps=self.apps,
             logger=self.logger,
@@ -301,76 +303,42 @@ or delete the old data directory, and re-run Briefcase.
         )
         command.clone_options(self)
         return command
+
+    @property
+    def create_command(self):
+        """Factory property; return an instance of CreateCommand for the same
+        format."""
+        return self._command_factory("create")
 
     @property
     def update_command(self):
-        """Factory property; return an instance of an update command for the
-        same format."""
-        format_module = importlib.import_module(self.__module__)
-        command = format_module.update(
-            base_path=self.base_path,
-            apps=self.apps,
-            logger=self.logger,
-            console=self.input,
-        )
-        command.clone_options(self)
-        return command
+        """Factory property; return an instance of UpdateCommand for the same
+        format."""
+        return self._command_factory("update")
 
     @property
     def build_command(self):
-        """Factory property; return an instance of a build command for the same
+        """Factory property; return an instance of BuildCommand for the same
         format."""
-        format_module = importlib.import_module(self.__module__)
-        command = format_module.build(
-            base_path=self.base_path,
-            apps=self.apps,
-            logger=self.logger,
-            console=self.input,
-        )
-        command.clone_options(self)
-        return command
+        return self._command_factory("build")
 
     @property
     def run_command(self):
-        """Factory property; return an instance of a run command for the same
+        """Factory property; return an instance of RunCommand for the same
         format."""
-        format_module = importlib.import_module(self.__module__)
-        command = format_module.run(
-            base_path=self.base_path,
-            apps=self.apps,
-            logger=self.logger,
-            console=self.input,
-        )
-        command.clone_options(self)
-        return command
+        return self._command_factory("run")
 
     @property
     def package_command(self):
-        """Factory property; return an instance of a package command for the
-        same format."""
-        format_module = importlib.import_module(self.__module__)
-        command = format_module.package(
-            base_path=self.base_path,
-            apps=self.apps,
-            logger=self.logger,
-            console=self.input,
-        )
-        command.clone_options(self)
-        return command
+        """Factory property; return an instance of PackageCommand for the same
+        format."""
+        return self._command_factory("package")
 
     @property
     def publish_command(self):
-        """Factory property; return an instance of a publish command for the
-        same format."""
-        format_module = importlib.import_module(self.__module__)
-        command = format_module.publish(
-            base_path=self.base_path,
-            apps=self.apps,
-            logger=self.logger,
-            console=self.input,
-        )
-        command.clone_options(self)
-        return command
+        """Factory property; return an instance of PublishCommand for the same
+        format."""
+        return self._command_factory("publish")
 
     @property
     def platform_path(self):

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -122,6 +122,8 @@ class BaseCommand(ABC):
         data_path=None,
         apps=None,
         input_enabled=True,
+        logger=None,
+        console=None,
     ):
         # Distinguish the top-level command from triggered commands, e.g. `run`
         # may trigger `update` and `build`.
@@ -192,7 +194,7 @@ a custom location for Briefcase's tools.
         # These are abstracted to enable testing without patching.
         self.cookiecutter = cookiecutter
         self.requests = requests
-        self.input = Console(enabled=input_enabled)
+        self.input = console or Console(enabled=input_enabled)
         self.os = os
         self.sys = sys
         self.stdlib_platform = platform
@@ -202,8 +204,8 @@ a custom location for Briefcase's tools.
         # The internal Briefcase integrations API.
         self.integrations = integrations
 
-        # Initialize default logger (replaced when options are parsed).
-        self.logger = Log()
+        # Initialize logging.
+        self.logger = logger or Log()
         self.save_log = False
 
     def check_obsolete_data_dir(self):
@@ -294,7 +296,8 @@ or delete the old data directory, and re-run Briefcase.
         command = format_module.create(
             base_path=self.base_path,
             apps=self.apps,
-            input_enabled=self.input.enabled,
+            logger=self.logger,
+            console=self.input,
         )
         command.clone_options(self)
         return command
@@ -307,7 +310,8 @@ or delete the old data directory, and re-run Briefcase.
         command = format_module.update(
             base_path=self.base_path,
             apps=self.apps,
-            input_enabled=self.input.enabled,
+            logger=self.logger,
+            console=self.input,
         )
         command.clone_options(self)
         return command
@@ -320,7 +324,8 @@ or delete the old data directory, and re-run Briefcase.
         command = format_module.build(
             base_path=self.base_path,
             apps=self.apps,
-            input_enabled=self.input.enabled,
+            logger=self.logger,
+            console=self.input,
         )
         command.clone_options(self)
         return command
@@ -333,7 +338,8 @@ or delete the old data directory, and re-run Briefcase.
         command = format_module.run(
             base_path=self.base_path,
             apps=self.apps,
-            input_enabled=self.input.enabled,
+            logger=self.logger,
+            console=self.input,
         )
         command.clone_options(self)
         return command
@@ -346,7 +352,8 @@ or delete the old data directory, and re-run Briefcase.
         command = format_module.package(
             base_path=self.base_path,
             apps=self.apps,
-            input_enabled=self.input.enabled,
+            logger=self.logger,
+            console=self.input,
         )
         command.clone_options(self)
         return command
@@ -359,7 +366,8 @@ or delete the old data directory, and re-run Briefcase.
         command = format_module.publish(
             base_path=self.base_path,
             apps=self.apps,
-            input_enabled=self.input.enabled,
+            logger=self.logger,
+            console=self.input,
         )
         command.clone_options(self)
         return command
@@ -546,9 +554,8 @@ or delete the old data directory, and re-run Briefcase.
 
         :param command: The command whose options are to be cloned
         """
-        self.input.enabled = command.input.enabled
-        self.logger = command.logger
         self.is_clone = True
+        self.save_log = command.save_log
 
     def add_default_options(self, parser):
         """Add the default options that exist on *all* commands.

--- a/tests/commands/base/test_properties.py
+++ b/tests/commands/base/test_properties.py
@@ -44,8 +44,25 @@ def test_input_state_transferred(tmp_path):
 
     # Check the enabled state of subcommands
     assert not command.create_command.input.enabled
+    assert command.create_command.logger is command.logger
+    assert command.create_command.input is command.input
+
     assert not command.update_command.input.enabled
+    assert command.update_command.logger is command.logger
+    assert command.update_command.input is command.input
+
     assert not command.build_command.input.enabled
+    assert command.build_command.logger is command.logger
+    assert command.build_command.input is command.input
+
     assert not command.run_command.input.enabled
+    assert command.run_command.logger is command.logger
+    assert command.run_command.input is command.input
+
     assert not command.package_command.input.enabled
+    assert command.package_command.logger is command.logger
+    assert command.package_command.input is command.input
+
     assert not command.publish_command.input.enabled
+    assert command.publish_command.logger is command.logger
+    assert command.publish_command.input is command.input

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -5,6 +5,7 @@ import pytest
 from briefcase import __version__
 from briefcase.cmdline import parse_cmdline
 from briefcase.commands import DevCommand, NewCommand, UpgradeCommand
+from briefcase.console import Log
 from briefcase.exceptions import (
     InvalidFormatError,
     NoCommandError,
@@ -14,6 +15,11 @@ from briefcase.exceptions import (
 from briefcase.platforms.linux.appimage import LinuxAppImageCreateCommand
 from briefcase.platforms.macOS.app import macOSAppCreateCommand, macOSAppPublishCommand
 from briefcase.platforms.windows.app import WindowsAppCreateCommand
+
+
+@pytest.fixture
+def logger():
+    return Log()
 
 
 def test_empty():
@@ -82,108 +88,115 @@ def test_unknown_command():
     )
 
 
-def test_new_command():
+def test_new_command(logger):
     """``briefcase new`` returns the New command."""
-    cmd, options = parse_cmdline("new".split())
+    cmd, options = parse_cmdline("new".split(), logger=logger)
 
     assert isinstance(cmd, NewCommand)
     assert cmd.platform == "all"
     assert cmd.output_format is None
     assert cmd.input.enabled
     assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
     assert options == {"template": None}
 
 
-def test_dev_command(monkeypatch):
+def test_dev_command(monkeypatch, logger):
     """``briefcase dev`` returns the Dev command."""
     # Pretend we're on macOS, regardless of where the tests run.
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    cmd, options = parse_cmdline("dev".split())
+    cmd, options = parse_cmdline("dev".split(), logger=logger)
 
     assert isinstance(cmd, DevCommand)
     assert cmd.platform == "macOS"
     assert cmd.output_format is None
     assert cmd.input.enabled
     assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
     assert options == {"appname": None, "update_dependencies": False, "run_app": True}
 
 
-def test_upgrade_command(monkeypatch):
+def test_upgrade_command(monkeypatch, logger):
     """``briefcase upgrade`` returns the upgrade command."""
     # Pretend we're on macOS, regardless of where the tests run.
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    cmd, options = parse_cmdline("upgrade".split())
+    cmd, options = parse_cmdline("upgrade".split(), logger=logger)
 
     assert isinstance(cmd, UpgradeCommand)
     assert cmd.platform == "macOS"
     assert cmd.output_format is None
     assert cmd.input.enabled
     assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
     assert options == {
         "list_tools": False,
         "tool_list": [],
     }
 
 
-def test_bare_command(monkeypatch):
+def test_bare_command(monkeypatch, logger):
     """``briefcase create`` returns the macOS create app command."""
     # Pretend we're on macOS, regardless of where the tests run.
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    cmd, options = parse_cmdline("create".split())
+    cmd, options = parse_cmdline("create".split(), logger=logger)
 
     assert isinstance(cmd, macOSAppCreateCommand)
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
     assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
     assert options == {}
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="requires Linux")
-def test_linux_default():
+def test_linux_default(logger):
     """``briefcase create`` returns the linux create appimage command on
     Linux."""
 
-    cmd, options = parse_cmdline("create".split())
+    cmd, options = parse_cmdline("create".split(), logger=logger)
 
     assert isinstance(cmd, LinuxAppImageCreateCommand)
     assert cmd.platform == "linux"
     assert cmd.output_format == "appimage"
     assert cmd.input.enabled
     assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
     assert options == {}
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS")
-def test_macOS_default():
+def test_macOS_default(logger):
     """``briefcase create`` returns the linux create appimage command on
     Linux."""
 
-    cmd, options = parse_cmdline("create".split())
+    cmd, options = parse_cmdline("create".split(), logger=logger)
 
     assert isinstance(cmd, macOSAppCreateCommand)
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
     assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
     assert options == {}
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="requires Windows")
-def test_windows_default():
+def test_windows_default(logger):
     """``briefcase create`` returns the Windows create app command on
     Windows."""
 
-    cmd, options = parse_cmdline("create".split())
+    cmd, options = parse_cmdline("create".split(), logger=logger)
 
     assert isinstance(cmd, WindowsAppCreateCommand)
     assert cmd.platform == "windows"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
     assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
     assert options == {}
 
 
@@ -247,34 +260,36 @@ def test_command_unknown_platform(monkeypatch):
     )
 
 
-def test_command_explicit_platform(monkeypatch):
+def test_command_explicit_platform(monkeypatch, logger):
     """``briefcase create linux`` returns linux create app command."""
     # Pretend we're on macOS, regardless of where the tests run.
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    cmd, options = parse_cmdline("create linux".split())
+    cmd, options = parse_cmdline("create linux".split(), logger=logger)
 
     assert isinstance(cmd, LinuxAppImageCreateCommand)
     assert cmd.platform == "linux"
     assert cmd.output_format == "appimage"
     assert cmd.input.enabled
     assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
     assert options == {}
 
 
-def test_command_explicit_platform_case_handling(monkeypatch):
+def test_command_explicit_platform_case_handling(monkeypatch, logger):
     """``briefcase create macOS`` returns macOS create app command."""
     # Pretend we're on macOS, regardless of where the tests run.
     monkeypatch.setattr(sys, "platform", "darwin")
 
     # This is all lower case; the command normalizes to macOS
-    cmd, options = parse_cmdline("create macOS".split())
+    cmd, options = parse_cmdline("create macOS".split(), logger=logger)
 
     assert isinstance(cmd, macOSAppCreateCommand)
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
     assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
     assert options == {}
 
 
@@ -311,18 +326,19 @@ def test_command_explicit_platform_show_formats(monkeypatch):
     assert set(excinfo.value.choices) == {"xcode", "app", "homebrew"}
 
 
-def test_command_explicit_format(monkeypatch):
+def test_command_explicit_format(monkeypatch, logger):
     """``briefcase create macOS app`` returns the macOS create app command."""
     # Pretend we're on macOS, regardless of where the tests run.
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    cmd, options = parse_cmdline("create macOS app".split())
+    cmd, options = parse_cmdline("create macOS app".split(), logger=logger)
 
     assert isinstance(cmd, macOSAppCreateCommand)
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
     assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
     assert options == {}
 
 
@@ -380,33 +396,35 @@ def test_command_explicit_format_show_formats(monkeypatch):
     assert set(excinfo.value.choices) == {"xcode", "app", "homebrew"}
 
 
-def test_command_disable_input(monkeypatch):
+def test_command_disable_input(monkeypatch, logger):
     """``briefcase create --no-input`` disables console input."""
     # Pretend we're on macOS, regardless of where the tests run.
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    cmd, options = parse_cmdline("create --no-input".split())
+    cmd, options = parse_cmdline("create --no-input".split(), logger=logger)
 
     assert isinstance(cmd, macOSAppCreateCommand)
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert not cmd.input.enabled
     assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
     assert options == {}
 
 
-def test_command_options(monkeypatch, capsys):
+def test_command_options(monkeypatch, capsys, logger):
     """Commands can provide their own arguments."""
     # Pretend we're on macOS, regardless of where the tests run.
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    # Invoke a command that is known to have it's own custom arguments
+    # Invoke a command that is known to have its own custom arguments
     # (In this case, the channel argument for publication)
-    cmd, options = parse_cmdline("publish macos app -c s3".split())
+    cmd, options = parse_cmdline("publish macos app -c s3".split(), logger=logger)
 
     assert isinstance(cmd, macOSAppPublishCommand)
     assert cmd.input.enabled
     assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
     assert options == {"channel": "s3"}
 
 


### PR DESCRIPTION
Currently, when `briefcase` executes multiple Commands (e.g. `update`/`build` on behalf of `run`), a new `Log` and `Console` are created for each Command. So far, this hasn't proven problematic since each copy is effectively identical and once a new one is created, the previous one is never referenced again. In principle, though, only one copy of these objects should exist.

Future changes (via #801) will (effectively) allow multiple Commands to exist at the same time. Given this, all Commands must reference the same `Log` and `Console` to ensure agreement of the state of the program.

This change ensures the existing `Log` and `Console` are passed to any Command created as a result of running the user-requested Command.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
