### PR TITLE
Shore Up File System Interactions to Avoid Unexpected Outcomes

### DIFF
--- a/changes/1144.bugfix.rst
+++ b/changes/1144.bugfix.rst
@@ -1,0 +1,1 @@
+When ``JAVA_HOME`` contains a path to a file instead of a directory, Briefcase will now warn the user and install an isolated copy of Java instead of logging a ``NotADirectoryError``.

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -44,8 +44,7 @@ class BuildCommand(BaseCommand):
         :param no_update: Should automated updates be disabled?
         :param test_mode: Is the app being build in test mode?
         """
-        target_file = self.bundle_path(app)
-        if not target_file.exists():
+        if not self.bundle_path(app).exists():
             state = self.create_command(app, test_mode=test_mode, **options)
         elif (
             update  # An explicit update has been requested

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -146,7 +146,7 @@ installation, and try again.
                 tools.logger.warning(cls.UNKNOWN_DOCKER_VERSION_WARNING)
         except subprocess.CalledProcessError:
             tools.logger.warning(cls.DOCKER_INSTALLATION_STATUS_UNKNOWN_WARNING)
-        except FileNotFoundError as e:
+        except OSError as e:
             # Docker executable doesn't exist.
             raise BriefcaseCommandError(
                 cls.DOCKER_NOT_INSTALLED_ERROR.format(

--- a/src/briefcase/integrations/flatpak.py
+++ b/src/briefcase/integrations/flatpak.py
@@ -67,7 +67,7 @@ class Flatpak(Tool):
 """
                 )
 
-        except FileNotFoundError as e:
+        except OSError as e:
             raise BriefcaseCommandError(
                 """\
 Briefcase requires the Flatpak toolchain, but it does not appear to be installed.
@@ -122,7 +122,7 @@ You must install both flatpak and flatpak-builder.
 """
                 )
 
-        except FileNotFoundError as e:
+        except OSError as e:
             raise BriefcaseCommandError(
                 """\
 Briefcase requires the full Flatpak development toolchain, but flatpak-builder

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -121,7 +121,7 @@ class JDK(Tool):
 
 """
 
-            except FileNotFoundError:
+            except OSError:
                 install_message = f"""
 *************************************************************************
 ** WARNING: JAVA_HOME does not point to a JDK                          **

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -248,11 +248,11 @@ class LinuxDeployLocalFilePlugin(LinuxDeployPluginBase):
                 self.local_path / self.file_name,
                 self.file_path / self.file_name,
             )
-        except FileNotFoundError:
+        except OSError as e:
             raise BriefcaseCommandError(
                 f"Could not locate linuxdeploy plugin {self.local_path / self.file_name}. "
                 "Is the path correct?"
-            )
+            ) from e
 
         self.prepare_executable()
 

--- a/src/briefcase/integrations/visualstudio.py
+++ b/src/briefcase/integrations/visualstudio.py
@@ -68,7 +68,7 @@ class VisualStudio(Tool):
             pass
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(
-                """MSBuild is on the path, but Briefcase cannot start it."""
+                "MSBuild is on the path, but Briefcase cannot start it."
             ) from e
 
         # try to find Visual Studio
@@ -137,6 +137,7 @@ installation.
                     KeyError,
                     CommandOutputParseError,
                     subprocess.CalledProcessError,
+                    OSError,
                 ) as e:
                     raise BriefcaseCommandError(
                         f"""\
@@ -174,7 +175,7 @@ Then restart Briefcase.
             # Try to invoke MSBuild at the established location
             try:
                 tools.subprocess.check_output([msbuild_path, "--version"])
-            except subprocess.CalledProcessError:
+            except (subprocess.CalledProcessError, OSError):
                 raise BriefcaseCommandError(
                     "MSBuild appears to exist, but Briefcase can't start it."
                 )

--- a/src/briefcase/integrations/wix.py
+++ b/src/briefcase/integrations/wix.py
@@ -83,8 +83,11 @@ class WiX(Tool):
             if not wix.exists():
                 raise BriefcaseCommandError(
                     f"""\
-The WIX environment variable does not point to an install of the
-WiX Toolset. Current value: {wix_home!r}
+The WIX environment variable:
+
+{wix_home}
+
+does not point to an install of the WiX Toolset.
 """
                 )
 
@@ -106,9 +109,9 @@ WiX Toolset. Current value: {wix_home!r}
 
     def exists(self):
         return (
-            self.heat_exe.exists()
-            and self.light_exe.exists()
-            and self.candle_exe.exists()
+            self.heat_exe.is_file()
+            and self.light_exe.is_file()
+            and self.candle_exe.is_file()
         )
 
     @property

--- a/src/briefcase/platforms/linux/__init__.py
+++ b/src/briefcase/platforms/linux/__init__.py
@@ -129,7 +129,7 @@ class LocalRequirementsMixin:
             self.tools.shutil.rmtree(local_requirements_path)
         self.tools.os.mkdir(local_requirements_path)
 
-        # Iterate over every requirements, looking for local references
+        # Iterate over every requirement, looking for local references
         for requirement in requires:
             if _is_local_requirement(requirement):
                 if Path(requirement).is_dir():
@@ -156,7 +156,7 @@ class LocalRequirementsMixin:
                     try:
                         # Requirement is an existing sdist or wheel file.
                         self.tools.shutil.copy(requirement, local_requirements_path)
-                    except FileNotFoundError as e:
+                    except OSError as e:
                         raise BriefcaseCommandError(
                             f"Unable to find local requirement {requirement}"
                         ) from e

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -234,7 +234,7 @@ class HTTPHandler(SimpleHTTPRequestHandler):
 
 
 class LocalHTTPServer(ThreadingHTTPServer):
-    """A HTTP server that serves local static content."""
+    """An HTTP server that serves local static content."""
 
     def __init__(self, base_path, host, port, RequestHandlerClass=HTTPHandler):
         self.base_path = base_path

--- a/tests/commands/create/test_properties.py
+++ b/tests/commands/create/test_properties.py
@@ -1,4 +1,7 @@
+import pytest
 import tomli_w
+
+from briefcase.exceptions import BriefcaseCommandError
 
 
 def test_template_url(create_command):
@@ -7,6 +10,11 @@ def test_template_url(create_command):
         create_command.app_template_url
         == "https://github.com/beeware/briefcase-Tester-Dummy-template.git"
     )
