### PR TITLE
Minor cleanups stemming from v0.3.11 release.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ venv*/
 *.wp[ur]
 
 tests/apps/verify-*/
+logs/

--- a/changes/918.misc.rst
+++ b/changes/918.misc.rst
@@ -1,0 +1,1 @@
+Minor problems with the release instructions were corrected.

--- a/docs/how-to/internal/release.rst
+++ b/docs/how-to/internal/release.rst
@@ -48,7 +48,7 @@ The procedure for cutting a new release is as follows:
 4. Tag the release, and push the branch and tag upstream::
 
     $ git tag v1.2.3
-    $ git push upstream main
+    $ git push upstream HEAD:main
     $ git push upstream v1.2.3
 
 5. Pushing the tag will start a workflow to create a draft release on GitHub.


### PR DESCRIPTION
The v0.3.11 release highlighted a couple of minor problems.

1. The push instructions for the detached branch weren't quite right
2. The gitignore file for the repo doesn't ignore `logs` directories.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
