### PR TITLE
Help text includes command descriptions, platforms, and output formats

### DIFF
--- a/changes/906.misc.rst
+++ b/changes/906.misc.rst
@@ -1,0 +1,1 @@
+The Briefcase help text now includes available output formats for the platform.

--- a/changes/907.misc.rst
+++ b/changes/907.misc.rst
@@ -1,0 +1,1 @@
+The Briefcase help text now includes a list of available commands, their descriptions, and the available platforms.

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -42,7 +42,7 @@ def parse_cmdline(args):
     :return: Command and command-specific arguments
     """
     platforms = get_platforms()
-    width = min(shutil.get_terminal_size().columns, 80) - 2
+    width = max(min(shutil.get_terminal_size().columns, 80) - 2, 20)
 
     briefcase_description = textwrap.fill(
         "Briefcase is a tool for converting a Python project "

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -56,7 +56,7 @@ def parse_cmdline(args):
         for cmd in COMMANDS
     )
 
-    platform_list = ", ".join([p.title() if p.islower() else p for p in platforms])
+    platform_list = ", ".join(sorted(platforms, key=str.lower))
 
     additional_instruction = textwrap.fill(
         "Each command, platform, and format has additional options. "

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -1,5 +1,7 @@
 import argparse
+import shutil
 import sys
+import textwrap
 from argparse import RawDescriptionHelpFormatter
 
 from briefcase import __version__
@@ -40,31 +42,44 @@ def parse_cmdline(args):
     :return: Command and command-specific arguments
     """
     platforms = get_platforms()
+    width = min(shutil.get_terminal_size().columns, 80) - 2
+
+    briefcase_description = textwrap.fill(
+        "Briefcase is a tool for converting a Python project "
+        "into a standalone native application for distribution.",
+        width=width,
+    )
 
     description_max_pad_len = max(len(cmd.command) for cmd in COMMANDS) + 2
