### PR TITLE
Allow to pack a Windows app as zip file

### DIFF
--- a/changes/457.feature.rst
+++ b/changes/457.feature.rst
@@ -1,0 +1,1 @@
+On Windows, it is now possible to build a zip folder for distribution by using ``package -p zip``.

--- a/changes/457.feature.rst
+++ b/changes/457.feature.rst
@@ -1,1 +1,1 @@
-On Windows, it is now possible to build a zip folder for distribution by using ``package -p zip``.
+Support for packaging Windows apps as simple ZIP files was added.

--- a/docs/reference/platforms/windows/app.rst
+++ b/docs/reference/platforms/windows/app.rst
@@ -14,6 +14,9 @@ enabled. To ensure .NET Framework 3.5 is enabled:
 3. Select "Turn Windows features On or Off"
 4. Ensure that ".NET framework 3.5 (includes .NET 2.0 and 3.0)" is selected.
 
+Instead of building an MSI installer, you can also pack the folders for
+distribution to a zip file using the ``briefcase package -p zip`` command.
+
 Icon format
 ===========
 

--- a/docs/reference/platforms/windows/app.rst
+++ b/docs/reference/platforms/windows/app.rst
@@ -3,7 +3,11 @@ Windows App
 ===========
 
 A Windows app is a stub binary, allow with a collection of folders that contain
-the Python code for the app and the Python runtime libraries.
+the Python code for the app and the Python runtime libraries. Briefcase supports
+two packaging formats for a Windows app:
+
+1. As an MSI installer
+2. As a ZIP file containing all files needed to run the app
 
 Briefcase uses the `WiX Toolset <https://wixtoolset.org/>`__ to build an MSI
 installer for a Windows App. WiX, in turn, requires that .NET Framework 3.5 is
@@ -13,9 +17,6 @@ enabled. To ensure .NET Framework 3.5 is enabled:
 2. Traverse to Programs -> Programs and Features
 3. Select "Turn Windows features On or Off"
 4. Ensure that ".NET framework 3.5 (includes .NET 2.0 and 3.0)" is selected.
-
-Instead of building an MSI installer, you can also pack the folders for
-distribution to a zip file using the ``briefcase package -p zip`` command.
 
 Icon format
 ===========

--- a/docs/reference/platforms/windows/index.rst
+++ b/docs/reference/platforms/windows/index.rst
@@ -7,7 +7,7 @@ The default output format for Windows is an :doc:`app <./app>`.
 Briefcase also supports creating a :doc:`Visual Studio project <./visualstudio>`
 which in turn can be used to build an app.
 
-Both output formats support packaging as a Microsoft software installer (MSI) or
+Both output formats support packaging as a Microsoft Software Installer (MSI) or
 as a ZIP file.
 
 .. toctree::

--- a/docs/reference/platforms/windows/index.rst
+++ b/docs/reference/platforms/windows/index.rst
@@ -7,7 +7,8 @@ The default output format for Windows is an :doc:`app <./app>`.
 Briefcase also supports creating a :doc:`Visual Studio project <./visualstudio>`
 which in turn can be used to build an app.
 
-Both output formats support packaging as an MSI.
+Both output formats support packaging as a Microsoft software installer (MSI) or
+as a ZIP file.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/reference/platforms/windows/visualstudio.rst
+++ b/docs/reference/platforms/windows/visualstudio.rst
@@ -28,6 +28,11 @@ ensure that you have installed the following:
   - All default packages
   - C++/CLI support for v143 build tools
 
+Briefcase supports two packaging formats for a Windows App:
+
+1. As an MSI installer
+2. As a ZIP file containing all files needed to run the app
+
 Briefcase uses the `WiX Toolset <https://wixtoolset.org/>`__ to build an MSI
 installer for a Windows App. WiX, in turn, requires that .NET Framework 3.5 is
 enabled. To ensure .NET Framework 3.5 is enabled:

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -118,7 +118,7 @@ class WindowsRunCommand(RunCommand):
 class WindowsPackageCommand(PackageCommand):
     @property
     def packaging_formats(self):
-        return ["msi"]
+        return ["msi", "zip"]
 
     @property
     def default_packaging_format(self):
