### PR TITLE
Convert log filters into generators.

### DIFF
--- a/changes/981.misc.rst
+++ b/changes/981.misc.rst
@@ -1,0 +1,1 @@
+Subprocess stream filters have been converted into generators.

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 import threading
 import time
-from contextlib import suppress
 from functools import wraps
 from pathlib import Path
 
@@ -609,24 +608,36 @@ class Subprocess(Tool):
         :param filter_func: a callable that will be invoked on every line
             of output that is streamed; see ``stream_output`` for details.
         """
-        # ValueError is raised if stdout is unexpectedly closed.
-        # This can happen if the user starts spamming CTRL+C, for instance.
-        # Silently exit to avoid Python printing the exception to the console.
-        # StopStreaming can be raised by a filter function to indicate that
-        # there's no need to stream any more.
-        with suppress(ValueError, StopStreaming):
+        try:
             while True:
-                # readline should always return at least a newline (ie \n)
-                # UNLESS the underlying process is exiting/gone; then "" is returned
-                output_line = ensure_str(popen_process.stdout.readline())
+                try:
+                    output_line = ensure_str(popen_process.stdout.readline())
+                except ValueError:
+                    # ValueError is raised if stdout is unexpectedly closed. This can
+                    # happen if the user starts spamming CTRL+C, for instance. Silently
+                    # exit to avoid Python printing the exception to the console.
+                    return
+
+                # readline should always return at least a newline (ie \n) UNLESS
+                # the underlying process is exiting/gone; then "" is returned.
                 if output_line:
                     if filter_func:
-                        for filtered_output in filter_func(output_line.rstrip("\n")):
-                            self.tools.logger.info(filtered_output)
+                        try:
+                            for filtered_output in filter_func(
+                                output_line.rstrip("\n")
+                            ):
+                                self.tools.logger.info(filtered_output)
+                        except StopStreaming:
+                            return
                     else:
                         self.tools.logger.info(output_line)
                 else:
                     return
+        except Exception as e:
+            self.tools.logger.error(
+                f"Error while streaming output: {e.__class__.__name__}: {e}"
+            )
+            self.tools.logger.capture_stacktrace()
 
     def cleanup(self, label, popen_process):
         """Clean up after a Popen process, gracefully terminating if possible;

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -637,7 +637,7 @@ class Subprocess(Tool):
             self.tools.logger.error(
                 f"Error while streaming output: {e.__class__.__name__}: {e}"
             )
