### PR TITLE
Remove PYTHONPATH from tox.ini

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         platform: ['macos', 'ubuntu', 'windows']
-        python-version: ['3.8', '3.9', '3.10', '3.11.0-alpha - 3.11.0']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     runs-on: ${{ matrix.platform }}-latest
     steps:
     - uses: actions/checkout@v3.1.0

--- a/changes/951.misc.rst
+++ b/changes/951.misc.rst
@@ -1,0 +1,1 @@
+Removed unnecessary PYTHONPATH from tox.ini to ensure that the tests are run against the built packages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,13 @@ build-backend = "setuptools.build_meta"
 parallel = true
 branch = true
 relative_files = true
-source = ["src/briefcase"]
+source_pkgs = ["briefcase"]
+
+[tool.coverage.paths]
+source = [
+    "src",
+    "**/site-packages",
+]
 
 [tool.coverage.report]
 show_missing = true

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist = towncrier-check,docs,package,py{38,39,310,311}
 skip_missing_interpreters = true
 
 [testenv]
-setenv = PYTHONPATH = {toxinidir}/src
 extras =
     test
 commands =


### PR DESCRIPTION
This line is no longer necessary, and it was breaking the rule that the tests should be run against the built packages.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
