### PR TITLE
Verify docs were built on RTD before creating a GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,20 @@ on:
 
 jobs:
   ci:
+    name: CI
     uses: ./.github/workflows/ci.yml
+
+  docs:
+    name: Verify Docs Build
+    uses: beeware/.github/.github/workflows/docs-build-verify.yml@main
+    secrets: inherit
+    with:
+      project-name: "briefcase"
+      project-version: ${{ github.ref_name }}
 
   release:
     name: Create Release
-    needs: ci
+    needs: [ ci, docs ]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -52,5 +61,5 @@ jobs:
       - name: Publish release to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
           password: ${{ secrets.TEST_PYPI_PASSWORD }}

--- a/changes/1186.misc.rst
+++ b/changes/1186.misc.rst
@@ -1,0 +1,1 @@
+An explicit check is now made during the automated release process to ensure ReadTheDocs docs were successfully built for the release.


### PR DESCRIPTION
## Changes
- Introduces a dependency on RTD successfully building docs for the new `v*` tag for creating a GitHub Release.

## Implementation
- When a new `v*` tag is pushed to the repo, GitHub initiates this repo's `release` workflow (and in turn the `publish` workflow as a consequence of a Release being "published").
- At the same time, presumably through a webhook between GitHub and RTD, the docs for the tag are built on RTD.
- So, this simply inserts a loop in the `release` workflow that confirms RTD successfully built the docs for the new version and allows the release process to progress.
  - This checks the `built` parameter of the payload returned from RTD's [version detail endpoint](https://docs.readthedocs.io/en/stable/api/v3.html#version-detail) which is defined as "the version has at least one successful build".
  - Since this is the first time RTD has seen the version, a value of `true` should imply the build that was just triggered completed successfully.
- As an example, consider the `v0.3.14` release from April 11 @ 0311 UTC:
  - GitHub `release` workflow [run](https://github.com/beeware/briefcase/actions/runs/4674210807)
  - RTD [build](https://readthedocs.org/projects/briefcase/builds/20086650/)

## Notes
- Depends on beeware/.github#30.
- Ref: #1182

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
