### PR TITLE
Convert Windows app runners to use log streaming

### DIFF
--- a/changes/787.bugfix.rst
+++ b/changes/787.bugfix.rst
@@ -1,0 +1,1 @@
+Console output of Windows apps is now captured in the Briefcase log.

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -268,15 +268,12 @@ class LinuxAppImageRunCommand(LinuxAppImagePassiveMixin, RunCommand):
                 bufsize=1,
             )
 
-            try:
-                # Start streaming logs for the app.
-                self.logger.info("=" * 75)
-                self.tools.subprocess.stream_output(
-                    app.app_name,
-                    log_popen,
-                )
-            finally:
-                self.tools.subprocess.cleanup(app.app_name, log_popen)
+            # Start streaming logs for the app.
+            self.logger.info("=" * 75)
+            self.tools.subprocess.stream_output(
+                app.app_name,
+                log_popen,
+            )
 
             # If the process didn't exit cleanly, raise an error.
             if log_popen.returncode != 0:

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -199,15 +199,12 @@ class LinuxFlatpakRunCommand(LinuxFlatpakMixin, RunCommand):
                 app_name=app.app_name,
             )
 
-            try:
-                # Start streaming logs for the app.
-                self.logger.info("=" * 75)
-                self.tools.subprocess.stream_output(
-                    app.app_name,
-                    log_popen,
-                )
-            finally:
-                self.tools.subprocess.cleanup(app.app_name, log_popen)
+            # Start streaming logs for the app.
+            self.logger.info("=" * 75)
+            self.tools.subprocess.stream_output(
+                app.app_name,
+                log_popen,
+            )
 
             # If the process didn't exit cleanly, raise an error.
             if log_popen.returncode != 0:

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -90,15 +90,12 @@ class WindowsRunCommand(RunCommand):
                 bufsize=1,
             )
 
-            try:
-                # Start streaming logs for the app.
-                self.logger.info("=" * 75)
-                self.tools.subprocess.stream_output(
-                    app.app_name,
-                    log_popen,
-                )
-            finally:
-                self.tools.subprocess.cleanup(app.app_name, log_popen)
+            # Start streaming logs for the app.
+            self.logger.info("=" * 75)
+            self.tools.subprocess.stream_output(
+                app.app_name,
+                log_popen,
+            )
 
             # If the process didn't exit cleanly, raise an error.
             if log_popen.returncode != 0:

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -100,6 +100,9 @@ class WindowsRunCommand(RunCommand):
             finally:
                 self.tools.subprocess.cleanup(app.app_name, log_popen)
 
+            # If the process didn't exit cleanly, raise an error.
+            if log_popen.returncode != 0:
+                raise BriefcaseCommandError(f"Problem running app {app.app_name}.")
         except KeyboardInterrupt:
             pass  # Catch CTRL-C to exit normally
         except OSError as e:

--- a/tests/platforms/linux/appimage/test_run.py
+++ b/tests/platforms/linux/appimage/test_run.py
@@ -86,9 +86,6 @@ def test_run_app(run_command, first_app_config, tmp_path):
         log_popen,
     )
 
-    # The stream was cleaned up
-    run_command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)
-
 
 def test_run_app_failed(run_command, first_app_config, tmp_path):
     """If there's a problem starting the app, an exception is raised."""
@@ -147,9 +144,6 @@ def test_run_app_error(run_command, first_app_config, tmp_path):
         log_popen,
     )
 
-    # The stream was cleaned up
-    run_command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)
-
 
 def test_run_app_ctrl_c(run_command, first_app_config, tmp_path, capsys):
     """When CTRL-C is sent while the App is running, Briefcase exits
@@ -188,6 +182,3 @@ def test_run_app_ctrl_c(run_command, first_app_config, tmp_path, capsys):
         "[first-app] Starting app...\n"
         "===========================================================================\n"
     )
-
-    # The stream was cleaned up
-    run_command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)

--- a/tests/platforms/linux/flatpak/test_run.py
+++ b/tests/platforms/linux/flatpak/test_run.py
@@ -45,9 +45,6 @@ def test_run(run_command, first_app_config):
         log_popen,
     )
 
-    # The stream was cleaned up
-    run_command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)
-
 
 def test_run_app_failed(run_command, first_app_config, tmp_path):
     """If there's a problem starting the app, an exception is raised."""
@@ -92,9 +89,6 @@ def test_run_error(run_command, first_app_config):
         log_popen,
     )
 
