### PR TITLE
Added a default fallback naming scheme for image resources with variants

### DIFF
--- a/changes/989.feature.rst
+++ b/changes/989.feature.rst
@@ -1,0 +1,1 @@
+Resources that require variants will now use the variant name as part of the filename by default.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -607,11 +607,13 @@ class CreateCommand(BaseCommand):
                     full_role = role
                 else:
                     try:
-                        source_filename = f"{source[variant]}{target.suffix}"
                         full_role = f"{variant} {role}"
-                    except (TypeError, KeyError):
+                        source_filename = f"{source[variant]}{target.suffix}"
+                    except TypeError:
+                        source_filename = f"{source}-{variant}{target.suffix}"
+                    except KeyError:
                         self.logger.info(
-                            f"Unable to find {variant} variant for {role}; using default"
+                            f"Unknown variant {variant!r} for {role}; using default"
                         )
                         return
             else:
@@ -631,11 +633,13 @@ class CreateCommand(BaseCommand):
                         full_role = f"{size}px {role}"
                 else:
                     try:
-                        source_filename = f"{source[variant]}-{size}{target.suffix}"
                         full_role = f"{size}px {variant} {role}"
-                    except (TypeError, KeyError):
+                        source_filename = f"{source[variant]}-{size}{target.suffix}"
+                    except TypeError:
+                        source_filename = f"{source}-{variant}-{size}{target.suffix}"
+                    except KeyError:
                         self.logger.info(
-                            f"Unable to find {size}px {variant} variant for {role}; using default"
+                            f"Unknown variant {variant!r} for {size}px {role}; using default"
                         )
                         return
 

--- a/tests/commands/create/test_install_image.py
+++ b/tests/commands/create/test_install_image.py
@@ -187,8 +187,8 @@ def test_variant_with_no_requested_size(create_command, tmp_path, capsys):
 def test_variant_without_variant_source_and_no_requested_size(
     create_command, tmp_path, capsys
 ):
-    """If the template specifies a variant with no size, but app doesn't have
-    variants, a message is reported."""
+    """If the template specifies a variant with no size, but app doesn't define
+    variants, the default construction is used."""
     create_command.tools.shutil = mock.MagicMock(spec_set=shutil)
 
     # Create the source image
@@ -208,7 +208,7 @@ def test_variant_without_variant_source_and_no_requested_size(
     )
 
     # The right message was written to output
-    expected = "Unable to find round variant for sample image; using default\n"
+    expected = "Unable to find input/original-round.png for round sample image; using default\n"
     assert capsys.readouterr().out == expected
 
     # No file was installed.
@@ -238,7 +238,7 @@ def test_unknown_variant_with_no_requested_size(create_command, tmp_path, capsys
     )
 
     # The right message was written to output
-    expected = "Unable to find unknown variant for sample image; using default\n"
+    expected = "Unknown variant 'unknown' for sample image; using default\n"
     assert capsys.readouterr().out == expected
 
     # No file was installed.
@@ -303,7 +303,38 @@ def test_variant_with_size_without_variants(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "Unable to find 3742px round variant for sample image; using default\n"
+    expected = "Unable to find input/original-round-3742.png for 3742px round sample image; using default\n"
+    assert capsys.readouterr().out == expected
+
+    # No file was installed.
+    create_command.tools.shutil.copy.assert_not_called()
+
+
+def test_unknown_variant_with_size(create_command, tmp_path, capsys):
+    """If the app specifies an unknown variant with a size, but no variants are
+    specified, a message is output."""
+    create_command.tools.shutil = mock.MagicMock(spec_set=shutil)
+
+    # Create the source image
+    source_file = tmp_path / "project" / "input" / "original-3742.png"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    with source_file.open("w") as f:
+        f.write("image")
+
+    # Try to install the image
+    out_path = tmp_path / "output.png"
+    create_command.install_image(
+        "sample image",
+        source={
+            "round": "input/original",
+        },
+        variant="unknown",
+        size="3742",
+        target=out_path,
+    )
+
+    # The right message was written to output
+    expected = "Unknown variant 'unknown' for 3742px sample image; using default\n"
     assert capsys.readouterr().out == expected
 
     # No file was installed.


### PR DESCRIPTION
Android requires a `square` and `circle` variant for it's icons; however, there's no fully "default" icon for Android, as you have to specify a `icons.round` and `icons.square` definition to provide a filename.

This PR adds a default fallback; if a pyproject.toml doesn't specifically provide a variant-based definition, the variant will be added to the filename in a default pattern. If a variant-based icon definition *is* provided, it is assumed that all required variants will be specified.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
