### PR TITLE
Block pip 23.1 from use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           experimental: false
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v3.5.0
       with:
         fetch-depth: 0
 
@@ -76,7 +76,9 @@ jobs:
 
     - name: Install dev dependencies
       run: |
-        python -m pip install --upgrade pip
+        # pip 23.1 has an issue with --user installs.
+        # See https://github.com/pypa/pip/issues/11982 for details
+        python -m pip install --upgrade "pip!=23.1"
         python -m pip install --upgrade setuptools
         # We don't actually want to install briefcase; we just want the dev
         # extras so we have a known version of tox and coverage.
@@ -102,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v3.5.0
       with:
         fetch-depth: 0
 
@@ -113,7 +115,9 @@ jobs:
 
     - name: Install dev dependencies
       run: |
-        python -m pip install --upgrade pip
+        # pip 23.1 has an issue with --user installs.
+        # See https://github.com/pypa/pip/issues/11982 for details
+        python -m pip install --upgrade "pip!=23.1"
         python -m pip install --upgrade setuptools
         # We don't actually want to install briefcase;
         # we just want the dev extras so that we have a known version of coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           experimental: false
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
       with:
         fetch-depth: 0
 
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v3.5.2
       with:
         fetch-depth: 0
 

--- a/changes/1195.misc.rst
+++ b/changes/1195.misc.rst
@@ -1,0 +1,1 @@
+pip 23.1 was blocked from use due to pip bug #11982.

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,9 @@ install_requires =
     # the most recent version.
     importlib_metadata >= 4.4; python_version <= "3.9"
     packaging >= 22.0
-    pip >= 22
+    # pip 23.1 has an issue with --user installs.
+    # See https://github.com/pypa/pip/issues/11982 for details
+    pip >= 22, != 23.1
     setuptools >= 60
     wheel >= 0.37
     build >= 0.10

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,10 @@
 passenv =
     # LOCALAPPDATA is needed to test data directory creation on Windows.
     LOCALAPPDATA
+# pip 23.1 has an issue with --user installs.
+# See https://github.com/pypa/pip/issues/11982 for details
+setenv =
+    VIRTUALENV_PIP=23.0.1
 extras =
     dev
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ passenv =
     LOCALAPPDATA
 # pip 23.1 has an issue with --user installs.
 # See https://github.com/pypa/pip/issues/11982 for details
+# FIXME - remove this as soon as an updated pip is released.
 setenv =
     VIRTUALENV_PIP=23.0.1
 extras =


### PR DESCRIPTION
Pip issue pypa/pip#11982 prevents the test suite from passing on winstore environments. 

This PR ensures that pip 23.1 can't be used, and forces the use of pip 23.0.1 (for now) in tox.

Refs #1195.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