-    cmd_helptext = "\n".join(
+    command_description_list = "\n".join(
         f"  {cmd.command}{' ' * (description_max_pad_len - len(cmd.command))}{cmd.description}"
         for cmd in COMMANDS
+    )
+
+    platform_list = ", ".join([p.title() if p.islower() else p for p in platforms])
+
+    additional_instruction = textwrap.fill(
+        "Each command, platform, and format has additional options. "
+        "Use the -h option on a specific command for more details.",
+        width=width,
     )
 
     parser = argparse.ArgumentParser(
         prog="briefcase",
         description=(
-            "Briefcase is a tool for converting a Python project into a standalone native\n"
-            "application for distribution.\n"
+            f"{briefcase_description}\n"
             "\n"
             "Commands:\n"
-            f"{cmd_helptext}\n"
+            f"{command_description_list}\n"
             "\n"
             "Platforms:\n"
-            f"  {', '.join([p.title() if p.islower() else p for p in platforms])}\n"
+            f"  {platform_list}\n"
             "\n"
-            "Each command, platform, and format has additional options. Use the -h option on\n"
-            "a specific command for more details."
+            f"{additional_instruction}"
         ),
         usage="briefcase [-h] <command> [<platform>] [<format>] ...",
         add_help=False,
-        formatter_class=lambda prog: RawDescriptionHelpFormatter(prog, width=80),
+        formatter_class=lambda prog: RawDescriptionHelpFormatter(prog, width=width),
     )
     parser.add_argument("-V", "--version", action="version", version=__version__)
 

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -27,14 +27,14 @@ from .exceptions import (
 COMMANDS = [
     NewCommand,
     DevCommand,
-    UpgradeCommand,
     CreateCommand,
-    UpdateCommand,
     OpenCommand,
     BuildCommand,
+    UpdateCommand,
     RunCommand,
     PackageCommand,
     PublishCommand,
+    UpgradeCommand,
 ]
 
 
@@ -46,9 +46,9 @@ def parse_cmdline(args):
     """
     platforms = get_platforms()
 
-    max_cmd_name_len = max(len(cmd.command) for cmd in COMMANDS)
+    description_max_pad_len = max(len(cmd.command) for cmd in COMMANDS) + 2
     cmd_helptext = "\n".join(
-        f"  {cmd.command}{' ' * (max_cmd_name_len - len(cmd.command) + 2)}{cmd.description}"
+        f"  {cmd.command}{' ' * (description_max_pad_len - len(cmd.command))}{cmd.description}"
         for cmd in COMMANDS
     )
 

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -17,12 +17,7 @@ from briefcase.commands import (
 )
 from briefcase.platforms import get_output_formats, get_platforms
 
-from .exceptions import (
-    InvalidFormatError,
-    NoCommandError,
-    ShowOutputFormats,
-    UnsupportedCommandError,
-)
+from .exceptions import InvalidFormatError, NoCommandError, UnsupportedCommandError
 
 COMMANDS = [
     NewCommand,
@@ -70,13 +65,6 @@ def parse_cmdline(args):
         usage="briefcase [-h] <command> [<platform>] [<format>] ...",
         add_help=False,
         formatter_class=lambda prog: RawDescriptionHelpFormatter(prog, width=80),
-    )
-    parser.add_argument(
-        "-f",
-        "--formats",
-        action="store_true",
-        dest="show_output_formats",
-        help="show the available output formats and exit (specify a platform for more details).",
     )
     parser.add_argument("-V", "--version", action="version", version=__version__)
 
@@ -150,21 +138,14 @@ def parse_cmdline(args):
         # Import the platform module
         platform_module = platforms[options.platform]
 
-        output_formats = get_output_formats(options.platform)
-        # If the user requested a list of available output formats, output them.
-        if options.show_output_formats:
-            raise ShowOutputFormats(
-                platform=options.platform,
-                default=platform_module.DEFAULT_OUTPUT_FORMAT,
-                choices=list(output_formats.keys()),
-            )
-
         # If the output format wasn't explicitly specified, check to see
         # Otherwise, extract and use the default output_format for the platform.
         if options.output_format is None:
             output_format = platform_module.DEFAULT_OUTPUT_FORMAT
         else:
             output_format = options.output_format
+
+        output_formats = get_output_formats(options.platform)
 
         # Normalise casing of output_format to be more forgiving.
         output_format = {n.lower(): n for n in output_formats}.get(

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -3,7 +3,9 @@ import importlib
 import inspect
 import os
 import platform
+import shutil
 import subprocess
+import textwrap
 from abc import ABC, abstractmethod
 from argparse import RawDescriptionHelpFormatter
 from pathlib import Path
@@ -547,14 +549,19 @@ a custom location for Briefcase's tools.
         else:
             formats_helptext = ""
 
+        width = min(shutil.get_terminal_size().columns, 80) - 2
         parser = argparse.ArgumentParser(
             prog=self.cmd_line.format(
                 command=self.command,
                 platform=self.platform,
                 output_format=self.output_format,
             ),
-            description=(f"{self.description}\n\n{formats_helptext}"),
-            formatter_class=lambda prog: RawDescriptionHelpFormatter(prog, width=80),
+            description=(
+                f"{textwrap.fill(self.description, width=width)}\n"
+                "\n"
+                f"{formats_helptext}"
+            ),
+            formatter_class=lambda prog: RawDescriptionHelpFormatter(prog, width=width),
         )
 
         self.add_default_options(parser)

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -549,7 +549,7 @@ a custom location for Briefcase's tools.
         else:
             formats_helptext = ""
 
-        width = min(shutil.get_terminal_size().columns, 80) - 2
+        width = max(min(shutil.get_terminal_size().columns, 80) - 2, 20)
         parser = argparse.ArgumentParser(
             prog=self.cmd_line.format(
                 command=self.command,

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -8,6 +8,7 @@ from .base import BaseCommand, full_options
 
 class BuildCommand(BaseCommand):
     command = "build"
+    description = "Build an App for a target platform"
 
     def add_options(self, parser):
         self._add_update_options(parser, context_label=" before building")

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -8,7 +8,7 @@ from .base import BaseCommand, full_options
 
 class BuildCommand(BaseCommand):
     command = "build"
-    description = "Build an app for a target platform"
+    description = "Build an app for a target platform."
 
     def add_options(self, parser):
         self._add_update_options(parser, context_label=" before building")

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -8,7 +8,7 @@ from .base import BaseCommand, full_options
 
 class BuildCommand(BaseCommand):
     command = "build"
-    description = "Build an App for a target platform"
+    description = "Build an app for a target platform"
 
     def add_options(self, parser):
         self._add_update_options(parser, context_label=" before building")

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -118,6 +118,7 @@ def write_dist_info(app: BaseConfig, dist_info_path: Path):
 
 class CreateCommand(BaseCommand):
     command = "create"
+    description = "Create a new App for a target platform"
 
     def __init__(self, *args, **options):
         super().__init__(*args, **options)

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -118,7 +118,7 @@ def write_dist_info(app: BaseConfig, dist_info_path: Path):
 
 class CreateCommand(BaseCommand):
     command = "create"
-    description = "Create a new app for a target platform"
+    description = "Create a new app for a target platform."
 
     def __init__(self, *args, **options):
         super().__init__(*args, **options)

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -118,7 +118,7 @@ def write_dist_info(app: BaseConfig, dist_info_path: Path):
 
 class CreateCommand(BaseCommand):
     command = "create"
-    description = "Create a new App for a target platform"
+    description = "Create a new app for a target platform"
 
     def __init__(self, *args, **options):
         super().__init__(*args, **options)

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -15,7 +15,7 @@ class DevCommand(BaseCommand):
     cmd_line = "briefcase dev"
     command = "dev"
     output_format = None
-    description = "Run a briefcase project in the dev environment"
+    description = "Run a Briefcase project in the dev environment"
 
     @property
     def platform(self):

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -15,7 +15,7 @@ class DevCommand(BaseCommand):
     cmd_line = "briefcase dev"
     command = "dev"
     output_format = None
-    description = "Run a Briefcase project in the dev environment"
+    description = "Run a Briefcase project in the dev environment."
 
     @property
     def platform(self):

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -64,7 +64,7 @@ class NewCommand(BaseCommand):
     command = "new"
     platform = "all"
     output_format = None
-    description = "Create a new Briefcase project"
+    description = "Create a new Briefcase project."
 
     def bundle_path(self, app):
         """A placeholder; New command doesn't have a bundle path."""

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -64,7 +64,7 @@ class NewCommand(BaseCommand):
     command = "new"
     platform = "all"
     output_format = None
-    description = "Create a new briefcase project"
+    description = "Create a new Briefcase project"
 
     def bundle_path(self, app):
         """A placeholder; New command doesn't have a bundle path."""

--- a/src/briefcase/commands/open.py
+++ b/src/briefcase/commands/open.py
@@ -7,7 +7,7 @@ from .base import BaseCommand, full_options
 
 class OpenCommand(BaseCommand):
     command = "open"
-    description = "Open an app in the build tool for the target platform"
+    description = "Open an app in the build tool for the target platform."
 
     def _open_app(self, app: BaseConfig):
         if self.tools.host_os == "Windows":

--- a/src/briefcase/commands/open.py
+++ b/src/briefcase/commands/open.py
@@ -7,7 +7,7 @@ from .base import BaseCommand, full_options
 
 class OpenCommand(BaseCommand):
     command = "open"
-    description = "Open an App for manual introspection"
+    description = "Open an app in the build tool for the target platform"
 
     def _open_app(self, app: BaseConfig):
         if self.tools.host_os == "Windows":

--- a/src/briefcase/commands/open.py
+++ b/src/briefcase/commands/open.py
@@ -7,6 +7,7 @@ from .base import BaseCommand, full_options
 
 class OpenCommand(BaseCommand):
     command = "open"
+    description = "Open an App for manual introspection"
 
     def _open_app(self, app: BaseConfig):
         if self.tools.host_os == "Windows":

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -7,6 +7,7 @@ from .base import BaseCommand, full_options
 
 class PackageCommand(BaseCommand):
     command = "package"
+    description = "Package an App for distribution"
 
     @property
     def packaging_formats(self):

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -7,7 +7,7 @@ from .base import BaseCommand, full_options
 
 class PackageCommand(BaseCommand):
     command = "package"
-    description = "Package an app for distribution"
+    description = "Package an app for distribution."
 
     @property
     def packaging_formats(self):

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -7,7 +7,7 @@ from .base import BaseCommand, full_options
 
 class PackageCommand(BaseCommand):
     command = "package"
-    description = "Package an App for distribution"
+    description = "Package an app for distribution"
 
     @property
     def packaging_formats(self):

--- a/src/briefcase/commands/publish.py
+++ b/src/briefcase/commands/publish.py
@@ -6,6 +6,7 @@ from .base import BaseCommand, full_options
 
 class PublishCommand(BaseCommand):
     command = "publish"
+    description = "Publish an App to a deployment"
 
     @property
     def publication_channels(self):

--- a/src/briefcase/commands/publish.py
+++ b/src/briefcase/commands/publish.py
@@ -6,7 +6,7 @@ from .base import BaseCommand, full_options
 
 class PublishCommand(BaseCommand):
     command = "publish"
-    description = "Publish an app to a distribution channel"
+    description = "Publish an app to a distribution channel."
 
     @property
     def publication_channels(self):

--- a/src/briefcase/commands/publish.py
+++ b/src/briefcase/commands/publish.py
@@ -6,7 +6,7 @@ from .base import BaseCommand, full_options
 
 class PublishCommand(BaseCommand):
     command = "publish"
-    description = "Publish an App to a deployment"
+    description = "Publish an app to a distribution channel"
 
     @property
     def publication_channels(self):

--- a/src/briefcase/commands/run.py
+++ b/src/briefcase/commands/run.py
@@ -142,6 +142,7 @@ class LogFilter:
 
 class RunCommand(BaseCommand):
     command = "run"
+    description = "Run a fully built App"
 
     def add_options(self, parser):
         parser.add_argument(

--- a/src/briefcase/commands/run.py
+++ b/src/briefcase/commands/run.py
@@ -142,7 +142,7 @@ class LogFilter:
 
 class RunCommand(BaseCommand):
     command = "run"
-    description = "Run a fully built App"
+    description = "Run an app"
 
     def add_options(self, parser):
         parser.add_argument(

--- a/src/briefcase/commands/run.py
+++ b/src/briefcase/commands/run.py
@@ -142,7 +142,7 @@ class LogFilter:
 
 class RunCommand(BaseCommand):
     command = "run"
-    description = "Run an app"
+    description = "Run an app."
 
     def add_options(self, parser):
         parser.add_argument(

--- a/src/briefcase/commands/update.py
+++ b/src/briefcase/commands/update.py
@@ -8,7 +8,7 @@ from .create import CreateCommand
 
 class UpdateCommand(CreateCommand):
     command = "update"
-    description = "Update the source, dependencies, and resources for an app"
+    description = "Update the source, dependencies, and resources for an app."
 
     def add_options(self, parser):
         self._add_update_options(

--- a/src/briefcase/commands/update.py
+++ b/src/briefcase/commands/update.py
@@ -8,6 +8,7 @@ from .create import CreateCommand
 
 class UpdateCommand(CreateCommand):
     command = "update"
+    description = "Update the source, dependencies, etc. for an App"
 
     def add_options(self, parser):
         self._add_update_options(

--- a/src/briefcase/commands/update.py
+++ b/src/briefcase/commands/update.py
@@ -8,7 +8,7 @@ from .create import CreateCommand
 
 class UpdateCommand(CreateCommand):
     command = "update"
-    description = "Update the source, dependencies, etc. for an App"
+    description = "Update the source, dependencies, and resources for an app"
 
     def add_options(self, parser):
         self._add_update_options(

--- a/src/briefcase/commands/upgrade.py
+++ b/src/briefcase/commands/upgrade.py
@@ -15,7 +15,7 @@ class UpgradeCommand(BaseCommand):
     cmd_line = "briefcase upgrade"
     command = "upgrade"
     output_format = None
-    description = "Upgrade Briefcase-managed tools"
+    description = "Upgrade Briefcase-managed tools."
 
     def __init__(self, *args, **options):
         super().__init__(*args, **options)

--- a/src/briefcase/commands/upgrade.py
+++ b/src/briefcase/commands/upgrade.py
@@ -15,7 +15,7 @@ class UpgradeCommand(BaseCommand):
     cmd_line = "briefcase upgrade"
     command = "upgrade"
     output_format = None
-    description = "Upgrade briefcase-managed tools"
+    description = "Upgrade Briefcase-managed tools"
 
     def __init__(self, *args, **options):
         super().__init__(*args, **options)

--- a/src/briefcase/exceptions.py
+++ b/src/briefcase/exceptions.py
@@ -34,7 +34,7 @@ class InvalidFormatError(BriefcaseError):
         self.choices = choices
 
     def __str__(self):
-        choices = ", ".join(sorted(self.choices))
+        choices = ", ".join(sorted(self.choices, key=str.lower))
         return f"Invalid format '{self.requested}'; (choose from: {choices})"
 
 

--- a/src/briefcase/exceptions.py
+++ b/src/briefcase/exceptions.py
@@ -27,17 +27,6 @@ class NoCommandError(HelpText):
         return self.msg
 
 
-class ShowOutputFormats(InfoHelpText):
-    def __init__(self, platform, default, choices):
-        super().__init__(
-            f"Available formats for {platform}: {', '.join(sorted(choices))}\n"
-            f"Default format: {default}"
-        )
-        self.platform = platform
-        self.default = default
-        self.choices = choices
-
-
 class InvalidFormatError(BriefcaseError):
     def __init__(self, requested, choices):
         super().__init__(error_code=-21, skip_logfile=True)

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -162,7 +162,7 @@ class GradleUpdateCommand(GradleCreateCommand, UpdateCommand):
 
 
 class GradleOpenCommand(GradleMixin, OpenCommand):
-    description = "Open the folder for an Android Gradle project."
+    description = "Open the folder for an existing Android Gradle project."
 
 
 class GradleBuildCommand(GradleMixin, BuildCommand):

--- a/src/briefcase/platforms/iOS/__init__.py
+++ b/src/briefcase/platforms/iOS/__init__.py
@@ -1,7 +1,7 @@
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.xcode import verify_xcode_install
 
-DEFAULT_OUTPUT_FORMAT = "xcode"
+DEFAULT_OUTPUT_FORMAT = "Xcode"
 
 
 class iOSMixin:

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -207,7 +207,9 @@ class LinuxAppImageUpdateCommand(LinuxAppImageCreateCommand, UpdateCommand):
 
 
 class LinuxAppImageOpenCommand(LinuxAppImageMostlyPassiveMixin, OpenCommand):
-    description = "Open the folder containing an existing Linux AppImage project."
+    description = (
+        "Open a shell in a Docker container for an existing Linux AppImage project."
+    )
 
     def _open_app(self, app: AppConfig):
         # If we're using Docker, open an interactive shell in the container

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -41,7 +41,7 @@ class macOSAppUpdateCommand(macOSAppCreateCommand, UpdateCommand):
 
 
 class macOSAppOpenCommand(macOSAppMixin, OpenCommand):
-    description = "Open the app bundle folder for a macOS app."
+    description = "Open the app bundle folder for an existing macOS app."
 
 
 class macOSAppBuildCommand(macOSAppMixin, macOSSigningMixin, BuildCommand):

--- a/src/briefcase/platforms/macOS/xcode.py
+++ b/src/briefcase/platforms/macOS/xcode.py
@@ -58,7 +58,7 @@ class macOSXcodeCreateCommand(macOSXcodeMixin, CreateCommand):
 
 
 class macOSXcodeOpenCommand(macOSXcodeMixin, OpenCommand):
-    description = "Open a macOS Xcode project."
+    description = "Open an existing macOS Xcode project."
 
 
 class macOSXcodeUpdateCommand(macOSXcodeCreateCommand, UpdateCommand):

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -53,7 +53,7 @@ class StaticWebUpdateCommand(StaticWebCreateCommand, UpdateCommand):
 
 
 class StaticWebOpenCommand(StaticWebMixin, OpenCommand):
-    description = "Open an existing static web project."
+    description = "Open the folder containing an existing static web project."
 
 
 class StaticWebBuildCommand(StaticWebMixin, BuildCommand):

--- a/src/briefcase/platforms/windows/app.py
+++ b/src/briefcase/platforms/windows/app.py
@@ -94,11 +94,11 @@ class WindowsAppRunCommand(WindowsAppMixin, WindowsRunCommand):
 
 
 class WindowsAppPackageCommand(WindowsAppMixin, WindowsPackageCommand):
-    description = "Package a Windows App as an MSI."
+    description = "Package a Windows app as an MSI."
 
 
 class WindowsAppPublishCommand(WindowsAppMixin, PublishCommand):
-    description = "Publish a Windows App."
+    description = "Publish a Windows app."
 
 
 # Declare the briefcase command bindings

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -43,9 +43,10 @@ def test_empty():
     assert excinfo.value.msg.startswith(
         "usage: briefcase [-h] <command> [<platform>] [<format>] ...\n"
         "\n"
-        "Package Python code for distribution.\n"
+        "Briefcase is a tool for converting a Python project into a standalone native\n"
+        "application for distribution.\n"
         "\n"
-        "positional arguments:\n"
+        "Commands:\n"
     )
 
 
@@ -57,9 +58,10 @@ def test_help_only():
     assert excinfo.value.msg.startswith(
         "usage: briefcase [-h] <command> [<platform>] [<format>] ...\n"
         "\n"
-        "Package Python code for distribution.\n"
+        "Briefcase is a tool for converting a Python project into a standalone native\n"
+        "application for distribution.\n"
         "\n"
-        "positional arguments:\n"
+        "Commands:\n"
     )
 
 
@@ -83,9 +85,10 @@ def test_show_output_formats_only():
     assert excinfo.value.msg.startswith(
         "usage: briefcase [-h] <command> [<platform>] [<format>] ...\n"
         "\n"
-        "Package Python code for distribution.\n"
+        "Briefcase is a tool for converting a Python project into a standalone native\n"
+        "application for distribution.\n"
         "\n"
-        "positional arguments:\n"
+        "Commands:\n"
     )
 
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -335,7 +335,7 @@ def test_command_unknown_format(monkeypatch, logger, console):
     # Pretend we're on macOS, regardless of where the tests run.
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    expected_exc_regex = r"Invalid format 'foobar'; \(choose from: Xcode, app\)"
+    expected_exc_regex = r"Invalid format 'foobar'; \(choose from: app, Xcode\)"
     with pytest.raises(InvalidFormatError, match=expected_exc_regex):
         do_cmdline_parse("create macOS foobar".split(), logger, console)
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -9,7 +9,6 @@ from briefcase.console import Console, Log
 from briefcase.exceptions import (
     InvalidFormatError,
     NoCommandError,
-    ShowOutputFormats,
     UnsupportedCommandError,
 )
 from briefcase.platforms.linux.appimage import LinuxAppImageCreateCommand
@@ -75,21 +74,6 @@ def test_version_only(capsys):
     # Version is displayed.
     output = capsys.readouterr().out
     assert output == f"{__version__}\n"
-
-
-def test_show_output_formats_only():
-    """``briefcase -f`` returns basic usage as a command is needed."""
-    with pytest.raises(NoCommandError, match=r"usage: briefcase") as excinfo:
-        cmdline.parse_cmdline("-f".split())
-
-    assert excinfo.value.msg.startswith(
-        "usage: briefcase [-h] <command> [<platform>] [<format>] ...\n"
-        "\n"
-        "Briefcase is a tool for converting a Python project into a standalone native\n"
-        "application for distribution.\n"
-        "\n"
-        "Commands:\n"
-    )
 
 
 def test_unknown_command():
@@ -259,20 +243,6 @@ def test_bare_command_version(capsys, logger, console):
     assert output == f"{__version__}\n"
 
 
-def test_bare_command_show_formats(monkeypatch, logger, console):
-    """``briefcase create -f`` returns an error indicating a platform is
-    needed."""
-    # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, "platform", "darwin")
-
-    with pytest.raises(ShowOutputFormats) as excinfo:
-        do_cmdline_parse("create -f".split(), logger, console)
-
-    assert excinfo.value.platform == "macOS"
-    assert excinfo.value.default == "app"
-    assert set(excinfo.value.choices) == {"Xcode", "app"}
-
-
 def test_command_unknown_platform(monkeypatch, logger, console):
     """``briefcase create foobar`` raises an unknown platform error."""
     # Pretend we're on macOS, regardless of where the tests run.
@@ -343,19 +313,6 @@ def test_command_explicit_platform_help(monkeypatch, capsys, logger, console):
     )
 
 
-def test_command_explicit_platform_show_formats(monkeypatch, logger, console):
-    """``briefcase create macOS -f`` shows formats for the platform."""
-    # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, "platform", "darwin")
-
-    with pytest.raises(ShowOutputFormats) as excinfo:
-        do_cmdline_parse("create macOS -f".split(), logger, console)
-
-    assert excinfo.value.platform == "macOS"
-    assert excinfo.value.default == "app"
-    assert set(excinfo.value.choices) == {"Xcode", "app"}
-
-
 def test_command_explicit_format(monkeypatch, logger, console):
     """``briefcase create macOS app`` returns the macOS create app command."""
     # Pretend we're on macOS, regardless of where the tests run.
@@ -420,19 +377,6 @@ def test_command_explicit_format_help(monkeypatch, capsys, logger, console):
         "\n"
         "Create and populate a macOS app.\n"
     )
-
-
-def test_command_explicit_format_show_formats(monkeypatch, logger, console):
-    """``briefcase create macOS app -f`` shows formats for the platform."""
-    # Pretend we're on macOS, regardless of where the tests run.
-    monkeypatch.setattr(sys, "platform", "darwin")
-
-    with pytest.raises(ShowOutputFormats) as excinfo:
-        do_cmdline_parse("create macOS app -f".split(), logger, console)
-
-    assert excinfo.value.platform == "macOS"
-    assert excinfo.value.default == "app"
-    assert set(excinfo.value.choices) == {"Xcode", "app"}
 
 
 def test_command_disable_input(monkeypatch, logger, console):


### PR DESCRIPTION
## Changes
Help text is updated to include:
- Commands and their descriptions for `briefcase` or `briefcase -h`
- Supported platforms for `briefcase` or `briefcase -h`
- Support formats for `briefcase <command> -h`

## Issues
- Fixes #906 
- Fixes #907

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
