### PR TITLE
Correct Python version where UNC path parsing changed

### DIFF
--- a/changes/1096.misc.rst
+++ b/changes/1096.misc.rst
@@ -1,0 +1,1 @@
+Correct Python version where UNC path parsing changed

--- a/tests/platforms/android/gradle/test_create.py
+++ b/tests/platforms/android/gradle/test_create.py
@@ -98,11 +98,12 @@ extract_packages_params = [
 extract_packages_params += [
     (
         ["//leading"],
-        ""
-        if sys.platform == "win32" and sys.version_info >= (3, 11, 2)
-        else '"leading"',
+        "" if sys.platform == "win32" and sys.version_info >= (3, 12) else '"leading"',
     ),
-    (["//leading/two"], "" if sys.platform == "win32" else '"two"'),
+    (
+        ["//leading/two"],
+        "" if sys.platform == "win32" else '"two"',
+    ),
     (["//leading/two/three"], '"three"'),
     (["//leading/two/three/four"], '"four"'),
 ]


### PR DESCRIPTION
Correction of #1088. After further testing, it turns out the relevant behavior change was not backported to Python 3.11.2, so I've adjusted the version cutoff to 3.12.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
