### PR TITLE
Simplify package build.

### DIFF
--- a/changes/1001.misc.rst
+++ b/changes/1001.misc.rst
@@ -1,0 +1,1 @@
+The packaging of sdist and wheel artefacts was simplified.

--- a/tox.ini
+++ b/tox.ini
@@ -36,5 +36,5 @@ deps =
     twine
 commands =
     check-manifest -v
-    python -m build --sdist --wheel --outdir dist/ .
+    python -m build --outdir dist/ .
     python -m twine check dist/*


### PR DESCRIPTION
Although the `--sdist --wheel` arguments to `build` cause an sdist and wheel to be packaged, they are completely isolated builds. If you omit these two arguments, an sdist and wheel are still built; but the wheel is built *using* the sdist, so there's an extra layer of security that the sdist contains everything it needs.

Thanks to @webknjaz for [this suggestion](https://github.com/beeware/briefcase/pull/995#issuecomment-1347563630)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
