### PR TITLE
Document use_full_install_path on Windows

### DIFF
--- a/changes/1199.feature.rst
+++ b/changes/1199.feature.rst
@@ -1,0 +1,1 @@
+The company/author name in the installation path for Windows MSI installers is now optional.

--- a/docs/reference/platforms/windows/app.rst
+++ b/docs/reference/platforms/windows/app.rst
@@ -62,6 +62,16 @@ If ``true`` the installer will attempt to install the app as a per-machine app,
 available to all users. If ``false``, the installer will install as a per-user
 app. If undefined the installer will ask the user for their preference.
 
+``use_full_install_path``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Controls whether the app will be installed using a path which includes both the
+application name *and* the company or developer's name. If ``true`` (the
+default), the app will be installed to ``Program Files\<Author Name>\<Project
+Name>``. If ``false``, it will be installed to ``Program Files\<Project Name>``.
+Using the full path makes sense for larger companies with multiple applications,
+but less so for a solo developer.
+
 ``version_triple``
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/reference/platforms/windows/visualstudio.rst
+++ b/docs/reference/platforms/windows/visualstudio.rst
@@ -86,6 +86,16 @@ If ``true`` the installer will attempt to install the app as a per-machine app,
 available to all users. If ``false``, the installer will install as a per-user
 app. If undefined the installer will ask the user for their preference.
 
+``use_full_install_path``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Controls whether the app will be installed using a path which includes both the
+application name *and* the company or developer's name. If ``true`` (the
+default), the app will be installed to ``Program Files\<Author Name>\<Project
+Name>``. If ``false``, it will be installed to ``Program Files\<Project Name>``.
+Using the full path makes sense for larger companies with multiple applications,
+but less so for a solo developer.
+
 ``version_triple``
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
There is now a new option `use_full_install_path` which defaults to `True` to install the application in `Programs/<author name>/<app name>`. If you include the option in the `pyproject.toml` with a value of `False`, it installs the application into `Programs/<app name>`.

Fixes #1199.
See also: beeware/briefcase-windows-app-template#11, beeware/briefcase-windows-VisualStudio-template#15

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct