### PR TITLE
Show Android emulator troubleshooting steps for CTRL-C

### DIFF
--- a/changes/929.misc.rst
+++ b/changes/929.misc.rst
@@ -1,0 +1,1 @@
+If the user sends CTRL-C while the Android emulator is starting, the troubleshooting steps are printed.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -812,7 +812,7 @@ Use the -d/--device option to explicitly specify the device to use.
                 f"""
 In future, you can specify this device by running:
 
-    $ briefcase run android -d @{avd}
+    $ briefcase run android -d "@{avd}"
 """
             )
         elif device:
@@ -999,6 +999,27 @@ In future, you can specify this device by running:
             start_new_session=True,
         )
 
+        # wrap AVD name in quotes since '@' is a special char on Windows
+        emulator_command = " ".join(
+            f'"{arg}"' if arg.startswith("@") else arg
+            for arg in map(str, emulator_popen.args)
+        )
+
+        error_msg = (
+            "{prologue}"
+            + f"""
+
+Try starting the emulator manually by running:
+
+    $ {emulator_command}
+
+Resolve any problems you discover, then try running your app again. You may
+find this page helpful in diagnosing emulator problems.
+
+    https://developer.android.com/studio/run/emulator-acceleration#accel-vm
+"""
+        )
+
         # The boot process happens in 2 phases.
         # First, the emulator appears in the device list. However, it's
         # not ready until the boot process has finished. To determine
@@ -1013,18 +1034,9 @@ In future, you can specify this device by running:
                 while adb is None:
                     if emulator_popen.poll() is not None:
                         raise BriefcaseCommandError(
-                            f"""\
-Android emulator was unable to start!
-
-Try starting the emulator manually by running:
-
-    $ {' '.join(str(arg) for arg in emulator_popen.args)}
-
-Resolve any problems you discover, then try running your app again. You may
-find this page helpful in diagnosing emulator problems.
-
-    https://developer.android.com/studio/run/emulator-acceleration#accel-vm
-"""
+                            error_msg.format(
+                                prologue="Android emulator was unable to start!"
+                            )
                         )
 
                     for device, details in sorted(self.devices().items()):
@@ -1053,27 +1065,28 @@ find this page helpful in diagnosing emulator problems.
                     while not adb.has_booted():
                         if emulator_popen.poll() is not None:
                             raise BriefcaseCommandError(
-                                f"""\
-Android emulator was unable to boot!
-
-Try starting the emulator manually by running:
-
-    $ {' '.join(str(arg) for arg in emulator_popen.args)}
-
-Resolve any problems you discover, then try running your app again. You may
-find this page helpful in diagnosing emulator problems.
-
-    https://developer.android.com/studio/run/emulator-acceleration#accel-vm
-"""
+                                error_msg.format(
+                                    prologue="Android emulator was unable to boot!"
+                                )
                             )
 
                         # Try again in 2 seconds...
                         self.sleep(2)
-        except Exception:
+        except BaseException as e:
             # if the emulator exited, this should return its output immediately;
             # if it is still running, this will quickly time out and print nothing.
             with suppress(subprocess.TimeoutExpired):
                 self.tools.logger.info(emulator_popen.communicate(timeout=1)[0])
+
+            # Provide troubleshooting steps if user gives up on the emulator starting
+            if isinstance(e, KeyboardInterrupt):
+                self.tools.logger.warning()
+                self.tools.logger.warning(
+                    error_msg.format(
+                        prologue="Is the Android emulator not starting up properly?"
+                    )
+                )
+
             raise
 
         # Return the device ID and full name.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -999,7 +999,7 @@ In future, you can specify this device by running:
             start_new_session=True,
         )
 
-        # wrap AVD name in quotes since '@' is a special char on Windows
+        # wrap AVD name in quotes since '@' is a special char in PowerShell
         emulator_command = " ".join(
             f'"{arg}"' if arg.startswith("@") else arg
             for arg in map(str, emulator_popen.args)

--- a/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
@@ -196,7 +196,7 @@ def test_select_running_emulator(mock_tools, android_sdk, capsys):
 
     # A re-run prompt has been provided
     out = capsys.readouterr().out
-    assert "briefcase run android -d @runningEmulator" in out
+    assert 'briefcase run android -d "@runningEmulator"' in out
 
 
 def test_select_idle_emulator(mock_tools, android_sdk, capsys):
@@ -214,7 +214,7 @@ def test_select_idle_emulator(mock_tools, android_sdk, capsys):
 
     # A re-run prompt has been provided
     out = capsys.readouterr().out
-    assert "briefcase run android -d @idleEmulator" in out
+    assert 'briefcase run android -d "@idleEmulator"' in out
 
 
 def test_select_create_emulator(mock_tools, android_sdk, capsys):


### PR DESCRIPTION
As discussed in #914, this is a less intrusive approach to provide more information when the user interrupts the process to start the Android emulator.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
