### PR TITLE
Remove the need to specify an iOS device when building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
       run: |
         cd tests/apps/verify-${{ matrix.framework }}
         briefcase create iOS
-        briefcase build iOS -d "iPhone SE (2nd generation)"
+        briefcase build iOS
         briefcase package iOS --adhoc-sign
     - name: Build Web App
       if: matrix.framework == 'toga'

--- a/changes/953.feature.rst
+++ b/changes/953.feature.rst
@@ -1,0 +1,1 @@
+It is no longer necessary to specify a device when building an iOS project.

--- a/docs/reference/platforms/iOS.rst
+++ b/docs/reference/platforms/iOS.rst
@@ -45,15 +45,6 @@ Additional options
 The following options can be provided at the command line when producing
 iOS projects
 
-build
------
-
-``-d <device>`` / ``--device <device>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The device simulator to target. Can be either a UDID, a device name (e.g.,
-``"iPhone 11"``), or a device name and OS version (``"iPhone 11::13.3"``).
-
 run
 ---
 
@@ -61,4 +52,4 @@ run
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The device simulator to target. Can be either a UDID, a device name (e.g.,
-``"iPhone 11"``), or a device name and OS version (``"iPhone 11::13.3"``).
+``"iPhone 11"``), or a device name and OS version (``"iPhone 11::iOS 13.3"``).

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -86,15 +86,17 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
             for the selected device.
         """
         simulators = self.get_simulators(self.tools, "iOS")
-
         try:
             # Try to convert to a UDID. If this succeeds, then the argument
             # is a UDID.
             udid = str(UUID(udid_or_device)).upper()
             # User has provided a UDID at the command line; look for it.
-            for iOS_version, devices in simulators.items():
+            for iOS_tag, devices in simulators.items():
                 try:
                     device = devices[udid]
+                    # iOS_tag will be of the form "iOS 15.5"
+                    # Drop the "iOS" prefix when reporting the version.
+                    iOS_version = iOS_tag.split(" ", 1)[-1]
                     return udid, iOS_version, device
                 except KeyError:
                     # UDID doesn't exist in this iOS version; try another.
@@ -109,7 +111,8 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
             # It must be a device or device+version
             if udid_or_device and "::" in udid_or_device:
                 # A device name::version.
-                device, iOS_version = udid_or_device.split("::")
+                device, iOS_tag = udid_or_device.split("::")
+
                 try:
                     # Convert the simulator dict into a dict where
                     # the iOS versions are lower cased, then do a lookup
@@ -117,10 +120,14 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
                     # However, also return the *unmodified* iOS version string
                     # so we can convert the user-provided iOS version into the
                     # "clean", official capitalization.
-                    iOS_version, devices = {
-                        clean_iOS_version.lower(): (clean_iOS_version, details)
-                        for clean_iOS_version, details in simulators.items()
-                    }[iOS_version.lower()]
+                    iOS_tag, devices = {
+                        clean_iOS_tag.lower(): (clean_iOS_tag, details)
+                        for clean_iOS_tag, details in simulators.items()
+                    }[iOS_tag.lower()]
+
+                    # iOS_tag will be of the form "iOS 15.5"
+                    # Drop the "iOS" prefix when reporting the version.
+                    iOS_version = iOS_tag.split(" ", 1)[-1]
                     try:
                         # Do a reverse lookup for UDID, based on a
                         # case-insensitive name lookup.
@@ -135,16 +142,16 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
                     except KeyError as e:
                         raise InvalidDeviceError("device name", device) from e
                 except KeyError as e:
-                    raise InvalidDeviceError("iOS Version", iOS_version) from e
+                    raise InvalidDeviceError("iOS Version", iOS_tag) from e
             elif udid_or_device:
                 # Just a device name
                 device = udid_or_device
 
                 # Search iOS versions, looking for most recent version first.
-                # The iOS version string will be something like "iOS 15.4";
+                # The iOS tag will be something like "iOS 15.4";
                 # Drop the prefix (if it exists), convert into the tuple (15, 4),
                 # and sort numerically.
-                for iOS_version, devices in sorted(
+                for iOS_tag, devices in sorted(
                     simulators.items(),
                     key=lambda item: tuple(
                         int(v) for v in item[0].split()[-1].split(".")
@@ -159,6 +166,11 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
                         # Found a match;
                         # normalize back to the official name and return.
                         device = devices[udid]
+
+                        # iOS_tag will be of the form "iOS 15.5"
+                        # Drop the "iOS" prefix when reporting the version.
+                        iOS_version = iOS_tag.split(" ", 1)[-1]
+
                         return udid, iOS_version, device
                     except KeyError:
                         # UDID doesn't exist in this iOS version; try another.
@@ -168,19 +180,19 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
         if len(simulators) == 0:
             raise BriefcaseCommandError("No iOS simulators available.")
         elif len(simulators) == 1:
-            iOS_version = list(simulators.keys())[0]
+            iOS_tag = list(simulators.keys())[0]
         else:
             self.input.prompt()
             self.input.prompt("Select iOS version:")
             self.input.prompt()
-            iOS_version = select_option(
-                {version: version for version in simulators.keys()}, input=self.input
+            iOS_tag = select_option(
+                {tag: tag for tag in simulators.keys()}, input=self.input
             )
 
-        devices = simulators[iOS_version]
+        devices = simulators[iOS_tag]
 
         if len(devices) == 0:
-            raise BriefcaseCommandError(f"No simulators available for {iOS_version}.")
+            raise BriefcaseCommandError(f"No simulators available for {iOS_tag}.")
         elif len(devices) == 1:
             udid = list(devices.keys())[0]
         else:
@@ -195,13 +207,18 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
             f"""
 In the future, you could specify this device by running:
 
