### PR TITLE
Manually update `pre-commit` hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -9,22 +9,22 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/myint/docformatter
-    rev: v1.5.0
+    rev: v1.5.1
     hooks:
     - id: docformatter
       args: [--in-place]
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
     - id: black
       language_version: python3

--- a/changes/1075.misc.rst
+++ b/changes/1075.misc.rst
@@ -1,0 +1,1 @@
+Updated the hooks for ``pre-commit`` to recent versions.


### PR DESCRIPTION
## Changes
- Primary impetus: https://github.com/PyCQA/isort/issues/2077
- All hooks updated to latest version except:
  - Leave `docformatter` at v1.5.1 until v1.6.0 is stable
  - Leave `flake8` at v5.0.4 until `flake8-eradiacate` supports v6.0.0

## Notes
- `docformatter` v1.6.0 is attempting to make two changes with the update:
  - The line length calculation appears to be happening differently.
    - Reported @ PyCQA/docformatter#160
  - Additionally, `docformatter` and `black` are disagreeing about empty lines after the docstring.
    - Introduced in v1.6.0.rc1 via PyCQA/docformatter#138
    - This seems to mostly be a problem for nested function defs.
    - `docformatter` removes the empty lines between the docstring and nested function while `black` adds it back...
    - Reported @ PyCQA/docformatter#161
- `flake8-eradicate` has an explicit upper bound of `flake8<6`
  - https://github.com/wemake-services/flake8-eradicate/pull/271

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
