### PR TITLE
Stop unintentionally creating a folder during tests on Windows

### DIFF
--- a/changes/1187.misc.rst
+++ b/changes/1187.misc.rst
@@ -1,0 +1,1 @@
+When running tests on Windows, a directory named ``a-path-that-will-cause-an-OSError`` is no longer created at the root of the current drive.

--- a/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
@@ -10,7 +10,7 @@ from briefcase.integrations import windows_sdk
 from briefcase.integrations.windows_sdk import WindowsSDK
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_winreg(monkeypatch):
     """Mock out winreg module."""
     winreg = MagicMock()
@@ -329,6 +329,7 @@ def test_winsdk_invalid_install_from_reg(
 
 def test_winsdk_valid_install_from_default_dir(
     mock_tools,
+    mock_winreg,
     tmp_path,
     capsys,
     monkeypatch,
@@ -371,6 +372,7 @@ def test_winsdk_valid_install_from_default_dir(
 
 def test_winsdk_invalid_install_from_default_dir(
     mock_tools,
+    mock_winreg,
     tmp_path,
     capsys,
     monkeypatch,


### PR DESCRIPTION
## Changes
- Testing failure from writing the log file was actually depending on the call to `mkdir()` to fail.
  - This was assuming creating a root directory would fail...and it does on non-Windows systems.
  - On Windows, the call to create the root directory succeeds....but writing the logfile then fails.
```
Failed to save log to \a-path-that-will-cause-an-OSError...\logs\briefcase.2023_04_16-11_10_46.dev.log: [WinError 3] The system cannot find the path specified: '\\a-path-that-will-cause-an-OSError...\\logs'
```
- Instead of depending on actual filesystem interaction to test failure while writing the log file, this updates the test to mock the filesystem error when the file write occurs.
- This also introduces a test case for failing to create the directory....although, it's admittedly a little obtuse and probably fragile.

## Reference
- Fixes #1187

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
