### PR TITLE
Add cookiecutter filter for escaping double quotes and backslashes #905

### DIFF
--- a/changes/905.bugfix.rst
+++ b/changes/905.bugfix.rst
@@ -1,0 +1,1 @@
+Backslashes and double quotes are now safe to be used for Formal Name and Description

--- a/src/briefcase/integrations/cookiecutter.py
+++ b/src/briefcase/integrations/cookiecutter.py
@@ -51,3 +51,17 @@ class RGBExtension(Extension):
         environment.filters["float_red"] = float_red
         environment.filters["float_green"] = float_green
         environment.filters["float_blue"] = float_blue
+
+
+class TOMLEscape(Extension):
+    """Jinja2 extension to escape strings so TOML don't break."""
+
+    def __init__(self, environment):
+        """Initialize the extension with the given environment."""
+        super().__init__(environment)
+
+        def escape_tag(obj):
+            """Escapes double quotes and backslashes."""
+            return obj.replace('"', '"').replace("\\", "\\\\")
+
+        environment.filters["escape_tag"] = escape_tag

--- a/src/briefcase/integrations/cookiecutter.py
+++ b/src/briefcase/integrations/cookiecutter.py
@@ -60,8 +60,8 @@ class TOMLEscape(Extension):
         """Initialize the extension with the given environment."""
         super().__init__(environment)
 
-        def escape_tag(obj):
+        def escape_toml(obj):
             """Escapes double quotes and backslashes."""
             return obj.replace('"', '"').replace("\\", "\\\\")
 
-        environment.filters["escape_tag"] = escape_tag
+        environment.filters["escape_toml"] = escape_toml

--- a/tests/integrations/cookiecutter/test_TOMLEscape.py
+++ b/tests/integrations/cookiecutter/test_TOMLEscape.py
@@ -18,4 +18,4 @@ def test_escape_tag(value, expected):
     env = MagicMock()
     env.filters = {}
     TOMLEscape(env)
-    assert env.filters["escape_tag"](value) == expected
+    assert env.filters["escape_toml"](value) == expected

--- a/tests/integrations/cookiecutter/test_TOMLEscape.py
+++ b/tests/integrations/cookiecutter/test_TOMLEscape.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.integrations.cookiecutter import TOMLEscape
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # Single digit minor
+        ("Hello World", "Hello World"),
+        ('Hello " World', 'Hello " World'),
+        ("Hello \\ World", "Hello \\\\ World"),
+    ],
+)
+def test_escape_tag(value, expected):
+    env = MagicMock()
+    env.filters = {}
+    TOMLEscape(env)
+    assert env.filters["escape_tag"](value) == expected

--- a/tests/integrations/cookiecutter/test_TOMLEscape.py
+++ b/tests/integrations/cookiecutter/test_TOMLEscape.py
@@ -14,7 +14,7 @@ from briefcase.integrations.cookiecutter import TOMLEscape
         ("Hello \\ World", "Hello \\\\ World"),
     ],
 )
-def test_escape_tag(value, expected):
+def test_escape_toml(value, expected):
     env = MagicMock()
     env.filters = {}
     TOMLEscape(env)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Add cookiecutter filter for escaping double quotes and backslashes in Formal Name and Description

<!--- What problem does this change solve? -->
Backslashes and double quotes are now safe to be used for Formal Name and Description

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #905 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
