### PR TITLE
Mitigate likelihood of ill-timed context switches in streamer tests

### DIFF
--- a/changes/1147.misc.rst
+++ b/changes/1147.misc.rst
@@ -1,0 +1,1 @@
+The "stuck streamer" test was updated to mitigate the possibility of a race condition failing it or other tests.

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -113,7 +113,7 @@ def test_stuck_streamer(mock_sub, streaming_process, monkeypatch, capsys):
 
     def monkeypatched_blocked_streamer(*a, **kw):
         """Simulate a streamer that blocks longer than it will be waited on."""
-        time.sleep(1)
+        time.sleep(1.5)
         if monkeypatched_streamer_should_exit.is_set():
             return
         print("This should not be printed while waiting on the streamer to exit")
@@ -129,14 +129,14 @@ def test_stuck_streamer(mock_sub, streaming_process, monkeypatch, capsys):
     with pytest.raises(KeyboardInterrupt):
         mock_sub.stream_output("testing", streaming_process, stop_func=send_ctrl_c)
 
+    monkeypatched_streamer_should_exit.set()
+
     # fmt: off
     assert capsys.readouterr().out == (
         "Stopping...\n"
         "Log stream hasn't terminated; log output may be corrupted.\n"
     )
     # fmt: on
-
-    monkeypatched_streamer_should_exit.set()
 
 
 def test_stdout_closes_unexpectedly(mock_sub, streaming_process, monkeypatch, capsys):

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -107,16 +107,19 @@ def test_stuck_streamer(mock_sub, streaming_process, monkeypatch, capsys):
     mock_time = mock.MagicMock(side_effect=range(1000, 1005))
     monkeypatch.setattr(time, "time", mock_time)
 
-    # Flag for the mock streamer to exit and prevent it
-    # potentially printing in the middle of a later test.
+    # Flag that Briefcase has finished simulating its waiting on the output
+    # streamer to exit normally; so, it should now exit.
     monkeypatched_streamer_should_exit = Event()
+    # Flag that Briefcase waited too long on the output streamer
+    monkeypatched_streamer_was_improperly_awaited = Event()
+    # Flag that output streamer has exited
+    monkeypatched_streamer_exited = Event()
 
     def monkeypatched_blocked_streamer(*a, **kw):
         """Simulate a streamer that blocks longer than it will be waited on."""
-        time.sleep(1.5)
-        if monkeypatched_streamer_should_exit.is_set():
-            return
-        print("This should not be printed while waiting on the streamer to exit")
+        if not monkeypatched_streamer_should_exit.wait(timeout=1):
+            monkeypatched_streamer_was_improperly_awaited.set()
+        monkeypatched_streamer_exited.set()
 
     monkeypatch.setattr(
         mock_sub,
@@ -137,6 +140,12 @@ def test_stuck_streamer(mock_sub, streaming_process, monkeypatch, capsys):
         "Log stream hasn't terminated; log output may be corrupted.\n"
     )
     # fmt: on
+
+    # Since the waiting around for the output streamer has been
+    # short-circuited, Briefcase should quickly give up waiting on
+    # the output streamer and it should exit...so, confirm it does.
+    assert monkeypatched_streamer_exited.wait(timeout=1)
+    assert not monkeypatched_streamer_was_improperly_awaited.is_set()
 
 
 def test_stdout_closes_unexpectedly(mock_sub, streaming_process, monkeypatch, capsys):


### PR DESCRIPTION
- In at least one [known case](https://github.com/beeware/briefcase/actions/runs/4507530299/jobs/7935404412), the thread created in the "stuck streamer" [test](https://github.com/beeware/briefcase/blob/788dd35b4be07e18ee559eceafa34edc6830b267/tests/integrations/subprocess/test_Subprocess__stream_output.py#L100) did not exit as expected and injected output in to the `stdout` of another test causing it to fail.
- This change sets the thread's exit flag sooner and slightly increases the amount of time the thread waits before checking the flag.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
