### PR TITLE
Update version handling in docs.

### DIFF
--- a/changes/1076.misc.rst
+++ b/changes/1076.misc.rst
@@ -1,0 +1,1 @@
+The handling of version information in the documentation sidebar was corrected.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,8 +48,10 @@ copyright = "2019, Russell Keith-Magee"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-# The full version, including alpha/beta/rc tags.
-version = metadata_version("briefcase")
+# The full version, including alpha/beta/rc tags
+release = metadata_version("briefcase")
+# The short X.Y version
+version = ".".join(release.split(".")[:2])
 
 autoclass_content = "both"
 
@@ -100,7 +102,7 @@ pygments_style = "sphinx"
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-# html_title = None
+html_title = f"Briefcase {release}"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 # html_short_title = None


### PR DESCRIPTION
As of the Briefcase 0.3.12 release (and the move to the Furo theme), the sidebar has the title "Briefcase documentation". This is a default value, based on the fact that `release` hasn't been defined.

This PR:
1. Defines `release` in addition to `version`2. 
2. Modifies the page title to be `Briefcase {version}` (the "Documentation" is redundant)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
