### PR TITLE
Deprecate use of the cgi module

### DIFF
--- a/changes/868.misc.rst
+++ b/changes/868.misc.rst
@@ -1,0 +1,1 @@
+Removed use of deprecated cgi module when parsing RFC6266 headers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,6 @@ multi_line_output = 3
 testpaths = ["tests"]
 filterwarnings = [
     "error",
-    # the cgi module is being deprecated in Python 3.13 (#868)
-    "ignore:'cgi':DeprecationWarning:briefcase.integrations.download:1",
 ]
 
 # need to ensure build directories aren't excluded from recursion


### PR DESCRIPTION
The `cgi` module has been [marked for removal in Python 3.13 by RFC494](https://peps.python.org/pep-0594/#cgi). 

The official recommended way to parse RFC6266 headers is to use the `email.message` module. This isn't ideal; but there doesn't appear to be a better option. There are multiple RFC6266 parsing modules available on PyPI, but unfortunately none of them look especially mature or maintained. 

Fixes #868.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
