### PR TITLE
Use Python development mode for `briefcase dev` (fixes #806)

### DIFF
--- a/changes/806.feature.rst
+++ b/changes/806.feature.rst
@@ -1,0 +1,1 @@
+All warnings from the App and its dependencies are now shown when running ``briefcase dev`` by invoking Python in `development mode <https://docs.python.org/3/library/devmode.html>`_.

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -91,6 +91,8 @@ class DevCommand(BaseCommand):
                 [
                     sys.executable,
                     "-u",
+                    "-X",
+                    "dev",
                     "-c",
                     (
                         "import runpy, sys;"

--- a/tests/commands/dev/test_run_dev_app.py
+++ b/tests/commands/dev/test_run_dev_app.py
@@ -13,6 +13,8 @@ def test_subprocess_running_successfully(dev_command, first_app, tmp_path):
         [
             sys.executable,
             "-u",
+            "-X",
+            "dev",
             "-c",
             (
                 "import runpy, sys;"
@@ -39,6 +41,8 @@ def test_subprocess_throws_error(dev_command, first_app, tmp_path):
         [
             sys.executable,
             "-u",
+            "-X",
+            "dev",
             "-c",
             (
                 "import runpy, sys;"


### PR DESCRIPTION
## Changes
`briefcase dev` now uses Python [development mode](https://docs.python.org/3/library/devmode.html) to show all warnings from the App and its dependencies.

While performance is definitely impacted by this setting, it should not be intolerable. I have been regularly using debug versions of Python to do Briefcase development; while it noticeably impacts Python's performance, even it isn't untolerable for dev.

In way of example, here are `pytest` timings (averaged over 10 consecutive runs) for Briefcase:
- Without `-X dev`:
```
real 19.79
user 10.60
sys 0.76
```
- With `-X dev`:
```
real 21.19
user 12.01
sys 0.78
```
- Debug Python (ooof)
```
real 71.80
user 62.45
sys 0.90
```

Also, as Victor [points out](https://vstinner.github.io/python37-dev-mode.html), (at least one) impetus for dev mode was apparently a more performant debug mode.

## Issues
- Fixes #806

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
