### PR TITLE
Add documentation for `build_gradle_extra_content`

### DIFF
--- a/changes/973.feature.rst
+++ b/changes/973.feature.rst
@@ -1,0 +1,1 @@
+The build.gradle file used to build Android apps can now include arbitrary additional settings.

--- a/docs/reference/platforms/android.rst
+++ b/docs/reference/platforms/android.rst
@@ -99,7 +99,7 @@ Additional options
 ==================
 
 The following options can be provided at the command line when producing
-Android projects
+Android projects:
 
 build
 -----
@@ -113,3 +113,16 @@ run
 ---
 
 The device simulator to target. Can be either a device ID, or a device name.
+
+Application configuration
+=========================
+
+The following options can be added to the
+``tool.briefcase.app.<appname>.android`` section of your ``pyproject.toml``
+file:
+
+``build_gradle_extra_content``
+------------------------------
+
+A string providing additional Gradle settings to use when building your app.
+This will be added verbatim to the end of your ``app/build.gradle`` file.


### PR DESCRIPTION
See:
* https://github.com/beeware/toga/pull/1687#discussion_r1028489995.
* https://github.com/beeware/briefcase-android-gradle-template/pull/57

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
