### PR TITLE
Converge `run` Command Behavior

### DIFF
--- a/changes/904.bugfix.rst
+++ b/changes/904.bugfix.rst
@@ -1,0 +1,1 @@
+Briefcase now exits normally when CTRL-C is sent while tailing logs for the App when using ``briefcase run``.

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -238,12 +238,15 @@ class GradleRunCommand(GradleMixin, RunCommand):
                 if not pid:
                     time.sleep(0.5)
 
-        self.logger.info(
-            "Following device log output (type CTRL-C to stop log)...",
-            prefix=app.app_name,
-        )
-        self.logger.info("=" * 75)
-        adb.logcat(pid)
+        try:
+            self.logger.info(
+                "Following device log output (type CTRL-C to stop log)...",
+                prefix=app.app_name,
+            )
+            self.logger.info("=" * 75)
+            adb.logcat(pid)
+        except KeyboardInterrupt:
+            pass  # catch CTRL-C to exit normally
 
 
 class GradlePackageCommand(GradleMixin, PackageCommand):

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -189,9 +189,7 @@ class GradleRunCommand(GradleMixin, RunCommand):
         :param device_or_avd: The device to target. If ``None``, the user will
             be asked to re-run the command selecting a specific device.
         """
-        device, name, avd = self.tools.android_sdk.select_target_device(
-            device_or_avd=device_or_avd
-        )
+        device, name, avd = self.tools.android_sdk.select_target_device(device_or_avd)
 
         # If there's no device ID, that means the emulator isn't running.
         # If there's no AVD either, it means the user has chosen to create

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -432,6 +432,8 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
             )
             self.logger.info("=" * 75)
             self.tools.subprocess.stream_output("log stream", simulator_log_popen)
+        except KeyboardInterrupt:
+            pass  # catch CTRL-C to exit normally
         finally:
             self.tools.subprocess.cleanup("log stream", simulator_log_popen)
 

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -259,12 +259,16 @@ class LinuxAppImageRunCommand(LinuxAppImagePassiveMixin, RunCommand):
         """
         self.logger.info("Starting app...", prefix=app.app_name)
         try:
+            # Start streaming logs for the app.
+            self.logger.info("=" * 75)
             self.tools.subprocess.run(
                 [os.fsdecode(self.binary_path(app))],
                 check=True,
                 cwd=self.tools.home_path,
                 stream_output=True,
             )
