### PR TITLE
Clean up pip exclusion.

### DIFF
--- a/changes/1195.misc.rst
+++ b/changes/1195.misc.rst
@@ -1,1 +1,1 @@
-pip 23.1 was blocked from use due to pip bug #11982.
+pip 23.1 was blocked from use due to pip bug #11982

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,9 @@
+[pkgenv]
+# 2023-04-22 The virtualenv used by Tox has pip 23.1 pinned into it
+# This version has a bug on winstore installs of Python, so we
+# need to force pip to be updated.
+download = True
+
 # The leading comma generates the "py" environment.
 [testenv:py{,38,39,310,311,312}]
 passenv =
@@ -5,6 +11,10 @@ passenv =
     LOCALAPPDATA
 extras =
     dev
+# 2023-04-22 The virtualenv used by Tox has pip 23.1 pinned into it
+# This version has a bug on winstore installs of Python, so we
+# need to force pip to be updated.
+download = True
 commands =
     python -m coverage run -m pytest -vv {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,6 @@
 passenv =
     # LOCALAPPDATA is needed to test data directory creation on Windows.
     LOCALAPPDATA
-# pip 23.1 has an issue with --user installs.
-# See https://github.com/pypa/pip/issues/11982 for details
-# FIXME - remove this as soon as an updated pip is released.
-setenv =
-    VIRTUALENV_PIP=23.0.1
 extras =
     dev
 commands =


### PR DESCRIPTION
#1196 added exclusions for pip 23.1; however, due to the way that tox auto-updates pip to the most-recent version, an explicit configuration was needed to avoid using pip 23.1 in practice. That configuration is no longer required, and hard-pinning an old version of pip isn't desirable.

Fixes #1195.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
