### PR TITLE
Default `stderr=subprocess.STDOUT` for `check_output`

### DIFF
--- a/changes/1059.misc.rst
+++ b/changes/1059.misc.rst
@@ -1,0 +1,1 @@
+For commands invoked with ``Subprocess.check_output()``, any output sent to ``stderr`` is now coalesced with ``stdout`` by default.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -345,7 +345,6 @@ its output for errors.
             self.tools.subprocess.check_output(
                 [os.fsdecode(self.sdkmanager_path), "--list_installed"],
                 env=self.env,
-                stderr=subprocess.STDOUT,
             )
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(
@@ -622,8 +621,7 @@ connection.
             # Capture `stderr` so that if the process exits with failure, the
             # stderr data is in `e.output`.
             output = self.tools.subprocess.check_output(
-                [os.fsdecode(self.emulator_path), "-list-avds"],
-                stderr=subprocess.STDOUT,
+                [os.fsdecode(self.emulator_path), "-list-avds"]
             ).strip()
 
             # AVD names are returned one per line.
@@ -639,8 +637,7 @@ connection.
             # Capture `stderr` so that if the process exits with failure, the
             # stderr data is in `e.output`.
             output = self.tools.subprocess.check_output(
-                [os.fsdecode(self.adb_path), "devices", "-l"],
-                stderr=subprocess.STDOUT,
+                [os.fsdecode(self.adb_path), "devices", "-l"]
             ).strip()
 
             # Process the output of `adb devices -l`.
@@ -1000,7 +997,6 @@ In future, you can specify this device by running:
                         device_type,
                     ],
                     env=self.env,
-                    stderr=subprocess.STDOUT,
                 )
             except subprocess.CalledProcessError as e:
                 raise BriefcaseCommandError("Unable to create Android emulator") from e
@@ -1253,7 +1249,6 @@ class ADB:
                     (os.fsdecode(arg) if isinstance(arg, Path) else arg)
                     for arg in arguments
                 ],
-                stderr=subprocess.STDOUT,
                 quiet=quiet,
             )
         except subprocess.CalledProcessError as e:

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -125,10 +125,7 @@ installation, and try again.
         # Verify Docker version is compatible.
         try:
             # Try to get the version of docker that is installed.
-            output = tools.subprocess.check_output(
-                ["docker", "--version"],
-                stderr=subprocess.STDOUT,
-            ).strip("\n")
+            output = tools.subprocess.check_output(["docker", "--version"]).strip("\n")
 
             # Do a simple check that the docker that was invoked
             # actually looks like the real deal, and is a version that
@@ -162,10 +159,7 @@ installation, and try again.
             # Invoke a docker command to check if the daemon is running,
             # and the user has sufficient permissions.
             # We don't care about the output, just that it succeeds.
-            tools.subprocess.check_output(
-                ["docker", "info"],
-                stderr=subprocess.STDOUT,
-            )
+            tools.subprocess.check_output(["docker", "info"])
         except subprocess.CalledProcessError as e:
             failure_output = e.output
             if "permission denied while trying to connect" in failure_output:

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -80,7 +80,6 @@ class JDK(Tool):
                 # raises an error.
                 java_home = tools.subprocess.check_output(
                     ["/usr/libexec/java_home"],
-                    stderr=subprocess.STDOUT,
                 ).strip("\n")
             except subprocess.CalledProcessError:
                 # No java on this machine.
@@ -95,7 +94,6 @@ class JDK(Tool):
                         os.fsdecode(Path(java_home) / "bin" / "javac"),
                         "-version",
                     ],
-                    stderr=subprocess.STDOUT,
                 )
                 # This should be a string of the form "javac 1.8.0_144\n"
                 version_str = output.strip("\n").split(" ")[1]
@@ -292,14 +290,12 @@ Delete {jdk_zip_path} and run briefcase again.
     @classmethod
     def verify_rosetta(cls, tools):
         try:
-            tools.subprocess.check_output(
-                ["arch", "-x86_64", "true"], stderr=subprocess.STDOUT
-            )
+            tools.subprocess.check_output(["arch", "-x86_64", "true"])
         except subprocess.CalledProcessError:
             tools.logger.info(
                 """\
-This command requires Rosetta, but it does not appear to be installed. Briefcase will
-attempt to install it now.
+This command requires Rosetta, but it does not appear to be installed.
+Briefcase will attempt to install it now.
 """
             )
             try:

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -464,6 +464,8 @@ class Subprocess(Tool):
            environment.
          - The `text` argument is defaulted to True so all output
            is returned as strings instead of bytes.
+         - The `stderr` argument is defaulted to `stdout` so _all_ output is
+           returned and `stderr` isn't unexpectedly printed to the console.
 
         :param quiet: Should the invocation of this command be silent, and
             *not* appear in the logs? This should almost always be False;
