### PR TITLE
Support commands listing help test with briefcase -h

### DIFF
--- a/changes/907.misc.rst
+++ b/changes/907.misc.rst
@@ -1,0 +1,1 @@
+Commands now display help descriptions in CLI

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -31,6 +31,12 @@ def get_command(
     platform={"darwin": "macOS", "linux": "linux", "win32": "windows"}[sys.platform],
     output_format=None,
 ):
+    """Given a command and optional filters, returns the command class.
+
+    :param command: command entered from the command line
+    :param platform: specified platform
+    :param output_format: specified output format
+    """
     # These commands are agnostic of platform or format
     if command == "new":
         return NewCommand


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Currently, ```briefcase -h``` only lists the commands that can be run.  It does not give any context of what the commands themselves do.
<!--- What problem does this change solve? -->
This will allow users to more quickly find the command they wish to use in the CLI
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #907

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] All new features have been tested
- [ x ] All new features have been documented
- [ x ] I have read the **CONTRIBUTING.md** file
- [ x ] I will abide by the code of conduct
