### PR TITLE
Start the dev interpreter in PEP540 UTF8 mode.

### DIFF
--- a/changes/985.bugfix.rst
+++ b/changes/985.bugfix.rst
@@ -1,0 +1,1 @@
+Development mode now starts apps in PEP540 UTF-8 mode, for consistency with the stub apps.

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -115,6 +115,8 @@ class DevCommand(BaseCommand):
                     "-u",
                     "-X",
                     "dev",
+                    "-X",
+                    "utf8",
                     "-c",
                     (
                         "import runpy, sys;"

--- a/tests/commands/dev/test_run_dev_app.py
+++ b/tests/commands/dev/test_run_dev_app.py
@@ -18,6 +18,8 @@ def test_subprocess_running_successfully(dev_command, first_app, tmp_path):
             "-u",
             "-X",
             "dev",
+            "-X",
+            "utf8",
             "-c",
             (
                 "import runpy, sys;"
@@ -51,6 +53,8 @@ def test_subprocess_throws_error(dev_command, first_app, tmp_path):
             "-u",
             "-X",
             "dev",
+            "-X",
+            "utf8",
             "-c",
             (
                 "import runpy, sys;"
@@ -77,6 +81,8 @@ def test_subprocess_test_mode_success(dev_command, first_app, tmp_path):
             "-u",
             "-X",
             "dev",
+            "-X",
+            "utf8",
             "-c",
             (
                 "import runpy, sys;"
@@ -112,6 +118,8 @@ def test_subprocess_test_mode_failure(dev_command, first_app, tmp_path):
             "-u",
             "-X",
             "dev",
+            "-X",
+            "utf8",
             "-c",
             (
                 "import runpy, sys;"


### PR DESCRIPTION
`briefcase dev` starts a Python interpreter. However, on some platforms (notably Windows) it will inherit the default system locale (often cp-1252), which can cause problems. Passing in the `-X utf8` command line option forces the use of [PEP540 UTF-8 mode](https://docs.python.org/3/library/os.html#utf8-mode).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