@@ -472,6 +474,9 @@ class Subprocess(Tool):
             be turned off so that log output isn't corrupted by thousands of
             polling calls.
         """
+        # if stderr isn't explicitly redirected, then send it to stdout.
+        kwargs.setdefault("stderr", subprocess.STDOUT)
+
         if not quiet:
             self._log_command(args)
             self._log_cwd(kwargs.get("cwd"))

--- a/src/briefcase/integrations/visualstudio.py
+++ b/src/briefcase/integrations/visualstudio.py
@@ -59,10 +59,7 @@ class VisualStudio(Tool):
 
         # Try running MSBuild, assuming it is on the PATH.
         try:
-            tools.subprocess.check_output(
-                ["MSBuild.exe", "--version"],
-                stderr=subprocess.STDOUT,
-            )
+            tools.subprocess.check_output(["MSBuild.exe", "--version"])
 
             # Create an explicit VisualStudio, with no install metadata
             visualstudio = VisualStudio(tools, msbuild_path=Path("MSBuild.exe"))
@@ -176,10 +173,7 @@ Then restart Briefcase.
 
             # Try to invoke MSBuild at the established location
             try:
-                tools.subprocess.check_output(
-                    [msbuild_path, "--version"],
-                    stderr=subprocess.STDOUT,
-                )
+                tools.subprocess.check_output([msbuild_path, "--version"])
             except subprocess.CalledProcessError:
                 raise BriefcaseCommandError(
                     "MSBuild appears to exist, but Briefcase can't start it."

--- a/src/briefcase/integrations/xcode.py
+++ b/src/briefcase/integrations/xcode.py
@@ -85,10 +85,7 @@ def ensure_command_line_tools_are_installed(tools: ToolCache):
     #
     # Any other status code is a problem.
     try:
-        tools.subprocess.check_output(
-            ["xcode-select", "--install"],
-            stderr=subprocess.STDOUT,
-        )
+        tools.subprocess.check_output(["xcode-select", "--install"])
         raise BriefcaseCommandError(
             """\
 Xcode command line developer tools are not installed.
