### PR TITLE
Convert Linux backends to use app log streaming

### DIFF
--- a/changes/967.misc.rst
+++ b/changes/967.misc.rst
@@ -1,0 +1,1 @@
+Linux backends were converted to use log streaming.

--- a/src/briefcase/integrations/flatpak.py
+++ b/src/briefcase/integrations/flatpak.py
@@ -239,22 +239,22 @@ flatpak run {bundle}.{app_name}
             raise BriefcaseCommandError(f"Error while building app {app_name}.") from e
 
     def run(self, bundle, app_name):
-        """Run a Flatpak.
+        """Run a Flatpak in a way that allows for log streaming.
 
         :param bundle: The bundle identifier for the app being built.
         :param app_name: The app name.
+        :returns: A Popen object for the running app.
         """
-        try:
-            self.tools.subprocess.run(
-                [
-                    "flatpak",
-                    "run",
-                    f"{bundle}.{app_name}",
-                ],
-                check=True,
-            )
-        except subprocess.CalledProcessError as e:
-            raise BriefcaseCommandError(f"Unable to start app {app_name}.") from e
+        return self.tools.subprocess.Popen(
+            [
+                "flatpak",
+                "run",
+                f"{bundle}.{app_name}",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=1,
+        )
 
     def bundle(self, repo_url, bundle, app_name, version, build_path, output_path):
         """Bundle a Flatpak for distribution.

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -278,6 +278,9 @@ class LinuxAppImageRunCommand(LinuxAppImagePassiveMixin, RunCommand):
             finally:
                 self.tools.subprocess.cleanup(app.app_name, log_popen)
 
+            # If the process didn't exit cleanly, raise an error.
+            if log_popen.returncode != 0:
+                raise BriefcaseCommandError(f"Problem running app {app.app_name}.")
         except KeyboardInterrupt:
             pass  # Catch CTRL-C to exit normally
         except OSError as e:

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -270,15 +270,10 @@ class LinuxAppImageRunCommand(LinuxAppImagePassiveMixin, RunCommand):
 
             try:
                 # Start streaming logs for the app.
-                self.logger.info(
-                    "Following log output (type CTRL-C to stop log)...",
-                    prefix=app.app_name,
-                )
                 self.logger.info("=" * 75)
                 self.tools.subprocess.stream_output(
                     app.app_name,
                     log_popen,
-                    stop_func=lambda: log_popen.poll() is not None,
                 )
             finally:
                 self.tools.subprocess.cleanup(app.app_name, log_popen)

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -276,22 +276,12 @@ class LinuxAppImageRunCommand(LinuxAppImagePassiveMixin, RunCommand):
                 )
                 self.logger.info("=" * 75)
                 self.tools.subprocess.stream_output(
-                    "log stream",
+                    app.app_name,
                     log_popen,
                     stop_func=lambda: log_popen.poll() is not None,
                 )
             finally:
-                # If the app hasn't exited, ensure it is terminated
-                # This is unlikely to happen unless the streamer stops
-                # for some reason, but clean up just in case.
-                return_code = log_popen.poll()
-                if return_code is None:
-                    log_popen.terminate()
-                    try:
-                        log_popen.wait(timeout=3)
-                    except subprocess.TimeoutExpired:
-                        self.tools.logger.warning(f"Forcibly killing {app.app_name}...")
-                        log_popen.kill()
+                self.tools.subprocess.cleanup(app.app_name, log_popen)
 
         except KeyboardInterrupt:
             pass  # Catch CTRL-C to exit normally

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -1,5 +1,3 @@
-import subprocess
-
 from briefcase.commands import (
     BuildCommand,
     CreateCommand,
@@ -209,22 +207,12 @@ class LinuxFlatpakRunCommand(LinuxFlatpakMixin, RunCommand):
                 )
                 self.logger.info("=" * 75)
                 self.tools.subprocess.stream_output(
-                    "log stream",
+                    app.app_name,
                     log_popen,
                     stop_func=lambda: log_popen.poll() is not None,
                 )
             finally:
