### PR TITLE
Make the macOS/iOS log filter less greedy.

### DIFF
--- a/changes/1179.bugfix.rst
+++ b/changes/1179.bugfix.rst
@@ -1,0 +1,1 @@
+Content before a closing square bracket (``]``) or ``.so)`` is no longer stripped by the macOS and iOS log filter.

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -28,8 +28,8 @@ DEFAULT_OUTPUT_FORMAT = "app"
 
 
 MACOS_LOG_PREFIX_REGEX = re.compile(
-    r"\d{4}-\d{2}-\d{2} (?P<timestamp>\d{2}:\d{2}:\d{2}.\d{3}) Df (.*?)\[.*?:.*\]"
-    r"(?P<subsystem>( \(libffi\.dylib\))|( \(_ctypes\.cpython-3\d{1,2}-.*\.so\)))? (?P<content>.*)"
+    r"\d{4}-\d{2}-\d{2} (?P<timestamp>\d{2}:\d{2}:\d{2}.\d{3}) Df (.*?)\[.*?:.*?\]"
+    r"(?P<subsystem>( \(libffi\.dylib\))|( \(_ctypes\.cpython-3\d{1,2}-.*?\.so\)))? (?P<content>.*)"
 )
 
 

--- a/tests/platforms/macOS/test_macOS_log_clean_filter.py
+++ b/tests/platforms/macOS/test_macOS_log_clean_filter.py
@@ -72,6 +72,17 @@ from briefcase.platforms.macOS import macOS_log_clean_filter
             "This doesn't match the regex",
             ("This doesn't match the regex", False),
         ),
+        # Log content that contains square brackets
+        (
+            "2022-11-14 13:21:15.341 Df My App[59972:780a15] (libffi.dylib) Test [1/5] ... OK",
+            ("Test [1/5] ... OK", True),
+        ),
+        # Log content that contains `.so`
+        (
+            "2022-11-14 13:21:15.341 Df My App[59972:780a15] (_ctypes.cpython-312-iphonesimulator.so) "
+            "A problem (foo.so) try to avoid it",
+            ("A problem (foo.so) try to avoid it", True),
+        ),
     ],
 )
 def test_filter(original, filtered):


### PR DESCRIPTION
Modifies the regex used to filter macOS/iOS log content to use non-greedy forms of `.*`. 

This prevents log lines from being truncated when the contain a closing square bracket, or the text `.so)`.

Fixes #1179 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
