### PR TITLE
Don't show warning when starting an Android emulator with no skin

### DIFF
--- a/changes/882.bugfix.rst
+++ b/changes/882.bugfix.rst
@@ -1,0 +1,1 @@
+Briefcase will no longer display warning about missing skin when running Android emulator with skin path set to `_no_skin`

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -468,8 +468,11 @@ connection.
         try:
             skin = avd_config["skin.name"]
             skin_path = Path(avd_config["skin.path"])
-
-            if skin_path != Path("skins") / skin:
+            if skin_path == Path("_no_skin"):
+                self.tools.logger.debug(
+                    "Skipping skin validation due to '_no_skin' being set as path."
+                )
+            elif skin_path != Path("skins") / skin:
                 self.tools.logger.warning(
                     f"""
 *************************************************************************

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_avd.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_avd.py
@@ -163,3 +163,42 @@ def test_unrecognized_emulator_skin(android_sdk, capsys):
 
     # The emulator skin was not verified
     android_sdk.verify_emulator_skin.assert_not_called()
+
+
+def test_no_skin_emulator_skin(android_sdk, capsys):
+    """If the AVD config contains an emulator skin set to _no_skin continiue
+    without validation."""
+    # Mock an AVD configuration that contains a skin.name and skin.path
+    # in an unexpected location
+    android_sdk.avd_config = mock.MagicMock(
+        return_value={
+            "avd.ini.encoding": "UTF-8",
+            "hw.device.manufacturer": "Google",
+            "hw.device.name": "pixel",
+            "weird.key": "good=bad",
+            "PlayStore.enabled": "no",
+            "avd.name": "beePhone",
+            "disk.cachePartition": "yes",
+            "disk.cachePartition.size": "42M",
+            # Add an emulator skin.
+            "skin.name": "768x1280",
+            "skin.path": "_no_skin",
+        }
+    )
+    android_sdk.verify_system_image = mock.MagicMock()
+    android_sdk.verify_emulator_skin = mock.MagicMock()
+
+    # Verify the AVD
+    android_sdk.verify_avd("goodDevice")
+
+    # The AVD config was loaded.
+    android_sdk.avd_config.assert_called_with("goodDevice")
+
+    # A warning message should not be output
+    assert "WARNING: Unrecognized device skin" not in capsys.readouterr().out
+
+    # The system image was not verified
+    android_sdk.verify_system_image.assert_not_called()
+
+    # The emulator skin was not verified
+    android_sdk.verify_emulator_skin.assert_not_called()


### PR DESCRIPTION
<!--- Describe your changes in detail -->
When `skin.path = _no_skin` warning about missing skin will be supressed.
<!--- What problem does this change solve? -->
Creating an emulator without skin through Android studio creates config with `skin.path = _no_skin`. This caused the warning to show up despite no skin being set up.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #882 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
