### PR TITLE
Add changenote for Windows threading mode change.

### DIFF
--- a/changes/930.bugfix.rst
+++ b/changes/930.bugfix.rst
@@ -1,0 +1,1 @@
+The stub executable used by Windows now clears the threading mode before starting the Python app. This caused problems with displaying dialogs in Qt apps.


### PR DESCRIPTION
Although there was no code change needed in Briefcase to address #930, it's a significant bug fix, so it should be mentioned in the Briefcase release notes.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