@@ -148,10 +145,7 @@ def ensure_xcode_is_installed(
     #  * The path to the currently active Xcode install; or
     #  * error code 2 - No Xcode installation
     try:
-        tools.subprocess.check_output(
-            ["xcode-select", "-p"],
-            stderr=subprocess.STDOUT,
-        )
+        tools.subprocess.check_output(["xcode-select", "-p"])
     except subprocess.CalledProcessError as e:
         raise BriefcaseCommandError(
             """\
@@ -173,10 +167,7 @@ you can re-run Briefcase.
         #   xcode-select: error: tool 'xcodebuild' requires Xcode, but active
         #   developer directory '/Library/Developer/CommandLineTools' is a
         #   command line tools instance
-        output = tools.subprocess.check_output(
-            ["xcodebuild", "-version"],
-            stderr=subprocess.STDOUT,
-        )
+        output = tools.subprocess.check_output(["xcodebuild", "-version"])
 
         if min_version is not None:
             # Look for a line in the output that reads "Xcode X.Y.Z"
@@ -285,10 +276,7 @@ def confirm_xcode_license_accepted(tools: ToolCache):
     # tools return a status code of 69 (nice...) if the license has not been
     # accepted. In this case, we can prompt the user to accept the license.
     try:
-        tools.subprocess.check_output(
-            ["/usr/bin/clang", "--version"],
-            stderr=subprocess.STDOUT,
-        )
+        tools.subprocess.check_output(["/usr/bin/clang", "--version"])
     except subprocess.CalledProcessError as e:
         if e.returncode == 69:
             tools.logger.info(

--- a/tests/integrations/android_sdk/ADB/test_kill.py
+++ b/tests/integrations/android_sdk/ADB/test_kill.py
@@ -25,7 +25,6 @@ def test_kill(mock_tools):
             "emu",
             "kill",
         ],
-        stderr=subprocess.STDOUT,
         quiet=False,
     )
 

--- a/tests/integrations/android_sdk/ADB/test_run.py
+++ b/tests/integrations/android_sdk/ADB/test_run.py
@@ -30,7 +30,6 @@ def test_simple_command(mock_tools, tmp_path):
             "example",
             "command",
         ],
-        stderr=subprocess.STDOUT,
         quiet=False,
     )
 
@@ -56,7 +55,6 @@ def test_quiet_command(mock_tools, tmp_path):
             "example",
             "command",
         ],
-        stderr=subprocess.STDOUT,
         quiet=True,
     )
 
@@ -107,6 +105,5 @@ def test_error_handling(mock_tools, tmp_path, name, exception):
             "example",
             "command",
         ],
-        stderr=subprocess.STDOUT,
         quiet=False,
     )

--- a/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
@@ -103,7 +103,6 @@ def test_create_emulator(
             "slab",
         ],
         env=android_sdk.env,
-        stderr=subprocess.STDOUT,
     )
 
     # Emulator configuration file has been appended.
@@ -178,7 +177,6 @@ def test_create_emulator_with_defaults(
             "pixel",
         ],
         env=android_sdk.env,
-        stderr=subprocess.STDOUT,
     )
 
     # Emulator configuration file has been appended.
@@ -226,7 +224,6 @@ def test_create_failure(mock_tools, android_sdk):
             "pixel",
         ],
         env=android_sdk.env,
-        stderr=subprocess.STDOUT,
     )
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_list_packages.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_list_packages.py
@@ -14,7 +14,6 @@ def test_list_packages(mock_tools, android_sdk):
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(android_sdk.sdkmanager_path), "--list_installed"],
         env=android_sdk.env,
-        stderr=subprocess.STDOUT,
     )
 
 
@@ -29,5 +28,4 @@ def test_list_packages_failure(mock_tools, android_sdk):
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(android_sdk.sdkmanager_path), "--list_installed"],
         env=android_sdk.env,
-        stderr=subprocess.STDOUT,
     )

--- a/tests/integrations/docker/test_DockerAppContext__check_output.py
+++ b/tests/integrations/docker/test_DockerAppContext__check_output.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import ANY
@@ -25,6 +26,7 @@ def test_simple_call(mock_docker_app_context, tmp_path, capsys):
         ],
         text=True,
         encoding=ANY,
+        stderr=subprocess.STDOUT,
     )
     assert capsys.readouterr().out == ""
 
@@ -61,6 +63,7 @@ def test_extra_mounts(mock_docker_app_context, tmp_path, capsys):
         ],
         text=True,
         encoding=ANY,
+        stderr=subprocess.STDOUT,
     )
     assert capsys.readouterr().out == ""
 
@@ -97,6 +100,7 @@ def test_call_with_arg_and_env(mock_docker_app_context, tmp_path, capsys):
         ],
         universal_newlines=True,
         encoding=ANY,
+        stderr=subprocess.STDOUT,
     )
     assert capsys.readouterr().out == ""
 
@@ -138,6 +142,7 @@ def test_call_with_path_arg_and_env(mock_docker_app_context, tmp_path, capsys):
         cwd=os.fsdecode(tmp_path / "cwd"),
         text=True,
         encoding=ANY,
+        stderr=subprocess.STDOUT,
     )
     assert capsys.readouterr().out == ""
 
@@ -166,6 +171,7 @@ def test_simple_verbose_call(mock_docker_app_context, tmp_path, capsys):
         ],
         text=True,
         encoding=ANY,
+        stderr=subprocess.STDOUT,
     )
     assert capsys.readouterr().out == (
         "\n"

--- a/tests/integrations/docker/test_Docker__verify.py
+++ b/tests/integrations/docker/test_Docker__verify.py
@@ -53,14 +53,8 @@ def test_docker_exists(mock_tools, valid_docker_version, capsys):
 
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(
-                ["docker", "--version"],
-                stderr=subprocess.STDOUT,
-            ),
-            call(
-                ["docker", "info"],
-                stderr=subprocess.STDOUT,
-            ),
+            call(["docker", "--version"]),
+            call(["docker", "info"]),
         ]
     )
 
@@ -80,10 +74,7 @@ def test_docker_doesnt_exist(mock_tools):
         Docker.verify(mock_tools)
 
     # But docker was invoked
-    mock_tools.subprocess.check_output.assert_called_with(
-        ["docker", "--version"],
-        stderr=subprocess.STDOUT,
-    )
+    mock_tools.subprocess.check_output.assert_called_with(["docker", "--version"])
 
 
 def test_docker_failure(mock_tools, capsys):
@@ -106,14 +97,8 @@ def test_docker_failure(mock_tools, capsys):
 
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(
-                ["docker", "--version"],
-                stderr=subprocess.STDOUT,
-            ),
-            call(
-                ["docker", "info"],
-                stderr=subprocess.STDOUT,
-            ),
+            call(["docker", "--version"]),
+            call(["docker", "info"]),
         ]
     )
 
@@ -150,14 +135,8 @@ def test_docker_unknown_version(mock_tools, capsys):
 
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(
-                ["docker", "--version"],
-                stderr=subprocess.STDOUT,
-            ),
-            call(
-                ["docker", "info"],
-                stderr=subprocess.STDOUT,
-            ),
+            call(["docker", "--version"]),
+            call(["docker", "info"]),
         ]
     )
 

--- a/tests/integrations/java/test_JDK__verify.py
+++ b/tests/integrations/java/test_JDK__verify.py
@@ -10,10 +10,11 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError, MissingToolError, NetworkFailure
 from briefcase.integrations.java import JDK
 
-CALL_JAVA_HOME = mock.call(["/usr/libexec/java_home"], stderr=subprocess.STDOUT)
-CALL_ROSETTA_CHECK = mock.call(["arch", "-x86_64", "true"], stderr=subprocess.STDOUT)
+CALL_JAVA_HOME = mock.call(["/usr/libexec/java_home"])
+CALL_ROSETTA_CHECK = mock.call(["arch", "-x86_64", "true"])
 CALL_ROSETTA_INSTALL = mock.call(
-    ["softwareupdate", "--install-rosetta", "--agree-to-license"], check=True
+    ["softwareupdate", "--install-rosetta", "--agree-to-license"],
+    check=True,
 )
 
 
@@ -50,10 +51,7 @@ def test_macos_tool_java_home(mock_tools, capsys):
     assert mock_tools.subprocess.check_output.mock_calls == [
         CALL_JAVA_HOME,
         # Second is a call to verify a valid Java version
-        mock.call(
-            [os.fsdecode(Path("/path/to/java/bin/javac")), "-version"],
-            stderr=subprocess.STDOUT,
-        ),
+        mock.call([os.fsdecode(Path("/path/to/java/bin/javac")), "-version"]),
     ]
 
     # No console output
@@ -115,7 +113,6 @@ def test_macos_provided_overrides_tool_java_home(mock_tools, capsys):
     # A single call to check output
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(Path("/path/to/java/bin/javac")), "-version"],
-        stderr=subprocess.STDOUT,
     ),
 
     # No console output
@@ -144,7 +141,6 @@ def test_valid_provided_java_home(mock_tools, capsys):
     # A single call to check output
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(Path("/path/to/java/bin/javac")), "-version"],
-        stderr=subprocess.STDOUT,
     ),
 
     # No console output
@@ -188,7 +184,6 @@ def test_invalid_jdk_version(mock_tools, host_os, java_home, tmp_path, capsys):
     # A single call was made to check javac
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(Path("/path/to/java/bin/javac")), "-version"],
-        stderr=subprocess.STDOUT,
     )
 
     # No console output (because Briefcase JDK exists)
@@ -232,7 +227,6 @@ def test_no_javac(mock_tools, host_os, java_home, tmp_path, capsys):
     # A single call was made to check javac
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(Path("/path/to/nowhere/bin/javac")), "-version"],
-        stderr=subprocess.STDOUT,
     ),
 
     # No console output (because Briefcase JDK exists)
@@ -277,7 +271,6 @@ def test_javac_error(mock_tools, host_os, java_home, tmp_path, capsys):
     # A single call was made to check javac
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(Path("/path/to/nowhere/bin/javac")), "-version"],
-        stderr=subprocess.STDOUT,
     ),
 
     # No console output (because Briefcase JDK exists)
@@ -320,7 +313,6 @@ def test_unparseable_javac_version(mock_tools, host_os, java_home, tmp_path, cap
     # A single call was made to check javac
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(Path("/path/to/nowhere/bin/javac")), "-version"],
-        stderr=subprocess.STDOUT,
     ),
 
     # No console output (because Briefcase JDK exists)

--- a/tests/integrations/subprocess/test_Subprocess__parse_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__parse_output.py
@@ -1,3 +1,4 @@
+import subprocess
 from unittest.mock import ANY
 
 import pytest
@@ -35,6 +36,7 @@ def test_call(mock_sub, capsys):
         ["hello", "world"],
         text=True,
         encoding=ANY,
+        stderr=subprocess.STDOUT,
     )
     assert capsys.readouterr().out == ""
 
@@ -53,6 +55,7 @@ def test_call_with_arg(mock_sub, capsys):
         extra_arg="asdf",
         text=True,
         encoding=ANY,
+        stderr=subprocess.STDOUT,
     )
     assert capsys.readouterr().out == ""
 
@@ -68,6 +71,7 @@ def test_call_with_parser_success(mock_sub, capsys):
         ["hello", "world"],
         text=True,
         encoding=ANY,
+        stderr=subprocess.STDOUT,
     )
     assert output == "more output line 2"
 
@@ -85,6 +89,7 @@ def test_call_with_parser_error(mock_sub, capsys):
         ["hello", "world"],
         text=True,
         encoding=ANY,
+        stderr=subprocess.STDOUT,
     )
     expected_output = (
         "\n"
@@ -114,4 +119,6 @@ def test_text_eq_true_default_overriding(mock_sub, in_kwargs, kwargs):
     override text=true default."""
 
     mock_sub.parse_output(splitlines_parser, ["hello", "world"], **in_kwargs)
-    mock_sub._subprocess.check_output.assert_called_with(["hello", "world"], **kwargs)
+    mock_sub._subprocess.check_output.assert_called_with(
+        ["hello", "world"], stderr=subprocess.STDOUT, **kwargs
+    )

--- a/tests/integrations/subprocess/test_ensure_console_is_safe.py
+++ b/tests/integrations/subprocess/test_ensure_console_is_safe.py
@@ -44,6 +44,7 @@ def test_check_output_windows_batch_script(mock_sub, batch_script):
         [batch_script, "World"],
         text=True,
         encoding=ANY,
+        stderr=subprocess.STDOUT,
     )
     mock_sub.tools.input.release_console_control.assert_called_once()
 
@@ -92,6 +93,7 @@ def test_negative_condition_not_controlled(mock_sub, cmdline, kwargs):
         **kwargs,
         text=True,
         encoding=ANY,
+        stderr=subprocess.STDOUT,
     )
 
     mock_sub.tools.input.release_console_control.assert_not_called()
@@ -118,5 +120,6 @@ def test_negative_condition_controlled(mock_sub, cmdline, kwargs):
         **kwargs,
         text=True,
         encoding=ANY,
+        stderr=subprocess.STDOUT,
     )
     mock_sub.tools.input.release_console_control.assert_not_called()

--- a/tests/integrations/visualstudio/test_VisualStudio__verify.py
+++ b/tests/integrations/visualstudio/test_VisualStudio__verify.py
@@ -83,7 +83,7 @@ def test_msbuild_on_path(mock_tools):
 
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
-        [call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT)],
+        [call(["MSBuild.exe", "--version"])],
         any_order=False,
     )
 
@@ -106,7 +106,7 @@ def test_msbuild_on_path_corrupt(mock_tools):
 
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
-        [call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT)],
+        [call(["MSBuild.exe", "--version"])],
         any_order=False,
     )
 
@@ -133,8 +133,8 @@ def test_msbuild_envvar(mock_tools, custom_msbuild_path):
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT),
-            call([custom_msbuild_path, "--version"], stderr=subprocess.STDOUT),
+            call(["MSBuild.exe", "--version"]),
+            call([custom_msbuild_path, "--version"]),
         ],
         any_order=False,
     )
@@ -159,7 +159,7 @@ def test_msbuild_envvar_doesnt_exist(mock_tools, tmp_path):
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT),
+            call(["MSBuild.exe", "--version"]),
         ],
         any_order=False,
     )
@@ -187,8 +187,8 @@ def test_msbuild_envvar_bad_executable(mock_tools, custom_msbuild_path):
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT),
-            call([custom_msbuild_path, "--version"], stderr=subprocess.STDOUT),
+            call(["MSBuild.exe", "--version"]),
+            call([custom_msbuild_path, "--version"]),
         ],
         any_order=False,
     )
@@ -209,7 +209,7 @@ def test_vswhere_does_not_exist(mock_tools):
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT),
+            call(["MSBuild.exe", "--version"]),
         ],
         any_order=False,
     )
@@ -233,7 +233,7 @@ def test_vswhere_bad_executable(mock_tools, vswhere_path):
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT),
+            call(["MSBuild.exe", "--version"]),
             call(
                 [vswhere_path, "-latest", "-prerelease", "-format", "json"],
                 stderr=subprocess.STDOUT,
@@ -262,7 +262,7 @@ def test_vswhere_bad_content(mock_tools, vswhere_path):
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT),
+            call(["MSBuild.exe", "--version"]),
             call(
                 [vswhere_path, "-latest", "-prerelease", "-format", "json"],
                 stderr=subprocess.STDOUT,
@@ -291,7 +291,7 @@ def test_vswhere_non_list_content(mock_tools, vswhere_path):
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT),
+            call(["MSBuild.exe", "--version"]),
             call(
                 [vswhere_path, "-latest", "-prerelease", "-format", "json"],
                 stderr=subprocess.STDOUT,
@@ -320,7 +320,7 @@ def test_vswhere_empty_list_content(mock_tools, vswhere_path):
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT),
+            call(["MSBuild.exe", "--version"]),
             call(
                 [vswhere_path, "-latest", "-prerelease", "-format", "json"],
                 stderr=subprocess.STDOUT,
@@ -357,7 +357,7 @@ def test_vswhere_msbuild_not_installed(mock_tools, tmp_path, vswhere_path):
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT),
+            call(["MSBuild.exe", "--version"]),
             call(
                 [vswhere_path, "-latest", "-prerelease", "-format", "json"],
                 stderr=subprocess.STDOUT,
@@ -403,12 +403,12 @@ def test_vswhere_msbuild_bad_executable(
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT),
+            call(["MSBuild.exe", "--version"]),
             call(
                 [vswhere_path, "-latest", "-prerelease", "-format", "json"],
                 stderr=subprocess.STDOUT,
             ),
-            call([msbuild_path, "--version"], stderr=subprocess.STDOUT),
+            call([msbuild_path, "--version"]),
         ],
         any_order=False,
     )
@@ -441,12 +441,12 @@ def test_vswhere_install(mock_tools, tmp_path, vswhere_path, msbuild_path):
     # Verification calls are as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            call(["MSBuild.exe", "--version"], stderr=subprocess.STDOUT),
+            call(["MSBuild.exe", "--version"]),
             call(
                 [vswhere_path, "-latest", "-prerelease", "-format", "json"],
                 stderr=subprocess.STDOUT,
             ),
-            call([msbuild_path, "--version"], stderr=subprocess.STDOUT),
+            call([msbuild_path, "--version"]),
         ],
         any_order=False,
     )

--- a/tests/integrations/xcode/test_confirm_xcode_license_accepted.py
+++ b/tests/integrations/xcode/test_confirm_xcode_license_accepted.py
@@ -13,8 +13,7 @@ def test_license_accepted(capsys, mock_tools):
 
     # ... clang was invoked ...
     mock_tools.subprocess.check_output.assert_called_once_with(
-        ["/usr/bin/clang", "--version"],
-        stderr=subprocess.STDOUT,
+        ["/usr/bin/clang", "--version"]
     )
 
     # ... and the user is none the wiser
@@ -26,7 +25,8 @@ def test_unknown_error(capsys, mock_tools):
     """If an unexpected problem occurred accepting the license, warn the
     user."""
     mock_tools.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        cmd=["/usr/bin/clang", "--version"], returncode=1
+        cmd=["/usr/bin/clang", "--version"],
+        returncode=1,
     )
 
     # Check passes without an error...
