### PR TITLE
Use `python -m pip` to invoke `pip` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/setup-python@v4.2.0
       with:
         python-version: ${{ env.python_version }}
-    - run: pip install tox
+    - run: python -m pip install tox
     - run: tox -e towncrier-check
 
   package:
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/setup-python@v4.2.0
       with:
         python-version: ${{ env.python_version }}
-    - run: pip install tox
+    - run: python -m pip install tox
     - run: tox -e package
     - uses: actions/upload-artifact@v3
       with:
@@ -85,9 +85,9 @@ jobs:
         path: dist
     - name: Install dependencies
       run: |
-        pip install --upgrade pip
-        pip install --upgrade setuptools
-        pip install setuptools_scm tox coverage[toml]
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools
+        python -m pip install setuptools_scm tox coverage[toml]
     - name: Test
       run: |
         tox -e py --installpkg dist/*.whl
@@ -117,9 +117,9 @@ jobs:
         python-version: "3.10"
     - name: Install dependencies
       run: |
-        pip install --upgrade pip
-        pip install --upgrade setuptools
-        pip install coverage[toml]
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools
+        python -m pip install coverage[toml]
     - name: Retrieve coverage data
       uses: actions/download-artifact@v3
       with:
@@ -197,7 +197,7 @@ jobs:
         name: packages
         path: dist
     - name: Install packages
-      run: pip install dist/*.whl
+      run: python -m pip install dist/*.whl
     - name: Create App
       run: |
         cd tests/apps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/setup-python@v4.2.0
       with:
         python-version: ${{ env.python_version }}
-    - run: python -m pip install tox
+    - run: pip install tox
     - run: tox -e towncrier-check
 
   package:
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/setup-python@v4.2.0
       with:
         python-version: ${{ env.python_version }}
-    - run: python -m pip install tox
+    - run: pip install tox
     - run: tox -e package
     - uses: actions/upload-artifact@v3
       with:
@@ -86,8 +86,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
-        python -m pip install setuptools_scm tox coverage[toml]
+        pip install --upgrade setuptools
+        pip install setuptools_scm tox coverage[toml]
     - name: Test
       run: |
         tox -e py --installpkg dist/*.whl
@@ -118,8 +118,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
-        python -m pip install coverage[toml]
+        pip install --upgrade setuptools
+        pip install coverage[toml]
     - name: Retrieve coverage data
       uses: actions/download-artifact@v3
       with:
@@ -197,7 +197,7 @@ jobs:
         name: packages
         path: dist
     - name: Install packages
-      run: python -m pip install dist/*.whl
+      run: pip install dist/*.whl
     - name: Create App
       run: |
         cd tests/apps

--- a/changes/923.misc.rst
+++ b/changes/923.misc.rst
@@ -1,0 +1,1 @@
+Use ``python -m pip`` to invoke ``pip`` in CI to avoid errors from ``pip.exe``.


### PR DESCRIPTION
Started seeing this error in CI for #921. The error seems like a false positive....idk

```
Run pip install --upgrade pip
  pip install --upgrade pip
  pip install --upgrade setuptools
  pip install setuptools_scm tox coverage[toml]
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
  env:
    python_version: 3.9
    pythonLocation: C:\hostedtoolcache\windows\Python\3.8.10\x64
    PKG_CONFIG_PATH: C:\hostedtoolcache\windows\Python\3.8.10\x64/lib/pkgconfig
    Python_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.8.10\x64
    Python2_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.8.10\x64
    Python3_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.8.10\x64
Requirement already satisfied: pip in c:\hostedtoolcache\windows\python\3.8.10\x64\lib\site-packages (22.2.2)
Collecting pip
  Downloading pip-22.3-py3-none-any.whl (2.1 MB)
     ---------------------------------------- 2.1/2.1 MB 21.7 MB/s eta 0:00:00
ERROR: To modify pip, please run the following command:
c:\hostedtoolcache\windows\python\3.8.10\x64\python.exe -m pip install --upgrade pip

Notice:  A new release of pip available: 22.2.2 -> 22.3
Notice:  To update, run: python.exe -m pip install --upgrade pip
Error: Process completed with exit code 1.
```

It seems as though https://github.com/pypa/pip/issues/6924 should have resolved this....but alas...

At any rate, I made two commits in this PR to demonstrate the issue in the first and the fix in the second.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
