### PR TITLE
Fix stuck streamer test....again

### DIFF
--- a/changes/1197.misc.rst
+++ b/changes/1197.misc.rst
@@ -1,0 +1,1 @@
+The stuck streamer test was updated to mitigate false failures potentially stemming from high load macOS GitHub runners.

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -117,7 +117,7 @@ def test_stuck_streamer(mock_sub, streaming_process, monkeypatch, capsys):
 
     def monkeypatched_blocked_streamer(*a, **kw):
         """Simulate a streamer that blocks longer than it will be waited on."""
-        if not monkeypatched_streamer_should_exit.wait(timeout=1):
+        if not monkeypatched_streamer_should_exit.wait(timeout=5):
             monkeypatched_streamer_was_improperly_awaited.set()
         monkeypatched_streamer_exited.set()
 
@@ -134,18 +134,18 @@ def test_stuck_streamer(mock_sub, streaming_process, monkeypatch, capsys):
 
     monkeypatched_streamer_should_exit.set()
 
+    # Since the waiting around for the output streamer has been
+    # short-circuited, Briefcase should quickly give up waiting on
+    # the output streamer and it should exit...so, confirm it does.
+    assert monkeypatched_streamer_exited.wait(timeout=1)
+    assert not monkeypatched_streamer_was_improperly_awaited.is_set()
+
     # fmt: off
     assert capsys.readouterr().out == (
         "Stopping...\n"
         "Log stream hasn't terminated; log output may be corrupted.\n"
     )
     # fmt: on
-
-    # Since the waiting around for the output streamer has been
-    # short-circuited, Briefcase should quickly give up waiting on
-    # the output streamer and it should exit...so, confirm it does.
-    assert monkeypatched_streamer_exited.wait(timeout=1)
-    assert not monkeypatched_streamer_was_improperly_awaited.is_set()
 
 
 def test_stdout_closes_unexpectedly(mock_sub, streaming_process, monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- `test_stuck_streamer` started failing in CI...although, I've only seen it fail for macOS
  - ex 1: https://github.com/beeware/briefcase/actions/runs/4755342491/jobs/8449399556
  - ex 2: https://github.com/beeware/briefcase/actions/runs/4726835832/jobs/8386820920
- In the previous [attempt](https://github.com/beeware/briefcase/pull/1147) to fix this, we talked about the code under test taking a total of 0.25 + 3 * 0.1 == 0.55 seconds while the monkeypatched output streamer persists for at least a second.
  - This time is actually slightly longer:
    - 0.1s for `stop_func()` to raise `KeyboardInterrupt`
    - 0.25s for the `KeyboardInterrupt` to propagate
    - 0.1s * 3 for each `sleep()` between checking if the output streamer exited
  - So, the total sleep time will take at least 0.65s
- Obviously other things are happening and I wouldn't expect all that to add up to more than 0.35s in this code.
- However, it does seem at times that macOS runners may be over-provisioned...and therefore experiencing heavy loads...so, perhaps among the context switches the runners are stalling under the load sometimes introducing _just_ enough delay to fail the test.
  - In most of the cases of failures, the line `Log stream hasn't terminated; log output may be corrupted.` is missing from the output check
    - This implies the monkeypatched streamer thread finished before `Subprocess` checked if it was still alive...and the streamer should have still been alive since the code under test should only be taking 0.65s to check this while the streamer runs for 1.0s
  - In another case, the `monkeypatched_streamer_was_improperly_awaited` Event was set but the output must have included `Log stream hasn't terminated; log output may be corrupted.` (because that `assert` passed).
    - So, the streamer stopped waiting after 1.0s, set that failed flag, and then exited but not before `Subprocess` apparently saw the streamer still running....when it should have exited.

## Changes
- Based on this, I just increased the time the monkeypatched streamer waits for the `should_exit` flag to 5 seconds.
- This should completely mitigate the possibility that the "code is just running slow" while under test.
- And the additional wait time would only ever be experienced under test failure conditions; normally the test will complete with the expected 0.65s code runtime.
- I also moved the logging check to the bottom of the test so any future failures show which flag isn't set correctly.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
