### PR TITLE
Verify the Docker buildx plugin is installed

### DIFF
--- a/changes/1153.bugfix.rst
+++ b/changes/1153.bugfix.rst
@@ -1,0 +1,1 @@
+If the Docker ``buildx`` plugin is not installed, users are now directed by Briefcase to install it instead of Docker failing to build the image.

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -19,7 +19,6 @@ version {docker_version}. Visit:
     {install_url}
 
 to download and install an updated version of Docker.
-{extra_content}
 """
     UNKNOWN_DOCKER_VERSION_WARNING = """
 *************************************************************************
@@ -70,7 +69,7 @@ Visit:
     {install_url}
 
 to download and install Docker manually.
-{extra_content}
+
 If you have installed Docker recently and are still getting this error, you may
 need to restart your terminal session.
 """
@@ -103,20 +102,10 @@ See https://docs.docker.com/go/buildx/ to install the buildx plugin.
 """
 
     # Platform-specific template context dictionary for Docker installation details
-    DOCKER_INSTALL_DETAILS = {
-        "Windows": {
-            "install_url": "https://docs.docker.com/docker-for-windows/install/",
-            "extra_content": "",
-        },
-        "Darwin": {
-            "install_url": "https://docs.docker.com/docker-for-mac/install/",
-            "extra_content": "",
-        },
-        "Linux": {
-            "install_url": "https://docs.docker.com/engine/install/#server",
-            "extra_content": "Alternatively, to run briefcase natively (i.e. without Docker), use the\n"
-            "`--no-docker` command-line argument.",
-        },
+    DOCKER_INSTALL_URL = {
+        "Windows": "https://docs.docker.com/docker-for-windows/install/",
+        "Darwin": "https://docs.docker.com/docker-for-mac/install/",
+        "Linux": "https://docs.docker.com/engine/install/#server",
     }
 
     def __init__(self, tools: ToolCache):
@@ -154,7 +143,7 @@ See https://docs.docker.com/go/buildx/ to install the buildx plugin.
                     raise BriefcaseCommandError(
                         cls.WRONG_DOCKER_VERSION_ERROR.format(
                             docker_version=docker_version,
-                            **cls.DOCKER_INSTALL_DETAILS[tools.host_os],
+                            install_url=cls.DOCKER_INSTALL_URL[tools.host_os],
                         )
                     )
 
@@ -166,7 +155,7 @@ See https://docs.docker.com/go/buildx/ to install the buildx plugin.
             # Docker executable doesn't exist.
             raise BriefcaseCommandError(
                 cls.DOCKER_NOT_INSTALLED_ERROR.format(
-                    **cls.DOCKER_INSTALL_DETAILS[tools.host_os]
+                    install_url=cls.DOCKER_INSTALL_URL[tools.host_os]
                 )
             ) from e
 

--- a/tests/integrations/docker/test_DockerAppContext__verify.py
+++ b/tests/integrations/docker/test_DockerAppContext__verify.py
@@ -38,6 +38,7 @@ def test_success(mock_tools, first_app_config, verify_kwargs):
     mock_tools.subprocess.check_output.side_effect = [
         "Docker version 19.03.8, build afacb8b\n",
         "docker info return value",
+        "github.com/docker/buildx v0.10.2 00ed17d\n",
     ]
 
     DockerAppContext.verify(mock_tools, first_app_config, **verify_kwargs)
@@ -86,6 +87,7 @@ def test_docker_image_build_fail(mock_tools, first_app_config, verify_kwargs):
     mock_tools.subprocess.check_output.side_effect = [
         "Docker version 19.03.8, build afacb8b\n",
         "docker info return value",
+        "github.com/docker/buildx v0.10.2 00ed17d\n",
     ]
 
     mock_tools.subprocess.run.side_effect = subprocess.CalledProcessError(

--- a/tests/integrations/docker/test_Docker__check_output.py
+++ b/tests/integrations/docker/test_Docker__check_output.py
@@ -15,7 +15,7 @@ def mock_tools(mock_tools) -> ToolCache:
 
 
 def test_check_output(mock_tools):
-    "A command can be invoked on a bare Docker image."
+    """A command can be invoked on a bare Docker image."""
 
     # Run the command in a container
     mock_tools.docker.check_output(["cmd", "arg1", "arg2"], image_tag="ubuntu:jammy")

--- a/tests/integrations/docker/test_Docker__prepare.py
+++ b/tests/integrations/docker/test_Docker__prepare.py
@@ -17,7 +17,7 @@ def mock_tools(mock_tools) -> ToolCache:
 
 
 def test_prepare(mock_tools):
-    "A docker image can be prepared"
+    """A docker image can be prepared"""
 
     # Prepare an image
     mock_tools.docker.prepare("ubuntu:jammy")
@@ -30,14 +30,14 @@ def test_prepare(mock_tools):
 
 
 def test_prepare_bad_image(mock_tools):
-    "If an image is invalid, an exception raised"
+    """If an image is invalid, an exception raised,"""
     # Mock a Docker failure due to a bad image
     mock_tools.subprocess.run.side_effect = subprocess.CalledProcessError(
         returncode=125,
         cmd="docker...",
     )
 
-    # Try to prepare an image thadt doesn't exist:
+    # Try to prepare an image that doesn't exist:
     with pytest.raises(
         BriefcaseCommandError,
         match=r"Unable to obtain the Docker base image ubuntu:does-not-exist.",

--- a/tests/integrations/docker/test_Docker__verify.py
+++ b/tests/integrations/docker/test_Docker__verify.py
@@ -31,10 +31,9 @@ def test_short_circuit(mock_tools):
 
 
 @pytest.mark.parametrize("host_os", ["Windows", "Linux", "Darwin"])
-def test_docker_install_details(host_os):
+def test_docker_install_url(host_os):
     """Docker details available for each OS."""
-    assert "install_url" in Docker.DOCKER_INSTALL_DETAILS[host_os]
-    assert "extra_content" in Docker.DOCKER_INSTALL_DETAILS[host_os]
+    assert host_os in Docker.DOCKER_INSTALL_URL
 
 
 def test_docker_exists(mock_tools, valid_docker_version, capsys):


### PR DESCRIPTION
Briefcase implicitly relies on the `buildx` plugin being installed. This is because Briefcase depends on Docker using the BuildKit backend and `buildx` is the necessary frontend component to enforce using BuildKit.

A growing collection of users are reporting this error; it currently manifests like this:
```
[beethings] Building Docker container image...

Entering Docker context...
Docker| ------------------------------------------------------------------
Docker| DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
Docker|             Install the buildx component to build images with BuildKit:
Docker|             https://docs.docker.com/go/buildx/
Docker| 
Docker| unknown flag: --progress
Docker| See 'docker build --help'.
Docker| ------------------------------------------------------------------
Leaving Docker context.
```

Fortunately, more recent versions of Docker on linux come bundled with the `buildx` plugin. Docker Desktop and rootless Docker (which are more prevalent on other platforms although popularity is likely to increase for linux) have bundled the `buildx` plugin for quite a bit longer.

This also sets up transitioning the image build step to use `buildx` directly via `docker buildx build ...`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
