### PR TITLE
Add clarifications to the documentation about dockerfile_extra_content.

### DIFF
--- a/changes/886.feature.rst
+++ b/changes/886.feature.rst
@@ -1,1 +1,1 @@
-The Dockerfile used to build AppImages can now include arbitrary additional instructions.
+The Dockerfile used to build AppImages can now include user-provided container setup instructions.

--- a/docs/reference/platforms/linux/appimage.rst
+++ b/docs/reference/platforms/linux/appimage.rst
@@ -142,6 +142,21 @@ used to build your Python app. For example, any dependencies that cannot be
 configured with ``apt-get`` could be installed. ``dockerfile_extra_content`` is
 string literal that will be added verbatim to the end of the project Dockerfile.
 
+Any Dockerfile instructions added by ``dockerfile_extra_content`` will be
+executed as the ``brutus`` user, rather than the ``root`` user. If you need to
+perform container setup operations as ``root``, switch the container's user to
+``root``, perform whatever operations are required, then switch back to the
+``brutus`` user - e.g.::
+
+    dockerfile_extra_content = """
+    RUN <first command run as brutus>
+
+    USER root
+    RUN <second command run as root>
+
+    USER brutus
+    """
+
 Runtime issues with AppImages
 =============================
 


### PR DESCRIPTION
Adds additional documentation clarifications about the user that runs Dockerfile operations.

Refs beeware/briefcase-linux-appimage-template#22.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
