### PR TITLE
Add workflow to add a change note to Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -1,0 +1,45 @@
+name: Dependabot Change Note
+on:
+  push:
+    branches:
+      - 'dependabot/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  changenote:
+    name: Dependabot Change Note
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.actor == 'dependabot[bot]'
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.BRUTUS_PAT_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --local user.email "$(git log --pretty='%ae' -1)"
+          git config --local user.name "Dependabot[bot]"
+
+      - name: Commit Change Note
+        run: |
+          # Fetch PR number for commit from Github API
+          API_URL="${{ github.api_url }}/repos/${{ github.repository }}/commits/${{ github.event.head_commit.id }}/pulls"
+          PR_NUM=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.[].number')
+
+          # Create change note from first line of dependabot commit
+          NEWS=$(printf "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bumps/Updated/')
+          printf "${NEWS}.\n" > "./changes/${PR_NUM}.misc.rst"
+
+          # Commit the change note
+          git add "./changes/${PR_NUM}.misc.rst"
+          # "dependabot skip" tells Dependabot to continue rebasing this branch despite foreign commits
+          git commit -m "Add changenote. [dependabot skip]"
+
+      - name: Push
+        run: git push origin

--- a/changes/885.misc.rst
+++ b/changes/885.misc.rst
@@ -1,0 +1,1 @@
+Added a Github Action workflow that automatically adds a change note to Dependabot PRs.


### PR DESCRIPTION
## Changes
Adds a change note to PRs from Dependabot.

I tested this in an isolated repo:
- Dependabot PR: https://github.com/rmartin16/test-briefcase-5/pull/5
- Non-Dependabot PR: https://github.com/rmartin16/test-briefcase-5/pull/6

## Strategy
Uses the `push` action to catch all commits but filters to those on branches starting with `dependabot/`. The primary advantage of this is the Workflow only runs or shows up in checks for PRs if that branch name condition is met. (I could not find a way to do this filtering this early with other events.)

By default, any commits made to a repo from within a Workflow do not trigger Workflows to run for those commits. To change this behavior, the repo must be checked out using a PAT for a user with write access to the repo. The @brutusthebee bot user can serve this purpose well.

**The PAT must be set as a secret for dependabot and named `BRUTUS_PAT_TOKEN`.** 
 - The token "only" needs `public_repo` permissions.
 - This token is not loaded into the Workflow Run if someone were to create a PR from a fork on a `dependabot/` branch.

## Trade-offs
Using the `pull` event makes other tasks slightly more difficult as opposed to using the `pull_request` event for instance.
- The relevant PR information isn't available from the `github` context so it must be fetched from the Github API.
- The `dependabot/fetch-metadata` action cannot be used to easily access details about what Dependabot did. So, instead, the commit message from Dependabot is used to create the change note.
- These aren't especially onerous, though, IMO.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct