### PR TITLE
Dependency pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
     - uses: actions/setup-python@v4.4.0
       with:
         python-version: ${{ env.python_version }}
-    # We don't actually want to install briefcase; we just want the test extras
+    # We don't actually want to install briefcase;
+    # we just want the dev extras so we have a known version of tox
     - run: pip install -e .[dev]
     - run: tox -e towncrier-check
 
@@ -55,7 +56,8 @@ jobs:
     - uses: actions/setup-python@v4.4.0
       with:
         python-version: ${{ env.python_version }}
-    # We don't actually want to install briefcase; we just want the test extras
+    # We don't actually want to install briefcase;
+    # we just want the dev extras so we have a known version of tox
     - run: pip install -e .[dev]
     - run: tox -e package
     - uses: actions/upload-artifact@v3
@@ -95,7 +97,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
-        pip install $(ls dist/briefcase-*.whl)[dev,test]
+        pip install $(ls dist/briefcase-*.whl)[dev]
     - name: Test
       run: |
         tox -e py --installpkg dist/*.whl
@@ -127,7 +129,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
-        # We don't actually want to install briefcase; we just want the test extras
+        # We don't actually want to install briefcase;
+        # we just want the test extras so that we have a known version of coverage
         pip install -e .[test]
     - name: Retrieve coverage data
       uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,8 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
         # We don't actually want to install briefcase;
-        # we just want the test extras so that we have a known version of coverage
-        python -m pip install -e .[test]
+        # we just want the dev extras so that we have a known version of coverage
+        python -m pip install -e .[dev]
     - name: Retrieve coverage data
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,13 @@ jobs:
     - uses: actions/setup-python@v4.4.0
       with:
         python-version: ${{ env.python_version }}
-    # We don't actually want to install briefcase;
-    # we just want the dev extras so we have a known version of tox
-    - run: pip install -e .[dev]
-    - run: tox -e towncrier-check
+    - name: Install dev dependencies
+      run: |
+        # We don't actually want to install briefcase;
+        # we just want the dev extras so we have a known version of tox
+        pip install -e .[dev]
+    - name: Run towncrier check
+      run: tox -e towncrier-check
 
   package:
     runs-on: ubuntu-latest
@@ -56,10 +59,13 @@ jobs:
     - uses: actions/setup-python@v4.4.0
       with:
         python-version: ${{ env.python_version }}
-    # We don't actually want to install briefcase;
-    # we just want the dev extras so we have a known version of tox
-    - run: pip install -e .[dev]
-    - run: tox -e package
+    - name: Install dev dependencies
+      run: |
+        # We don't actually want to install briefcase;
+        # we just want the dev extras so we have a known version of tox
+        pip install -e .[dev]
+    - name: Build wheels
+      run: tox -e package
     - uses: actions/upload-artifact@v3
       with:
         name: packages
@@ -93,14 +99,16 @@ jobs:
       with:
         name: packages
         path: dist
-    - name: Install dependencies
+    - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
+        # We don't actually want to install briefcase; we just want the dev
+        # extras so we have a known version of tox and coverage.
         pip install $(ls dist/briefcase-*.whl)[dev]
     - name: Test
       run: |
-        tox -e py --installpkg dist/*.whl
+        tox -e py --installpkg dist/briefcase-*.whl
     - name: Store coverage data
       uses: actions/upload-artifact@v3
       with:
@@ -125,7 +133,7 @@ jobs:
       with:
         # Use latest, so it understands all syntax.
         python-version: "3.10"
-    - name: Install dependencies
+    - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
@@ -203,7 +211,7 @@ jobs:
         name: packages
         path: dist
     - name: Install packages
-      run: pip install dist/*.whl
+      run: pip install dist/briefcase-*.whl
     - name: Create App
       run: |
         cd tests/apps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
     - uses: actions/setup-python@v4.4.0
       with:
         python-version: ${{ env.python_version }}
-    - run: pip install tox~=4.0
+    # We don't actually want to install briefcase; we just want the test extras
+    - run: pip install -e .[dev]
     - run: tox -e towncrier-check
 
   package:
@@ -54,7 +55,8 @@ jobs:
     - uses: actions/setup-python@v4.4.0
       with:
         python-version: ${{ env.python_version }}
-    - run: pip install tox~=4.0
+    # We don't actually want to install briefcase; we just want the test extras
+    - run: pip install -e .[dev]
     - run: tox -e package
     - uses: actions/upload-artifact@v3
       with:
@@ -93,7 +95,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
-        pip install setuptools_scm[toml]~=7.0 tox~=4.0 coverage[toml]~=7.0
+        pip install $(ls dist/briefcase-*.whl)[dev,test]
     - name: Test
       run: |
         tox -e py --installpkg dist/*.whl
@@ -125,7 +127,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
-        pip install coverage[toml]~=7.0
+        # We don't actually want to install briefcase; we just want the test extras
+        pip install -e .[test]
     - name: Retrieve coverage data
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         # We don't actually want to install briefcase;
         # we just want the dev extras so we have a known version of tox
-        pip install -e .[dev]
+        python -m pip install -e .[dev]
     - name: Run towncrier check
       run: tox -e towncrier-check
 
@@ -63,7 +63,7 @@ jobs:
       run: |
         # We don't actually want to install briefcase;
         # we just want the dev extras so we have a known version of tox
-        pip install -e .[dev]
+        python -m pip install -e .[dev]
     - name: Build wheels
       run: tox -e package
     - uses: actions/upload-artifact@v3
@@ -102,10 +102,10 @@ jobs:
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade setuptools
+        python -m pip install --upgrade setuptools
         # We don't actually want to install briefcase; we just want the dev
         # extras so we have a known version of tox and coverage.
-        pip install $(ls dist/briefcase-*.whl)[dev]
+        python -m pip install $(ls dist/briefcase-*.whl)[dev]
     - name: Test
       run: |
         tox -e py --installpkg dist/briefcase-*.whl
@@ -136,10 +136,10 @@ jobs:
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade setuptools
+        python -m pip install --upgrade setuptools
         # We don't actually want to install briefcase;
         # we just want the test extras so that we have a known version of coverage
-        pip install -e .[test]
+        python -m pip install -e .[test]
     - name: Retrieve coverage data
       uses: actions/download-artifact@v3
       with:
@@ -211,7 +211,7 @@ jobs:
         name: packages
         path: dist
     - name: Install packages
-      run: pip install dist/briefcase-*.whl
+      run: python -m pip install dist/briefcase-*.whl
     - name: Create App
       run: |
         cd tests/apps

--- a/changes/1041.bugfix.rst
+++ b/changes/1041.bugfix.rst
@@ -1,0 +1,1 @@
+The way dependency versions are specified has been modified to make Briefcase as accomodating as possible with end-user environments, but as stable as possible for development environments.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,18 +90,6 @@ pygments_style = "sphinx"
 
 # -- Options for HTML output ---------------------------------------------------
 
-# on_rtd: whether we are on readthedocs.org
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    try:
-        import sphinx_rtd_theme
-    except ImportError:
-        html_theme = "default"
-    else:
-        html_theme = "sphinx_rtd_theme"
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
@@ -175,14 +163,7 @@ html_static_path = ["_static"]
 # Output file base name for HTML help builder.
 htmlhelp_basename = "briefcasedoc"
 
-try:
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-except ImportError:
-    # The sphinx-rtd-theme package is not installed, so to the default
-    pass
+html_theme = "furo"
 
 # -- Options for LaTeX output --------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,30 +1,3 @@
-.. raw:: html
-
-    <style>
-        .row {clear: both}
-
-        .column img {border: 1px solid black;}
-
-        @media only screen and (min-width: 1000px),
-               only screen and (min-width: 500px) and (max-width: 768px){
-
-            .column {
-                padding-left: 5px;
-                padding-right: 5px;
-                float: left;
-            }
-
-            .column3  {
-                width: 33.3%;
-            }
-
-            .column2  {
-                width: 50%;
-            }
-        }
-    </style>
-
-
 =========
 Briefcase
 =========
@@ -42,57 +15,39 @@ native application. It supports producing binaries for:
 It is also extensible, allowing for additional platforms and installation
 formats to be produced.
 
-.. rst-class::  row
-
 Table of contents
 =================
-
-.. rst-class:: clearfix row
-
-.. rst-class:: column column2
 
 :ref:`Tutorial <tutorial>`
 --------------------------
 
-Get started with a hands-on introduction for beginners
-
-
-.. rst-class:: column column2
+Get started with a hands-on introduction for beginners.
 
 :ref:`How-to guides <how-to>`
 -----------------------------
 
-Guides and recipes for common problems and tasks, including how to contribute
-
-
-.. rst-class:: column column2
+Guides and recipes for common problems and tasks, including how to contribute.
 
 :ref:`Background <background>`
 ------------------------------
 
-Explanation and discussion of key topics and concepts
-
-
-.. rst-class:: column column2
+Explanation and discussion of key topics and concepts.
 
 :ref:`Reference <reference>`
 ----------------------------
 
-Technical reference - commands, modules, classes, methods
-
-
-.. rst-class:: clearfix row
+Technical reference - commands, modules, classes, methods.
 
 Community
 =========
 
 Briefcase is part of the `BeeWare suite`_. You can talk to the community through:
 
- * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
+* `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
- * `Discord <https://beeware.org/bee/chat/>`__
+* `Discord <https://beeware.org/bee/chat/>`__
 
- * The Briefcase `Github Discussions forum <https://github.com/beeware/briefcase/discussions>`__
+* The Briefcase `Github Discussions forum <https://github.com/beeware/briefcase/discussions>`__
 
 .. _BeeWare suite: http://beeware.org
 .. _Read The Docs: https://briefcase.readthedocs.io

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,6 @@ dev =
     pre-commit == 2.21.0
     setuptools_scm[toml] == 7.0.5
     tox == 4.0.1
-test =
     pytest == 7.2.0
     pytest-tldr == 0.2.5
     coverage[toml] == 7.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,45 +56,50 @@ include_package_data = True
 package_dir =
     = src
 install_requires =
+    # Dependencies required at runtime are set as ranges to ensure maximum
+    # compatibility with the end-user's development environment.
+    #
     # Any dependency that is part of the "core python toolchain" (e.g. pip,
     # wheel) specify a minimum version, but no maximum, because we always want
-    # the most recent version. We use the same approach on projects that use
-    # calver, because the upper version provides no basis for determining API
-    # stability. Projects using semver are pinned to prevent the next major
-    # version (which will potentially cause API breakages), and to allow the
-    # lowest possible minor version that satisfies our API needs.
+    # the most recent version.
+    importlib_metadata >= 4.4; python_version <= "3.9"
+    packaging >= 22.0
     pip >= 22
     setuptools >= 60
     wheel >= 0.37
+    # For the remaining packages: We set the lower version limit to the lowest
+    # possible version that satisfies our API needs. If the package uses semver,
+    # we set a limit to prevent the next major version (which will potentially
+    # cause API breakages). If the package uses calver, we don't pin the upper
+    # version, as the upper version provides no basis for determining API
+    # stability.
     cookiecutter >= 2.1, < 3.0
-    tomli >= 2.0, < 3.0; python_version <= "3.10"
-    importlib_metadata >= 4.4; python_version <= "3.9"
-    requests >= 2.28, < 3.0
-    GitPython >= 3.1, < 4.0
     dmgbuild >= 1.6, < 2.0; sys_platform == "darwin"
-    psutil >= 5.9, < 6.0
-    rich >= 12.6, < 14.0
+    GitPython >= 3.1, < 4.0
     platformdirs >= 2.6, < 3.0
-    packaging >= 22.0
+    psutil >= 5.9, < 6.0
+    requests >= 2.28, < 3.0
+    rich >= 12.6, < 14.0
+    tomli >= 2.0, < 3.0; python_version <= "3.10"
     tomli_w >= 1.0, < 2.0
 
 [options.extras_require]
 # Extras used by developers *of* briefcase are pinned to specific versions to
 # ensure environment consistency.
 dev =
+    coverage[toml] == 7.0.4
     pre-commit == 2.21.0
-    setuptools_scm[toml] == 7.0.5
-    tox == 4.0.1
     pytest == 7.2.0
     pytest-tldr == 0.2.5
-    coverage[toml] == 7.0.4
+    setuptools_scm[toml] == 7.0.5
+    tox == 4.0.1
 docs =
-    sphinx == 6.1.2
-    sphinxcontrib-spelling == 7.7.0
-    pyenchant == 3.2.2
-    sphinx-autobuild == 2021.3.14
     furo == 2022.12.7
+    pyenchant == 3.2.2
+    sphinx == 6.1.2
     sphinx_tabs == 3.4.1
+    sphinx-autobuild == 2021.3.14
+    sphinxcontrib-spelling == 7.7.0
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,17 +59,17 @@ install_requires =
     pip >= 22
     setuptools >= 60
     wheel >= 0.37
-    cookiecutter >= 2.1
-    tomli >= 2.0; python_version <= "3.10"
+    cookiecutter >= 2.1, < 3.0
+    tomli >= 2.0, < 3.0; python_version <= "3.10"
     importlib_metadata >= 4.4; python_version <= "3.9"
-    requests >= 2.28
-    GitPython >= 3.1
-    dmgbuild >= 1.6; sys_platform == "darwin"
-    psutil >= 5.9
-    rich >= 12.6
-    platformdirs >= 2.6
+    requests >= 2.28, < 3.0
+    GitPython >= 3.1, < 4.0
+    dmgbuild >= 1.6, < 2.0; sys_platform == "darwin"
+    psutil >= 5.9, < 6.0
+    rich >= 12.6, < 14.0
+    platformdirs >= 2.6, < 3.0
     packaging >= 22.0
-    tomli_w >= 1.0
+    tomli_w >= 1.0, < 2.0
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,11 +76,10 @@ dev =
     pre-commit == 2.21.0
     setuptools_scm[toml] == 7.0.5
     tox == 4.0.1
-    coverage[toml] == 7.0.4
 test =
     pytest == 7.2.0
     pytest-tldr == 0.2.5
-    pytest-cov == 4.0.0
+    coverage[toml] == 7.0.4
 docs =
     sphinx == 6.1.2
     sphinxcontrib-spelling == 7.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,7 @@ docs =
     sphinxcontrib-spelling == 7.7.0
     pyenchant == 3.2.2
     sphinx-autobuild == 2021.3.14
-    sphinx_rtd_theme == 1.1.1
+    furo == 2022.12.7
     sphinx_tabs == 3.4.1
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,13 @@ include_package_data = True
 package_dir =
     = src
 install_requires =
+    # Any dependency that is part of the "core python toolchain" (e.g. pip,
+    # wheel) specify a minimum version, but no maximum, because we always want
+    # the most recent version. We use the same approach on projects that use
+    # calver, because the upper version provides no basis for determining API
+    # stability. Projects using semver are pinned to prevent the next major
+    # version (which will potentially cause API breakages), and to allow the
+    # lowest possible minor version that satisfies our API needs.
     pip >= 22
     setuptools >= 60
     wheel >= 0.37
@@ -72,6 +79,8 @@ install_requires =
     tomli_w >= 1.0, < 2.0
 
 [options.extras_require]
+# Extras used by developers *of* briefcase are pinned to specific versions to
+# ensure environment consistency.
 dev =
     pre-commit == 2.21.0
     setuptools_scm[toml] == 7.0.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,36 +58,36 @@ package_dir =
 install_requires =
     pip >= 22
     setuptools >= 60
-    wheel ~= 0.37
-    cookiecutter ~= 2.1
-    tomli ~= 2.0; python_version <= "3.10"
+    wheel >= 0.37
+    cookiecutter >= 2.1
+    tomli >= 2.0; python_version <= "3.10"
     importlib_metadata >= 4.4; python_version <= "3.9"
-    requests ~= 2.28
-    GitPython ~= 3.1
-    dmgbuild ~= 1.6; sys_platform == "darwin"
-    psutil ~= 5.9
-    rich ~= 12.6
-    platformdirs ~= 2.6
-    packaging ~= 22.0
-    tomli_w ~= 1.0
+    requests >= 2.28
+    GitPython >= 3.1
+    dmgbuild >= 1.6; sys_platform == "darwin"
+    psutil >= 5.9
+    rich >= 12.6
+    platformdirs >= 2.6
+    packaging >= 22.0
+    tomli_w >= 1.0
 
 [options.extras_require]
 dev =
-    pre-commit~=2.20
-    setuptools_scm[toml] ~= 7.0
-    tox ~= 4.0
-    coverage[toml] ~= 7.0
+    pre-commit == 2.21.0
+    setuptools_scm[toml] == 7.0.5
+    tox == 4.0.1
+    coverage[toml] == 7.0.4
 test =
-    pytest~=7.2
-    pytest-tldr~=0.2
-    pytest-cov~=4.0
+    pytest == 7.2.0
+    pytest-tldr == 0.2.5
+    pytest-cov == 4.0.0
 docs =
-    sphinx~=5.3
-    sphinxcontrib-spelling~=7.7
-    pyenchant~=3.2
-    sphinx-autobuild~=2021.3
-    sphinx_rtd_theme~=1.1
-    sphinx_tabs~=3.3
+    sphinx == 6.1.2
+    sphinxcontrib-spelling == 7.7.0
+    pyenchant == 3.2.2
+    sphinx-autobuild == 2021.3.14
+    sphinx_rtd_theme == 1.1.1
+    sphinx_tabs == 3.4.1
 
 [options.packages.find]
 where = src

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # The leading comma generates the "py" environment.
 [testenv:py{,38,39,310,311,312}]
 extras =
-    test
+    dev
 commands =
     python -m coverage run -m pytest -vv
 


### PR DESCRIPTION
Modify the usage of dependency pins:

* Runtime dependencies are all specified as open ended, with a minimum version. Packages using semver also have an upper version. Packages that are part of the "core python toolchain" (e.g., wheel) do not have an upper pin as we always want the most recent versions those tools. Packages that use calver have no upper pin on the basis that there is no rationale for an upper pin as a basis for API stability.
* Development dependencies are are hard-pinned to a specific version. This ensures development environment consistency.

Updating to the most recent version of Sphinx caused a version incompatibility with the RTD theme; since we've planning to move to Furo on Toga anyway, I figured this is as good a time as any to make that change.

Refs #1026.
Refs #1027.
Refs #1037.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