-            self.tools.logger.capture_stacktrace()
+            self.tools.logger.capture_stacktrace("Output thread")
 
     def cleanup(self, label, popen_process):
         """Clean up after a Popen process, gracefully terminating if possible;

--- a/tests/console/test_Log.py
+++ b/tests/console/test_Log.py
@@ -33,7 +33,9 @@ def test_capture_stacktrace():
     except ZeroDivisionError:
         logger.capture_stacktrace()
 
-    assert isinstance(logger.stacktrace, Trace)
+    assert len(logger.stacktraces) == 1
+    assert logger.stacktraces[0][0] == "Main thread"
+    assert isinstance(logger.stacktraces[0][1], Trace)
     assert logger.skip_log is False
 
 
@@ -48,7 +50,9 @@ def test_capture_stacktrace_for_briefcaseerror(skip_logfile):
     except BriefcaseError:
         logger.capture_stacktrace()
 
-    assert isinstance(logger.stacktrace, Trace)
+    assert len(logger.stacktraces) == 1
+    assert logger.stacktraces[0][0] == "Main thread"
+    assert isinstance(logger.stacktraces[0][1], Trace)
     assert logger.skip_log is skip_logfile
 
 
@@ -61,6 +65,9 @@ def test_save_log_to_file_do_not_log():
     logger.save_log = False
     logger.save_log_to_file(command=command)
     command.input.wait_bar.assert_not_called()
+
+    # There were no stack traces captured
+    assert len(logger.stacktraces) == 0
 
 
 def test_save_log_to_file_no_exception(tmp_path, now):
@@ -145,8 +152,41 @@ def test_save_log_to_file_with_exception(tmp_path, now):
     with open(log_filepath, encoding="utf-8") as log:
         log_contents = log.read()
 
+    assert len(logger.stacktraces) == 1
     assert log_contents.startswith("Date/Time:       2022-06-25 16:12:29")
     assert TRACEBACK_HEADER in log_contents
+    assert log_contents.splitlines()[-1].startswith("ZeroDivisionError")
+
+
+def test_save_log_to_file_with_multiple_exceptions(tmp_path, now):
+    """Log file contains exception stacktrace when more than one is
+    captured."""
+    command = MagicMock()
+    command.base_path = Path(tmp_path)
+    command.command = "dev"
+    command.tools.os.environ = {}
+
+    logger = Log()
+    logger.save_log = True
+    for i in range(1, 5):
+        try:
+            1 / 0
+        except ZeroDivisionError:
+            logger.capture_stacktrace(f"Thread {i}")
+
+    logger.save_log_to_file(command=command)
+
+    log_filepath = tmp_path / logger.LOG_DIR / "briefcase.2022_06_25-16_12_29.dev.log"
+
+    log_filepath.exists()
+    with open(log_filepath, encoding="utf-8") as log:
+        log_contents = log.read()
+
+    assert len(logger.stacktraces) == 4
+    assert log_contents.startswith("Date/Time:       2022-06-25 16:12:29")
+    assert TRACEBACK_HEADER in log_contents
+    for i in range(1, 5):
+        assert f"\nThread {i} traceback:\n" in log_contents
     assert log_contents.splitlines()[-1].startswith("ZeroDivisionError")
 
 

--- a/tests/console/test_Log.py
+++ b/tests/console/test_Log.py
@@ -148,7 +148,7 @@ def test_save_log_to_file_with_exception(tmp_path, now):
 
     log_filepath = tmp_path / logger.LOG_DIR / "briefcase.2022_06_25-16_12_29.dev.log"
 
-    log_filepath.exists()
+    assert log_filepath.exists()
     with open(log_filepath, encoding="utf-8") as log:
         log_contents = log.read()
 
@@ -178,7 +178,7 @@ def test_save_log_to_file_with_multiple_exceptions(tmp_path, now):
 
     log_filepath = tmp_path / logger.LOG_DIR / "briefcase.2022_06_25-16_12_29.dev.log"
 
-    log_filepath.exists()
+    assert log_filepath.exists()
     with open(log_filepath, encoding="utf-8") as log:
         log_contents = log.read()
 

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -159,7 +159,7 @@ def test_filter_func(mock_sub, streaming_process, capsys):
     """A filter can be added to modify an output stream."""
     # Define a filter function that converts "output" into "filtered"
     def filter_func(line):
-        return line.replace("output", "filtered")
+        yield line.replace("output", "filtered")
 
     mock_sub.stream_output("testing", streaming_process, filter_func=filter_func)
 
@@ -180,8 +180,8 @@ def test_filter_func_reject(mock_sub, streaming_process, capsys):
     # Define a filter function that ignores blank lines
     def filter_func(line):
         if len(line) == 0:
-            return None
-        return line
+            return
+        yield line
 
     mock_sub.stream_output("testing", streaming_process, filter_func=filter_func)
 
@@ -202,8 +202,9 @@ def test_filter_func_line_ends(mock_sub, streaming_process, capsys):
     # The newline is *not* included.
     def filter_func(line):
         if line.endswith("line 1"):
-            return line.replace("line 1", "**REDACTED**")
-        return line
+            yield line.replace("line 1", "**REDACTED**")
+        else:
+            yield line
 
     mock_sub.stream_output("testing", streaming_process, filter_func=filter_func)
 
@@ -219,14 +220,38 @@ def test_filter_func_line_ends(mock_sub, streaming_process, capsys):
     mock_sub.cleanup.assert_called_once_with("testing", streaming_process)
 
 
+def test_filter_func_line_multiple_output(mock_sub, streaming_process, capsys):
+    """Filter functions can generate multiple lines from a single input."""
+    # Define a filter function that adds an extra line of content when the
+    # lines that end with 1
+    def filter_func(line):
+        yield line
+        if line.endswith("line 1"):
+            yield "Extra content!"
+
+    mock_sub.stream_output("testing", streaming_process, filter_func=filter_func)
+
+    # fmt: off
+    # Output has been transformed; newline exists in output
+    assert capsys.readouterr().out == (
+        "output line 1\n"
+        "Extra content!\n"
+        "\n"
+        "output line 3\n"
+    )
+    # fmt: on
+
+    mock_sub.cleanup.assert_called_once_with("testing", streaming_process)
+
+
 def test_filter_func_stop_iteration(mock_sub, streaming_process, capsys):
     """A filter can indicate that logging should stop."""
     # Define a filter function that converts "output" into "filtered",
-    # and terminates logging when a blank line is seen.
+    # and terminates streaming when a blank line is seen.
     def filter_func(line):
         if line == "":
-            raise StopIteration()
-        return line.replace("output", "filtered")
+            raise subprocess.StopStreaming()
+        yield line.replace("output", "filtered")
 
     mock_sub.stream_output("testing", streaming_process, filter_func=filter_func)
 
@@ -234,6 +259,31 @@ def test_filter_func_stop_iteration(mock_sub, streaming_process, capsys):
     # Output has been transformed, but is truncated when the empty line was received.
     assert capsys.readouterr().out == (
         "filtered line 1\n"
+    )
+    # fmt: on
+
+    mock_sub.cleanup.assert_called_once_with("testing", streaming_process)
+
+
+def test_filter_func_output_and_stop_iteration(mock_sub, streaming_process, capsys):
+    """A filter can indicate that logging should stop, and also output
+    content."""
+    # Define a filter function that converts "output" into "filtered",
+    # and terminates streaming when a blank line is seen; but outputs
+    # one more line before terminating.
+    def filter_func(line):
+        if line == "":
+            yield "This should be the last line"
+            raise subprocess.StopStreaming()
+        yield line.replace("output", "filtered")
+
+    mock_sub.stream_output("testing", streaming_process, filter_func=filter_func)
+
+    # fmt: off
+    # Output has been transformed, but is truncated when the empty line was received.
+    assert capsys.readouterr().out == (
+        "filtered line 1\n"
+        "This should be the last line\n"
     )
     # fmt: on
 


### PR DESCRIPTION
Modifies log filtering so that the filter is required to be a generator, rather than a filter function.

This allows greater flexibility over how input is handled (1 line of input can cause 0-N lines of output) without complicating the interface of the filter function itself.

It also removes the need for an extra line of content to cause the termination of the log stream.

Fixes #981

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