-    # The stream was cleaned up
-    run_command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)
-
 
 def test_run_ctrl_c(run_command, first_app_config, capsys):
     """When CTRL-C is sent while the App is running, Briefcase exits
@@ -126,6 +120,3 @@ def test_run_ctrl_c(run_command, first_app_config, capsys):
         "[first-app] Starting app...\n"
         "===========================================================================\n"
     )
-
-    # The stream was cleaned up
-    run_command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)

--- a/tests/platforms/windows/app/test_run.py
+++ b/tests/platforms/windows/app/test_run.py
@@ -59,9 +59,6 @@ def test_run_app(run_command, first_app_config, tmp_path):
         log_popen,
     )
 
-    # The stream was cleaned up
-    run_command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)
-
 
 def test_run_app_failed(run_command, first_app_config, tmp_path):
     """If there's a problem started the app, an exception is raised."""
@@ -133,9 +130,6 @@ def test_run_app_error(run_command, first_app_config, tmp_path):
         log_popen,
     )
 
-    # The stream was cleaned up
-    run_command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)
-
 
 def test_run_app_ctrl_c(run_command, first_app_config, tmp_path, capsys):
     """When CTRL-C is sent while the App is running, Briefcase exits
@@ -180,6 +174,3 @@ def test_run_app_ctrl_c(run_command, first_app_config, tmp_path, capsys):
         "[first-app] Starting app...\n"
         "===========================================================================\n"
     )
-
-    # The stream was cleaned up
-    run_command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)

--- a/tests/platforms/windows/app/test_run.py
+++ b/tests/platforms/windows/app/test_run.py
@@ -1,5 +1,5 @@
 import os
-from subprocess import CalledProcessError
+import subprocess
 from unittest import mock
 
 import pytest
@@ -10,8 +10,8 @@ from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.windows.app import WindowsAppRunCommand
 
 
-def test_run_app(first_app_config, tmp_path):
-    """A Windows app can be started."""
+@pytest.fixture
+def run_command(first_app_config, tmp_path):
     command = WindowsAppRunCommand(
         logger=Log(),
         console=Console(),
@@ -21,9 +21,20 @@ def test_run_app(first_app_config, tmp_path):
     command.tools.home_path = tmp_path / "home"
     command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
 
-    command.run_app(first_app_config)
+    return command
 
-    command.tools.subprocess.run.assert_called_with(
+
+def test_run_app(run_command, first_app_config, tmp_path):
+    """A Windows app can be started."""
+    # Set up the log streamer to return a known stream
+    log_popen = mock.MagicMock()
+    run_command.tools.subprocess.Popen.return_value = log_popen
+
+    # Run the app
+    run_command.run_app(first_app_config)
+
+    # The process was started
+    run_command.tools.subprocess.Popen.assert_called_with(
         [
             os.fsdecode(
                 tmp_path
@@ -36,29 +47,31 @@ def test_run_app(first_app_config, tmp_path):
             ),
         ],
         cwd=tmp_path / "home",
-        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
     )
 
+    # The streamer was started
+    run_command.tools.subprocess.stream_output.assert_called_once_with(
+        "first-app",
+        log_popen,
+    )
 
-def test_run_app_failed(first_app_config, tmp_path):
+    # The stream was cleaned up
+    run_command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)
+
+
+def test_run_app_failed(run_command, first_app_config, tmp_path):
     """If there's a problem started the app, an exception is raised."""
-    command = WindowsAppRunCommand(
-        logger=Log(),
-        console=Console(),
-        base_path=tmp_path / "base_path",
-        data_path=tmp_path / "briefcase",
-    )
-    command.tools.home_path = tmp_path / "home"
-    command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
-    command.tools.subprocess.run.side_effect = CalledProcessError(
-        cmd=["First App.exe"], returncode=1
-    )
+
+    run_command.tools.subprocess.Popen.side_effect = OSError
 
     with pytest.raises(BriefcaseCommandError, match=r"Unable to start app first-app."):
-        command.run_app(first_app_config)
+        run_command.run_app(first_app_config)
 