+
+
+def test_missing_briefcase_toml(create_command, myapp):
+    with pytest.raises(BriefcaseCommandError, match=r"Unable to find.*briefcase.toml'"):
+        _ = create_command.app_path(myapp)
 
 
 def test_app_path(create_command, myapp):


### PR DESCRIPTION
## Changes
- Uses of `subprocess` with user-input derived filepaths to executables now catch `OSError` in case those executables have unepxected aspects that causes `subprocess` to raise variations of `OSError`.
- Checks for filesystem existence that also assumed it was either a file or a directory now explicitly check for that characteristic.
- As a specific example, if the filepath in `JAVA_HOME` is not exlusively made up of directories, then `subprocess` will raise `NotADirectoryError`. For instance, if `JAVA_HOME` points to a binary itself such as `/usr/lib/jvm/bin/java`, then the check for `javac`, i.e. `subprocess.check_output(['/usr/lib/jvm/bin/java/bin/javac', '-version'])` raises `NotADirectoryError` since `java` is not a directory.

I was not previously aware of this behavior from `subprocess`. It seems to stem from the fact that the state returned from forking the child is an `OSError` number `0x14`.....instead of `OSError` number `0x2` for `FileNotFoundError`, for instance.

This is simple to replicate, though:
```python
>>> import subprocess
>>> subprocess.check_output(['/bin/sh/asdf'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/russell/.pyenv/versions/3.10.9-debug/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/home/russell/.pyenv/versions/3.10.9-debug/lib/python3.10/subprocess.py", line 503, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/home/russell/.pyenv/versions/3.10.9-debug/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/home/russell/.pyenv/versions/3.10.9-debug/lib/python3.10/subprocess.py", line 1847, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
NotADirectoryError: [Errno 20] Not a directory: '/bin/sh/asdf'
```

## TODO:
- [x] Identify other uses of `subprocess` with potentially problematic exe filepaths.
  - The most vulnerable are those filepaths composed from user/external input.

## Reference:
- beeware/beeware#198

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
