### PR TITLE
Updated FAQ to include text produced by iOS when installing binary packages

### DIFF
--- a/changes/857.misc.rst
+++ b/changes/857.misc.rst
@@ -1,0 +1,1 @@
+Updated FAQ to include the iOS message when compiling binary modules.

--- a/docs/background/faq.rst
+++ b/docs/background/faq.rst
@@ -60,10 +60,11 @@ that is on PyPI. If you experience problems when building or running an app on a
 mobile platform that appear to be related to a missing dependency, check the
 build logs for your app. If you see:
 
+* On Android: the error `"Chaquopy cannot compile native code"
+  <https://chaquo.com/chaquopy/doc/current/faq.html#chaquopy-cannot-compile-native-code>`__
+* On iOS: the error "Cannot compile native code"
 * A reference to downloading a ``.tar.gz`` version of the package
 * A reference to ``Building wheels for collected packages: <package>``
-* The error `"Chaquopy cannot compile native code"
-  <https://chaquo.com/chaquopy/doc/current/faq.html#chaquopy-cannot-compile-native-code>`__
 
 The binary dependency isn't supported on mobile. Binary mobile packages are
 currently maintained by the BeeWare team; if you have a particular third-party

--- a/docs/background/faq.rst
+++ b/docs/background/faq.rst
@@ -62,7 +62,7 @@ build logs for your app. If you see:
 
 * On Android: the error `"Chaquopy cannot compile native code"
   <https://chaquo.com/chaquopy/doc/current/faq.html#chaquopy-cannot-compile-native-code>`__
-* On iOS: the error "Cannot compile native code"
+* On iOS: the error "Cannot compile native modules"
 * A reference to downloading a ``.tar.gz`` version of the package
 * A reference to ``Building wheels for collected packages: <package>``
 

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -216,6 +216,7 @@ class iOSXcodeCreateCommand(iOSXcodePassiveMixin, CreateCommand):
         :returns: A list of additional arguments
         """
         return [
+            "--prefer-binary",
             "--extra-index-url",
             "https://pypi.anaconda.org/beeware/simple",
         ]

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -22,6 +22,7 @@ def test_extra_pip_args(first_app_generated, tmp_path):
             "--upgrade",
             "--no-user",
             f"--target={tmp_path / 'iOS' / 'Xcode' / 'First App' / 'app_packages'}",
+            "--prefer-binary",
             "--extra-index-url",
             "https://pypi.anaconda.org/beeware/simple",
             "something==1.2.3",

--- a/tests/platforms/iOS/xcode/test_update.py
+++ b/tests/platforms/iOS/xcode/test_update.py
@@ -22,6 +22,7 @@ def test_extra_pip_args(first_app_generated, tmp_path):
             "--upgrade",
             "--no-user",
             f"--target={tmp_path / 'iOS' / 'Xcode' / 'First App' / 'app_packages'}",
+            "--prefer-binary",
             "--extra-index-url",
             "https://pypi.anaconda.org/beeware/simple",
             "something==1.2.3",


### PR DESCRIPTION
[This commit](https://github.com/beeware/Python-Apple-support/pull/161/commits/92089b7f6ec01fab7c752fe0b2675765f6a1be20) adds a monkeypatch to distutils to disable the C compiler. This PR updates the FAQ to reference the message that will be generated.

Also adds the `--prefer-binary` flag when installing packages so that an older binary will be preferred to a more recent source package.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