-    # The run command was still invoked, though
-    command.tools.subprocess.run.assert_called_with(
+    # Popen was still invoked, though
+    run_command.tools.subprocess.Popen.assert_called_with(
         [
             os.fsdecode(
                 tmp_path
@@ -71,28 +84,30 @@ def test_run_app_failed(first_app_config, tmp_path):
             ),
         ],
         cwd=tmp_path / "home",
-        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
     )
 
+    # No attempt to stream was made
+    run_command.tools.subprocess.stream_output.assert_not_called()
 
-def test_run_app_ctrl_c(first_app_config, tmp_path, capsys):
+
+def test_run_app_ctrl_c(run_command, first_app_config, tmp_path, capsys):
     """When CTRL-C is sent while the App is running, Briefcase exits
     normally."""
-    command = WindowsAppRunCommand(
-        logger=Log(),
-        console=Console(),
-        base_path=tmp_path / "base_path",
-        data_path=tmp_path / "briefcase",
-    )
-    command.tools.home_path = tmp_path / "home"
-    command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
-    command.tools.subprocess.run.side_effect = KeyboardInterrupt
+    # Set up the log streamer to return a known stream
+    log_popen = mock.MagicMock()
+    run_command.tools.subprocess.Popen.return_value = log_popen
+
+    # Mock the effect of CTRL-C being hit while streaming
+    run_command.tools.subprocess.stream_output.side_effect = KeyboardInterrupt
 
     # Invoke run_app (and KeyboardInterrupt does not surface)
-    command.run_app(first_app_config)
+    run_command.run_app(first_app_config)
 
     # App is started
-    command.tools.subprocess.run.assert_called_with(
+    run_command.tools.subprocess.Popen.assert_called_with(
         [
             os.fsdecode(
                 tmp_path
@@ -105,7 +120,15 @@ def test_run_app_ctrl_c(first_app_config, tmp_path, capsys):
             ),
         ],
         cwd=tmp_path / "home",
-        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+    )
+
+    # An attempt was made to stream
+    run_command.tools.subprocess.stream_output.assert_called_once_with(
+        "first-app",
+        log_popen,
     )
 
     # Shows the try block for KeyboardInterrupt was entered
@@ -113,3 +136,6 @@ def test_run_app_ctrl_c(first_app_config, tmp_path, capsys):
         "[first-app] Starting app...\n"
         "===========================================================================\n"
     )
+
+    # The stream was cleaned up
+    run_command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)

--- a/tests/platforms/windows/app/test_run.py
+++ b/tests/platforms/windows/app/test_run.py
@@ -26,8 +26,9 @@ def run_command(first_app_config, tmp_path):
 
 def test_run_app(run_command, first_app_config, tmp_path):
     """A Windows app can be started."""
-    # Set up the log streamer to return a known stream
+    # Set up the log streamer to return a known stream with a good returncode
     log_popen = mock.MagicMock()
+    log_popen.returncode = 0
     run_command.tools.subprocess.Popen.return_value = log_popen
 
     # Run the app
@@ -91,6 +92,49 @@ def test_run_app_failed(run_command, first_app_config, tmp_path):
 
     # No attempt to stream was made
     run_command.tools.subprocess.stream_output.assert_not_called()
+
+
+def test_run_app_error(run_command, first_app_config, tmp_path):
+    """If a Windows app raises an error, the error is caught."""
+    # Set up the log streamer to return a known stream with a bad returncode
+    log_popen = mock.MagicMock()
+    log_popen.returncode = 42
+    run_command.tools.subprocess.Popen.return_value = log_popen
+
+    # Run the app
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r"Problem running app first-app",
+    ):
+        run_command.run_app(first_app_config)
+
+    # The process was started
+    run_command.tools.subprocess.Popen.assert_called_with(
+        [
+            os.fsdecode(
+                tmp_path
+                / "base_path"
+                / "windows"
+                / "app"
+                / "First App"
+                / "src"
+                / "First App.exe"
+            ),
+        ],
+        cwd=tmp_path / "home",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+    )
+
+    # The streamer was started
+    run_command.tools.subprocess.stream_output.assert_called_once_with(
+        "first-app",
+        log_popen,
+    )
+
+    # The stream was cleaned up
+    run_command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)
 
 
 def test_run_app_ctrl_c(run_command, first_app_config, tmp_path, capsys):

--- a/tests/platforms/windows/visualstudio/test_run.py
+++ b/tests/platforms/windows/visualstudio/test_run.py
@@ -21,8 +21,9 @@ def test_run_app(first_app_config, tmp_path):
     command.tools.home_path = tmp_path / "home"
     command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
 
-    # Set up the log streamer to return a known stream
+    # Set up the log streamer to return a known stream with a good returncode
     log_popen = mock.MagicMock()
+    log_popen.returncode = 0
     command.tools.subprocess.Popen.return_value = log_popen
 
     # Run the app

--- a/tests/platforms/windows/visualstudio/test_run.py
+++ b/tests/platforms/windows/visualstudio/test_run.py
@@ -54,6 +54,3 @@ def test_run_app(first_app_config, tmp_path):
         "first-app",
         log_popen,
     )
-
-    # The stream was cleaned up
-    command.tools.subprocess.cleanup.assert_called_once_with("first-app", log_popen)


### PR DESCRIPTION
In order to support test mode (Refs #962), we need to convert app runners to use streamers, rather than just outputting logs directly to stdout. To make the code easier to review, I've split the introduction of streaming to the Windows backends as a standalone PR, similar to what has been done with #966 for Android and #967 for Linux.

Requires a small change to the app templates (Refs beeware/briefcase-windows-VisualStudio-template#5); that template change corrects #787. That change will need to be propagated into the windows-app template.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
