### PR TITLE
Ensure cache directory exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
   unit-tests:
     name: Unit tests
     needs: [pre-commit, towncrier, package]
-    runs-on: ${{ fromJSON('{"winstore":"windows"}')[matrix.platform] || matrix.platform }}-latest
+    runs-on: ${{ matrix.platform }}-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
@@ -86,23 +86,23 @@ jobs:
         - python-version: "3.12-dev"
           experimental: true
         # Run tests against the latest Windows Store Python
-        - platform: "winstore"
-          python-version: "3.11"
+        - platform: "windows"
+          python-version: "winstore"
           experimental: false
     steps:
     - uses: actions/checkout@v3.3.0
       with:
         fetch-depth: 0
     - name: Set up Python
-      if: matrix.platform != 'winstore'
+      if: matrix.python-version != 'winstore'
       uses: actions/setup-python@v4.5.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Windows Store Python
-      if: matrix.platform == 'winstore'
+      if: matrix.python-version == 'winstore'
       uses: beeware/.github/.github/actions/install-win-store-python@main
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.11
     - name: Get packages
       uses: actions/download-artifact@v3
       with:
@@ -132,7 +132,7 @@ jobs:
   coverage:
     name: Combine & check coverage.
     runs-on: ubuntu-latest
-    needs: unit-tests
+    needs: [unit-tests]
     steps:
     - uses: actions/checkout@v3.3.0
       with:
@@ -168,7 +168,7 @@ jobs:
 
   verify-apps:
     name: Build apps
-    needs: unit-tests
+    needs: [unit-tests]
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
 
 env:
-  python_version: '3.9'
+  python_version: "3.9"
 
 defaults:
   run:
@@ -75,23 +75,32 @@ jobs:
   unit-tests:
     name: Unit tests
     needs: [pre-commit, towncrier, package]
+    runs-on: ${{ fromJSON('{"winstore":"windows"}')[matrix.platform] || matrix.platform }}-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         platform: ["macos", "ubuntu", "windows"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         include:
-          - experimental: false
-
-          - python-version: "3.12-dev"
-            experimental: true
-    runs-on: ${{ matrix.platform }}-latest
-    continue-on-error: ${{ matrix.experimental }}
+        - experimental: false
+        - python-version: "3.12-dev"
+          experimental: true
+        # Run tests against the latest Windows Store Python
+        - platform: "winstore"
+          python-version: "3.11"
+          experimental: false
     steps:
     - uses: actions/checkout@v3.3.0
       with:
         fetch-depth: 0
     - name: Set up Python
+      if: matrix.platform != 'winstore'
       uses: actions/setup-python@v4.5.0
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Windows Store Python
+      if: matrix.platform == 'winstore'
+      uses: beeware/.github/.github/actions/install-win-store-python@main
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get packages
@@ -123,8 +132,7 @@ jobs:
   coverage:
     name: Combine & check coverage.
     runs-on: ubuntu-latest
-    needs:
-    - unit-tests
+    needs: unit-tests
     steps:
     - uses: actions/checkout@v3.3.0
       with:
@@ -132,7 +140,7 @@ jobs:
     - uses: actions/setup-python@v4.5.0
       with:
         # Use latest, so it understands all syntax.
-        python-version: "3.10"
+        python-version: '3.x'
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip
@@ -161,6 +169,7 @@ jobs:
   verify-apps:
     name: Build apps
     needs: unit-tests
+    runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
         os_name: ['macOS', 'windows', 'linux']
@@ -183,7 +192,6 @@ jobs:
           pip-cache-dir: ~/.cache/pip
           # cache action cannot cache docker images (actions/cache#31)
           # docker-cache-dir: /var/lib/docker
-    runs-on: ${{ matrix.platform }}
     steps:
     - name: Cache Briefcase tools
       uses: actions/cache@v3.2.3

--- a/changes/922.bugfix.rst
+++ b/changes/922.bugfix.rst
@@ -1,1 +1,1 @@
-On Windows, Briefcase now ensures the cache directory is created in %LOCALAPPDATA% instead of the sandboxed location enforced for Windows Store apps.
+When using the Windows Store version of Python, Briefcase now ensures the cache directory is created in %LOCALAPPDATA% instead of the sandboxed location enforced for Windows Store apps.

--- a/changes/922.bugfix.rst
+++ b/changes/922.bugfix.rst
@@ -1,0 +1,1 @@
+On Windows, Briefcase now ensures the cache directory is created in %LOCALAPPDATA% instead of the sandboxed location enforced for Windows Store apps.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 # The leading comma generates the "py" environment.
 [testenv:py{,38,39,310,311,312}]
+passenv =
+    # LOCALAPPDATA is needed to test data directory creation on Windows.
+    LOCALAPPDATA
 extras =
     dev
 commands =


### PR DESCRIPTION
## Changes
- On Windows, create the cache directory with `cmd` to bypass the filesystem redirection of `%LOCALAPPDATA%` enforced for Python installed from the Windows Store.
- For Linux and macOS, the directory is created via `os.makedirs()`.
- Run the unit tests against the latest Windows Store Python.

## Related Issues
- Fixes #922

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
