### PR TITLE
Handle differences in UNC path parsing when generating extractPackages

### DIFF
--- a/changes/1087.misc.rst
+++ b/changes/1087.misc.rst
@@ -1,0 +1,1 @@
+Handle differences in UNC path parsing when generating extractPackages.

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -179,7 +179,9 @@ class GradleCreateCommand(GradleMixin, CreateCommand):
             # Extract test packages, to enable features like test discovery and assertion
             # rewriting.
             "extract_packages": ", ".join(
-                f'"{Path(path).name}"' for path in (app.test_sources or [])
+                f'"{name}"'
+                for path in (app.test_sources or [])
+                if (name := Path(path).name)
             ),
         }
 

--- a/tests/platforms/android/gradle/test_create.py
+++ b/tests/platforms/android/gradle/test_create.py
@@ -78,19 +78,35 @@ def test_version_code(create_command, first_app_config, version, build, version_
 
 extract_packages_params = [
     ([], ""),
+    ([""], ""),
     (["one"], '"one"'),
     (["one/two"], '"two"'),
+    (["one//two"], '"two"'),
     (["one/two/three"], '"three"'),
     (["one", "two"], '"one", "two"'),
     (["one", "two", "three"], '"one", "two", "three"'),
     (["one/two", "three/four"], '"two", "four"'),
     (["/leading"], '"leading"'),
-    (["//leading"], '"leading"'),
     (["/leading/two"], '"two"'),
+    (["/leading/two/three"], '"three"'),
     (["trailing/"], '"trailing"'),
     (["trailing//"], '"trailing"'),
     (["trailing/two/"], '"two"'),
 ]
+
+# Handle differences in UNC path parsing (https://github.com/python/cpython/pull/100351).
+extract_packages_params += [
+    (
+        ["//leading"],
+        ""
+        if sys.platform == "win32" and sys.version_info >= (3, 11, 2)
+        else '"leading"',
+    ),
+    (["//leading/two"], "" if sys.platform == "win32" else '"two"'),
+    (["//leading/two/three"], '"three"'),
+    (["//leading/two/three/four"], '"four"'),
+]
+
 if sys.platform == "win32":
     extract_packages_params += [
         ([path.replace("/", "\\") for path in test_sources], expected)


### PR DESCRIPTION
Closes #1087 by simply skipping over any `test_sources` items whose basename is empty. Since these are incomplete paths, `briefcase create android` should already give an appropriate error message when it tries to copy them into the app, and this behavior hasn't changed. So I've marked the changenote as `misc`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
