### PR TITLE
Make pytest regexes accept content after the time

### DIFF
--- a/changes/984.misc.rst
+++ b/changes/984.misc.rst
@@ -1,0 +1,1 @@
+Made pytest regexes accept content after the time

--- a/src/briefcase/commands/run.py
+++ b/src/briefcase/commands/run.py
@@ -21,7 +21,7 @@ class LogFilter:
         r"(^=+ ("
         r"((, )?\d+ (passed|skipped|deselected|xfailed|xpassed|warnings?))*"
         r"|(no tests ran)"
-        r") in -?\d+\.\d+s =+$)"
+        r") in -?\d+\.\d+s.* =+$)"
     )
 
     DEFAULT_FAILURE_REGEX = (
@@ -36,7 +36,7 @@ class LogFilter:
         r"(^=+ ("
         r"(\d+ failed((, )?\d+ (passed|skipped|deselected|xfailed|xpassed|warnings?|errors?))*)"
         r"|((\d+ (failed|passed|skipped|deselected|xfailed|xpassed|warnings?)(, )?)*\d+ errors?)"
-        r") in -?\d+.\d+s =+$)"
+        r") in -?\d+.\d+s.* =+$)"
     )
 
     def __init__(

--- a/tests/commands/run/test_LogFilter__test_failure_filter.py
+++ b/tests/commands/run/test_LogFilter__test_failure_filter.py
@@ -209,6 +209,11 @@ from briefcase.commands.run import LogFilter
             "FAILED tests/foobar/test_things.py::test_fail2 - assert 1 == 2",
             "============================= 6 failed in -12.345s =============================",
         ],
+        # - Failures with content after the time.
+        [
+            "tests/test_thirdparty.py::test_pandas PASSED                              [100%]",
+            "==================== 24 failed, 5 passed in 89.65s (0:01:29) ===================",
+        ],
         # Until https://github.com/chaquo/chaquopy/issues/746 is resolved, Android output
         # will contain extra line breaks because it produces a line for each call to `write`,
         # not just on newlines. The unittest regex contains extra named groups to

--- a/tests/commands/run/test_LogFilter__test_success_filter.py
+++ b/tests/commands/run/test_LogFilter__test_success_filter.py
@@ -160,6 +160,11 @@ from briefcase.commands.run import LogFilter
             "",
             "============================= 7 passed in 12.345s ==============================",
         ],
+        # - Passes with content after the time.
+        [
+            "tests/test_thirdparty.py::test_pandas PASSED                              [100%]",
+            "=================== 24 passed, 5 skipped in 89.65s (0:01:29) ===================",
+        ],
         # Until https://github.com/chaquo/chaquopy/issues/746 is resolved, Android output
         # will contain extra line breaks because the log is written whenever the buffer is
         # flushed, not just on newlines. The unittest regex contains extra named groups to


### PR DESCRIPTION
[This CI run](https://github.com/beeware/Python-support-testbed/actions/runs/3580373832/jobs/6023434680) shows that when the run takes longer than a minute, pytest will display the elapsed time in two different formats. Our regexes don't currently accept this.

Fortunately the first format is the one we already accept, so I've just made it accept any content at all between the time and the closing line of `=`s. I think the rest of the regex is selective enough that this won't cause any false positives. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
