### PR TITLE
Adds briefcase project version to briefcase cli

### DIFF
--- a/changes/360.feature.rst
+++ b/changes/360.feature.rst
@@ -1,0 +1,1 @@
+add `briefcase project version` command to briefcase

--- a/docs/reference/commands/index.rst
+++ b/docs/reference/commands/index.rst
@@ -12,5 +12,6 @@ Command reference
    build
    run
    package
+   project
    publish
    upgrade

--- a/docs/reference/commands/project.rst
+++ b/docs/reference/commands/project.rst
@@ -22,4 +22,4 @@ The following options can be provided at the command line.
 ``version``
 ---------------------------------------
 
-Returns information about the project version from the pyproject.toml file.
+Returns information about the project version from the ``pyproject.toml`` file.

--- a/docs/reference/commands/project.rst
+++ b/docs/reference/commands/project.rst
@@ -1,0 +1,25 @@
+=======
+project
+=======
+Get information on project version.
+
+Usage
+=====
+
+To get project version info run::
+
+    $ briefcase project version
+
+
+
+
+
+Options
+=======
+
+The following options can be provided at the command line.
+
+``version``
+---------------------------------------
+
+Returns information about the project version from the pyproject.toml file.

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -12,6 +12,7 @@ from briefcase.commands import (
     NewCommand,
     OpenCommand,
     PackageCommand,
+    ProjectCommand,
     PublishCommand,
     RunCommand,
     UpdateCommand,
@@ -31,6 +32,7 @@ COMMANDS = [
     UpdateCommand,
     RunCommand,
     PackageCommand,
+    ProjectCommand,
     PublishCommand,
     UpgradeCommand,
 ]
@@ -128,6 +130,8 @@ def parse_cmdline(args):
         Command = DevCommand
     elif options.command == "upgrade":
         Command = UpgradeCommand
+    elif options.command == "project":
+        Command = ProjectCommand
 
     # Commands dependent on the platform and format
     else:

--- a/src/briefcase/commands/__init__.py
+++ b/src/briefcase/commands/__init__.py
@@ -4,6 +4,7 @@ from .dev import DevCommand  # noqa: F401
 from .new import NewCommand  # noqa: F401
 from .open import OpenCommand  # noqa: F401
 from .package import PackageCommand  # noqa: F401
+from .project import ProjectCommand  # noqa: F401
 from .publish import PublishCommand  # noqa: F401
 from .run import RunCommand  # noqa: F401
 from .update import UpdateCommand  # noqa: F401

--- a/src/briefcase/commands/project.py
+++ b/src/briefcase/commands/project.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from briefcase.commands.base import BaseCommand
+from briefcase.config import BaseConfig
+
+
+class ProjectCommand(BaseCommand):
+    command = "project"
+    description = "project test."
+    output_format = None
+    platform = "all"
+
+    def add_options(self, parser):
+        parser.add_argument(
+            "action",
+            help="The app to run",
+        )
+
+    def binary_path(self, app):
+        NotImplementedError()
+
+    def __call__(
+        self,
+        app: Optional[BaseConfig] = None,
+        update_requirements: bool = False,
+        update_resources: bool = False,
+        test_mode: bool = False,
+        **options,
+    ):
+        app = list(self.apps.values())[0]
+        self.finalize(app)
+        self.logger.print(f"project.version={app.version}")
+        return app.version

--- a/src/briefcase/commands/project.py
+++ b/src/briefcase/commands/project.py
@@ -13,7 +13,7 @@ class ProjectCommand(BaseCommand):
     def add_options(self, parser):
         parser.add_argument(
             "action",
-            help="The app to run",
+            help="Project information",
         )
 
     def binary_path(self, app):

--- a/tests/commands/project/conftest.py
+++ b/tests/commands/project/conftest.py
@@ -1,0 +1,125 @@
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.commands import ProjectCommand
+from briefcase.commands.base import full_options
+from briefcase.config import AppConfig
+from briefcase.console import Console, Log
+from briefcase.integrations.subprocess import Subprocess
+
+from ...utils import create_file
+
+
+class DummyProjectCommand(ProjectCommand):
+    """A dummy project command that doesn't actually do anything.
+
+    It only serves to track which actions would be performed.
+    """
+
+    # Platform and format contain upper case to test case normalization
+    platform = "Tester"
+    output_format = "Dummy"
+    description = "Dummy Project command"
+
+    def __init__(self, *args, apps, **kwargs):
+        kwargs.setdefault("logger", Log())
+        kwargs.setdefault("console", Console())
+        super().__init__(*args, apps=apps, **kwargs)
+
+        # Override the OS services that are used when opening
+        self.tools.os = MagicMock(spec_set=os)
+        self.tools.subprocess = MagicMock(spec_set=Subprocess)
+
+        self.actions = []
+
+    def binary_path(self, app):
+        raise NotImplementedError(
+            "Required by interface contract, but should not be used"
+        )
+
+    def project_path(self, app):
+        return self.bundle_path(app) / f"{app.formal_name}.project"
+
+    def verify_host(self):
+        super().verify_host()
+        self.actions.append(("verify-host",))
+
+    def verify_tools(self):
+        super().verify_tools()
+        self.actions.append(("verify-tools",))
+
+    def finalize_app_config(self, app):
+        super().finalize_app_config(app=app)
+        self.actions.append(("finalize-app-config", app.app_name))
+
+    def verify_app_tools(self, app):
+        super().verify_app_tools(app=app)
+        self.actions.append(("verify-app-tools", app.app_name))
+
+    def _open_app(self, app):
+        super()._open_app(app)
+        self.actions.append(("open", app.app_name))
+
+    # These commands override the default behavior, simply tracking that
+    # they were invoked, rather than instantiating a Create command.
+    # This is for testing purposes.
+    def create_command(self, app, **kwargs):
+        self.actions.append(("create", app.app_name, kwargs))
+        return full_options({"create_state": app.app_name}, kwargs)
+
+
+@pytest.fixture
+def project_command(tmp_path):
+    return DummyProjectCommand(
+        base_path=tmp_path / "base_path",
+        apps={
+            "first": AppConfig(
+                app_name="first",
+                bundle="com.example",
+                version="0.0.1",
+                description="The first simple app",
+                sources=["src/first"],
+            ),
+            "second": AppConfig(
+                app_name="second",
+                bundle="com.example",
+                version="0.0.2",
+                description="The second simple app",
+                sources=["src/second"],
+            ),
+        },
+    )
+
+
+@pytest.fixture
+def first_app(tmp_path):
+    """Populate skeleton app content for the first app."""
+    project_file = (
+        tmp_path
+        / "base_path"
+        / "build"
+        / "first"
+        / "tester"
+        / "dummy"
+        / "first.project"
+    )
+    create_file(project_file, "first project")
+    return project_file
+
+
+@pytest.fixture
+def second_app(tmp_path):
+    """Populate skeleton app content for the second app."""
+    project_file = (
+        tmp_path
+        / "base_path"
+        / "build"
+        / "second"
+        / "tester"
+        / "dummy"
+        / "second.project"
+    )
+    create_file(project_file, "second project")
+    return project_file

--- a/tests/commands/project/test_project_version.py
+++ b/tests/commands/project/test_project_version.py
@@ -1,0 +1,3 @@
+def test_project_command(project_command, capsys):
+    project_command(app=project_command.apps["first"])
+    assert capsys.readouterr().out == "project.version=0.0.1\n"

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 from briefcase import __version__, cmdline
-from briefcase.commands import DevCommand, NewCommand, UpgradeCommand
+from briefcase.commands import DevCommand, NewCommand, ProjectCommand, UpgradeCommand
 from briefcase.console import Console, Log
 from briefcase.exceptions import (
     InvalidFormatError,
@@ -503,3 +503,16 @@ def test_unknown_command_options(monkeypatch, capsys, logger, console):
         "                                     [-c {s3}]\n"
         "briefcase publish macOS Xcode: error: unrecognized arguments: -x"
     )
+
+
+def test_project_command(logger, console):
+    """``briefcase project version`` returns the Project command."""
+    cmd, options = do_cmdline_parse("project version".split(), logger, console)
+
+    assert isinstance(cmd, ProjectCommand)
+    assert cmd.platform == "all"
+    assert cmd.output_format is None
+    assert cmd.input.enabled
+    assert cmd.logger.verbosity == 1
+    assert cmd.logger is logger
+    assert cmd.input is console


### PR DESCRIPTION
<!--- Describe your changes in detail -->
This change adds a feature to the briefcase cli that allows the user to get their project version with the command `briefcase project version`. The output of `project version` is, for example,  `project.version=0.0.1`
<!--- What problem does this change solve? -->

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
This PR implements the feature requested in issue #360

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