@@ -259,6 +259,16 @@ class WindowsPackageCommand(PackageCommand):
         :param timestamp_url: Timestamp authority server to use in code signing.
         :param timestamp_digest: Hashing algorithm to request from the timestamp server.
         """
+
+        # Just pack the 'binary' folders in a zip file:
+        if app.packaging_format == "zip":
+            self.logger.info("Building zip file...", prefix=app.app_name)
+            self.tools.shutil.make_archive(
+                self.distribution_path(app).with_suffix(""),
+                "zip",
+                self.bundle_path(app) / self.packaging_root,
+            )
+            return
 
         if sign_app and not identity:
             sign_app = False

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -279,18 +279,16 @@ class WindowsPackageCommand(PackageCommand):
 
         if app.packaging_format == "zip":
             self._package_zip(app)
-            # The zip can't be signed, so:
-            return
         else:
             self._package_msi(app)
 
-        if sign_app:
-            self.logger.info("Signing package...", prefix=app.app_name)
-            self.sign_file(
-                app=app,
-                filepath=self.distribution_path(app),
-                **sign_options,
-            )
+            if sign_app:
+                self.logger.info("Signing MSI...", prefix=app.app_name)
+                self.sign_file(
+                    app=app,
+                    filepath=self.distribution_path(app),
+                    **sign_options,
+                )
 
     def _package_msi(self, app):
         """Build the msi installer."""

--- a/src/briefcase/platforms/windows/app.py
+++ b/src/briefcase/platforms/windows/app.py
@@ -133,7 +133,7 @@ class WindowsAppRunCommand(WindowsAppMixin, WindowsRunCommand):
 
 
 class WindowsAppPackageCommand(WindowsAppMixin, WindowsPackageCommand):
-    description = "Package a Windows app as an MSI."
+    description = "Package a Windows app."
 
 
 class WindowsAppPublishCommand(WindowsAppMixin, PublishCommand):

--- a/src/briefcase/platforms/windows/visualstudio.py
+++ b/src/briefcase/platforms/windows/visualstudio.py
@@ -75,7 +75,7 @@ class WindowsVisualStudioPackageCommand(
     WindowsVisualStudioMixin,
     WindowsPackageCommand,
 ):
-    description = "Package a Visual Studio project as an MSI."
+    description = "Package a Visual Studio project."
 
 
 class WindowsVisualStudioPublishCommand(WindowsVisualStudioMixin, PublishCommand):

--- a/tests/platforms/conftest.py
+++ b/tests/platforms/conftest.py
@@ -18,7 +18,6 @@ def first_app_config():
         sources=["src/first_app"],
         requires=["foo==1.2.3", "bar>=4.5"],
         test_requires=["pytest"],
-        packaging_format="",
     )
 
 

--- a/tests/platforms/conftest.py
+++ b/tests/platforms/conftest.py
@@ -18,6 +18,7 @@ def first_app_config():
         sources=["src/first_app"],
         requires=["foo==1.2.3", "bar>=4.5"],
         test_requires=["pytest"],
+        packaging_format="",
     )
 
 

--- a/tests/platforms/windows/app/test_package.py
+++ b/tests/platforms/windows/app/test_package.py
@@ -47,12 +47,9 @@ def package_command_with_files(package_command):
     src_path.mkdir(parents=True)
 
     # Mock some typical folders and files in the src folder:
-    package_command.paths = (
-        "app/",
-        "app/first-app/",
+    paths = (
         "app/first-app/resources/",
         "app/first-app-0.0.1.dist-info/",
-        "app_packages/",
         "app_packages/toga_winforms/",
     )
     package_command.files = (
@@ -65,8 +62,8 @@ def package_command_with_files(package_command):
         "app_packages/clr.py",
         "app_packages/toga_winforms/command.py",
     )
-    for path in package_command.paths:
-        (src_path / path).mkdir()
+    for path in paths:
+        (src_path / path).mkdir(parents=True)
     for file in package_command.files:
         open(f"{src_path}/{file}", "x").close()
     return package_command
@@ -256,9 +253,7 @@ def test_package_zip(package_command_with_files, first_app_config, tmp_path):
     package_command_with_files.package_app(first_app_config)
 
     archive_file = tmp_path / "base_path" / "dist" / "First App-0.0.1.zip"
-    src_files_and_paths = (
-        package_command_with_files.paths + package_command_with_files.files + ("",)
-    )
+    source_files = package_command_with_files.files
 
     # The zip file exists
     assert archive_file.exists()
@@ -269,10 +264,10 @@ def test_package_zip(package_command_with_files, first_app_config, tmp_path):
         # All files in zip are from source
         for name in archive.namelist():
             # name.removeprefix(f'{root}/') will only work in Python > 3.8
-            assert name[16:] in (src_files_and_paths)
+            assert name[16:] in source_files
         # All files from source are in zip
-        for entity in src_files_and_paths:
-            assert f"{root}/{entity}" in archive.namelist()
+        for file in source_files:
+            assert f"{root}/{file}" in archive.namelist()
 
 
 @pytest.mark.parametrize(

--- a/tests/platforms/windows/conftest.py
+++ b/tests/platforms/windows/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+# Windows' AppConfig requires attribute 'packaging_format'
+@pytest.fixture
+def first_app_config(first_app_config):
+    first_app_config.packaging_format = "msi"
+    return first_app_config


### PR DESCRIPTION
As discussed in issue #457 and elsewhere on the discord channel, a Windows app packed as zip file could be a nice alternative for shipping and will sometimes be preferable to an MSI installer.

I also got the impression that @freakboy3742 wouldn't block such a PR per se, so I'll give it a try ;-)

Fixes #457 

## PR Checklist:
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
