### PR TITLE
Add `ToolCache` typing

### DIFF
--- a/changes/964.misc.rst
+++ b/changes/964.misc.rst
@@ -1,0 +1,1 @@
+The ``ToolCache`` and its tools are now typed to better support IDE hints and auto-completion.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ precision = 1
 exclude_lines = [
     "pragma: no cover",
     "@(abc\\.)?abstractmethod",
-    "NotImplementedError\\(\\)"
+    "NotImplementedError\\(\\)",
+    "if TYPE_CHECKING:",
 ]
 
 [tool.isort]

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -26,6 +26,8 @@ from briefcase.exceptions import (
     NetworkFailure,
 )
 from briefcase.integrations.base import ToolCache
+from briefcase.integrations.download import Download
+from briefcase.integrations.subprocess import Subprocess
 
 
 class InvalidTemplateRepository(BriefcaseCommandError):
@@ -145,6 +147,10 @@ class BaseCommand(ABC):
             console=console,
             base_path=self.data_path / "tools",
         )
+
+        # Immediately add tools that must be always available
+        Subprocess.verify(tools=self.tools)
+        Download.verify(tools=self.tools)
 
         self.global_config = None
         self._path_index = {}

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import shutil
@@ -5,6 +7,7 @@ import subprocess
 import time
 from contextlib import suppress
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from briefcase.config import PEP508_NAME_RE
 from briefcase.console import InputDisabled, select_option
@@ -14,6 +17,9 @@ from briefcase.exceptions import (
     MissingToolError,
 )
 from briefcase.integrations.java import JDK
+
+if TYPE_CHECKING:  # pragma: no cover
+    from briefcase.integrations.base import ToolCache
 
 DEVICE_NOT_FOUND = re.compile(r"^error: device '[^']*' not found")
 
@@ -40,7 +46,7 @@ class AndroidSDK:
     name = "android_sdk"
     full_name = "Android SDK"
 
-    def __init__(self, tools, root_path):
+    def __init__(self, tools: ToolCache, root_path: Path):
         self.tools = tools
         self.dot_android_path = self.tools.home_path / ".android"
         self.root_path = root_path
@@ -129,7 +135,7 @@ class AndroidSDK:
         )
 
     @classmethod
-    def verify(cls, tools, install=True):
+    def verify(cls, tools: ToolCache, install=True):
         """Verify an Android SDK is available.
 
         If the ANDROID_SDK_ROOT environment variable is set, that location will
@@ -1100,7 +1106,7 @@ find this page helpful in diagnosing emulator problems.
 
 
 class ADB:
-    def __init__(self, tools, device):
+    def __init__(self, tools: ToolCache, device):
         """An API integration for the Android Debug Bridge (ADB).
 
         :param tools: ToolCache of available tools

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -220,7 +220,8 @@ class AndroidSDK(Tool):
                 else:
                     raise MissingToolError("Android SDK")
 
-        return tools.add_tool(name=cls.name, tool=sdk)
+        tools.android_sdk = sdk
+        return sdk
 
     def exists(self):
         """Confirm that the SDK actually exists.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import re
 import shutil
@@ -7,7 +5,6 @@ import subprocess
 import time
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from briefcase.config import PEP508_NAME_RE
 from briefcase.console import InputDisabled, select_option
@@ -16,10 +13,8 @@ from briefcase.exceptions import (
     InvalidDeviceError,
     MissingToolError,
 )
+from briefcase.integrations.base import Tool, ToolCache
 from briefcase.integrations.java import JDK
-
-if TYPE_CHECKING:  # pragma: no cover
-    from briefcase.integrations.base import ToolCache
 
 DEVICE_NOT_FOUND = re.compile(r"^error: device '[^']*' not found")
 
@@ -42,7 +37,7 @@ this device as a deployment target.
         )
 
 
-class AndroidSDK:
+class AndroidSDK(Tool):
     name = "android_sdk"
     full_name = "Android SDK"
 
@@ -225,8 +220,7 @@ class AndroidSDK:
                 else:
                     raise MissingToolError("Android SDK")
 
-        tools.android_sdk = sdk
-        return sdk
+        return tools.add_tool(name=cls.name, tool=sdk)
 
     def exists(self):
         """Confirm that the SDK actually exists.
@@ -1106,7 +1100,7 @@ find this page helpful in diagnosing emulator problems.
 
 
 class ADB:
