### PR TITLE
Verify `briefcase.integrations.__all__` is accurate

### DIFF
--- a/changes/972.misc.rst
+++ b/changes/972.misc.rst
@@ -1,0 +1,1 @@
+The list of modules in ``briefcase.integrations.__all__`` is now verified against existing modules in ``briefcase.integrations``.

--- a/tests/integrations/base/test_ToolCache.py
+++ b/tests/integrations/base/test_ToolCache.py
@@ -40,12 +40,25 @@ def tools_for_module(tool_module_name: str) -> set:
 
 def test_toolcache_typing():
     """Tool typing for ToolCache is correct."""
+    # Modules in ``briefcase.integrations`` that do not contain tools.
+    nontool_modules = {"base"}
     # Tools that are intentionally not annotated in ToolCache.
     tools_unannotated = {"cookiecutter"}
     # Tool names to exclude from the dynamic annotation checks; they are manually checked.
     tool_names_skip_dynamic_check = {"app_context", "git", "xcode", "xcode_cli"}
     # Tool classes to exclude from dynamic annotation checks.
     tool_klasses_skip_dynamic_checks = {"DockerAppContext", "NativeAppContext"}
+
+    # Ensure all modules containing Tools are exported in ``briefcase.integrations``.
+    tool_modules = {
+        module
+        for module, _ in inspect.getmembers(
+            sys.modules["briefcase.integrations"],
+            inspect.ismodule,
+        )
+    }
+    tool_modules = tool_modules - nontool_modules
+    assert sorted(tool_modules) == sorted(briefcase.integrations.__all__)
 
     # Ensure defined Tool modules/classes are annotated in ToolCache.
     for tool_module_name in briefcase.integrations.__all__:

--- a/tests/integrations/base/test_ToolCache.py
+++ b/tests/integrations/base/test_ToolCache.py
@@ -1,6 +1,7 @@
 import importlib
 import inspect
 import os
+import pkgutil
 import platform
 import shutil
 import sys
@@ -51,13 +52,10 @@ def test_toolcache_typing():
 
     # Ensure all modules containing Tools are exported in ``briefcase.integrations``.
     tool_modules = {
-        module
-        for module, _ in inspect.getmembers(
-            sys.modules["briefcase.integrations"],
-            inspect.ismodule,
-        )
+        module.name
+        for module in pkgutil.iter_modules(briefcase.integrations.__path__)
+        if module.name not in nontool_modules
     }
-    tool_modules = tool_modules - nontool_modules
     assert sorted(tool_modules) == sorted(briefcase.integrations.__all__)
 
     # Ensure defined Tool modules/classes are annotated in ToolCache.


### PR DESCRIPTION
After I merged the `ToolCache` typing changes in to my Windows codesigning PR, I expected the new tests to fail. When they didn't fail, adding this additional check seemed prudent....since we're already this far in.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
