### PR TITLE
Correct some markup errors in docs.

### DIFF
--- a/changes/1167.misc.rst
+++ b/changes/1167.misc.rst
@@ -1,0 +1,1 @@
+Some minor docs markup errors were corrected.

--- a/docs/reference/commands/new.rst
+++ b/docs/reference/commands/new.rst
@@ -24,7 +24,7 @@ A local directory path or URL to use as a cookiecutter template for the new
 project.
 
 ``--template-branch <branch>``
------------------------------
+------------------------------
 
 The branch of the cookiecutter template repo to use for the new project. If not
 specified, Briefcase will attempt to use a template branch matching the version

--- a/docs/reference/platforms/iOS.rst
+++ b/docs/reference/platforms/iOS.rst
@@ -43,7 +43,7 @@ Additional options
 ==================
 
 The following options can be provided at the command line when producing
-iOS projects
+iOS projects:
 
 run
 ---

--- a/docs/reference/platforms/linux/appimage.rst
+++ b/docs/reference/platforms/linux/appimage.rst
@@ -192,7 +192,7 @@ include ``libcrypt.so.1`` as part of the base OS configuration. This can usually
 be fixed by installing the ``libxcrypt-compat`` package.
 
 Failure to load ``libpango-1.0-so.0``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Older Linux distributions (e.g., Ubuntu 18.04) may not be compatible with
 AppImages of Toga apps produced by Briefcase, complaining about problems with

--- a/docs/reference/platforms/linux/flatpak.rst
+++ b/docs/reference/platforms/linux/flatpak.rst
@@ -61,7 +61,7 @@ Application configuration
 
 The following options can be added to the
 ``tool.briefcase.app.<appname>.linux.flatpak`` section of your
-``pyproject.toml`` file.
+``pyproject.toml`` file:
 
 ``flatpak_runtime_repo_alias``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/reference/platforms/linux/system.rst
+++ b/docs/reference/platforms/linux/system.rst
@@ -89,7 +89,7 @@ Additional options
 ==================
 
 The following options can be provided at the command line when producing
-Deb packages.
+Deb packages:
 
 ``--target``
 ~~~~~~~~~~~~

--- a/docs/reference/platforms/web.rst
+++ b/docs/reference/platforms/web.rst
@@ -43,10 +43,10 @@ Application configuration
 
 The following options can be added to the
 ``tool.briefcase.app.<appname>.web`` section of your ``pyproject.toml``
-file.
+file:
 
 ``extra_pyscript_toml_content``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 Any additional configuration that you wish to add to the ``pyscript.toml`` file
 for your deployed site. For example, you can use this to change the runtime
@@ -68,7 +68,7 @@ Additional options
 ==================
 
 The following options can be provided at the command line when producing
-iOS projects
+web projects:
 
 run
 ---


### PR DESCRIPTION
Doing a local build of docs, I noticed some non-critical warnings and typographical inconsistencies. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
