### PR TITLE
refactor linux mixins to remove target option for run command

### DIFF
--- a/changes/1207.bugfix.rst
+++ b/changes/1207.bugfix.rst
@@ -1,0 +1,1 @@
+Refactored Linux system mixins to remove ``target`` option and related processing from ``run`` command.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Make ``use_docker`` False by default in ``LinuxSystemPassiveMixin`` and move docker processing and related ``target`` option to ``LinuxSystemMostlyPassiveMixin``.
<!--- What problem does this change solve? -->
This removes the ``target`` option from the run command, which avoids a confusing error when trying to use that option. It was decided  that the option does not make sense for the run command.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
refs #1207 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] All new features have been tested
- [ ] All new features have been documented
- [ x] I have read the **CONTRIBUTING.md** file
- [x ] I will abide by the code of conduct
