### PR TITLE
Print Android Emulator Output for CTRL+C During Startup

### DIFF
--- a/changes/914.feature.rst
+++ b/changes/914.feature.rst
@@ -1,0 +1,1 @@
+When the Android emulator startup process is interrupted with CTRL+C, the emulator output is now printed in the console.

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from unittest.mock import MagicMock, call
+from unittest.mock import ANY, MagicMock, call
 
 import pytest
 
@@ -303,6 +303,14 @@ def test_emulator_fail_to_start(mock_tools, android_sdk):
         ]
     )
 
+    # Emulator output printed to the console
+    mock_tools.subprocess.stream_output.assert_called_with(
+        label="Android emulator",
+        popen_process=ANY,
+        stop_func=ANY,
+        skip_cleanup=True,
+    )
+
     # Took a total of 2 naps before failing.
     assert android_sdk.sleep.call_count == 2
 
@@ -408,6 +416,14 @@ def test_emulator_fail_to_boot(mock_tools, android_sdk):
             call("shell", "getprop", "sys.boot_completed"),
             call("shell", "getprop", "sys.boot_completed"),
         ]
+    )
+
+    # Emulator output printed to the console
+    mock_tools.subprocess.stream_output.assert_called_with(
+        label="Android emulator",
+        popen_process=ANY,
+        stop_func=ANY,
+        skip_cleanup=True,
     )
 
     # Took a total of 4 naps.


### PR DESCRIPTION
Some of the comments in #903 are demonstrating that potentially useful emulator output is not being printed if the emulator seemingly goes rogue and doesn't terminate....or at least doesn't work as expected.

This stems from the fact that calling `communicate()` on the emulator process with a `timeout` is all or nothing. So, emulator output is only printed if the emulator process actually terminated.

These changes allow (as much as reasonable) output to be read from the emulator regardless of the state of the process and shows it to the user and includes it in the log.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
