### PR TITLE
Document process of customizing AppImage DockerFile.

### DIFF
--- a/changes/886.feature.rst
+++ b/changes/886.feature.rst
@@ -1,0 +1,1 @@
+The Dockerfile used to build AppImages can now include arbitrary additional instructions.

--- a/docs/reference/platforms/linux/appimage.rst
+++ b/docs/reference/platforms/linux/appimage.rst
@@ -134,6 +134,14 @@ Or, if you were using a plugin stored as a local file::
 
     linuxdeploy_plugins = ["DEPLOY_GTK_VERSION=3 path/to/plugins/linuxdeploy-gtk-plugin.sh"]
 
+``dockerfile_extra_content``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Any additional Docker instructions that are required to configure the container
+used to build your Python app. For example, any dependencies that cannot be
+configured with ``apt-get`` could be installed. ``dockerfile_extra_content`` is
+string literal that will be added verbatim to the end of the project Dockerfile.
+
 Runtime issues with AppImages
 =============================
 


### PR DESCRIPTION
beeware/briefcase-linux-appimage-template#22 added the option of Dockerfile customisation to the template. No changes to Briefcase are needed to support this; however, this new option needs to be documented.

Refs beeware/briefcase-linux-appimage-template#22
Refs #886

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
