### PR TITLE
Pin CI requirement versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ env.python_version }}
-    - run: pip install tox==3.27.1
+    - run: pip install tox~=3.27
     - run: tox -e towncrier-check
 
   package:
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ env.python_version }}
-    - run: pip install tox==3.27.1
+    - run: pip install tox~=3.27
     - run: tox -e package
     - uses: actions/upload-artifact@v3
       with:
@@ -93,7 +93,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
-        pip install setuptools_scm==7.0.5 tox==3.27.1 coverage[toml]==6.5.0
+        pip install setuptools_scm[toml]~=7.0 tox~=3.27 coverage[toml]~=6.5
     - name: Test
       run: |
         tox -e py --installpkg dist/*.whl
@@ -125,7 +125,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
-        pip install coverage[toml]==6.5.0
+        pip install coverage[toml]~=6.5
     - name: Retrieve coverage data
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ env.python_version }}
-    - run: pip install tox
+    - run: pip install tox==3.27.1
     - run: tox -e towncrier-check
 
   package:
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ env.python_version }}
-    - run: pip install tox
+    - run: pip install tox==3.27.1
     - run: tox -e package
     - uses: actions/upload-artifact@v3
       with:
@@ -93,7 +93,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
-        pip install setuptools_scm tox coverage[toml]
+        pip install setuptools_scm==7.0.5 tox==3.27.1 coverage[toml]==6.5.0
     - name: Test
       run: |
         tox -e py --installpkg dist/*.whl
@@ -125,7 +125,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
-        pip install coverage[toml]
+        pip install coverage[toml]==6.5.0
     - name: Retrieve coverage data
       uses: actions/download-artifact@v3
       with:

--- a/changes/994.misc.rst
+++ b/changes/994.misc.rst
@@ -1,0 +1,1 @@
+Pinned CI requirement versions

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,8 @@ install_requires =
 dev =
     pre-commit
     setuptools_scm[toml] ~= 7.0
-    tox
+    tox ~= 3.27
+    coverage[toml] ~= 6.5
 test =
     pytest
     pytest-tldr


### PR DESCRIPTION
A new version of tox was released today which broke our CI workflow (see [here](https://github.com/beeware/briefcase/actions/runs/3642076566/jobs/6148779467)). This PR fixes that by pinning the versions of most requirements used by the workflow. However, it doesn't pin pip and setuptools, because those will be provided by the Briefcase user, so if our packages don't work with a new version we'd want to be notified about that ASAP.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