@@ -35,7 +35,6 @@ def test_unknown_error(capsys, mock_tools):
     # ... clang was invoked ...
     mock_tools.subprocess.check_output.assert_called_once_with(
         ["/usr/bin/clang", "--version"],
-        stderr=subprocess.STDOUT,
     )
 
     # ...but stdout contains a warning
@@ -46,7 +45,8 @@ def test_unknown_error(capsys, mock_tools):
 def test_accept_license(mock_tools):
     """If the user accepts the license, continue without error."""
     mock_tools.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        cmd=["/usr/bin/clang", "--version"], returncode=69
+        cmd=["/usr/bin/clang", "--version"],
+        returncode=69,
     )
 
     # Check passes without an error...
@@ -55,7 +55,6 @@ def test_accept_license(mock_tools):
     # ... clang *and* xcodebuild were invoked ...
     mock_tools.subprocess.check_output.assert_called_once_with(
         ["/usr/bin/clang", "--version"],
-        stderr=subprocess.STDOUT,
     )
     mock_tools.subprocess.run.assert_called_once_with(
         ["sudo", "xcodebuild", "-license"],
@@ -67,10 +66,12 @@ def test_accept_license(mock_tools):
 def test_sudo_fail(mock_tools):
     """If the sudo call fails, an exception is raised."""
     mock_tools.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        cmd=["/usr/bin/clang", "--version"], returncode=69
+        cmd=["/usr/bin/clang", "--version"],
+        returncode=69,
     )
     mock_tools.subprocess.run.side_effect = subprocess.CalledProcessError(
-        cmd=["sudo", "xcodebuild", "-license"], returncode=1
+        cmd=["sudo", "xcodebuild", "-license"],
+        returncode=1,
     )
 
     # Check raises an error:
@@ -83,7 +84,6 @@ def test_sudo_fail(mock_tools):
     # ... clang *and* xcodebuild were invoked ...
     mock_tools.subprocess.check_output.assert_called_once_with(
         ["/usr/bin/clang", "--version"],
-        stderr=subprocess.STDOUT,
     )
     mock_tools.subprocess.run.assert_called_once_with(
         ["sudo", "xcodebuild", "-license"],
@@ -95,10 +95,12 @@ def test_sudo_fail(mock_tools):
 def test_license_not_accepted(mock_tools):
     """If the sudo call fails, an exception is raised."""
     mock_tools.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        cmd=["/usr/bin/clang", "--version"], returncode=69
+        cmd=["/usr/bin/clang", "--version"],
+        returncode=69,
     )
     mock_tools.subprocess.run.side_effect = subprocess.CalledProcessError(
-        cmd=["sudo", "xcodebuild", "-license"], returncode=69
+        cmd=["sudo", "xcodebuild", "-license"],
+        returncode=69,
     )
 
     # Check raises an error:
@@ -110,7 +112,6 @@ def test_license_not_accepted(mock_tools):
     # ... clang *and* xcodebuild were invoked ...
     mock_tools.subprocess.check_output.assert_called_once_with(
         ["/usr/bin/clang", "--version"],
-        stderr=subprocess.STDOUT,
     )
     mock_tools.subprocess.run.assert_called_once_with(
         ["sudo", "xcodebuild", "-license"],
@@ -122,10 +123,12 @@ def test_license_not_accepted(mock_tools):
 def test_license_status_unknown(capsys, mock_tools):
     """If we get an unusual response from the license, warn but continue."""
     mock_tools.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        cmd=["/usr/bin/clang", "--version"], returncode=69
+        cmd=["/usr/bin/clang", "--version"],
+        returncode=69,
     )
     mock_tools.subprocess.run.side_effect = subprocess.CalledProcessError(
-        cmd=["sudo", "xcodebuild", "-license"], returncode=42
+        cmd=["sudo", "xcodebuild", "-license"],
+        returncode=42,
     )
 
     # Check passes without error...
@@ -134,7 +137,6 @@ def test_license_status_unknown(capsys, mock_tools):
     # ... clang *and* xcodebuild were invoked ...
     mock_tools.subprocess.check_output.assert_called_once_with(
         ["/usr/bin/clang", "--version"],
-        stderr=subprocess.STDOUT,
     )
     mock_tools.subprocess.run.assert_called_once_with(
         ["sudo", "xcodebuild", "-license"],

--- a/tests/integrations/xcode/test_ensure_command_line_tools_are_installed.py
+++ b/tests/integrations/xcode/test_ensure_command_line_tools_are_installed.py
@@ -14,14 +14,14 @@ def test_not_installed(mock_tools):
     # xcode-select was invoked
     mock_tools.subprocess.check_output.assert_called_once_with(
         ["xcode-select", "--install"],
-        stderr=subprocess.STDOUT,
     )
 
 
 def test_installed(capsys, mock_tools):
     """If cmdline dev tools *are* installed, check passes without comment."""
     mock_tools.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        cmd=["xcode-select", "--install"], returncode=1
+        cmd=["xcode-select", "--install"],
+        returncode=1,
     )
 
     # Check passes without an error...
@@ -30,7 +30,6 @@ def test_installed(capsys, mock_tools):
     # ... xcode-select was invoked
     mock_tools.subprocess.check_output.assert_called_once_with(
         ["xcode-select", "--install"],
-        stderr=subprocess.STDOUT,
     )
 
     # ...and the user is none the wiser
