### PR TITLE
Ensure that Briefcase runs a CI pass on System packages.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,12 +139,11 @@ jobs:
     needs: unit-tests
     uses: beeware/.github/.github/workflows/app-build-verify.yml@main
     with:
-      # This *must* be the version of Python that is the system Python
-      # on the Ubuntu version used to run Linux tests. We use a fixed
-      # ubuntu-22.04 rather than latest because at some point, `-latest`
-      # will become `-24.04`, but it will be a soft changeover, which
-      # will cause havoc with the hard Python version requirement for
-      # local system packages.
+      # This *must* be the version of Python that is the system Python on the
+      # Ubuntu version used to run Linux tests. We use a fixed ubuntu-22.04
+      # rather than `-latest` because at some point, `-latest` will become
+      # `-24.04`, but it will be a soft changeover, which will cause havoc with
+      # the hard Python version requirement for local system packages.
       python-version: "3.10"
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -153,3 +152,12 @@ jobs:
       matrix:
         framework: [ "toga", "pyside2", "pyside6", "ppb" ]
         runner-os: [ "macos-latest", "ubuntu-22.04", "windows-latest" ]
+
+        # PySide2 is uninstallable on most modern Linux/Python combos, as
+        # there's either (a) no wheel for the system python version, or (b) the
+        # wheel is a manylinux_2_28 wheel. That's a very narrow window of
+        # support; most current linux distro ship with Py3.11 or newer; the ones
+        # that don't aren't always manylinux_2_28 compatible.
+        exclude:
+          - framework: "pyside2"
+            runner-os: "ubuntu-22.04"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,11 +139,13 @@ jobs:
     needs: unit-tests
     uses: beeware/.github/.github/workflows/app-build-verify.yml@main
     with:
-      python-version: "3.9"
+      # This *must* be the version of Python that is the system Python
+      # on the Ubuntu version used to run Linux tests.
+      python-version: "3.10"
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
     strategy:
       fail-fast: false
       matrix:
         framework: [ "toga", "pyside2", "pyside6", "ppb" ]
-        runner-os: [ "macos-latest", "ubuntu-latest", "windows-latest" ]
+        runner-os: [ "macos-latest", "ubuntu-22.04", "windows-latest" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,11 @@ jobs:
     uses: beeware/.github/.github/workflows/app-build-verify.yml@main
     with:
       # This *must* be the version of Python that is the system Python
-      # on the Ubuntu version used to run Linux tests.
+      # on the Ubuntu version used to run Linux tests. We use a fixed
+      # ubuntu-22.04 rather than latest because at some point, `-latest`
+      # will become `-24.04`, but it will be a soft changeover, which
+      # will cause havoc with the hard Python version requirement for
+      # local system packages.
       python-version: "3.10"
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}

--- a/changes/1130.misc.rst
+++ b/changes/1130.misc.rst
@@ -1,0 +1,1 @@
+CI configuration was modified to ensure that System packages will complete successfully.


### PR DESCRIPTION
At the time #1106 landed, the .github configuration didn't include System package builds in the CI configuration (Refs beeware/.github#14). 

This makes the tweak necessary to ensure that system packages builds will pass.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
