### PR TITLE
Correct the branch reference in the README CI badge.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,10 +18,10 @@ Briefcase
    :alt: Maturity
 
 .. image:: https://img.shields.io/pypi/l/briefcase.svg
-   :target: https://github.com/beeware/briefcase/blob/master/LICENSE
+   :target: https://github.com/beeware/briefcase/blob/main/LICENSE
    :alt: BSD License
 
-.. image:: https://github.com/beeware/briefcase/workflows/CI/badge.svg?branch=master
+.. image:: https://github.com/beeware/briefcase/workflows/CI/badge.svg?branch=main
    :target: https://github.com/beeware/briefcase/actions
    :alt: Build Status
 

--- a/changes/1049.misc.rst
+++ b/changes/1049.misc.rst
@@ -1,0 +1,1 @@
+A stale reference to the master branch in README badges was corrected.


### PR DESCRIPTION
An oversight of the master->main conversion - the CI badges in the README still referred to the master branch.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