-    def __init__(self, tools: ToolCache, device):
+    def __init__(self, tools: ToolCache, device: str):
         """An API integration for the Android Debug Bridge (ADB).
 
         :param tools: ToolCache of available tools

--- a/src/briefcase/integrations/base.py
+++ b/src/briefcase/integrations/base.py
@@ -8,8 +8,7 @@ from abc import ABC
 from collections import defaultdict
 from collections.abc import Mapping
 from pathlib import Path
-from types import ModuleType
-from typing import TYPE_CHECKING, DefaultDict, TypeVar, Union
+from typing import TYPE_CHECKING, DefaultDict
 
 import requests
 from cookiecutter.main import cookiecutter
@@ -18,7 +17,9 @@ from briefcase.config import AppConfig
 from briefcase.console import Console, Log
 
 if TYPE_CHECKING:
-    import git as _git
+    # Tools are imported only for type checking
+    # to avoid circular import errors.
+    import git as git_
 
     from briefcase.integrations.android_sdk import AndroidSDK
     from briefcase.integrations.docker import Docker, DockerAppContext
@@ -37,9 +38,6 @@ class Tool(ABC):
     """Tool Base."""  # pragma: no cover
 
 
-TOOL_T = TypeVar("TOOL_T", bound=Union[Tool, ModuleType])
-
-
 class ToolCache(Mapping):
     # Briefcase tools
     android_sdk: AndroidSDK
@@ -47,7 +45,7 @@ class ToolCache(Mapping):
     docker: Docker
     download: Download
     flatpak: Flatpak
-    git: _git
+    git: git_
     java: JDK
     linuxdeploy: LinuxDeploy
     rcedit: RCEdit
@@ -104,17 +102,6 @@ class ToolCache(Mapping):
                 home_path=self.home_path,
             )
         )
-
-    def add_tool(self, name: str, tool: TOOL_T) -> TOOL_T:
-        """Add a tool to the cache.
-
-        :param name: Name of the tool to add to the cache; The tool will be
-            accessible as an attribute of the ToolCache using this name.
-        :param tool: The instantiated Tool to make available.
-        :return: The added Tool.
-        """
-        setattr(self, name, tool)
-        return tool
 
     def __getitem__(self, app: AppConfig) -> ToolCache:
         return self.app_tools[app]

--- a/src/briefcase/integrations/base.py
+++ b/src/briefcase/integrations/base.py
@@ -8,7 +8,7 @@ from abc import ABC
 from collections import defaultdict
 from collections.abc import Mapping
 from pathlib import Path
-from typing import DefaultDict
+from typing import TYPE_CHECKING, DefaultDict
 
 import requests
 from cookiecutter.main import cookiecutter
@@ -18,6 +18,18 @@ from briefcase.console import Console, Log
 from briefcase.integrations.download import Download
 from briefcase.integrations.subprocess import Subprocess
 
+if TYPE_CHECKING:  # pragma: no cover
+    import git as _git
+
+    from briefcase.integrations.android_sdk import AndroidSDK
+    from briefcase.integrations.docker import Docker, DockerAppContext
+    from briefcase.integrations.flatpak import Flatpak
+    from briefcase.integrations.java import JDK
+    from briefcase.integrations.linuxdeploy import LinuxDeploy
+    from briefcase.integrations.rcedit import RCEdit
+    from briefcase.integrations.visualstudio import VisualStudio
+    from briefcase.integrations.wix import Wix
+
 
 # TODO: Implement Tool base class
 class Tool(ABC):
@@ -25,11 +37,29 @@ class Tool(ABC):
 
 
 class ToolCache(Mapping):
+    # Briefcase tools
+    android_sdk: AndroidSDK
+    app_context: Subprocess | DockerAppContext
+    docker: Docker
+    download: Download
+    flatpak: Flatpak
+    git: _git
+    java: JDK
+    linuxdeploy: LinuxDeploy
+    rcedit: RCEdit
+    subprocess: Subprocess
+    visualstudio: VisualStudio
+    wix: Wix
+    xcode: bool
+    xcode_cli: bool
+
+    # Python stdlib tools
     platform = platform
     os = os
     shutil = shutil
     sys = sys
 
+    # Third party tools
     cookiecutter = staticmethod(cookiecutter)
     requests = requests
 

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
 import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from briefcase.config import AppConfig
 from briefcase.exceptions import BriefcaseCommandError
+
+if TYPE_CHECKING:  # pragma: no cover
+    from briefcase.integrations.base import ToolCache
 
 
 class Docker:
@@ -107,11 +114,11 @@ installation, and try again.
         },
     }
 
-    def __init__(self, tools):
+    def __init__(self, tools: ToolCache):
         self.tools = tools
 
     @classmethod
-    def verify(cls, tools):
+    def verify(cls, tools: ToolCache):
         """Verify Docker is installed and operational."""
         # short circuit since already verified and available
         if hasattr(tools, "docker"):
@@ -180,7 +187,7 @@ installation, and try again.
 
 
 class DockerAppContext:
-    def __init__(self, tools, app):
+    def __init__(self, tools: ToolCache, app: AppConfig):
         self.tools = tools
         self.app = app
 
@@ -198,8 +205,8 @@ class DockerAppContext:
     @classmethod
     def verify(
         cls,
-        tools,
-        app,
+        tools: ToolCache,
+        app: AppConfig,
         image_tag: str,
         dockerfile_path: Path,
         app_base_path: Path,

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -180,7 +180,8 @@ installation, and try again.
             else:
                 raise BriefcaseCommandError(cls.GENERIC_DOCKER_ERROR) from e
 
-        return tools.add_tool(name=cls.name, tool=Docker(tools=tools))
+        tools.docker = Docker(tools=tools)
+        return tools.docker
 
 
 class DockerAppContext(Tool):
@@ -232,7 +233,7 @@ class DockerAppContext(Tool):
 
         Docker.verify(tools=tools)
 
-        tools[app].add_tool(name="app_context", tool=DockerAppContext(tools, app))
+        tools[app].app_context = DockerAppContext(tools, app)
         tools[app].app_context.prepare(
             image_tag=image_tag,
             dockerfile_path=dockerfile_path,

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -1,19 +1,17 @@
-from __future__ import annotations
-
 import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from briefcase.config import AppConfig
 from briefcase.exceptions import BriefcaseCommandError
-
-if TYPE_CHECKING:  # pragma: no cover
-    from briefcase.integrations.base import ToolCache
+from briefcase.integrations.base import Tool, ToolCache
 
 
-class Docker:
+class Docker(Tool):
+    name = "docker"
+    full_name = "Docker"
+
     WRONG_DOCKER_VERSION_ERROR = """\
 Briefcase requires Docker 19 or higher, but you are currently running
 version {docker_version}. Visit:
@@ -182,11 +180,10 @@ installation, and try again.
             else:
                 raise BriefcaseCommandError(cls.GENERIC_DOCKER_ERROR) from e
 
-        tools.docker = Docker(tools=tools)
-        return tools.docker
+        return tools.add_tool(name=cls.name, tool=Docker(tools=tools))
 
 
-class DockerAppContext:
+class DockerAppContext(Tool):
     def __init__(self, tools: ToolCache, app: AppConfig):
         self.tools = tools
         self.app = app
@@ -235,7 +232,7 @@ class DockerAppContext:
 
         Docker.verify(tools=tools)
 
