### PR TITLE
Avoid ResourceWarnings during tests for /dev/null handle

### DIFF
--- a/changes/879.misc.rst
+++ b/changes/879.misc.rst
@@ -1,0 +1,1 @@
+The ``/dev/null`` file handle for the logfile Rich Console is now closed before pytest exits to avoid ResourceWarning errors being printed.

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -64,11 +64,12 @@ class Printer:
     # We need to be wide enough to render `sdkmanager --list_installed` output without
     # line wrapping.
     LOG_FILE_WIDTH = 180
+    # Rich only records what's being logged if it is actually written somewhere;
+    # writing to /dev/null allows Rich to do so without needing to print the logs
+    # in the console or save them to file before it is known a file is wanted.
+    dev_null = open(os.devnull, "w", encoding="utf-8", errors="ignore")
     log = RichConsole(
-        # Rich only records what's being logged if it is actually written somewhere;
-        # writing to /dev/null allows Rich to do so without needing to print the logs
-        # in the console or save them to file before it is known a file is wanted.
-        file=open(os.devnull, "w", encoding="utf-8", errors="ignore"),
+        file=dev_null,
         record=True,
         width=LOG_FILE_WIDTH,
         no_color=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,11 @@ from git import exc as git_exceptions
 from briefcase.config import AppConfig
 from briefcase.console import Printer
 
-# Stop Rich from inserting line breaks in to long lines of text.
-# Rich does this to prevent individual words being split between
-# two lines in the terminal...however, these additional line breaks
-# cause some tests to fail unexpectedly.
-Printer.console.soft_wrap = True
+
+def pytest_sessionfinish(session, exitstatus):
+    """When pytest is wrapping up, close the /dev/null file handle for the
+    logfile Rich Console to avoid spurious ResourceWarning errors."""
+    Printer.dev_null.close()
 
 
 @pytest.fixture


### PR DESCRIPTION
After #867, `pytest` will raise for all Python errors including those normally suppressed. This change is also causing the errors/warnings below to be printed _sometimes_ when pytest is run.

```
(venv3.10) rkm@eunectes briefcase % pytest tests/commands/new/test_call.py 
..
------------------------------------------------------------------------------
Ran 2 tests in 0.01s

OK
Exception ignored in: <_io.FileIO name='/dev/null' mode='wb' closefd=True>
ResourceWarning: unclosed file <_io.TextIOWrapper name='/dev/null' mode='w' encoding='utf-8'>
```

These changes ensure the file handle for `/dev/null/ that's opened for the logfile Rich Console is closed before `pytest` exits so this error is showed to developers and avoids subsequent confusion.

In practice, these errors are innocuous. Furthermore, end-users cannot see these errors unless they run a debug version of Python or use the `-Werror` (or perhaps the `-Wdefault`) flag.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