-                # If the app hasn't exited, ensure it is terminated
-                # This is unlikely to happen unless the streamer stops
-                # for some reason, but clean up just in case.
-                return_code = log_popen.poll()
-                if return_code is None:
-                    log_popen.terminate()
-                    try:
-                        log_popen.wait(timeout=3)
-                    except subprocess.TimeoutExpired:
-                        self.tools.logger.warning(f"Forcibly killing {app.app_name}...")
-                        log_popen.kill()
+                self.tools.subprocess.cleanup(app.app_name, log_popen)
 
         except KeyboardInterrupt:
             pass  # Catch CTRL-C to exit normally

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -201,15 +201,10 @@ class LinuxFlatpakRunCommand(LinuxFlatpakMixin, RunCommand):
 
             try:
                 # Start streaming logs for the app.
-                self.logger.info(
-                    "Following log output (type CTRL-C to stop log)...",
-                    prefix=app.app_name,
-                )
                 self.logger.info("=" * 75)
                 self.tools.subprocess.stream_output(
                     app.app_name,
                     log_popen,
-                    stop_func=lambda: log_popen.poll() is not None,
                 )
             finally:
                 self.tools.subprocess.cleanup(app.app_name, log_popen)

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from briefcase.commands import (
     BuildCommand,
     CreateCommand,
@@ -193,14 +195,41 @@ class LinuxFlatpakRunCommand(LinuxFlatpakMixin, RunCommand):
         """
         self.logger.info("Starting app...", prefix=app.app_name)
         try:
-            # Start streaming logs for the app.
-            self.tools.logger.info("=" * 75)
-            self.tools.flatpak.run(
+            # Start the app in a way that lets us stream the logs
+            log_popen = self.tools.flatpak.run(
                 bundle=app.bundle,
                 app_name=app.app_name,
             )
+
+            try:
+                # Start streaming logs for the app.
+                self.logger.info(
+                    "Following log output (type CTRL-C to stop log)...",
+                    prefix=app.app_name,
+                )
+                self.logger.info("=" * 75)
+                self.tools.subprocess.stream_output(
+                    "log stream",
+                    log_popen,
+                    stop_func=lambda: log_popen.poll() is not None,
+                )
+            finally:
+                # If the app hasn't exited, ensure it is terminated
+                # This is unlikely to happen unless the streamer stops
+                # for some reason, but clean up just in case.
+                return_code = log_popen.poll()
+                if return_code is None:
+                    log_popen.terminate()
+                    try:
+                        log_popen.wait(timeout=3)
+                    except subprocess.TimeoutExpired:
+                        self.tools.logger.warning(f"Forcibly killing {app.app_name}...")
+                        log_popen.kill()
+
         except KeyboardInterrupt:
             pass  # Catch CTRL-C to exit normally
+        except OSError as e:
+            raise BriefcaseCommandError(f"Unable to start app {app.app_name}.") from e
 
 
 class LinuxFlatpakPackageCommand(LinuxFlatpakMixin, PackageCommand):

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -209,6 +209,9 @@ class LinuxFlatpakRunCommand(LinuxFlatpakMixin, RunCommand):
             finally:
                 self.tools.subprocess.cleanup(app.app_name, log_popen)
 
+            # If the process didn't exit cleanly, raise an error.
+            if log_popen.returncode != 0:
+                raise BriefcaseCommandError(f"Problem running app {app.app_name}.")
         except KeyboardInterrupt:
             pass  # Catch CTRL-C to exit normally
         except OSError as e:

--- a/tests/integrations/flatpak/test_Flatpak__run.py
+++ b/tests/integrations/flatpak/test_Flatpak__run.py
@@ -1,40 +1,30 @@
 import subprocess
-
-import pytest
-
-from briefcase.exceptions import BriefcaseCommandError
+from unittest import mock
 
 
 def test_run(flatpak):
     """A Flatpak project can be executed."""
+    # Set up the log streamer to return a known stream
+    log_popen = mock.MagicMock()
+    flatpak.tools.subprocess.Popen.return_value = log_popen
 
-    flatpak.run(
+    # Call run()
+    result = flatpak.run(
         bundle="com.example",
         app_name="my-app",
     )
 
     # The expected call was made
-    flatpak.tools.subprocess.run.assert_called_once_with(
+    flatpak.tools.subprocess.Popen.assert_called_once_with(
         [
             "flatpak",
             "run",
             "com.example.my-app",
         ],
-        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
     )
 
-
-def test_run_fail(flatpak):
-    """If execution fails, an error is raised."""
-    flatpak.tools.subprocess.run.side_effect = subprocess.CalledProcessError(
-        cmd="flatpak install", returncode=1
-    )
-
-    with pytest.raises(
-        BriefcaseCommandError,
-        match=r"Unable to start app my-app.",
-    ):
-        flatpak.run(
-            bundle="com.example",
-            app_name="my-app",
-        )
+    # The popen object was returned.
+    assert result == log_popen

--- a/tests/platforms/linux/appimage/test_run.py
+++ b/tests/platforms/linux/appimage/test_run.py
@@ -165,7 +165,7 @@ def test_run_app_ctrl_c(run_command, first_app_config, tmp_path, capsys):
         "===========================================================================\n"
     )
 
-    # The app was poll in the finally block
+    # The app was polled in the finally block
     log_popen.poll.assert_called_once_with()
 
     # A successful attempt to terminate occured
@@ -221,7 +221,7 @@ def test_run_app_terminate_failure(run_command, first_app_config, tmp_path, caps
         "Forcibly killing first-app...\n"
     )
 
-    # The app was poll in the finally block
+    # The app was polled in the finally block
     log_popen.poll.assert_called_once_with()
 
     # A successful attempt to terminate occured

--- a/tests/platforms/linux/appimage/test_run.py
+++ b/tests/platforms/linux/appimage/test_run.py
@@ -63,13 +63,6 @@ def test_run_app(run_command, first_app_config, tmp_path):
     log_popen = mock.MagicMock()
     run_command.tools.subprocess.Popen.return_value = log_popen
 
-    # To satisfy coverage, the stop function must be invoked at least once
-    # when invoking stream_output.
-    def mock_stream_output(label, popen_process, stop_func):
-        stop_func()
-
-    run_command.tools.subprocess.stream_output.side_effect = mock_stream_output
-
     # Run the app
     run_command.run_app(first_app_config)
 
@@ -88,7 +81,8 @@ def test_run_app(run_command, first_app_config, tmp_path):
 
     # The streamer was started
     run_command.tools.subprocess.stream_output.assert_called_once_with(
-        "first-app", log_popen, stop_func=mock.ANY
+        "first-app",
+        log_popen,
     )
 
     # The stream was cleaned up
@@ -147,14 +141,13 @@ def test_run_app_ctrl_c(run_command, first_app_config, tmp_path, capsys):
 
     # An attempt was made to stream
     run_command.tools.subprocess.stream_output.assert_called_once_with(
-        "first-app", log_popen, stop_func=mock.ANY
+        "first-app",
+        log_popen,
     )
 
     # Shows the try block for KeyboardInterrupt was entered
     assert capsys.readouterr().out.endswith(
         "[first-app] Starting app...\n"
-        "\n"
-        "[first-app] Following log output (type CTRL-C to stop log)...\n"
         "===========================================================================\n"
     )
 

--- a/tests/platforms/linux/flatpak/test_run.py
+++ b/tests/platforms/linux/flatpak/test_run.py
@@ -29,13 +29,6 @@ def test_run(run_command, first_app_config):
     log_popen = mock.MagicMock()
     run_command.tools.flatpak.run.return_value = log_popen
 
-    # To satisfy coverage, the stop function must be invoked at least once
-    # when invoking stream_output.
-    def mock_stream_output(label, popen_process, stop_func):
-        stop_func()
-
-    run_command.tools.subprocess.stream_output.side_effect = mock_stream_output
-
     # Run the app
     run_command.run_app(first_app_config)
 
@@ -47,7 +40,8 @@ def test_run(run_command, first_app_config):
 
     # The streamer was started
     run_command.tools.subprocess.stream_output.assert_called_once_with(
-        "first-app", log_popen, stop_func=mock.ANY
+        "first-app",
+        log_popen,
     )
 
     # The stream was cleaned up
@@ -92,14 +86,13 @@ def test_run_ctrl_c(run_command, first_app_config, capsys):
 
     # An attempt was made to stream
     run_command.tools.subprocess.stream_output.assert_called_once_with(
-        "first-app", log_popen, stop_func=mock.ANY
+        "first-app",
+        log_popen,
     )
 
     # Shows the try block for KeyboardInterrupt was entered
     assert capsys.readouterr().out.endswith(
         "[first-app] Starting app...\n"
-        "\n"
-        "[first-app] Following log output (type CTRL-C to stop log)...\n"
         "===========================================================================\n"
     )
 

--- a/tests/platforms/linux/flatpak/test_run.py
+++ b/tests/platforms/linux/flatpak/test_run.py
@@ -1,12 +1,17 @@
+import subprocess
 from unittest import mock
 
+import pytest
+
 from briefcase.console import Console, Log
+from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.flatpak import Flatpak
+from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.linux.flatpak import LinuxFlatpakRunCommand
 
 
-def test_run(first_app_config, tmp_path):
-    """A flatpak can be executed."""
+@pytest.fixture
+def run_command(tmp_path):
     command = LinuxFlatpakRunCommand(
         logger=Log(),
         console=Console(),
@@ -14,39 +19,153 @@ def test_run(first_app_config, tmp_path):
         data_path=tmp_path / "briefcase",
     )
     command.tools.flatpak = mock.MagicMock(spec_set=Flatpak)
+    command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
 
-    command.run_app(first_app_config)
+    return command
+
+
+def test_run(run_command, first_app_config):
+    """A flatpak can be executed."""
+    # Set up the log streamer to return a known stream
+    log_popen = mock.MagicMock()
+    run_command.tools.flatpak.run.return_value = log_popen
+
+    # Set a normal return code for the process
+    log_popen.poll.return_value = 0
+
+    # To satisfy coverage, the stop function must be invoked at least once
+    # when invoking stream_output.
+    def mock_stream_output(label, popen_process, stop_func):
+        stop_func()
+
+    run_command.tools.subprocess.stream_output.side_effect = mock_stream_output
+
+    # Run the app
+    run_command.run_app(first_app_config)
 
     # App is executed
-    command.tools.flatpak.run.assert_called_once_with(
+    run_command.tools.flatpak.run.assert_called_once_with(
         bundle="com.example",
         app_name="first-app",
     )
 
+    # The streamer was started
+    run_command.tools.subprocess.stream_output.assert_called_once_with(
+        "log stream", log_popen, stop_func=mock.ANY
+    )
 
-def test_run_ctrl_c(first_app_config, tmp_path, capsys):
+    # The app was polled twice; once by the stream stop function,
+    # and once in the finally block.
+    assert log_popen.poll.mock_calls == [mock.call()] * 2
+
+
+def test_run_app_failed(run_command, first_app_config, tmp_path):
+    """If there's a problem starting the app, an exception is raised."""
+    run_command.tools.flatpak.run.side_effect = OSError
+
+    with pytest.raises(BriefcaseCommandError):
+        run_command.run_app(first_app_config)
+
+    # The run command was still invoked
+    run_command.tools.flatpak.run.assert_called_once_with(
+        bundle="com.example",
+        app_name="first-app",
+    )
+
+    # No attempt to stream was made
+    run_command.tools.subprocess.stream_output.assert_not_called()
+
+
+def test_run_ctrl_c(run_command, first_app_config, capsys):
     """When CTRL-C is sent while the App is running, Briefcase exits
     normally."""
-    command = LinuxFlatpakRunCommand(
-        logger=Log(),
-        console=Console(),
-        base_path=tmp_path / "base_path",
-        data_path=tmp_path / "briefcase",
-    )
-    command.tools.flatpak = mock.MagicMock(spec_set=Flatpak)
-    command.tools.flatpak.run.side_effect = KeyboardInterrupt
+    # Set up the log streamer to return a known stream
+    log_popen = mock.MagicMock()
+    run_command.tools.flatpak.run.return_value = log_popen
+
+    # When polled, the process is still running
+    log_popen.poll.return_value = None
+
+    # Mock the effect of CTRL-C being hit while streaming
+    run_command.tools.subprocess.stream_output.side_effect = KeyboardInterrupt
 
     # Invoke run_app (and KeyboardInterrupt does not surface)
-    command.run_app(first_app_config)
+    run_command.run_app(first_app_config)
 
     # App is executed
-    command.tools.flatpak.run.assert_called_once_with(
+    run_command.tools.flatpak.run.assert_called_once_with(
         bundle="com.example",
         app_name="first-app",
+    )
+
+    # An attempt was made to stream
+    run_command.tools.subprocess.stream_output.assert_called_once_with(
+        "log stream", log_popen, stop_func=mock.ANY
     )
 
     # Shows the try block for KeyboardInterrupt was entered
     assert capsys.readouterr().out.endswith(
         "[first-app] Starting app...\n"
+        "\n"
+        "[first-app] Following log output (type CTRL-C to stop log)...\n"
         "===========================================================================\n"
     )
+
+    # The app was poll in the finally block
+    log_popen.poll.assert_called_once_with()
+
+    # A successful attempt to terminate occured
+    log_popen.terminate.assert_called_once_with()
+    log_popen.wait.assert_called_once_with(timeout=3)
+
+    # No kill call was made
+    log_popen.kill.assert_not_called()
+
+
+def test_run_app_terminate_failure(run_command, first_app_config, capsys):
+    """If the app can't be terminated on exit, it's force killed.."""
+    # Set up the log streamer to return a known stream
+    log_popen = mock.MagicMock()
+    run_command.tools.flatpak.run.return_value = log_popen
+
+    # When polled, the process is still running
+    log_popen.poll.return_value = None
+
+    # Mock the effect of an unsuccessful termination.
+    log_popen.wait.side_effect = subprocess.TimeoutExpired(cmd="appimage", timeout=3)
+
+    # Mock the effect of CTRL-C being hit while streaming
+    run_command.tools.subprocess.stream_output.side_effect = KeyboardInterrupt
+
+    # Invoke run_app (and KeyboardInterrupt does not surface)
+    run_command.run_app(first_app_config)
+
+    # App is executed
+    run_command.tools.flatpak.run.assert_called_once_with(
+        bundle="com.example",
+        app_name="first-app",
+    )
+
+    # An attempt was made to stream
+    run_command.tools.subprocess.stream_output.assert_called_once_with(
+        "log stream", log_popen, stop_func=mock.ANY
+    )
+
+    # Shows the try block for KeyboardInterrupt was entered
+    assert capsys.readouterr().out.endswith(
+        "[first-app] Starting app...\n"
+        "\n"
+        "[first-app] Following log output (type CTRL-C to stop log)...\n"
+        "===========================================================================\n"
+        "Forcibly killing first-app...\n"
+    )
+
+    # The app was polled in the finally block
+    log_popen.poll.assert_called_once_with()
+
+    # A successful attempt to terminate occured
+    log_popen.terminate.assert_called_once_with()
+    log_popen.wait.assert_called_once_with(timeout=3)
+
+    # A kill call was made
+    log_popen.kill.assert_called_once_with()


### PR DESCRIPTION
In order to support test mode (Refs #962), we need to convert app runners to use streamers, rather than just outputting logs directly to stdout. To make the code easier to review, I've split the introduction of streaming to the linux backends as a standalone PR, similar to what has been done with #966 for Android.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
