### PR TITLE
Run Python with unbuffered output via subprocess (Fixes #891)

### DIFF
--- a/changes/891.bugfix.rst
+++ b/changes/891.bugfix.rst
@@ -1,0 +1,1 @@
+Output from spawned Python processes, such as when running ``briefcase dev``, is no longer buffered and displays in the console immediately.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -470,6 +470,7 @@ class CreateCommand(BaseCommand):
                     self.tools[app].app_context.run(
                         [
                             sys.executable,
+                            "-u",
                             "-m",
                             "pip",
                             "install",

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -65,6 +65,7 @@ class DevCommand(BaseCommand):
                     self.tools.subprocess.run(
                         [
                             sys.executable,
+                            "-u",
                             "-m",
                             "pip",
                             "install",
@@ -89,6 +90,7 @@ class DevCommand(BaseCommand):
             self.tools.subprocess.run(
                 [
                     sys.executable,
+                    "-u",
                     "-c",
                     (
                         "import runpy, sys;"

--- a/tests/commands/create/test_install_app_dependencies.py
+++ b/tests/commands/create/test_install_app_dependencies.py
@@ -116,6 +116,7 @@ def test_app_packages_valid_requires(
     create_command.tools[myapp].app_context.run.assert_called_with(
         [
             sys.executable,
+            "-u",
             "-m",
             "pip",
             "install",
@@ -158,6 +159,7 @@ def test_app_packages_valid_requires_no_support_package(
     create_command.tools[myapp].app_context.run.assert_called_with(
         [
             sys.executable,
+            "-u",
             "-m",
             "pip",
             "install",
@@ -187,7 +189,7 @@ def test_app_packages_invalid_requires(
     create_command.tools[
         myapp
     ].app_context.run.side_effect = subprocess.CalledProcessError(
-        cmd=["python", "-m", "pip", "..."], returncode=1
+        cmd=["python", "-u", "-m", "pip", "..."], returncode=1
     )
 
     with pytest.raises(DependencyInstallError):
@@ -197,6 +199,7 @@ def test_app_packages_invalid_requires(
     create_command.tools[myapp].app_context.run.assert_called_with(
         [
             sys.executable,
+            "-u",
             "-m",
             "pip",
             "install",
@@ -233,7 +236,7 @@ def test_app_packages_offline(
     create_command.tools[
         myapp
     ].app_context.run.side_effect = subprocess.CalledProcessError(
-        cmd=["python", "-m", "pip", "..."], returncode=1
+        cmd=["python", "-u", "-m", "pip", "..."], returncode=1
     )
 
     with pytest.raises(DependencyInstallError):
@@ -243,6 +246,7 @@ def test_app_packages_offline(
     create_command.tools[myapp].app_context.run.assert_called_with(
         [
             sys.executable,
+            "-u",
             "-m",
             "pip",
             "install",
@@ -291,6 +295,7 @@ def test_app_packages_install_dependencies(
     create_command.tools[myapp].app_context.run.assert_called_with(
         [
             sys.executable,
+            "-u",
             "-m",
             "pip",
             "install",
@@ -350,6 +355,7 @@ def test_app_packages_replace_existing_dependencies(
     create_command.tools[myapp].app_context.run.assert_called_with(
         [
             sys.executable,
+            "-u",
             "-m",
             "pip",
             "install",

--- a/tests/commands/dev/test_install_dev_dependencies.py
+++ b/tests/commands/dev/test_install_dev_dependencies.py
@@ -15,6 +15,7 @@ def test_install_dependencies_no_error(dev_command, first_app):
     dev_command.tools.subprocess.run.assert_called_once_with(
         [
             sys.executable,
+            "-u",
             "-m",
             "pip",
             "install",
@@ -41,6 +42,7 @@ def test_install_dependencies_error(dev_command, first_app):
     dev_command.tools.subprocess.run.assert_called_once_with(
         [
             sys.executable,
+            "-u",
             "-m",
             "pip",
             "install",

--- a/tests/commands/dev/test_run_dev_app.py
+++ b/tests/commands/dev/test_run_dev_app.py
@@ -12,6 +12,7 @@ def test_subprocess_running_successfully(dev_command, first_app, tmp_path):
     dev_command.tools.subprocess.run.assert_called_once_with(
         [
             sys.executable,
+            "-u",
             "-c",
             (
                 "import runpy, sys;"
@@ -38,6 +39,7 @@ def test_subprocess_throws_error(dev_command, first_app, tmp_path):
     dev_command.tools.subprocess.run.assert_called_once_with(
         [
             sys.executable,
+            "-u",
             "-c",
             (
                 "import runpy, sys;"

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -23,6 +23,7 @@ def test_extra_pip_args(first_app_generated, tmp_path):
     command.tools[first_app_generated].app_context.run.assert_called_once_with(
         [
             sys.executable,
+            "-u",
             "-m",
             "pip",
             "install",

--- a/tests/platforms/iOS/xcode/test_update.py
+++ b/tests/platforms/iOS/xcode/test_update.py
@@ -23,6 +23,7 @@ def test_extra_pip_args(first_app_generated, tmp_path):
     command.tools[first_app_generated].app_context.run.assert_called_once_with(
         [
             sys.executable,
+            "-u",
             "-m",
             "pip",
             "install",

--- a/tests/platforms/linux/appimage/test_create.py
+++ b/tests/platforms/linux/appimage/test_create.py
@@ -82,6 +82,7 @@ def test_install_app_dependencies_in_docker(first_app_config, tmp_path):
             "--rm",
             "briefcase/com.example.first-app:py3.X",
             "python3.X",
+            "-u",
             "-m",
             "pip",
             "install",
@@ -132,6 +133,7 @@ def test_install_app_dependencies_no_docker(first_app_config, tmp_path):
     command.tools[first_app_config].app_context.run.assert_called_with(
         [
             sys.executable,
+            "-u",
             "-m",
             "pip",
             "install",


### PR DESCRIPTION
Python buffers its output if `stdout` isn't connected to a tty. This is the case when using the output streamer.

This change adds `-u` to all invocations of Python. Alternatively, we could inject `PYTHONUNBUFFERED=1` in to the environment for subprocess calls.

- Fixes #891 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct