### PR TITLE
Relax the dependabot update schedule.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,15 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      # Check for updates on Sunday, 8PM UTC
+      interval: "weekly"
+      day: "sunday"
+      time: "20:00"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      # Check for updates on Sunday, 8PM UTC
+      interval: "weekly"
+      day: "sunday"
+      time: "20:00"

--- a/changes/896.misc.rst
+++ b/changes/896.misc.rst
@@ -1,0 +1,1 @@
+The dependabot release cadence was relaxed to weekly.


### PR DESCRIPTION
While it's important to stay up to date, *daily* dependabot updates are a little excessive. Relax the update cadence to weekly; 8PM UTC Sunday means we'll have updates in our inbox on a Monday morning.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
