### PR TITLE
Capture app output in log

### DIFF
--- a/changes/859.misc.rst
+++ b/changes/859.misc.rst
@@ -1,0 +1,1 @@
+When an app runs, its output is captured is the ``briefcase`` log.

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -99,6 +99,7 @@ class DevCommand(BaseCommand):
                 env=env,
                 check=True,
                 cwd=self.home_path,
+                stream_output=True,
             )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1232,7 +1232,6 @@ Activity class not found while starting app.
     def logcat(self, pid):
         """Start tailing the adb log for the device."""
         try:
-            # stream output so it's captured in logging
             self.command.subprocess.run(
                 [
                     os.fsdecode(self.android_sdk.adb_path),

--- a/src/briefcase/integrations/flatpak.py
+++ b/src/briefcase/integrations/flatpak.py
@@ -252,6 +252,7 @@ flatpak run {bundle}.{app_name}
                     f"{bundle}.{app_name}",
                 ],
                 check=True,
+                stream_output=True,
             )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(f"Unable to start app {app_name}.") from e

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -180,7 +180,7 @@ class GradleRunCommand(GradleMixin, RunCommand):
         """Start the application.
 
         :param app: The config object for the app
-        :param device: The device to target. If ``None``, the user will
+        :param device_or_avd: The device to target. If ``None``, the user will
             be asked to re-run the command selecting a specific device.
         """
         device, name, avd = self.android_sdk.select_target_device(

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -287,6 +287,7 @@ class LinuxAppImageRunCommand(LinuxAppImagePassiveMixin, RunCommand):
                 ],
                 check=True,
                 cwd=self.home_path,
+                stream_output=True,
             )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(f"Unable to start app {app.app_name}.") from e

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -88,6 +88,7 @@ class WindowsRunCommand(RunCommand):
                 [os.fsdecode(self.binary_path(app))],
                 cwd=self.home_path,
                 check=True,
+                stream_output=True,
             )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(f"Unable to start app {app.app_name}.") from e

--- a/tests/commands/dev/test_run_dev_app.py
+++ b/tests/commands/dev/test_run_dev_app.py
@@ -22,6 +22,7 @@ def test_subprocess_running_successfully(dev_command, first_app, tmp_path):
         env=env,
         cwd=dev_command.home_path,
         check=True,
+        stream_output=True,
     )
 
 
@@ -45,4 +46,5 @@ def test_subprocess_throws_error(dev_command, first_app, tmp_path):
         env=env,
         cwd=dev_command.home_path,
         check=True,
+        stream_output=True,
     )

--- a/tests/integrations/flatpak/test_Flatpak__run.py
+++ b/tests/integrations/flatpak/test_Flatpak__run.py
@@ -21,6 +21,7 @@ def test_run(flatpak):
             "com.example.my-app",
         ],
         check=True,
+        stream_output=True,
     )
 
 

--- a/tests/platforms/linux/appimage/test_run.py
+++ b/tests/platforms/linux/appimage/test_run.py
@@ -62,6 +62,7 @@ def test_run_app(first_app_config, tmp_path):
         [os.fsdecode(tmp_path / "base" / "linux" / "First_App-0.0.1-wonky.AppImage")],
         cwd=tmp_path / "home",
         check=True,
+        stream_output=True,
     )
 
 
@@ -86,4 +87,5 @@ def test_run_app_failed(first_app_config, tmp_path):
         [os.fsdecode(tmp_path / "base" / "linux" / "First_App-0.0.1-wonky.AppImage")],
         cwd=tmp_path / "home",
         check=True,
+        stream_output=True,
     )

--- a/tests/platforms/windows/app/test_run.py
+++ b/tests/platforms/windows/app/test_run.py
@@ -8,7 +8,7 @@ from briefcase.platforms.windows.app import WindowsAppRunCommand
 
 
 def test_run_app(first_app_config, tmp_path):
-    """A windows app can be started."""
+    """A Windows app can be started."""
     command = WindowsAppRunCommand(
         base_path=tmp_path / "base",
         home_path=tmp_path / "home",
@@ -31,6 +31,7 @@ def test_run_app(first_app_config, tmp_path):
         ],
         cwd=tmp_path / "home",
         check=True,
+        stream_output=True,
     )
 
 
@@ -61,4 +62,5 @@ def test_run_app_failed(first_app_config, tmp_path):
         ],
         cwd=tmp_path / "home",
         check=True,
+        stream_output=True,
     )

--- a/tests/platforms/windows/visualstudio/test_run.py
+++ b/tests/platforms/windows/visualstudio/test_run.py
@@ -1,4 +1,4 @@
-# The run command inherits most of it's behavior from the common base
+# The run command inherits most of its behavior from the common base
 # implementation. Do a surface-level verification here, but the app
 # tests provide the actual test coverage.
 import os
@@ -32,4 +32,5 @@ def test_run_app(first_app_config, tmp_path):
         ],
         cwd=tmp_path / "home",
         check=True,
+        stream_output=True,
     )


### PR DESCRIPTION
Ensure output from running the app is captured in the `briefcase` log.

Windows apps are excepted because of [windows fun](https://github.com/beeware/briefcase/pull/782#discussion_r920621894).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
