### PR TITLE
Disable the debug malloc on Windows.

### DIFF
--- a/changes/987.misc.rst
+++ b/changes/987.misc.rst
@@ -1,0 +1,1 @@
+The Python debug malloc has been disabled when running on Windows.

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -136,11 +136,19 @@ class DevCommand(BaseCommand):
     def get_environment(self, app, test_mode: bool):
         # Create a shell environment where PYTHONPATH points to the source
         # directories described by the app config.
-        return {
+        env = {
             "PYTHONPATH": os.pathsep.join(
                 os.fsdecode(Path.cwd() / path) for path in app.PYTHONPATH(test_mode)
             )
         }
+
+        # On Windows, we need to disable the debug allocator because it
+        # conflicts with Python.net. See
+        # https://github.com/pythonnet/pythonnet/issues/1977 for details.
+        if self.platform == "windows":
+            env["PYTHONMALLOC"] = "default"
+
+        return env
 
     def __call__(
         self,

--- a/tests/commands/dev/test_get_environment.py
+++ b/tests/commands/dev/test_get_environment.py
@@ -4,18 +4,21 @@ from pathlib import Path
 import pytest
 
 PYTHONPATH = "PYTHONPATH"
+PYTHONMALLOC = "PYTHONMALLOC"
 
 
-def test_pythonpath_with_one_source(dev_command, first_app):
+def test_pythonpath_with_one_source_in_windows(dev_command, first_app):
     """Test get environment with one source."""
     env = dev_command.get_environment(first_app, test_mode=False)
     assert env[PYTHONPATH] == f"{Path.cwd() / 'src'}"
+    assert env[PYTHONMALLOC] == "default"
 
 
-def test_pythonpath_with_one_source_test_mode(dev_command, first_app):
+def test_pythonpath_with_one_source_test_mode_in_windows(dev_command, first_app):
     """Test get environment with one source, no tests sources, in test mode."""
     env = dev_command.get_environment(first_app, test_mode=True)
     assert env[PYTHONPATH] == f"{Path.cwd() / 'src'}"
+    assert env[PYTHONMALLOC] == "default"
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Relevant only for windows")
@@ -23,6 +26,7 @@ def test_pythonpath_with_two_sources_in_windows(dev_command, third_app):
     """Test get environment with two sources in windows."""
     env = dev_command.get_environment(third_app, test_mode=False)
     assert env[PYTHONPATH] == f"{Path.cwd() / 'src'};{Path.cwd()}"
+    assert env[PYTHONMALLOC] == "default"
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Relevant only for windows")
@@ -34,6 +38,23 @@ def test_pythonpath_with_two_sources_and_tests_in_windows(dev_command, third_app
         env[PYTHONPATH]
         == f"{Path.cwd() / 'src'};{Path.cwd()};{Path.cwd() / 'path' / 'to'}"
     )
+    assert env[PYTHONMALLOC] == "default"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Relevant only for non-windows")
+def test_pythonpath_with_one_source(dev_command, first_app):
+    """Test get environment with one source."""
+    env = dev_command.get_environment(first_app, test_mode=False)
+    assert env[PYTHONPATH] == f"{Path.cwd() / 'src'}"
+    assert PYTHONMALLOC not in env
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Relevant only for non-windows")
+def test_pythonpath_with_one_source_test_mode(dev_command, first_app):
+    """Test get environment with one source, no tests sources, in test mode."""
+    env = dev_command.get_environment(first_app, test_mode=True)
+    assert env[PYTHONPATH] == f"{Path.cwd() / 'src'}"
+    assert PYTHONMALLOC not in env
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Relevant only for non-windows")
@@ -41,6 +62,7 @@ def test_pythonpath_with_two_sources_in_linux(dev_command, third_app):
     """Test get environment with two sources in linux."""
     env = dev_command.get_environment(third_app, test_mode=False)
     assert env[PYTHONPATH] == f"{Path.cwd() / 'src'}:{Path.cwd()}"
+    assert PYTHONMALLOC not in env
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Relevant only for non-windows")
@@ -51,3 +73,4 @@ def test_pythonpath_with_two_sources_and_tests_in_linux(dev_command, third_app):
         env[PYTHONPATH]
         == f"{Path.cwd() / 'src'}:{Path.cwd()}:{Path.cwd() / 'path' / 'to'}"
     )
+    assert PYTHONMALLOC not in env

--- a/tests/commands/dev/test_get_environment.py
+++ b/tests/commands/dev/test_get_environment.py
@@ -7,6 +7,7 @@ PYTHONPATH = "PYTHONPATH"
 PYTHONMALLOC = "PYTHONMALLOC"
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Relevant only for windows")
 def test_pythonpath_with_one_source_in_windows(dev_command, first_app):
     """Test get environment with one source."""
     env = dev_command.get_environment(first_app, test_mode=False)
@@ -14,6 +15,7 @@ def test_pythonpath_with_one_source_in_windows(dev_command, first_app):
     assert env[PYTHONMALLOC] == "default"
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Relevant only for windows")
 def test_pythonpath_with_one_source_test_mode_in_windows(dev_command, first_app):
     """Test get environment with one source, no tests sources, in test mode."""
     env = dev_command.get_environment(first_app, test_mode=True)


### PR DESCRIPTION
Following the recommendation from https://github.com/pythonnet/pythonnet/issues/1977, disables the debug malloc in dev mode. While it would be desirable to have the debug malloc, it's better to have code that doesn't throw errors.

Fixes #987.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