+        except KeyboardInterrupt:
+            pass  # Catch CTRL-C to exit normally
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(f"Unable to start app {app.app_name}.") from e
 

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -192,10 +192,15 @@ class LinuxFlatpakRunCommand(LinuxFlatpakMixin, RunCommand):
         :param app: The config object for the app
         """
         self.logger.info("Starting app...", prefix=app.app_name)
-        self.tools.flatpak.run(
-            bundle=app.bundle,
-            app_name=app.app_name,
-        )
+        try:
+            # Start streaming logs for the app.
+            self.tools.logger.info("=" * 75)
+            self.tools.flatpak.run(
+                bundle=app.bundle,
+                app_name=app.app_name,
+            )
+        except KeyboardInterrupt:
+            pass  # Catch CTRL-C to exit normally
 
 
 class LinuxFlatpakPackageCommand(LinuxFlatpakMixin, PackageCommand):

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -2,6 +2,7 @@ import os
 import re
 import subprocess
 import time
+from contextlib import suppress
 from pathlib import Path
 from signal import SIGTERM
 from zipfile import ZipFile
@@ -107,7 +108,8 @@ class macOSRunMixin:
                 )
             finally:
                 # Ensure the App also terminates when exiting
-                self.tools.os.kill(app_pid, SIGTERM)
+                with suppress(ProcessLookupError):
+                    self.tools.os.kill(app_pid, SIGTERM)
         except KeyboardInterrupt:
             pass  # Catch CTRL-C to exit normally
         finally:

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -107,6 +107,8 @@ class macOSRunMixin:
                 self.tools.subprocess.stream_output(
                     "log stream", log_popen, stop_func=lambda: is_process_dead(app_pid)
                 )
+        except KeyboardInterrupt:
+            pass  # catch CTRL-C to exit normally
         finally:
             self.tools.subprocess.cleanup("log stream", log_popen)
 

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -275,7 +275,7 @@ class StaticWebRunCommand(StaticWebMixin, RunCommand):
             url = f"http://{host}:{port}"
 
             self.logger.info(f"Web server open on {url}")
-            # If requested, open a brower tab on the newly opened server.
+            # If requested, open a browser tab on the newly opened server.
             if open_browser:
                 webbrowser.open_new_tab(url)
 

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -89,6 +89,8 @@ class WindowsRunCommand(RunCommand):
                 check=True,
                 stream_output=True,
             )
+        except KeyboardInterrupt:
+            pass  # Catch CTRL-C to exit normally
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(f"Unable to start app {app.app_name}.") from e
 

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -221,6 +221,28 @@ def test_run_idle_device(run_command, first_app_config):
     run_command.tools.mock_adb.logcat.assert_called_once_with("777")
 
 
+def test_run_ctrl_c(run_command, first_app_config, capsys):
+    """When CTRL-C is sent during logcat, Briefcase exits normally."""
+    # Set up device selection to return a running physical device.
+    run_command.tools.android_sdk.select_target_device = MagicMock(
+        return_value=("exampleDevice", "ExampleDevice", None)
+    )
+
+    run_command.tools.mock_adb.logcat.side_effect = KeyboardInterrupt
+
+    # Invoke run_app (and KeyboardInterrupt does not surface)
+    run_command.run_app(first_app_config, device_or_avd="exampleDevice")
+
+    # logcat is called and raised KeyboardInterrupt
+    run_command.tools.mock_adb.logcat.assert_called_once_with("777")
+
+    # Shows the try block for KeyboardInterrupt was entered
+    assert capsys.readouterr().out.endswith(
+        "[first-app] Following device log output (type CTRL-C to stop log)...\n"
+        "===========================================================================\n"
+    )
+
+
 def test_log_file_extra(run_command, monkeypatch):
     """Android commands register a log file extra to list SDK packages."""
     verify = MagicMock(return_value=run_command.tools.android_sdk)

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -90,7 +90,7 @@ def test_run_existing_device(run_command, first_app_config):
 
     # select_target_device was invoked with a specific device
     run_command.tools.android_sdk.select_target_device.assert_called_once_with(
-        device_or_avd="exampleDevice"
+        "exampleDevice"
     )
 
     # The ADB wrapper is created

--- a/tests/platforms/linux/appimage/test_run.py
+++ b/tests/platforms/linux/appimage/test_run.py
@@ -116,3 +116,42 @@ def test_run_app_failed(first_app_config, tmp_path):
         check=True,
         stream_output=True,
     )
+
+
+def test_run_app_ctrl_c(first_app_config, tmp_path, capsys):
+    """When CTRL-C is sent while the App is running, Briefcase exits
+    normally."""
+    command = LinuxAppImageRunCommand(
+        logger=Log(),
+        console=Console(),
+        base_path=tmp_path / "base_path",
+        data_path=tmp_path / "briefcase",
+    )
+    command.tools.home_path = tmp_path / "home"
+
+    # Set the host architecture for test purposes.
+    command.tools.host_arch = "wonky"
+
+    command.tools.subprocess = MagicMock(spec_set=Subprocess)
+    command.tools.subprocess.run.side_effect = KeyboardInterrupt
+
+    # Invoke run_app (and KeyboardInterrupt does not surface)
+    command.run_app(first_app_config)
+
+    # AppImage is run and raises KeyboardInterrupt
+    command.tools.subprocess.run.assert_called_with(
+        [
+            os.fsdecode(
+                tmp_path / "base_path" / "linux" / "First_App-0.0.1-wonky.AppImage"
+            )
+        ],
+        cwd=tmp_path / "home",
+        check=True,
+        stream_output=True,
+    )
+
+    # Shows the try block for KeyboardInterrupt was entered
+    assert capsys.readouterr().out.endswith(
+        "[first-app] Starting app...\n"
+        "===========================================================================\n"
+    )

--- a/tests/platforms/linux/flatpak/test_run.py
+++ b/tests/platforms/linux/flatpak/test_run.py
@@ -22,3 +22,31 @@ def test_run(first_app_config, tmp_path):
         bundle="com.example",
         app_name="first-app",
     )
+
+
+def test_run_ctrl_c(first_app_config, tmp_path, capsys):
+    """When CTRL-C is sent while the App is running, Briefcase exits
+    normally."""
+    command = LinuxFlatpakRunCommand(
+        logger=Log(),
+        console=Console(),
+        base_path=tmp_path / "base_path",
+        data_path=tmp_path / "briefcase",
+    )
+    command.tools.flatpak = mock.MagicMock(spec_set=Flatpak)
+    command.tools.flatpak.run.side_effect = KeyboardInterrupt
+
+    # Invoke run_app (and KeyboardInterrupt does not surface)
+    command.run_app(first_app_config)
+
+    # App is executed
+    command.tools.flatpak.run.assert_called_once_with(
+        bundle="com.example",
+        app_name="first-app",
+    )
+
+    # Shows the try block for KeyboardInterrupt was entered
+    assert capsys.readouterr().out.endswith(
+        "[first-app] Starting app...\n"
+        "===========================================================================\n"
+    )

--- a/tests/platforms/macOS/app/test_run.py
+++ b/tests/platforms/macOS/app/test_run.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from signal import SIGTERM
 from unittest import mock
 
 import pytest
@@ -22,6 +23,7 @@ def test_run_app(first_app_config, tmp_path, monkeypatch):
     command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
     command.tools.subprocess.Popen.return_value = log_stream_process
+    command.tools.os.kill = mock.MagicMock()
 
     # To satisfy coverage, the stop function must be invoked at least once
     # when invoking stream_output.
@@ -33,6 +35,7 @@ def test_run_app(first_app_config, tmp_path, monkeypatch):
     monkeypatch.setattr(
         "briefcase.platforms.macOS.get_process_id_by_command", lambda *a, **kw: 100
     )
+
     command.run_app(first_app_config)
 
     # Calls were made to start the app and to start a log stream.
@@ -63,6 +66,7 @@ def test_run_app(first_app_config, tmp_path, monkeypatch):
         log_stream_process,
         stop_func=mock.ANY,
     )
+    command.tools.os.kill.assert_called_with(100, SIGTERM)
     command.tools.subprocess.cleanup.assert_called_with(
         "log stream", log_stream_process
     )
@@ -136,7 +140,9 @@ def test_run_app_find_pid_failed(first_app_config, tmp_path, monkeypatch, capsys
         "briefcase.platforms.macOS.get_process_id_by_command",
         lambda *a, **kw: None,
     )
-    command.run_app(first_app_config)
+
+    with pytest.raises(BriefcaseCommandError) as exc_info:
+        command.run_app(first_app_config)
 
     # Calls were made to start the app and to start a log stream.
     bin_path = command.binary_path(first_app_config)
@@ -161,11 +167,8 @@ def test_run_app_find_pid_failed(first_app_config, tmp_path, monkeypatch, capsys
         cwd=tmp_path / "home",
         check=True,
     )
-    assert capsys.readouterr().out == (
-        "\n"
-        "[first-app] Starting app...\n"
-        "\n"
-        "Unable to find process for app first-app to start log streaming.\n"
+    assert exc_info.value.msg == (
+        "Unable to find process for app first-app to start log streaming."
     )
     command.tools.subprocess.stream_output.assert_not_called()
     command.tools.subprocess.cleanup.assert_called_with(


### PR DESCRIPTION
## Changes
macOS
- Removed CTRL-C instruction
- Catch `KeyboardInterrupt` to exit normally
- Send `SIGTERM` to App when Briefcase exits

Windows
- Catch `KeyboardInterrupt` to exit normally

Linux
- Catch `KeyboardInterrupt` to exit normally
- Add `====` App log header

iOS:
- Catch `KeyboardInterrupt` to exit normally

Android:
- Catch `KeyboardInterrupt` to exit normally

## Issues
- Fixes #904

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
