### PR TITLE
Update CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python
-        uses: actions/setup-python@v3.1.2
+        uses: actions/setup-python@v4.2.0
         with:
           python-version: ${{ env.python_version }}
       - name: Lint with Pre-commit
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
 
   beefore:
     name: Pre-test checks
@@ -36,15 +36,15 @@ jobs:
         - 'package'
     steps:
     # Check out main; needed for towncrier comparisons.
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.0.2
       with:
         fetch-depth: 0
         ref: main
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.0.2
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v3.1.2
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: ${{ env.python_version }}
     - name: Install dependencies
@@ -61,11 +61,11 @@ jobs:
     needs: beefore
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.0.2
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v3.1.2
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: ${{ env.python_version }}
     - name: Install dependencies
@@ -77,7 +77,7 @@ jobs:
       run: |
         tox -e py
     - name: Check coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3.1.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
@@ -96,11 +96,11 @@ jobs:
       matrix:
         python-version: ['3.8', '3.10', '3.11.0-alpha - 3.11.0']
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.0.2
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3.1.2
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -112,7 +112,7 @@ jobs:
       run: |
         tox -e py
     - name: Check coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3.1.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
@@ -128,11 +128,11 @@ jobs:
         platform: ['macos-latest', 'windows-latest']
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.0.2
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v3.1.2
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: ${{ env.python_version }}
     - name: Install dependencies
@@ -144,7 +144,7 @@ jobs:
       run: |
         tox -e py
     - name: Check coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3.1.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
@@ -180,7 +180,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Cache Briefcase tools
-      uses: actions/cache@v3
+      uses: actions/cache@v3.0.8
       with:
         key: briefcase-${{ matrix.platform }}
         path: |
@@ -188,11 +188,11 @@ jobs:
           ${{ matrix.briefcase-data-dir }}
           ${{ matrix.pip-cache-dir }}
           ${{ matrix.docker-cache-dir }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.0.2
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v3.1.2
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: ${{ env.python_version }}
     - name: Install system dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         framework: ['toga', 'pyside2', 'pyside6', 'ppb']
         include:
         - os_name: macOS
-          platform: macos-latest
+          platform: macos-12
           briefcase-data-dir: ~/Library/Caches/org.beeware.briefcase
           pip-cache-dir: ~/Library/Caches/pip
           docker-cache-dir: ~/Library/Containers/com.docker.docker/Data/vms/0/
@@ -244,7 +244,7 @@ jobs:
         briefcase build android
         briefcase package android --adhoc-sign
     - name: Build iOS App
-      if: matrix.platform == 'macos-latest' && matrix.framework == 'toga'
+      if: matrix.platform == 'macos-12' && matrix.framework == 'toga'
       run: |
         cd tests/apps/verify-${{ matrix.framework }}
         briefcase create iOS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3.0.2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/changes/874.misc.rst
+++ b/changes/874.misc.rst
@@ -1,0 +1,1 @@
+Updated the Github CI actions to their latest versions.


### PR DESCRIPTION
## Updates
Manually update CI actions until we determine a process to automatically apply changenotes to dependabot PRs.

## Notes
 - I updated all GH Actions to use fully qualified versions (e.g. `v3.0.2` instead of `v3`).
   - Dependabot will be more chatty but new versions are then tested first.
 - The `create-release` action is [apparently deprecated](https://github.com/actions/create-release) and should probably be replaced.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
