### PR TITLE
Allow test suite completion and test suite exit to be different.

### DIFF
--- a/changes/998.misc.rst
+++ b/changes/998.misc.rst
@@ -1,0 +1,1 @@
+Test suites can now define an independent criterion to match for test suite exit.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -406,6 +406,18 @@ Briefcase defaults to regular expressions that are able to match the output of
 ``unittest`` or ``pytest``; if you use a different test framework, you will need
 to customize these settings.
 
+``test_exit_regex``
+~~~~~~~~~~~~~~~~~~~
+
+A regular expression that will be used to determine when the test suite has
+finished. The ``re.MULTILINE`` flag will be used.
+
+This option is only required if there is test suite content generated *after* the
+success/failure criteria has been output that you wish to preserve in the log
+(e.g., a coverage report). If ``test_exit_regex`` is *not* specified, Briefcase
+will assume that the test suite has completed as soon as a success or failure
+pattern has matched.
+
 ``url``
 ~~~~~~~
 


### PR DESCRIPTION
At present, under `briefcase run --test`, the test suite exits as soon as the success or failure criterion is found.

However, if there is output in the test log that is emitted *after* the test suite, that output is not displayed. The most obvious use case for this is coverage; the coverage report is output after the test suite completes.

This PR adds a `test_exit_regex` setting that allows a project to define a criterion for exiting the test suite that is independent of the success or failure of the test suite.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
