### PR TITLE
Subprocess `stream_output=False` fixes

### DIFF
--- a/changes/1055.bugfix.rst
+++ b/changes/1055.bugfix.rst
@@ -1,0 +1,1 @@
+To prevent console corruption, dynamic console elements, such as the Wait Bar, are temporarily removed when output streaming is disabled for a command.

--- a/tests/integrations/subprocess/test_ensure_console_is_safe.py
+++ b/tests/integrations/subprocess/test_ensure_console_is_safe.py
@@ -34,7 +34,7 @@ def test_run_windows_batch_script(mock_sub, batch_script):
 def test_check_output_windows_batch_script(mock_sub, batch_script):
     """Console control is released for a Windows batch script in
     check_output."""
-    # Console control is only released on Windows
+    # Console control is only released on Windows for batch scripts
     mock_sub.tools.host_os = "Windows"
 
     with mock_sub.tools.input.wait_bar("Testing..."):
@@ -42,6 +42,30 @@ def test_check_output_windows_batch_script(mock_sub, batch_script):
 
     mock_sub._subprocess.check_output.assert_called_with(
         [batch_script, "World"],
+        text=True,
+        encoding=ANY,
+    )
+    mock_sub.tools.input.release_console_control.assert_called_once()
+
+
+@pytest.mark.parametrize("sub_kwargs", [{"stream_output": True}, {}])
+def test_run_stream_output_true(mock_sub, sub_kwargs):
+    """Console control is not released when stream_output=True or is
+    unspecified."""
+    with mock_sub.tools.input.wait_bar("Testing..."):
+        mock_sub.run(["Hello", "World"], **sub_kwargs)
+
+    mock_sub._run_and_stream_output.assert_called_with(["Hello", "World"])
+    mock_sub.tools.input.release_console_control.assert_not_called()
+
+
+def test_run_stream_output_false(mock_sub):
+    """Console control is released when stream_output=False."""
+    with mock_sub.tools.input.wait_bar("Testing..."):
+        mock_sub.run(["Hello", "World"], stream_output=False)
+
+    mock_sub._subprocess.run.assert_called_with(
+        ["Hello", "World"],
         text=True,
         encoding=ANY,
     )


### PR DESCRIPTION
## Changes
- When `steam_output=False`, disable dynamic console elements such as the Wait Bar.
- Remove condition of console control or output redirection for output streaming a command. These are irrelevant since output streaming will happen regardless unless `stream_output=False`...in which case console control will be released anyway now.

## Related Issues
- Fixes #1055 

## Notes
Looking at the tests and so forth (especially those in `test_Subprocess__run__controlled_console.py`), it seems clear that `stream_output=False` was not expected to actually disable streaming if the console was currently controlled. This was the wrong implementation.....but one that was probably based on the assumption that upstream code would not invoke commands that could not be streamed at the same time the console was controlled (e.g. running an unstreamable command in the Wait Bar). Earlier on, this was probably a reasonable assumption but we've made the framework much more flexible and accommodating since then.

Additionally, when #943 updated the default for `stream_output` from `False` to `True`, it probably should have also reconsidered downstream logic assuming `stream_output` would usually be `False`.

These changes should help streamline all this now.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
