### PR TITLE
Dependency Management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       matrix:
         task:
         - 'towncrier-check'
-        - 'docs'
         - 'package'
     steps:
     # Check out main; needed for towncrier comparisons.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.8.0
     hooks:
     - id: black
       language_version: python3
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-eradicate==1.2.0]
+        additional_dependencies: [flake8-eradicate==1.4.0]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -24,12 +24,12 @@ repos:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v2.38.2
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/myint/docformatter
-    rev: v1.4
+    rev: v1.5.0
     hooks:
     - id: docformatter
       args: [--in-place]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,4 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.8.0
-    hooks:
-    - id: black
-      language_version: python3
-  - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-eradicate==1.4.0]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
@@ -33,3 +23,13 @@ repos:
     hooks:
     - id: docformatter
       args: [--in-place]
+  - repo: https://github.com/psf/black
+    rev: 22.8.0
+    hooks:
+    - id: black
+      language_version: python3
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-eradicate==1.4.0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     rev: v2.38.2
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
   - repo: https://github.com/myint/docformatter
     rev: v1.5.0
     hooks:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+    - docs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include tox.ini
 include .coveragerc
 include .git-blame-ignore-revs
 include .pre-commit-config.yaml
+include .readthedocs.yaml
 recursive-include changes *.rst
 recursive-include src *.py
 recursive-include docs *.bat

--- a/changes/867.misc.rst
+++ b/changes/867.misc.rst
@@ -1,0 +1,1 @@
+Dependencies are now monitored by dependabot and requirements are moved in to setup.cfg.