-    $ briefcase {self.command} iOS -d "{device}::{iOS_version}"
+    $ briefcase {self.command} iOS -d "{device}::{iOS_tag}"
 
 or:
 
     $ briefcase {self.command} iOS -d {udid}
 """
         )
+
+        # iOS_tag will be of the form "iOS 15.5"
+        # Drop the "iOS" prefix when reporting the version.
+        iOS_version = iOS_tag.split(" ", 1)[-1]
+
         return udid, iOS_version, device
 
 
@@ -230,46 +247,32 @@ class iOSXcodeOpenCommand(iOSXcodePassiveMixin, OpenCommand):
     description = "Open an existing iOS Xcode project."
 
 
-class iOSXcodeBuildCommand(iOSXcodeMixin, BuildCommand):
+class iOSXcodeBuildCommand(iOSXcodePassiveMixin, BuildCommand):
     description = "Build an iOS Xcode project."
 
-    def build_app(self, app: BaseConfig, udid=None, **kwargs):
+    def build_app(self, app: BaseConfig, **kwargs):
         """Build the Xcode project for the application.
 
         :param app: The application to build
-        :param udid: The device UDID to target. If ``None``, the user will
-            be asked to select a device at runtime.
         """
-        try:
-            udid, iOS_version, device = self.select_target_device(udid)
-        except InputDisabled as e:
-            raise BriefcaseCommandError(
-                "Input has been disabled; can't select a device to target."
-            ) from e
-
-        self.logger.info(
-            f"Targeting an {device} running {iOS_version} (device UDID {udid})",
-            prefix=app.app_name,
-        )
-
         self.logger.info("Building XCode project...", prefix=app.app_name)
         with self.input.wait_bar("Building..."):
             try:
                 self.tools.subprocess.run(
                     [
                         "xcodebuild",
+                        "build",
                         "-project",
                         self.project_path(app),
                         "-destination",
-                        f'platform="iOS Simulator,name={device},OS={iOS_version}"',
-                        "-quiet",
+                        'platform="iOS Simulator"',
                         "-configuration",
                         "Debug",
                         "-arch",
                         self.tools.host_arch,
                         "-sdk",
                         "iphonesimulator",
-                        "build",
+                        "-quiet",
                     ],
                     check=True,
                 )
@@ -277,9 +280,6 @@ class iOSXcodeBuildCommand(iOSXcodeMixin, BuildCommand):
                 raise BriefcaseCommandError(
                     f"Unable to build app {app.app_name}."
                 ) from e
-
-        # Preserve the device selection as state.
-        return {"udid": udid}
 
 
 class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
@@ -308,7 +308,7 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
             ) from e
 
         self.logger.info(
-            f"Starting app on an {device} running {iOS_version} (device UDID {udid})",
+            f"Starting app on an {device} running iOS {iOS_version} (device UDID {udid})",
             prefix=app.app_name,
         )
 

--- a/tests/commands/create/test_install_app_dependencies.py
+++ b/tests/commands/create/test_install_app_dependencies.py
@@ -6,7 +6,8 @@ from unittest import mock
 import pytest
 import tomli_w
 
-from briefcase.commands.create import BriefcaseCommandError, DependencyInstallError
+from briefcase.commands.create import DependencyInstallError
+from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 
 

--- a/tests/platforms/iOS/xcode/mixin/test_select_target_device.py
+++ b/tests/platforms/iOS/xcode/mixin/test_select_target_device.py
@@ -52,7 +52,7 @@ def test_explicit_device_udid(dummy_command):
     udid, iOS_version, device = result
 
     assert udid == "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"
-    assert iOS_version == "iOS 13.2"
+    assert iOS_version == "13.2"
     assert device == "iPhone 11"
 
 
@@ -78,7 +78,7 @@ def test_explicit_device_name_should_find_highest_version(dummy_command):
     udid, iOS_version, device = dummy_command.select_target_device("iphone 8")
 
     assert udid == "C9A005C8-9468-47C5-8376-68A6E3408209"
-    assert iOS_version == "iOS 13.2"
+    assert iOS_version == "13.2"
     assert device == "iPhone 8"
 
     # User input was not solicited
@@ -140,7 +140,7 @@ def test_explicit_device_name_and_version(dummy_command):
     udid, iOS_version, device = dummy_command.select_target_device("iphone 8::ios 10.3")
 
     assert udid == "68A6E340-8376-47C5-9468-C9A005C88209"
-    assert iOS_version == "iOS 10.3"
+    assert iOS_version == "10.3"
     assert device == "iPhone 8"
 
     # User input was not solicited
@@ -234,7 +234,7 @@ def test_implied_device(dummy_command):
     udid, iOS_version, device = dummy_command.select_target_device()
 
     assert udid == "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"
-    assert iOS_version == "iOS 13.2"
+    assert iOS_version == "13.2"
     assert device == "iPhone 11"
 
     # No user input was solicited
@@ -258,7 +258,7 @@ def test_implied_os(dummy_command):
     udid, iOS_version, device = dummy_command.select_target_device()
 
     assert udid == "EEEBA06C-81F9-407C-885A-2261306DB2BE"
-    assert iOS_version == "iOS 13.2"
+    assert iOS_version == "13.2"
     assert device == "iPhone 11 Pro Max"
 
     # User input was solicited once
@@ -287,7 +287,7 @@ def test_multiple_os_implied_device(dummy_command):
     udid, iOS_version, device = dummy_command.select_target_device()
 
     assert udid == "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"
-    assert iOS_version == "iOS 13.2"
+    assert iOS_version == "13.2"
     assert device == "iPhone 11"
 
     # User input was solicited once
@@ -317,7 +317,7 @@ def test_os_and_device_options(dummy_command):
     udid, iOS_version, device = dummy_command.select_target_device()
 
     assert udid == "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"
-    assert iOS_version == "iOS 13.2"
+    assert iOS_version == "13.2"
     assert device == "iPhone 11"
 
     # User input was solicited twice

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -20,6 +20,13 @@ def run_command(tmp_path):
     )
 
 
+def test_device_option(run_command):
+    """The -d option can be parsed."""
+    options = run_command.parse_options(["-d", "myphone"])
+
+    assert options == {"udid": "myphone", "update": False, "appname": None}
+
+
 def test_run_multiple_devices_input_disabled(run_command, first_app_config):
     """If input is disabled, but there are multiple devices, an error is
     raised."""


### PR DESCRIPTION
It is possible to build an iOS project by only specifying a device type, not a specific device. 

Also includes a small change to the handling of iOS versions, differentiating between a "tag" ("iOS 16.1") and the version ("16.1"). This matters because some commands to xcodebuild require the *version*, rather than the tag. At some point in the past, the format returned by the tool reporting simulator images changed, adding the "iOS" prefix. The test cases include examples of both, but despite comments in the code to the contrary, the iOS prefix wasn't being stripped.

Discovered as part of #949.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