@@ -41,7 +40,8 @@ def test_installed(capsys, mock_tools):
 def test_unsure_if_installed(capsys, mock_tools):
     """If xcode-select returns something odd, mention it but don't break."""
     mock_tools.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        cmd=["xcode-select", "--install"], returncode=69
+        cmd=["xcode-select", "--install"],
+        returncode=69,
     )
 
     # Check passes without an error...
@@ -49,8 +49,7 @@ def test_unsure_if_installed(capsys, mock_tools):
 
     # ... xcode-select was invoked
     mock_tools.subprocess.check_output.assert_called_once_with(
-        ["xcode-select", "--install"],
-        stderr=subprocess.STDOUT,
+        ["xcode-select", "--install"]
     )
 
     # ...but stdout contains a warning

--- a/tests/integrations/xcode/test_ensure_xcode_is_installed.py
+++ b/tests/integrations/xcode/test_ensure_xcode_is_installed.py
@@ -23,7 +23,8 @@ def xcode(default_xcode_install_path):
 def test_not_installed(tmp_path, mock_tools):
     """If No Xcode is installed, raise an error."""
     mock_tools.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        cmd=["xcode-select", "-p"], returncode=2
+        cmd=["xcode-select", "-p"],
+        returncode=2,
     )
 
     # Test a location where Xcode *won't* be installed
@@ -32,12 +33,7 @@ def test_not_installed(tmp_path, mock_tools):
 
     # subprocess was invoked as expected
     mock_tools.subprocess.check_output.assert_has_calls(
-        [
-            mock.call(
-                ["xcode-select", "-p"],
-                stderr=subprocess.STDOUT,
-            ),
-        ],
+        [mock.call(["xcode-select", "-p"])],
         any_order=False,
     )
 
@@ -58,14 +54,8 @@ def test_custom_install_location(default_xcode_install_path, tmp_path, mock_tool
     # subprocess was invoked as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            mock.call(
-                ["xcode-select", "-p"],
-                stderr=subprocess.STDOUT,
-            ),
-            mock.call(
-                ["xcodebuild", "-version"],
-                stderr=subprocess.STDOUT,
-            ),
+            mock.call(["xcode-select", "-p"]),
+            mock.call(["xcodebuild", "-version"]),
         ],
         any_order=False,
     )
@@ -93,14 +83,8 @@ def test_command_line_tools_only(default_xcode_install_path, mock_tools):
     # subprocess was invoked as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            mock.call(
-                ["xcode-select", "-p"],
-                stderr=subprocess.STDOUT,
-            ),
-            mock.call(
-                ["xcodebuild", "-version"],
-                stderr=subprocess.STDOUT,
-            ),
+            mock.call(["xcode-select", "-p"]),
+            mock.call(["xcodebuild", "-version"]),
         ],
         any_order=False,
     )
@@ -133,14 +117,8 @@ def test_installed_but_command_line_tools_selected(
     # subprocess was invoked as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            mock.call(
-                ["xcode-select", "-p"],
-                stderr=subprocess.STDOUT,
-            ),
-            mock.call(
-                ["xcodebuild", "-version"],
-                stderr=subprocess.STDOUT,
-            ),
+            mock.call(["xcode-select", "-p"]),
+            mock.call(["xcodebuild", "-version"]),
         ],
         any_order=False,
     )
@@ -177,14 +155,8 @@ def test_custom_install_with_command_line_tools(
     # subprocess was invoked as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            mock.call(
-                ["xcode-select", "-p"],
-                stderr=subprocess.STDOUT,
-            ),
-            mock.call(
-                ["xcodebuild", "-version"],
-                stderr=subprocess.STDOUT,
-            ),
+            mock.call(["xcode-select", "-p"]),
+            mock.call(["xcodebuild", "-version"]),
         ],
         any_order=False,
     )
@@ -209,14 +181,8 @@ def test_installed_but_corrupted(xcode, mock_tools):
     # subprocess was invoked as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            mock.call(
-                ["xcode-select", "-p"],
-                stderr=subprocess.STDOUT,
-            ),
-            mock.call(
-                ["xcodebuild", "-version"],
-                stderr=subprocess.STDOUT,
-            ),
+            mock.call(["xcode-select", "-p"]),
+            mock.call(["xcodebuild", "-version"]),
         ],
         any_order=False,
     )
@@ -236,14 +202,8 @@ def test_installed_no_minimum_version(xcode, mock_tools):
     # subprocess was invoked as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            mock.call(
-                ["xcode-select", "-p"],
-                stderr=subprocess.STDOUT,
-            ),
-            mock.call(
-                ["xcodebuild", "-version"],
-                stderr=subprocess.STDOUT,
-            ),
+            mock.call(["xcode-select", "-p"]),
+            mock.call(["xcodebuild", "-version"]),
         ],
         any_order=False,
     )
@@ -270,14 +230,8 @@ def test_installed_extra_output(capsys, xcode, mock_tools):
     # subprocess was invoked as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            mock.call(
