### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,13 @@ jobs:
     strategy:
       matrix:
         platform: ["macos", "ubuntu", "windows"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.0-alpha - 3.12.0"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        experimental: [false]
+        include:
+          - python-version: "3.12-dev"
+            experimental: true
     runs-on: ${{ matrix.platform }}-latest
+    continue-on-error: ${{ matrix.experimental }}
     steps:
     - uses: actions/checkout@v3.1.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,9 @@ jobs:
       matrix:
         platform: ["macos", "ubuntu", "windows"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
-        experimental: [false]
         include:
+          - experimental: false
+
           - python-version: "3.12-dev"
             experimental: true
     runs-on: ${{ matrix.platform }}-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
     needs: [pre-commit, towncrier, package]
     strategy:
       matrix:
-        platform: ['macos', 'ubuntu', 'windows']
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        platform: ["macos", "ubuntu", "windows"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.0-alpha - 3.12.0"]
     runs-on: ${{ matrix.platform }}-latest
     steps:
     - uses: actions/checkout@v3.1.0

--- a/changes/965.feature.rst
+++ b/changes/965.feature.rst
@@ -1,0 +1,1 @@
+Support for Python 3.12 was added.

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
     Topic :: Software Development
     Topic :: Utilities


### PR DESCRIPTION
With the release of 3.12.0a1, we can start testing for 3.12 support.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