-        tools[app].app_context = DockerAppContext(tools, app)
+        tools[app].add_tool(name="app_context", tool=DockerAppContext(tools, app))
         tools[app].app_context.prepare(
             image_tag=image_tag,
             dockerfile_path=dockerfile_path,

--- a/src/briefcase/integrations/download.py
+++ b/src/briefcase/integrations/download.py
@@ -28,7 +28,8 @@ class Download(Tool):
         if hasattr(tools, "download"):
             return tools.download
 
-        return tools.add_tool(name=cls.name, tool=Download(tools=tools))
+        tools.download = Download(tools=tools)
+        return tools.download
 
     def file(self, url, download_path, role=None):
         """Download a given URL, caching it. If it has already been downloaded,

--- a/src/briefcase/integrations/download.py
+++ b/src/briefcase/integrations/download.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import os
 import tempfile
 from contextlib import suppress
 from email.message import Message
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import requests.exceptions as requests_exceptions
@@ -12,13 +15,16 @@ from briefcase.exceptions import (
     NetworkFailure,
 )
 
+if TYPE_CHECKING:  # pragma: no cover
+    from briefcase.integrations.base import ToolCache
+
 
 class Download:
-    def __init__(self, tools):
+    def __init__(self, tools: ToolCache):
         self.tools = tools
 
     @classmethod
-    def verify(cls, tools):
+    def verify(cls, tools: ToolCache):
         """Make downloader available in tool cache."""
         # short circuit since already verified and available
         if hasattr(tools, "download"):
@@ -31,9 +37,9 @@ class Download:
         """Download a given URL, caching it. If it has already been downloaded,
         return the value that has been cached.
 
-        This is a utility method used to obtain assets used by the
-        install process. The cached filename will be the filename portion of
-        the URL, appended to the download path.
+        This is a utility method used to obtain assets used by the installation
+        process. The cached filename will be the filename portion of the URL,
+        appended to the download path.
 
         :param url: The URL to download
         :param download_path: The path to the download cache folder. This path

--- a/src/briefcase/integrations/download.py
+++ b/src/briefcase/integrations/download.py
@@ -1,10 +1,7 @@
-from __future__ import annotations
-
 import os
 import tempfile
 from contextlib import suppress
 from email.message import Message
-from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import requests.exceptions as requests_exceptions
@@ -14,12 +11,13 @@ from briefcase.exceptions import (
     MissingNetworkResourceError,
     NetworkFailure,
 )
-
-if TYPE_CHECKING:  # pragma: no cover
-    from briefcase.integrations.base import ToolCache
+from briefcase.integrations.base import Tool, ToolCache
 
 
-class Download:
+class Download(Tool):
+    name = "download"
+    full_name = "Download"
+
     def __init__(self, tools: ToolCache):
         self.tools = tools
 
@@ -30,8 +28,7 @@ class Download:
         if hasattr(tools, "download"):
             return tools.download
 
-        tools.download = Download(tools=tools)
-        return tools.download
+        return tools.add_tool(name=cls.name, tool=Download(tools=tools))
 
     def file(self, url, download_path, role=None):
         """Download a given URL, caching it. If it has already been downloaded,

--- a/src/briefcase/integrations/flatpak.py
+++ b/src/briefcase/integrations/flatpak.py
@@ -1,15 +1,13 @@
-from __future__ import annotations
-
 import subprocess
-from typing import TYPE_CHECKING
 
 from briefcase.exceptions import BriefcaseCommandError
-
-if TYPE_CHECKING:  # pragma: no cover
-    from briefcase.integrations.base import ToolCache
+from briefcase.integrations.base import Tool, ToolCache
 
 
-class Flatpak:
+class Flatpak(Tool):
+    name = "flatpak"
+    full_name = "Flatpak"
+
     DEFAULT_REPO_ALIAS = "flathub"
     DEFAULT_REPO_URL = "https://flathub.org/repo/flathub.flatpakrepo"
 
@@ -140,8 +138,7 @@ You must install both flatpak and flatpak-builder.
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError("Unable to invoke flatpak-builder.") from e
 
-        tools.flatpak = flatpak
-        return flatpak
+        return tools.add_tool(name=cls.name, tool=flatpak)
 
     def verify_repo(self, repo_alias, url):
         """Verify that the Flatpak repository has been registered.

--- a/src/briefcase/integrations/flatpak.py
+++ b/src/briefcase/integrations/flatpak.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
 import subprocess
+from typing import TYPE_CHECKING
 
 from briefcase.exceptions import BriefcaseCommandError
+
+if TYPE_CHECKING:  # pragma: no cover
+    from briefcase.integrations.base import ToolCache
 
 
 class Flatpak:
@@ -11,11 +17,11 @@ class Flatpak:
     DEFAULT_RUNTIME_VERSION = "21.08"
     DEFAULT_SDK = "org.freedesktop.Sdk"
 
-    def __init__(self, tools):
+    def __init__(self, tools: ToolCache):
         self.tools = tools
 
     @classmethod
-    def verify(cls, tools):
+    def verify(cls, tools: ToolCache):
         """Verify that the Flatpak toolchain is available.
 
         :param tools: ToolCache of available tools

--- a/src/briefcase/integrations/flatpak.py
+++ b/src/briefcase/integrations/flatpak.py
@@ -138,7 +138,8 @@ You must install both flatpak and flatpak-builder.
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError("Unable to invoke flatpak-builder.") from e
 
-        return tools.add_tool(name=cls.name, tool=flatpak)
+        tools.flatpak = flatpak
+        return flatpak
 
     def verify_repo(self, repo_alias, url):
         """Verify that the Flatpak repository has been registered.

--- a/src/briefcase/integrations/git.py
+++ b/src/briefcase/integrations/git.py
@@ -1,11 +1,5 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 from briefcase.exceptions import BriefcaseCommandError
-
-if TYPE_CHECKING:  # pragma: no cover
-    from briefcase.integrations.base import ToolCache
+from briefcase.integrations.base import ToolCache
 
 
 def verify_git_is_installed(tools: ToolCache):
@@ -69,5 +63,4 @@ need to restart your terminal session.
 """
             ) from e
 
-    tools.git = git
-    return git
+    return tools.add_tool(name="git", tool=git)

--- a/src/briefcase/integrations/git.py
+++ b/src/briefcase/integrations/git.py
@@ -63,4 +63,5 @@ need to restart your terminal session.
 """
             ) from e
 