--- a/changes/template.rst
+++ b/changes/template.rst
@@ -1,13 +1,3 @@
-{% if top_line %}
-{{ top_line }}
-{{ top_underline * ((top_line)|length)}}
-{% elif versiondata.name %}
-{{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.name + versiondata.version + versiondata.date)|length + 4)}}
-{% else %}
-{{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}
-{% endif %}
 {% for section, _ in sections.items() %}
 {% set underline = underlines[0] %}{% if section %}{{section}}
 {{ underline * section|length }}{% set underline = underlines[1] %}

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -15,7 +15,7 @@ Setting up your development environment
 
 The recommended way of setting up your development environment for Briefcase is
 to use a `virtual environment <https://docs.python.org/3/library/venv.html>`__,
-and then install the development dependencies:
+and then install the development version of Briefcase and its dependencies:
 
 .. tabs::
 
@@ -27,7 +27,7 @@ and then install the development dependencies:
       $ cd briefcase
       $ python3 -m venv venv
       $ . venv/bin/activate
-      (venv) $ python3 -m pip install -r requirements.dev.txt
+      (venv) $ python3 -m pip install -Ue .[dev]
 
   .. group-tab:: Linux
 
@@ -37,7 +37,7 @@ and then install the development dependencies:
       $ cd briefcase
       $ python3 -m venv venv
       $ . venv/bin/activate
-      (venv) $ python3 -m pip install -r requirements.dev.txt
+      (venv) $ python3 -m pip install -Ue .[dev]
 
   .. group-tab:: Windows
 
@@ -47,30 +47,7 @@ and then install the development dependencies:
       C:\...>cd briefcase
       C:\...>py -m venv venv
       C:\...>venv\Scripts\activate
-      (venv) C:\...>python3 -m pip install -r requirements.dev.txt
-
-To install all the development version of Briefcase, along with all it's
-requirements, run the following commands within your virtual environment:
-
-.. tabs::
-
-  .. group-tab:: macOS
-
-    .. code-block:: bash
-
-      (venv) $ pip install -e .
-
-  .. group-tab:: Linux
-
-    .. code-block:: bash
-
-      (venv) $ pip install -e .
-
-  .. group-tab:: Windows
-
-    .. code-block:: doscon
-
-      (venv) C:\...>pip install -e .
+      (venv) C:\...>python3 -m pip install -Ue .[dev]
 
 Briefcase uses a tool called `Pre-Commit <https://pre-commit.com>`__ to identify
 simple issues and standardize code formatting. It does this by installing a git

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,6 +1,0 @@
-sphinx
-sphinxcontrib-spelling
-pyenchant
-sphinx-autobuild
-sphinx_rtd_theme
-sphinx_tabs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ multi_line_output = 3
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+filterwarnings = [
+    "error",
+    # the cgi module is being deprecated in Python 3.13 (#868)
+    "ignore:'cgi':DeprecationWarning:briefcase.integrations.download:1",
+]
 
 # need to ensure build directories aren't excluded from recursion
 norecursedirs = []

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,0 @@
-setuptools_scm[toml]>=7.0
-pre-commit
-tox

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,4 +1,0 @@
-pytest
-pytest-tldr
-pytest-cov
-tomli_w

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,17 +53,35 @@ package_dir =
 install_requires =
     pip >= 22
     setuptools >= 60
-    wheel >= 0.34
-    cookiecutter >= 1.0
-    tomli >= 2.0.0; python_version <= "3.10"
-    importlib_metadata>=4.4.0; python_version <= "3.9"
-    requests >= 2.22.0
-    GitPython >= 3.0.8
-    dmgbuild >= 1.3.3; sys_platform == "darwin"
-    psutil >= 5.9.0
-    rich >= 12.4.1
-    platformdirs >= 2.5.2
-    packaging >= 21.3
+    wheel ~= 0.34
+    cookiecutter ~= 2.1
+    tomli ~= 2.0; python_version <= "3.10"
+    importlib_metadata ~= 4.4; python_version <= "3.9"
+    requests ~= 2.22
+    GitPython ~= 3.1
+    dmgbuild ~= 1.4; sys_platform == "darwin"
+    psutil ~= 5.9
+    rich ~= 12.4
+    platformdirs ~= 2.5
+    packaging ~= 21.3
+
+[options.extras_require]
+dev =
+    pre-commit
+    setuptools_scm[toml] ~= 7.0
+    tox
+test =
+    pytest
+    pytest-tldr
+    pytest-cov
+    tomli_w
+docs =
+    sphinx
+    sphinxcontrib-spelling
+    pyenchant
+    sphinx-autobuild
+    sphinx_rtd_theme
+    sphinx_tabs
 
 [options.packages.find]
 where = src

--- a/tests/console/test_Log.py
+++ b/tests/console/test_Log.py
@@ -69,7 +69,8 @@ def test_save_log_to_file_no_exception(tmp_path, now):
     log_filepath = tmp_path / "briefcase.2022_06_25-16_12_29.dev.log"
 
     assert log_filepath.exists()
-    log_contents = open(log_filepath, encoding="utf-8").read()
+    with open(log_filepath, encoding="utf-8") as log:
+        log_contents = log.read()
 
     assert log_contents.startswith("Date/Time:       2022-06-25 16:12:29")
     assert f"{Log.DEBUG_PREFACE}this is debug output" in log_contents
@@ -108,7 +109,8 @@ def test_save_log_to_file_with_exception(tmp_path, now):
     log_filepath = tmp_path / "briefcase.2022_06_25-16_12_29.dev.log"
 
     log_filepath.exists()
-    log_contents = open(log_filepath, encoding="utf-8").read()
+    with open(log_filepath, encoding="utf-8") as log:
+        log_contents = log.read()
 
     assert log_contents.startswith("Date/Time:       2022-06-25 16:12:29")
     assert TRACEBACK_HEADER in log_contents
@@ -137,7 +139,8 @@ def test_save_log_to_file_extra(tmp_path, now):
         logger.add_log_file_extra(extra)
     logger.save_log_to_file(command=command)
     log_filepath = tmp_path / "briefcase.2022_06_25-16_12_29.dev.log"
-    log_contents = open(log_filepath, encoding="utf-8").read()
+    with open(log_filepath, encoding="utf-8") as log:
+        log_contents = log.read()
 
     assert EXTRA_HEADER in log_contents
     assert "Log extra 1" in log_contents

--- a/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import sys
 from unittest.mock import ANY, MagicMock
 
 import pytest
@@ -9,7 +8,6 @@ from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.android_sdk import AndroidSDK
 from briefcase.integrations.base import ToolCache
-from tests.utils import FsPathMock
 
 
 @pytest.fixture
@@ -182,12 +180,6 @@ def test_default_name(mock_tools, android_sdk, tmp_path):
     with avd_config_path.open("w") as f:
         f.write("hw.device.name=pixel\n")
 
-    # Consider to remove if block when we drop py3.7 support.
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    if sys.version_info < (3, 8):
-        skin_tgz_path = FsPathMock("")
-        mock_tools.download.file.return_value = skin_tgz_path
-
     # Create the emulator
     avd = android_sdk.create_emulator()
 
@@ -218,12 +210,6 @@ def test_default_name_with_collisions(mock_tools, android_sdk, tmp_path):
     avd_config_path.parent.mkdir(parents=True)
     with avd_config_path.open("w") as f:
         f.write("hw.device.name=pixel\n")
-
-    # Consider to remove if block when we drop py3.7 support.
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    if sys.version_info < (3, 8):
-        skin_tgz_path = FsPathMock("")
-        mock_tools.download.file.return_value = skin_tgz_path
 
     # Create the emulator
     avd = android_sdk.create_emulator()

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
@@ -1,11 +1,9 @@
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError, NetworkFailure
-from tests.utils import FsPathMock
 
 
 def test_existing_skin(mock_tools, android_sdk):
@@ -24,11 +22,8 @@ def test_new_skin(mock_tools, android_sdk):
     """If the skin doesn't exist, an attempt is made to download it."""
     # MagicMock below py3.8 doesn't have __fspath__ attribute.
     # Remove if block when we drop py3.7 support.
-    if sys.version_info < (3, 8):
-        skin_tgz_path = FsPathMock("/path/to/skin.tgz")
-    else:
-        skin_tgz_path = MagicMock(spec_set=Path)
-        skin_tgz_path.__fspath__.return_value = "/path/to/skin.tgz"
+    skin_tgz_path = MagicMock(spec_set=Path)
+    skin_tgz_path.__fspath__.return_value = "/path/to/skin.tgz"
     mock_tools.download.file.return_value = skin_tgz_path
 
     # Verify the skin, triggering a download
@@ -57,11 +52,8 @@ def test_skin_download_failure(mock_tools, android_sdk, tmp_path):
     """If the skin download fails, an error is raised."""
     # MagicMock below py3.8 doesn't have __fspath__ attribute.
     # Remove if block when we drop py3.7 support.
-    if sys.version_info < (3, 8):
-        skin_tgz_path = FsPathMock("/path/to/skin.tgz")
-    else:
-        skin_tgz_path = MagicMock(spec_set=Path)
-        skin_tgz_path.__fspath__.return_value = "/path/to/skin.tgz"
+    skin_tgz_path = MagicMock(spec_set=Path)
+    skin_tgz_path.__fspath__.return_value = "/path/to/skin.tgz"
     mock_tools.download.file.return_value = skin_tgz_path
 
     # Mock a failure downloading the skin
@@ -89,11 +81,8 @@ def test_unpack_failure(mock_tools, android_sdk, tmp_path):
     # Mock the result of the download of a skin
     # Consider to remove if block when we drop py3.7 support, only keep statements from else.
     # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    if sys.version_info < (3, 8):
-        skin_tgz_path = FsPathMock("/path/to/skin.tgz")
-    else:
-        skin_tgz_path = MagicMock(spec_set=Path)
-        skin_tgz_path.__fspath__.return_value = "/path/to/skin.tgz"
+    skin_tgz_path = MagicMock(spec_set=Path)
+    skin_tgz_path.__fspath__.return_value = "/path/to/skin.tgz"
     mock_tools.download.file.return_value = skin_tgz_path
 
     # Mock a failure unpacking the skin

--- a/tests/integrations/docker/test_Docker__verify.py
+++ b/tests/integrations/docker/test_Docker__verify.py
@@ -180,7 +180,7 @@ Server:
 ERROR: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: """
 
     message2 = """Get http://%2Fvar%2Frun%2Fdocker.sock/v1.40/info: dial unix /var/run/docker.sock: connect: permission denied
-errors pretty printing info"""
+errors pretty printing info"""  # noqa: E501
 
     error_message = message1 + message2
     # splitting it up is to appease flake8 line length - not sure how to add noqa to a triple quoted string line

--- a/tests/integrations/java/test_JDK__verify.py
+++ b/tests/integrations/java/test_JDK__verify.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from unittest import mock
 
@@ -9,7 +8,6 @@ import pytest
 
 from briefcase.exceptions import BriefcaseCommandError, MissingToolError, NetworkFailure
 from briefcase.integrations.java import JDK
-from tests.utils import FsPathMock
 
 
 def test_short_circuit(mock_tools):
@@ -356,11 +354,8 @@ def test_successful_jdk_download(
     # Mock the cached download path
     # Consider to remove if block when we drop py3.7 support, only keep statements from else.
     # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    if sys.version_info < (3, 8):
-        archive = FsPathMock("/path/to/download.zip")
-    else:
-        archive = mock.MagicMock()
-        archive.__fspath__.return_value = "/path/to/download.zip"
+    archive = mock.MagicMock()
+    archive.__fspath__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Create a directory to make it look like Java was downloaded and unpacked.
@@ -436,11 +431,8 @@ def test_invalid_jdk_archive(mock_tools, tmp_path):
     # Mock the cached download path
     # Consider to remove if block when we drop py3.7 support, only keep statements from else.
     # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    if sys.version_info < (3, 8):
-        archive = FsPathMock("/path/to/download.zip")
-    else:
-        archive = mock.MagicMock()
-        archive.__fspath__.return_value = "/path/to/download.zip"
+    archive = mock.MagicMock()
+    archive.__fspath__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Mock an unpack failure due to an invalid archive

--- a/tests/integrations/java/test_JDK_upgrade.py
+++ b/tests/integrations/java/test_JDK_upgrade.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import sys
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,7 +12,6 @@ from briefcase.exceptions import (
 )
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.java import JDK
-from tests.utils import FsPathMock
 
 
 @pytest.fixture
@@ -65,11 +63,8 @@ def test_existing_install(mock_tools, tmp_path):
     # Mock the cached download path.
     # Consider to remove if block when we drop py3.7 support, only keep statements from else.
     # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    if sys.version_info < (3, 8):
-        archive = FsPathMock("/path/to/download.zip")
-    else:
-        archive = MagicMock()
-        archive.__fspath__.return_value = "/path/to/download.zip"
+    archive = MagicMock()
+    archive.__fspath__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Create a directory to make it look like Java was downloaded and unpacked.
@@ -120,11 +115,8 @@ def test_macOS_existing_install(mock_tools, tmp_path):
     # Mock the cached download path.
     # Consider to remove if block when we drop py3.7 support, only keep statements from else.
     # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    if sys.version_info < (3, 8):
-        archive = FsPathMock("/path/to/download.zip")
-    else:
-        archive = MagicMock()
-        archive.__fspath__.return_value = "/path/to/download.zip"
+    archive = MagicMock()
+    archive.__fspath__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Create a directory to make it look like Java was downloaded and unpacked.
@@ -210,11 +202,8 @@ def test_unpack_fail(mock_tools, tmp_path):
     # Mock the cached download path
     # Consider to remove if block when we drop py3.7 support, only keep statements from else.
     # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    if sys.version_info < (3, 8):
-        archive = FsPathMock("/path/to/download.zip")
-    else:
-        archive = MagicMock()
-        archive.__fspath__.return_value = "/path/to/download.zip"
+    archive = MagicMock()
+    archive.__fspath__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Mock an unpack failure due to an invalid archive

--- a/tests/integrations/wix/test_WiX__upgrade.py
+++ b/tests/integrations/wix/test_WiX__upgrade.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,7 +10,6 @@ from briefcase.exceptions import (
     NonManagedToolError,
 )
 from briefcase.integrations.wix import WIX_DOWNLOAD_URL, WiX
-from tests.utils import FsPathMock
 
 
 def test_non_managed_install(mock_tools, tmp_path, capsys):
@@ -57,11 +55,8 @@ def test_existing_wix_install(mock_tools, tmp_path):
     wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
     # Consider to remove if block when we drop py3.7 support, only keep statements from else.
     # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    if sys.version_info < (3, 8):
-        wix_zip = FsPathMock(wix_zip_path)
-    else:
-        wix_zip = MagicMock()
-        wix_zip.__fspath__.return_value = wix_zip_path
+    wix_zip = MagicMock()
+    wix_zip.__fspath__.return_value = wix_zip_path
 
     mock_tools.download.file.return_value = wix_zip
 
@@ -134,11 +129,8 @@ def test_unpack_fail(mock_tools, tmp_path):
     wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
     # Consider to remove if block when we drop py3.7 support, only keep statements from else.
     # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    if sys.version_info < (3, 8):
-        wix_zip = FsPathMock(wix_zip_path)
-    else:
-        wix_zip = MagicMock()
-        wix_zip.__fspath__.return_value = wix_zip_path
+    wix_zip = MagicMock()
+    wix_zip.__fspath__.return_value = wix_zip_path
 
     mock_tools.download.file.return_value = wix_zip
 

--- a/tests/integrations/wix/test_WiX__verify.py
+++ b/tests/integrations/wix/test_WiX__verify.py
@@ -1,12 +1,10 @@
 import os
-import sys
 from unittest.mock import MagicMock
 
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError, MissingToolError, NetworkFailure
 from briefcase.integrations.wix import WIX_DOWNLOAD_URL, WiX
-from tests.utils import FsPathMock
 
 
 def test_short_circuit(mock_tools):
@@ -104,11 +102,8 @@ def test_download_wix(mock_tools, tmp_path):
     wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
     # Consider to remove if block when we drop py3.7 support, only keep statements from else.
     # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    if sys.version_info < (3, 8):
-        wix_zip = FsPathMock(wix_zip_path)
-    else:
-        wix_zip = MagicMock()
-        wix_zip.__fspath__.return_value = wix_zip_path
+    wix_zip = MagicMock()
+    wix_zip.__fspath__.return_value = wix_zip_path
 
     mock_tools.download.file.return_value = wix_zip
 
@@ -194,11 +189,8 @@ def test_unpack_fail(mock_tools, tmp_path):
     wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
     # Consider to remove if block when we drop py3.7 support, only keep statements from else.
     # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    if sys.version_info < (3, 8):
-        wix_zip = FsPathMock(wix_zip_path)
-    else:
-        wix_zip = MagicMock()
-        wix_zip.__fspath__.return_value = wix_zip_path
+    wix_zip = MagicMock()
+    wix_zip.__fspath__.return_value = wix_zip_path
 
     mock_tools.download.file.return_value = wix_zip
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,6 @@ import io
 import os
 import tarfile
 import zipfile
-from unittest.mock import MagicMock
 
 from briefcase.console import Console, InputDisabled
 
@@ -18,20 +17,6 @@ class DummyConsole(Console):
             raise InputDisabled()
         self.prompts.append(prompt)
         return self.values.pop(0)
-
-
-# Consider to remove  class definition when we drop python 3.7 support.
-class FsPathMock(MagicMock):
-    def __init__(self, path):
-        super().__init__()
-        self.path = path
-
-    def __fspath__(self):
-        return self.path
-
-    def _get_child_mock(self, **kw):
-        """Create child mocks with right MagicMock class."""
-        return MagicMock(**kw)
 
 
 def create_file(filepath, content, mode="w", chmod=None):

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,11 @@ skip_missing_interpreters = true
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}/src
-deps =
-    -r{toxinidir}/requirements.test.txt
-
+extras =
+    test
+allowlist_externals =
+    pytest
+    coverage
 commands =
     pytest --cov -vv
     coverage xml
@@ -26,13 +28,13 @@ commands =
 [testenv:towncrier]
 skip_install = True
 deps =
-    towncrier == 21.9.0
+    towncrier ~= 22.8
 commands =
     towncrier {posargs}
 
 [testenv:docs]
-deps =
-    -r{toxinidir}/docs/requirements_docs.txt
+extras =
+    docs
 commands =
     python setup.py build_sphinx -W
 


### PR DESCRIPTION
## Changes
 - Update project dependencies to align with their most recent major release
 - Use `dependabot` to update python requirements and CI actions
 - Update `pre-commit` dependencies
 - Replace requirements files with `options.extras_require` in setup.cfg
 - Promote `pytest` warnings to errors

## Noteworthy/Controversial
- Removing `requirements.txt` files
  - Every time i set up a new environment, I have to run `pip` multiple times.
  - This allows `pip install -e .[dev,test,docs]` to set up a dev environment.
- Promote all warnings to errors
  - Useful to find sneaky problems...but can be overly noisy. I fixed all the current issues.
- Dependency versions use any "[compatible release](https://peps.python.org/pep-0440/#compatible-release)" 
  - I updated the minimum version for all dependencies to their most recent major version using `~=` so any bumps in their minor versions are automatically used....but major version bumps will not be used.
  - `dependabot` should let us know when major version releases happen.
  - A few notes:
    - `cookiecutter`
       - briefcase requires at least 1.5 to run
       - 1.7.0 was a revive in 2019; 2.1 released May 2022
     - `GitPython`
       - 10 days after 3.0.8 was released, they moved to 3.1 where they are today
     - `dmgbuild`
       - 1.4 released one year after 1.3.3
       - they've been looking for a new maintainer since the 1.4 release

## Related:
- #868

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
