### PR TITLE
Allow to run tox on single test files

### DIFF
--- a/changes/1181.misc.rst
+++ b/changes/1181.misc.rst
@@ -1,0 +1,1 @@
+The possibility to run ``tox`` on single test files was added.

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -260,21 +260,18 @@ the process while developing, you can run the tests on one Python version only:
     .. code-block:: bash
 
       (venv) $ tox -e py
-      (venv) $ tox -e py -- tests/path_to_test_file/test_some_test.py
 
   .. group-tab:: Linux
 
     .. code-block:: bash
 
       (venv) $ tox -e py
-      (venv) $ tox -e py -- tests/path_to_test_file/test_some_test.py
 
   .. group-tab:: Windows
 
     .. code-block:: bash
 
       (venv) C:\...>tox -e py
-      (venv) C:\...>tox -e py -- tests/path_to_test_file/test_some_test.py
 
 Or, you can run a single test file on a single version of Python:
 

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -251,8 +251,7 @@ To set up a testing environment and run the full test suite:
 By default this will run the test suite multiple times, once on each Python
 version supported by Briefcase, as well as running some pre-commit checks of
 code style and validity. This can take a while, so if you want to speed up
-the process while developing, you can run the tests on one Python version only
-or even on a single test file:
+the process while developing, you can run the tests on one Python version only:
 
 .. tabs::
 
@@ -275,6 +274,28 @@ or even on a single test file:
     .. code-block:: bash
 
       (venv) C:\...>tox -e py
+      (venv) C:\...>tox -e py -- tests/path_to_test_file/test_some_test.py
+
+Or, you can run a single test file on a single version of Python:
+
+.. tabs::
+
+  .. group-tab:: macOS
+
+    .. code-block:: bash
+
+      (venv) $ tox -e py -- tests/path_to_test_file/test_some_test.py
+
+  .. group-tab:: Linux
+
+    .. code-block:: bash
+
+      (venv) $ tox -e py -- tests/path_to_test_file/test_some_test.py
+
+  .. group-tab:: Windows
+
+    .. code-block:: bash
+
       (venv) C:\...>tox -e py -- tests/path_to_test_file/test_some_test.py
 
 Or, to run using a specific version of Python, e.g. when you want to use Python 3.7:

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -251,7 +251,8 @@ To set up a testing environment and run the full test suite:
 By default this will run the test suite multiple times, once on each Python
 version supported by Briefcase, as well as running some pre-commit checks of
 code style and validity. This can take a while, so if you want to speed up
-the process while developing, you can run the tests on one Python version only:
+the process while developing, you can run the tests on one Python version only
+or even on a single test file:
 
 .. tabs::
 
@@ -260,18 +261,21 @@ the process while developing, you can run the tests on one Python version only:
     .. code-block:: bash
 
       (venv) $ tox -e py
+      (venv) $ tox -e py -- tests/path_to_test_file/test_some_test.py
 
   .. group-tab:: Linux
 
     .. code-block:: bash
 
       (venv) $ tox -e py
+      (venv) $ tox -e py -- tests/path_to_test_file/test_some_test.py
 
   .. group-tab:: Windows
 
     .. code-block:: bash
 
       (venv) C:\...>tox -e py
+      (venv) C:\...>tox -e py -- tests/path_to_test_file/test_some_test.py
 
 Or, to run using a specific version of Python, e.g. when you want to use Python 3.7:
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -53,6 +53,7 @@ Passthrough
 pre
 precompiled
 px
+Pygame
 Pyodide
 pyproject
 PyScript

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ passenv =
 extras =
     dev
 commands =
-    python -m coverage run -m pytest -vv
+    python -m coverage run -m pytest -vv {posargs}
 
 [testenv:towncrier-check]
 package_env = none


### PR DESCRIPTION
Running `tox` always runs through the whole test suite, which can take a while, even when doing `tox -e py`. This small change in the `tox.ini` allows to pass single files, which I found quite helpful during the dev process.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