-    return tools.add_tool(name="git", tool=git)
+    tools.git = git
+    return git

--- a/src/briefcase/integrations/git.py
+++ b/src/briefcase/integrations/git.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from briefcase.exceptions import BriefcaseCommandError
 
+if TYPE_CHECKING:  # pragma: no cover
+    from briefcase.integrations.base import ToolCache
 
-def verify_git_is_installed(tools):
+
+def verify_git_is_installed(tools: ToolCache):
     """Verify if git is installed.
 
     Unfortunately, `import git` triggers a call on the operating system

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -1,22 +1,17 @@
-from __future__ import annotations
-
 import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from briefcase.exceptions import (
     BriefcaseCommandError,
     MissingToolError,
     NonManagedToolError,
 )
-
-if TYPE_CHECKING:  # pragma: no cover
-    from briefcase.integrations.base import ToolCache
+from briefcase.integrations.base import Tool, ToolCache
 
 
-class JDK:
+class JDK(Tool):
     name = "java"
     full_name = "Java JDK"
 
@@ -222,8 +217,7 @@ class JDK:
                 else:
                     raise MissingToolError("Java")
 
-        tools.java = java
-        return java
+        return tools.add_tool(name=cls.name, tool=java)
 
     def exists(self):
         return (self.java_home / "bin").exists()

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -217,7 +217,8 @@ class JDK(Tool):
                 else:
                     raise MissingToolError("Java")
 
-        return tools.add_tool(name=cls.name, tool=java)
+        tools.java = java
+        return java
 
     def exists(self):
         return (self.java_home / "bin").exists()

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import os
 import shutil
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from briefcase.exceptions import (
     BriefcaseCommandError,
@@ -9,12 +12,15 @@ from briefcase.exceptions import (
     NonManagedToolError,
 )
 
+if TYPE_CHECKING:  # pragma: no cover
+    from briefcase.integrations.base import ToolCache
+
 
 class JDK:
     name = "java"
     full_name = "Java JDK"
 
-    def __init__(self, tools, java_home):
+    def __init__(self, tools: ToolCache, java_home: Path):
         self.tools = tools
 
         # As of April 10 2020, 8u242-b08 is the current AdoptOpenJDK
@@ -43,7 +49,7 @@ class JDK:
         )
 
     @classmethod
-    def verify(cls, tools, install=True):
+    def verify(cls, tools: ToolCache, install=True):
         """Verify that a Java 8 JDK exists.
 
         If ``JAVA_HOME`` is set, try that version. If it is a JRE, or its *not*

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -1,10 +1,7 @@
-from __future__ import annotations
-
 import hashlib
 import shlex
 from abc import abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from briefcase.exceptions import (
@@ -12,9 +9,7 @@ from briefcase.exceptions import (
     CorruptToolError,
     MissingToolError,
 )
-
-if TYPE_CHECKING:  # pragma: no cover
-    from briefcase.integrations.base import ToolCache
+from briefcase.integrations.base import Tool, ToolCache
 
 ELF_HEADER_IDENT = bytes.fromhex("7F454C46")
 ELF_PATCH_OFFSET = 0x08
@@ -22,7 +17,7 @@ ELF_PATCH_ORIGINAL_BYTES = bytes.fromhex("414902")
 ELF_PATCH_PATCHED_BYTES = bytes.fromhex("000000")
 
 
-class LinuxDeployBase:
+class LinuxDeployBase(Tool):
     name: str
     full_name: str
     install_msg: str
@@ -100,7 +95,7 @@ class LinuxDeployBase:
                 raise MissingToolError(cls.name)
 
         if not is_plugin:
-            tools.linuxdeploy = tool
+            tools.add_tool(name=cls.name, tool=tool)
 
         return tool
 

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import hashlib
 import shlex
 from abc import abstractmethod
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from briefcase.exceptions import (
@@ -10,6 +13,9 @@ from briefcase.exceptions import (
     MissingToolError,
 )
 
+if TYPE_CHECKING:  # pragma: no cover
+    from briefcase.integrations.base import ToolCache
+
 ELF_HEADER_IDENT = bytes.fromhex("7F454C46")
 ELF_PATCH_OFFSET = 0x08
 ELF_PATCH_ORIGINAL_BYTES = bytes.fromhex("414902")
@@ -17,7 +23,11 @@ ELF_PATCH_PATCHED_BYTES = bytes.fromhex("000000")
 
 
 class LinuxDeployBase:
-    def __init__(self, tools, **kwargs):
+    name: str
+    full_name: str
+    install_msg: str
+
+    def __init__(self, tools: ToolCache, **kwargs):
         self.tools = tools
 
     @property
@@ -62,7 +72,7 @@ class LinuxDeployBase:
                 self.patch_elf_header()
 
     @classmethod
-    def verify(cls, tools, install=True, **kwargs):
+    def verify(cls, tools: ToolCache, install=True, **kwargs):
         """Verify that linuxdeploy tool or plugin is available.
 
         :param tools: ToolCache of available tools

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -17,7 +17,7 @@ ELF_PATCH_ORIGINAL_BYTES = bytes.fromhex("414902")
 ELF_PATCH_PATCHED_BYTES = bytes.fromhex("000000")
 
 
-class LinuxDeployBase(Tool):
+class LinuxDeployBase:
     name: str
     full_name: str
     install_msg: str
@@ -95,7 +95,7 @@ class LinuxDeployBase(Tool):
                 raise MissingToolError(cls.name)
 
         if not is_plugin:
-            tools.add_tool(name=cls.name, tool=tool)
+            tools.linuxdeploy = tool
 
         return tool
 
@@ -295,7 +295,7 @@ class LinuxDeployURLPlugin(LinuxDeployPluginBase):
         return self._download_url
 
 
-class LinuxDeploy(LinuxDeployBase):
+class LinuxDeploy(LinuxDeployBase, Tool):
     name = "linuxdeploy"
     full_name = "linuxdeploy"
     install_msg = "linuxdeploy was not found; downloading and installing..."

--- a/src/briefcase/integrations/rcedit.py
+++ b/src/briefcase/integrations/rcedit.py
@@ -1,14 +1,8 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 from briefcase.exceptions import MissingToolError
-
-if TYPE_CHECKING:  # pragma: no cover
-    from briefcase.integrations.base import ToolCache
+from briefcase.integrations.base import Tool, ToolCache
 
 
-class RCEdit:
+class RCEdit(Tool):
     name = "rcedit"
     full_name = "RCEdit"
 
@@ -50,8 +44,7 @@ class RCEdit:
             else:
                 raise MissingToolError("RCEdit")
 
-        tools.rcedit = rcedit
-        return rcedit
+        return tools.add_tool(name=cls.name, tool=rcedit)
 
     def exists(self):
         return self.rcedit_path.exists()

--- a/src/briefcase/integrations/rcedit.py
+++ b/src/briefcase/integrations/rcedit.py
@@ -1,11 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from briefcase.exceptions import MissingToolError
+
+if TYPE_CHECKING:  # pragma: no cover
+    from briefcase.integrations.base import ToolCache
 
 
 class RCEdit:
     name = "rcedit"
     full_name = "RCEdit"
 
-    def __init__(self, tools):
+    def __init__(self, tools: ToolCache):
         self.tools = tools
 
     @property
@@ -19,7 +26,7 @@ class RCEdit:
         return self.tools.base_path / "rcedit-x64.exe"
 
     @classmethod
-    def verify(cls, tools, install=True):
+    def verify(cls, tools: ToolCache, install=True):
         """Verify that rcedit is available.
 
         :param tools: ToolCache of available tools

--- a/src/briefcase/integrations/rcedit.py
+++ b/src/briefcase/integrations/rcedit.py
@@ -44,7 +44,8 @@ class RCEdit(Tool):
             else:
                 raise MissingToolError("RCEdit")
 
-        return tools.add_tool(name=cls.name, tool=rcedit)
+        tools.rcedit = rcedit
+        return rcedit
 
     def exists(self):
         return self.rcedit_path.exists()

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import operator
 import os
@@ -9,11 +11,16 @@ import time
 from contextlib import suppress
 from functools import wraps
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import psutil
 
+from briefcase.config import AppConfig
 from briefcase.console import Log
 from briefcase.exceptions import CommandOutputParseError
+
+if TYPE_CHECKING:  # pragma: no cover
+    from briefcase.integrations.base import ToolCache
 
 
 class ParseError(Exception):
@@ -97,7 +104,7 @@ def ensure_console_is_safe(sub_method):
     """
 
     @wraps(sub_method)
-    def inner(sub, args, **kwargs):
+    def inner(sub: Subprocess, args, **kwargs):
         """Evaluate whether conditions are met to remove any dynamic elements
         in the console before returning control to Subprocess.
 
@@ -133,7 +140,7 @@ class NativeAppContext:
     """A wrapper around subprocess for use as an app-bound tool."""
 
     @classmethod
-    def verify(cls, tools, app):
+    def verify(cls, tools: ToolCache, app: AppConfig):
         """Make subprocess available as app-bound tool."""
         # short circuit since already verified and available
         if hasattr(tools[app], "app_context"):
@@ -147,7 +154,7 @@ class Subprocess:
     """A wrapper around subprocess that can be used as a logging point for
     commands that are executed."""
 
-    def __init__(self, tools):
+    def __init__(self, tools: ToolCache):
         self.tools = tools
         self._subprocess = subprocess
 
@@ -246,7 +253,7 @@ class Subprocess:
         return kwargs
 
     @classmethod
-    def verify(cls, tools):
+    def verify(cls, tools: ToolCache):
         """Make subprocess available in tool cache."""
         # short circuit since already verified and available
         if hasattr(tools, "subprocess"):

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -143,7 +143,8 @@ class NativeAppContext(Tool):
         if hasattr(tools[app], "app_context"):
             return tools[app].app_context
 
-        return tools[app].add_tool(name="app_context", tool=tools.subprocess)
+        tools[app].app_context = tools.subprocess
+        return tools[app].app_context
 
 
 class Subprocess(Tool):
@@ -258,7 +259,8 @@ class Subprocess(Tool):
         if hasattr(tools, "subprocess"):
             return tools.subprocess
 
-        return tools.add_tool(name=cls.name, tool=Subprocess(tools))
+        tools.subprocess = Subprocess(tools)
+        return tools.subprocess
 
     @ensure_console_is_safe
     def run(self, args, stream_output=True, **kwargs):

--- a/src/briefcase/integrations/visualstudio.py
+++ b/src/briefcase/integrations/visualstudio.py
@@ -1,18 +1,14 @@
-from __future__ import annotations
-
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from briefcase.exceptions import BriefcaseCommandError, CommandOutputParseError
+from briefcase.integrations.base import Tool, ToolCache
 from briefcase.integrations.subprocess import json_parser
 
-if TYPE_CHECKING:  # pragma: no cover
-    from briefcase.integrations.base import ToolCache
 
-
-class VisualStudio:
+class VisualStudio(Tool):
     name = "visualstudio"
+    full_name = "Visual Studio"
     VSCODE_REQUIRED_COMPONENTS = """
     * .NET Desktop Development
       - Default packages
@@ -21,7 +17,12 @@ class VisualStudio:
       - C++/CLI support for v143 build tools
 """
 
-    def __init__(self, tools: ToolCache, msbuild_path: Path, install_metadata=None):
+    def __init__(
+        self,
+        tools: ToolCache,
+        msbuild_path: Path,
+        install_metadata: dict = None,
+    ):
         self.tools = tools
         self._msbuild_path = msbuild_path
         self._install_metadata = install_metadata
@@ -190,8 +191,7 @@ Then restart Briefcase.
                 install_metadata=install_metadata,
             )
 
-        tools.visualstudio = visualstudio
-        return visualstudio
+        return tools.add_tool(name=cls.name, tool=visualstudio)
 
     @property
     def managed_install(self):

--- a/src/briefcase/integrations/visualstudio.py
+++ b/src/briefcase/integrations/visualstudio.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from briefcase.exceptions import BriefcaseCommandError, CommandOutputParseError
 from briefcase.integrations.subprocess import json_parser
+
+if TYPE_CHECKING:  # pragma: no cover
+    from briefcase.integrations.base import ToolCache
 
 
 class VisualStudio:
@@ -15,7 +21,7 @@ class VisualStudio:
       - C++/CLI support for v143 build tools
 """
 
-    def __init__(self, tools, msbuild_path, install_metadata=None):
+    def __init__(self, tools: ToolCache, msbuild_path: Path, install_metadata=None):
         self.tools = tools
         self._msbuild_path = msbuild_path
         self._install_metadata = install_metadata
@@ -37,7 +43,7 @@ class VisualStudio:
         return self._install_metadata
 
     @classmethod
-    def verify(cls, tools):
+    def verify(cls, tools: ToolCache):
         """Verify that Visual Studio is available.
 
         :param tools: ToolCache of available tools

--- a/src/briefcase/integrations/visualstudio.py
+++ b/src/briefcase/integrations/visualstudio.py
@@ -191,7 +191,8 @@ Then restart Briefcase.
                 install_metadata=install_metadata,
             )
 
