### PR TITLE
macOS signing and notarization fixes

### DIFF
--- a/changes/1100.bugfix.rst
+++ b/changes/1100.bugfix.rst
@@ -1,0 +1,1 @@
+The command to store notarization credentials no longer causes Briefcase to hang.

--- a/docs/how-to/code-signing/macOS.rst
+++ b/docs/how-to/code-signing/macOS.rst
@@ -182,5 +182,5 @@ certificate.
 Next steps
 ----------
 
-Now it's time to start using the Developer ID Application Certificate to sign,
-notarize, and distribute your application!
+Now you can use the certificate to sign and notarize your application with the
+:doc:`briefcase package </reference/commands/package>` command.

--- a/docs/reference/commands/package.rst
+++ b/docs/reference/commands/package.rst
@@ -62,4 +62,4 @@ Sign app with adhoc identity.
 ``-i <identity>`` / ``--identity <identity>``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The code signing identity to use when signing the app.
+The :doc:`code signing identity </how-to/code-signing/index>` to use when signing the app.

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -243,7 +243,10 @@ class macOSSigningMixin:
                     ) from e
 
         if len(identities) == 0:
-            raise BriefcaseCommandError("No code signing identities are available.")
+            raise BriefcaseCommandError(
+                "No code signing identities are available: see "
+                "https://briefcase.readthedocs.io/en/stable/how-to/code-signing/macOS.html"
+            )
         elif len(identities) == 1:
             identity, identity_name = list(identities.items())[0]
         else:
@@ -497,6 +500,7 @@ password:
                                 profile,
                             ],
                             check=True,
+                            stream_output=False,  # Command reads from stdin.
                         )
                     except subprocess.CalledProcessError as e:
                         raise BriefcaseCommandError(

--- a/tests/platforms/macOS/app/test_package__notarize.py
+++ b/tests/platforms/macOS/app/test_package__notarize.py
@@ -176,6 +176,7 @@ def test_notarize_dmg_unknown_credentials(package_command, first_app_dmg):
                     "briefcase-macOS-DEADBEEF",
                 ],
                 check=True,
+                stream_output=False,
             ),
             # Submit for notarization a second time
             mock.call(
@@ -269,6 +270,7 @@ def test_credential_storage_failure_app(
                     "briefcase-macOS-DEADBEEF",
                 ],
                 check=True,
+                stream_output=False,
             ),
         ]
     )
@@ -326,6 +328,7 @@ def test_credential_storage_failure_dmg(package_command, first_app_dmg):
                     "briefcase-macOS-DEADBEEF",
                 ],
                 check=True,
+                stream_output=False,
             ),
         ]
     )
@@ -480,6 +483,7 @@ def test_notarize_unknown_credentials_after_storage(package_command, first_app_d
                     "briefcase-macOS-DEADBEEF",
                 ],
                 check=True,
+                stream_output=False,
             ),
             # Submit for notarization a second time
             mock.call(

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -190,7 +190,10 @@ def test_no_identities(dummy_command):
 
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"No code signing identities are available.",
+        match=(
+            r"No code signing identities are available: see "
+            r"https://briefcase.readthedocs.io/en/stable/how-to/code-signing/macOS.html"
+        ),
     ):
         dummy_command.select_identity()
 


### PR DESCRIPTION
* #943 did not check whether the notarization commands require `stream_output=False`. It turns out that one of them does, because it reads your Apple username and password from stdin.
* Made the code signing and `briefcase package` documentation pages link to each other. Also added a link in the error message when no code signing identities are available.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
