### PR TITLE
Fix typo 'Bumps' to 'Bump'

### DIFF
--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -33,7 +33,7 @@ jobs:
           PR_NUM=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.[].number')
 
           # Create change note from first line of dependabot commit
-          NEWS=$(printf "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bumps/Updated/')
+          NEWS=$(printf "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bump/Updated/')
           printf "${NEWS}.\n" > "./changes/${PR_NUM}.misc.rst"
 
           # Commit the change note

--- a/changes/888.misc.rst
+++ b/changes/888.misc.rst
@@ -1,0 +1,1 @@
+Corrected typo when generating a change note for Dependabot pull requests.


### PR DESCRIPTION
Dependabot [commit titles](https://github.com/beeware/briefcase/pull/873/commits) start with the word `Bump`...not `Bumps` like the first word of the PR text.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
