### PR TITLE
Corrected configuration of autoclose_loader.

### DIFF
--- a/changes/1004.bugfix.rst
+++ b/changes/1004.bugfix.rst
@@ -1,0 +1,1 @@
+Web project configuration has been updated to reflect recent changes to PyScript.

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -170,7 +170,7 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
                     "name": app.formal_name,
                     "description": app.description,
                     "version": app.version,
-                    "autoclose_loader": True,
+                    "splashscreen": {"autoclose": True},
                     # Ensure that we're using Unix path separators, as the content
                     # will be parsed by pyscript in the browser.
                     "packages": [

--- a/tests/platforms/web/static/test_build.py
+++ b/tests/platforms/web/static/test_build.py
@@ -116,7 +116,7 @@ def test_build_app(build_command, first_app_generated, tmp_path):
             "name": "First App",
             "description": "The first simple app \\ demonstration",
             "version": "0.0.1",
-            "autoclose_loader": True,
+            "splashscreen": {"autoclose": True},
             "packages": [
                 "/static/wheels/dependency-1.2.3-py3-none-any.whl",
                 "/static/wheels/first_app-1.2.3-py3-none-any.whl",
@@ -288,7 +288,7 @@ def test_build_app_no_requirements(build_command, first_app_generated, tmp_path)
             "name": "First App",
             "description": "The first simple app \\ demonstration",
             "version": "0.0.1",
-            "autoclose_loader": True,
+            "splashscreen": {"autoclose": True},
             "packages": [
                 "/static/wheels/first_app-1.2.3-py3-none-any.whl",
             ],


### PR DESCRIPTION
PyScript recently changed the configuration handling for autoclose_loader. This PR modifies the configuration file generated during build to reflect the new format.

Fixes #1004.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