-        return tools.add_tool(name=cls.name, tool=visualstudio)
+        tools.visualstudio = visualstudio
+        return visualstudio
 
     @property
     def managed_install(self):

--- a/src/briefcase/integrations/wix.py
+++ b/src/briefcase/integrations/wix.py
@@ -106,7 +106,8 @@ WiX Toolset. Current value: {wix_home!r}
                 else:
                     raise MissingToolError("WiX")
 
-        return tools.add_tool(name=cls.name, tool=wix)
+        tools.wix = wix
+        return wix
 
     def exists(self):
         return (

--- a/src/briefcase/integrations/wix.py
+++ b/src/briefcase/integrations/wix.py
@@ -1,23 +1,18 @@
-from __future__ import annotations
-
 import os
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from briefcase.exceptions import (
     BriefcaseCommandError,
     MissingToolError,
     NonManagedToolError,
 )
-
-if TYPE_CHECKING:  # pragma: no cover
-    from briefcase.integrations.base import ToolCache
+from briefcase.integrations.base import Tool, ToolCache
 
 WIX_DOWNLOAD_URL = "https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip"
 
 
-class WiX:
+class WiX(Tool):
     name = "wix"
     full_name = "WiX"
 
@@ -111,8 +106,7 @@ WiX Toolset. Current value: {wix_home!r}
                 else:
                     raise MissingToolError("WiX")
 
-        tools.wix = wix
-        return wix
+        return tools.add_tool(name=cls.name, tool=wix)
 
     def exists(self):
         return (

--- a/src/briefcase/integrations/wix.py
+++ b/src/briefcase/integrations/wix.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
 import os
 import shutil
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from briefcase.exceptions import (
     BriefcaseCommandError,
     MissingToolError,
     NonManagedToolError,
 )
+
+if TYPE_CHECKING:  # pragma: no cover
+    from briefcase.integrations.base import ToolCache
 
 WIX_DOWNLOAD_URL = "https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip"
 
@@ -15,7 +21,7 @@ class WiX:
     name = "wix"
     full_name = "WiX"
 
-    def __init__(self, tools, wix_home=None, bin_install=False):
+    def __init__(self, tools: ToolCache, wix_home: Path = None, bin_install=False):
         """Create a wrapper around a WiX install.
 
         :param tools: ToolCache of available tools.
@@ -55,7 +61,7 @@ class WiX:
             return self.wix_home / "bin" / "candle.exe"
 
     @classmethod
-    def verify(cls, tools, install=True):
+    def verify(cls, tools: ToolCache, install=True):
         """Verify that there is a WiX install available.
 
         If the WIX environment variable is set, that location will be checked

--- a/src/briefcase/integrations/xcode.py
+++ b/src/briefcase/integrations/xcode.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 import enum
 import re
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from briefcase.exceptions import BriefcaseCommandError, CommandOutputParseError
 from briefcase.integrations.subprocess import json_parser
+
+if TYPE_CHECKING:  # pragma: no cover
+    from briefcase.integrations.base import ToolCache
 
 
 class DeviceState(enum.Enum):
@@ -14,7 +20,7 @@ class DeviceState(enum.Enum):
     UNKNOWN = 99
 
 
-def verify_xcode_install(tools, min_version=None):
+def verify_xcode_install(tools: ToolCache, min_version=None):
     """Verify that Xcode and the command line developer tools are installed and
     ready for use.
 
@@ -43,7 +49,7 @@ def verify_xcode_install(tools, min_version=None):
     tools.xcode = True
 
 
-def verify_command_line_tools_install(tools):
+def verify_command_line_tools_install(tools: ToolCache):
     """Verify that command line developer tools are installed and ready for
     use.
 
@@ -64,7 +70,7 @@ def verify_command_line_tools_install(tools):
     tools.xcode_cli = True
 
 
-def ensure_command_line_tools_are_installed(tools):
+def ensure_command_line_tools_are_installed(tools: ToolCache):
     """Determine if the Xcode command line tools are installed.
 
     If they are not installed, an exception is raised; in addition, an OS dialog
@@ -126,7 +132,7 @@ Re-run Briefcase once that installation is complete.
 
 
 def ensure_xcode_is_installed(
-    tools,
+    tools: ToolCache,
     min_version=None,
     xcode_location="/Applications/Xcode.app",
 ):
@@ -275,7 +281,7 @@ installation is complete.
             ) from e
 
 
-def confirm_xcode_license_accepted(tools):
+def confirm_xcode_license_accepted(tools: ToolCache):
     """Confirm if the Xcode license has been accepted.
 
     :param tools: ToolCache of available tools
@@ -382,8 +388,8 @@ You need to accept the Xcode license before Briefcase can package your app.
 
 
 def get_simulators(
-    tools,
-    os_name,
+    tools: ToolCache,
+    os_name: str,
     simulator_location="/Library/Developer/PrivateFrameworks/CoreSimulator.framework/",
 ):
     """Obtain the simulators available on this machine.
@@ -458,7 +464,7 @@ Press Return to continue: """
         raise BriefcaseCommandError("Unable to run xcrun simctl.") from e
 
 
-def get_device_state(tools, udid):
+def get_device_state(tools: ToolCache, udid: str):
     """Determine the state of an iOS simulator device.
 
     :param tools: ToolCache of available tools
@@ -493,7 +499,7 @@ def get_device_state(tools, udid):
 IDENTITY_RE = re.compile(r"\s*\d+\) ([0-9A-F]{40}) \"(.*)\"")
 
 
-def get_identities(tools, policy):
+def get_identities(tools: ToolCache, policy: str):
     """Obtain a set of valid identities for the given policy.
 
     :param tools: ToolCache of available tools

--- a/src/briefcase/integrations/xcode.py
+++ b/src/briefcase/integrations/xcode.py
@@ -1,16 +1,11 @@
-from __future__ import annotations
-
 import enum
 import re
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from briefcase.exceptions import BriefcaseCommandError, CommandOutputParseError
+from briefcase.integrations.base import ToolCache
 from briefcase.integrations.subprocess import json_parser
-
-if TYPE_CHECKING:  # pragma: no cover
-    from briefcase.integrations.base import ToolCache
 
 
 class DeviceState(enum.Enum):
@@ -20,7 +15,7 @@ class DeviceState(enum.Enum):
     UNKNOWN = 99
 
 
-def verify_xcode_install(tools: ToolCache, min_version=None):
+def verify_xcode_install(tools: ToolCache, min_version: tuple = None):
     """Verify that Xcode and the command line developer tools are installed and
     ready for use.
 
@@ -133,7 +128,7 @@ Re-run Briefcase once that installation is complete.
 
 def ensure_xcode_is_installed(
     tools: ToolCache,
-    min_version=None,
+    min_version: tuple = None,
     xcode_location="/Applications/Xcode.app",
 ):
     """Determine if Xcode is installed; and if so, that it meets minimum

--- a/tests/commands/base/test_verify_tools.py
+++ b/tests/commands/base/test_verify_tools.py
@@ -1,3 +1,10 @@
+from briefcase.integrations.download import Download
+from briefcase.integrations.subprocess import Subprocess
+
+
 def test_base_tools_exist(base_command):
-    """No verification required for base command."""
+    """Ensure default tools are always available."""
+    assert isinstance(base_command.tools.subprocess, Subprocess)
+    assert isinstance(base_command.tools.download, Download)
+
     base_command.verify_tools()

--- a/tests/integrations/base/test_ToolCache.py
+++ b/tests/integrations/base/test_ToolCache.py
@@ -10,8 +10,6 @@ from cookiecutter.main import cookiecutter
 
 from briefcase.console import Console, Log
 from briefcase.integrations.base import ToolCache
-from briefcase.integrations.download import Download
-from briefcase.integrations.subprocess import Subprocess
 
 
 @pytest.fixture
@@ -23,6 +21,29 @@ def simple_tools(tmp_path):
     )
 
 
+def test_toolcache_typing():
+    """Tool typing for ToolCache is correct."""
+    expected_type_defs = {
+        "android_sdk": "AndroidSDK",
+        "docker": "Docker",
+        "download": "Download",
+        "flatpak": "Flatpak",
+        "java": "JDK",
+        "linuxdeploy": "LinuxDeploy",
+        "rcedit": "RCEdit",
+        "subprocess": "Subprocess",
+        "visualstudio": "VisualStudio",
+        "wix": "WiX",
+        "xcode": "bool",
+        "xcode_cli": "bool",
+    }
+    for tool_name, tool_type in expected_type_defs.items():
+        assert ToolCache.__annotations__[tool_name] == tool_type
+
+    assert "DockerAppContext" in ToolCache.__annotations__["app_context"]
+    assert "Subprocess" in ToolCache.__annotations__["app_context"]
+
+
 def test_third_party_tools_available():
     """Third party tools are available."""
     assert ToolCache.os is os
@@ -32,14 +53,6 @@ def test_third_party_tools_available():
 
     assert ToolCache.cookiecutter is cookiecutter
     assert ToolCache.requests is requests
-
-
-def test_default_tools_available(simple_tools):
-    """Default tools are always available."""
-    assert isinstance(simple_tools.subprocess, Subprocess)
-    assert isinstance(simple_tools["app"].subprocess, Subprocess)
-    assert isinstance(simple_tools.download, Download)
-    assert isinstance(simple_tools["app"].download, Download)
 
 
 def test_always_true(simple_tools, tmp_path):
@@ -123,3 +136,17 @@ def test_windows_home_path(home_path, expected_path, tmp_path):
         home_path=home_path,
     )
     assert tools.home_path == expected_path
+
+
+def test_add_tool():
+    """Added tools are returned and available via attribute."""
+    tools = ToolCache(
+        logger=Log(),
+        console=Console(),
+        base_path="/home/data",
+    )
+    tool_name = "toolname"
+    tool = object()
+
+    assert tools.add_tool(name=tool_name, tool=tool) is tool
+    assert getattr(tools, tool_name) is tool

--- a/tests/integrations/base/test_ToolCache.py
+++ b/tests/integrations/base/test_ToolCache.py
@@ -1,3 +1,5 @@
+import importlib
+import inspect
 import os
 import platform
 import shutil
@@ -8,8 +10,9 @@ import pytest
 import requests
 from cookiecutter.main import cookiecutter
 
+import briefcase.integrations
 from briefcase.console import Console, Log
-from briefcase.integrations.base import ToolCache
+from briefcase.integrations.base import Tool, ToolCache
 
 
 @pytest.fixture
@@ -21,27 +24,60 @@ def simple_tools(tmp_path):
     )
 
 
+def tools_for_module(tool_module_name: str) -> set:
+    """Return names of classes that subclass Tool in a module in
+    ``briefcase.integrations``, e.g. "android_sdk"."""
+    return {
+        klass_name
+        for klass_name, _ in inspect.getmembers(
+            sys.modules[f"briefcase.integrations.{tool_module_name}"],
+            lambda klass: (
+                inspect.isclass(klass) and issubclass(klass, Tool) and klass is not Tool
+            ),
+        )
+    }
+
+
 def test_toolcache_typing():
     """Tool typing for ToolCache is correct."""
-    expected_type_defs = {
-        "android_sdk": "AndroidSDK",
-        "docker": "Docker",
-        "download": "Download",
-        "flatpak": "Flatpak",
-        "java": "JDK",
-        "linuxdeploy": "LinuxDeploy",
-        "rcedit": "RCEdit",
-        "subprocess": "Subprocess",
-        "visualstudio": "VisualStudio",
-        "wix": "WiX",
-        "xcode": "bool",
-        "xcode_cli": "bool",
-    }
-    for tool_name, tool_type in expected_type_defs.items():
-        assert ToolCache.__annotations__[tool_name] == tool_type
+    # Tools that are intentionally not annotated in ToolCache.
+    tools_unannotated = {"cookiecutter"}
+    # Tool names to exclude from the dynamic annotation checks; they are manually checked.
+    tool_names_skip_dynamic_check = {"app_context", "git", "xcode", "xcode_cli"}
+    # Tool classes to exclude from dynamic annotation checks.
+    tool_klasses_skip_dynamic_checks = {"DockerAppContext", "NativeAppContext"}
 
-    assert "DockerAppContext" in ToolCache.__annotations__["app_context"]
-    assert "Subprocess" in ToolCache.__annotations__["app_context"]
+    # Ensure defined Tool modules/classes are annotated in ToolCache.
+    for tool_module_name in briefcase.integrations.__all__:
+        if tool_module_name not in tools_unannotated:
+            assert tool_module_name in ToolCache.__annotations__.keys()
+        for tool_name in tools_for_module(tool_module_name):
+            if tool_name not in tool_klasses_skip_dynamic_checks:
+                assert tool_name in ToolCache.__annotations__.values()
+
+    # Ensure annotated tools use valid Tool names.
+    for tool_name, tool_klass_name in ToolCache.__annotations__.items():
+        if tool_name not in tool_names_skip_dynamic_check:
+            assert tool_name in briefcase.integrations.__all__
+            assert tool_klass_name in tools_for_module(tool_name)
+            tool_klass = getattr(
+                importlib.import_module(f"briefcase.integrations.{tool_name}"),
+                tool_klass_name,
+            )
+            assert tool_name == tool_klass.name
+
+    # Manually check tools that aren't Tool classes or use special annotations.
+    app_context_klasses = [
+        briefcase.integrations.docker.DockerAppContext.__name__,
+        briefcase.integrations.subprocess.Subprocess.__name__,
+    ]
+    app_context_annotated = ToolCache.__annotations__["app_context"].split(" | ")
+    assert sorted(app_context_klasses) == sorted(app_context_annotated)
+
+    assert ToolCache.__annotations__["xcode"] == "bool"
+    assert ToolCache.__annotations__["xcode_cli"] == "bool"
+
+    assert ToolCache.__annotations__["git"] == "git_"
 
 
 def test_third_party_tools_available():
@@ -136,17 +172,3 @@ def test_windows_home_path(home_path, expected_path, tmp_path):
         home_path=home_path,
     )
     assert tools.home_path == expected_path
-
-
-def test_add_tool():
-    """Added tools are returned and available via attribute."""
-    tools = ToolCache(
-        logger=Log(),
-        console=Console(),
-        base_path="/home/data",
-    )
-    tool_name = "toolname"
-    tool = object()
-
-    assert tools.add_tool(name=tool_name, tool=tool) is tool
-    assert getattr(tools, tool_name) is tool

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -14,17 +14,9 @@ from briefcase.integrations.subprocess import Subprocess
 from tests.utils import DummyConsole
 
 
-class ProxyToolCache(ToolCache):
-    def add_tool(self, name, tool):
-        """Ensure any tools being added are properly typed in ToolCache."""
-        if "dummy" not in name.lower():  # ignore testing tools
-            assert name in ToolCache.__annotations__
-        return super().add_tool(name=name, tool=tool)
-
-
 @pytest.fixture
 def mock_tools(tmp_path) -> ToolCache:
-    mock_tools = ProxyToolCache(
+    mock_tools = ToolCache(
         logger=Log(),
         console=DummyConsole(),
         base_path=tmp_path / "tools",

--- a/tests/integrations/rcedit/conftest.py
+++ b/tests/integrations/rcedit/conftest.py
@@ -2,13 +2,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.rcedit import RCEdit
 from briefcase.integrations.subprocess import Subprocess
 
 
 @pytest.fixture
-def mock_tools(tmp_path, mock_tools):
+def mock_tools(tmp_path, mock_tools) -> ToolCache:
     mock_tools.host_arch = "wonky"
 
     # Mock default tools


### PR DESCRIPTION
## Changes 
Added typing support for `ToolCache` for QoL.
Specifically:
- Enumerate each Tool and its type in `ToolCache`
- Type `tools` as `ToolCache` each place it is introduced in a Tool

## Rationale
Personally, I really like my IDE's hints and auto-completion. The current implementation of `ToolCache` prevents any of these luxuries because its attributes cannot be inferred.
- This is most noticeable for tools in `briefcase.integrations` because `self.tools` cannot be inferred as a `ToolCache`.
- Within commands, `self.tools` is at least inferred to be a `ToolCache` (at least for the subclasses that aren't mix-ins) but since none of the Tools are actually defined within `ToolCache`, none of them can be inferred.

## Tradeoff
Unfortunately, this typing requires jumping through a few hoops and a bit more maintenance due to new dependencies within `ToolCache` itself....but I think its ultimately a win.

Also interested to know if this is just a PyCharm problem or if VS is in the same boat.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