-                ["xcode-select", "-p"],
-                stderr=subprocess.STDOUT,
-            ),
-            mock.call(
-                ["xcodebuild", "-version"],
-                stderr=subprocess.STDOUT,
-            ),
+            mock.call(["xcode-select", "-p"]),
+            mock.call(["xcodebuild", "-version"]),
         ],
         any_order=False,
     )
@@ -347,14 +301,8 @@ def test_installed_with_minimum_version_success(
     # assert xcode-select and xcodebuild were invoked
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            mock.call(
-                ["xcode-select", "-p"],
-                stderr=subprocess.STDOUT,
-            ),
-            mock.call(
-                ["xcodebuild", "-version"],
-                stderr=subprocess.STDOUT,
-            ),
+            mock.call(["xcode-select", "-p"]),
+            mock.call(["xcodebuild", "-version"]),
         ],
         any_order=False,
     )
@@ -398,14 +346,8 @@ def test_installed_with_minimum_version_failure(
     # subprocess was invoked as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            mock.call(
-                ["xcode-select", "-p"],
-                stderr=subprocess.STDOUT,
-            ),
-            mock.call(
-                ["xcodebuild", "-version"],
-                stderr=subprocess.STDOUT,
-            ),
+            mock.call(["xcode-select", "-p"]),
+            mock.call(["xcodebuild", "-version"]),
         ],
         any_order=False,
     )
@@ -428,14 +370,8 @@ def test_unexpected_version_output(capsys, xcode, mock_tools):
     # subprocess was invoked as expected
     mock_tools.subprocess.check_output.assert_has_calls(
         [
-            mock.call(
-                ["xcode-select", "-p"],
-                stderr=subprocess.STDOUT,
-            ),
-            mock.call(
-                ["xcodebuild", "-version"],
-                stderr=subprocess.STDOUT,
-            ),
+            mock.call(["xcode-select", "-p"]),
+            mock.call(["xcodebuild", "-version"]),
         ],
         any_order=False,
     )

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import platform
-import subprocess
 import sys
 import time
 from os.path import normpath
@@ -427,7 +426,6 @@ def test_log_file_extra(run_command, monkeypatch):
             "ANDROID_SDK_ROOT": str(run_command.tools.android_sdk.root_path),
             "JAVA_HOME": str(run_command.tools.java.java_home),
         },
-        stderr=subprocess.STDOUT,
     )
 
 


### PR DESCRIPTION
## Changes
Briefcase's use of `subprocess.check_output()` is practically exclusively intended to run a command without any output to the console. By default, though, `check_output()` will only return the value of `stdout` to the caller while `stderr` flows to the console.

This PR updates `check_output()` to default coalescing `stderr` into `stdout` to better align with how Briefcase uses it.

The prompt for pursuing this was @mhsmith's [comment](https://github.com/beeware/briefcase/pull/1058/files#r1084323585) on a recent PR showing console corruption from such an instance of `stderr` leaking in to the console while the console was controlled.

Of the 22 current uses of `check_output()`, all but the 5 below were already setting `stderr=subprocess.STDOUT` manually. The non-xcode calls are quite unlikely to produce output for `stderr`. I am less familiar with the `xcode` calls; though, I'm inclined to believe similarly.
```
src/briefcase/integrations/flatpak.py:            output = tools.subprocess.check_output(["flatpak", "--version"]).strip("\n")

src/briefcase/integrations/flatpak.py:            output = tools.subprocess.check_output(
src/briefcase/integrations/flatpak.py:                ["flatpak-builder", "--version"]
src/briefcase/integrations/flatpak.py:            ).strip("\n")

src/briefcase/integrations/xcode.py:        output = tools.subprocess.check_output(
src/briefcase/integrations/xcode.py:            ["security", "find-identity", "-v", "-p", policy],
src/briefcase/integrations/xcode.py:        )

src/briefcase/platforms/iOS/xcode.py:                output = self.tools.subprocess.check_output(
src/briefcase/platforms/iOS/xcode.py:                    ["xcrun", "simctl", "launch", udid, app_identifier]
src/briefcase/platforms/iOS/xcode.py:                )

src/briefcase/platforms/linux/appimage.py:            base_path = self.tools[app].app_context.check_output(echo_cmd).strip()
```

## Considerations
The nature of the handling of `stderr` within `subprocess.check_output()` means that this defaulting cannot be undone; that is, `stderr` cannot now be configured in such a way to show it in the console. (Although, on second thought, setting `stderr=None` may override this defaulting...) I think this is fine though; if a dev needs more nuanced control of the output, they should simply use `Subprocess.run()`. That said, if `stderr` is not useful, setting it to `subprocess.PIPE` or `subprocess.DEVNULL` effectively ignores it.

The primary basis for this PR (IMO) is integrating the intended usage behavior of `subprocess.check_output()` in to Briefcase beyond just calling convention. Along with this, though, we have a hole such that `subprocess.check_output()` can allow printing within a controlled console. So, in lieu of merging this PR, something should be implemented to avoid the child process writing to a controlled console....whether that's streaming it or perhaps throwing an error when the console is controlled and `stderr` isn't being redirected.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct