### PR TITLE
misc: Replace flake8, isort, and pyupgrade with ruff

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,16 @@
+# https://beta.ruff.rs
+name: ruff
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user ruff
+    - run: ruff --format=github .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,22 +8,17 @@ repos:
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.255
     hooks:
-      - id: isort
-        additional_dependencies: [toml]
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
+      - id: ruff
+        # args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:
     - id: black
       language_version: python3
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.12.1
     hooks:
-      - id: flake8
+      - id: validate-pyproject

--- a/changes/+ruff.doc.rst
+++ b/changes/+ruff.doc.rst
@@ -1,0 +1,1 @@
+misc: Replace flake8, isort, and pyupgrade with ruff

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,6 @@
 
 import os
 import sys
-
 from importlib.metadata import version as metadata_version
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,15 +26,6 @@ exclude_lines = [
     "if TYPE_CHECKING:",
 ]
 
-[tool.isort]
-profile = "black"
-skip_glob = [
-    "docs/conf.py",
-    "venv*",
-    "local",
-]
-multi_line_output = 3
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 filterwarnings = [
@@ -43,6 +34,20 @@ filterwarnings = [
 
 # need to ensure build directories aren't excluded from recursion
 norecursedirs = []
+
+[tool.ruff]
+line-length = 117
+select = ["C40", "C9", "E", "F", "I", "PLE", "S", "UP", "W", "YTT"]
+target-version = "py38"
+
+[tool.ruff.isort]
+known-first-party = ["briefcase"]
+
+[tool.ruff.mccabe]
+max-complexity = 26
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["C408", "S101"]
 
 [tool.setuptools_scm]
 # To enable SCM versioning, we need an empty tool configuration for setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -144,17 +144,3 @@ briefcase.formats.windows =
 
 [aliases]
 test=pytest
-
-[flake8]
-# https://flake8.readthedocs.org/en/latest/
-exclude=\
-    venv*/*,\
-    local/*,\
-    docs/*,\
-    build/*,\
-    tests/apps/*,\
-    .eggs/*,\
-    .tox/*
-max-complexity = 10
-max-line-length = 119
-ignore = E121,E123,E126,E203,E226,E24,E704,W503,W504,C901

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -91,7 +91,7 @@ def parse_cmdline(args):
     # usage string so that the instructions displayed are correct
     parser.add_argument(
         "command",
-        choices=list(cmd.command for cmd in COMMANDS),
+        choices=[cmd.command for cmd in COMMANDS],
         metavar="command",
         nargs="?",
         help=argparse.SUPPRESS,

--- a/tests/integrations/android_sdk/ADB/test_pid_exists.py
+++ b/tests/integrations/android_sdk/ADB/test_pid_exists.py
@@ -25,5 +25,5 @@ def test_pid_does_not_exist(mock_tools):
     not existing."""
     adb = ADB(mock_tools, "exampleDevice")
     adb.run = Mock(side_effect=subprocess.CalledProcessError(returncode=1, cmd="test"))
-    assert not adb.pid_exists("9999") is None
+    assert adb.pid_exists("9999") is not None
     adb.run.assert_called_once_with("shell", "test", "-e", "/proc/9999")

--- a/tests/platforms/macOS/app/conftest.py
+++ b/tests/platforms/macOS/app/conftest.py
@@ -77,7 +77,7 @@ entitlements_path="Entitlements.plist"
     # Mach-O file that is executable, with an odd extension
     with (lib_path / "special.binary").open("wb") as f:
         f.write(b"\xCA\xFE\xBA\xBEBinary content here")
-    os.chmod(lib_path / "special.binary", 0o755)
+    os.chmod(lib_path / "special.binary", 0o755)  # noqa: S103
 
     # An embedded app
     (lib_path / "Extras.app" / "Contents" / "MacOS").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
<!--- Describe your changes in detail -->

[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) including bandit, isort, pylint, pyupgrade, and flake8 plus its plugins, and is written in Rust for speed.

The `ruff` Action uses minimal steps to run in ~10 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)

<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
