### PR TITLE
allow micropip to install pyodide wheels

### DIFF
--- a/changes/1225.bugfix.rst
+++ b/changes/1225.bugfix.rst
@@ -1,0 +1,1 @@
+Web platform: Allow micropip to install binary dependencies.

--- a/changes/1225.bugfix.rst
+++ b/changes/1225.bugfix.rst
@@ -1,1 +1,1 @@
-Web platform: Allow micropip to install binary dependencies.
+Web platform: Allow micropip to attempt to install binary dependencies if wasm32 binary wheel is not bundled.

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -183,10 +183,11 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
                 }
                 # Ensure that non-pyodide-compatible wheels are passed as package names
                 # so that micropip can try to install it from the pyodide index.
-                # TODO: get pyodide whl and bundle it instead of relying on micropip
+                # TODO: get pyodide whl so it can be bundled
                 for wheel in packages:
                     name, version, build, tags = parse_wheel_filename(wheel.name)
-                    if not any(tag.platform == "any" for tag in tags):
+                    if not any(tag.platform == "any" or "wasm32" in tag.platform
+                               for tag in tags):
                         packages[wheel] = name
                 config = {
                     "name": app.formal_name,

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -7,8 +7,9 @@ from pathlib import Path
 from typing import Any, List
 from zipfile import ZipFile
 
-from briefcase.console import Log
 from packaging.utils import parse_wheel_filename
+
+from briefcase.console import Log
 
 try:
     import tomllib
@@ -186,8 +187,10 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
                 # TODO: get pyodide whl so it can be bundled
                 for wheel in packages:
                     name, version, build, tags = parse_wheel_filename(wheel.name)
-                    if not any(tag.platform == "any" or "wasm32" in tag.platform
-                               for tag in tags):
+                    if not any(
+                        tag.platform == "any" or "wasm32" in tag.platform
+                        for tag in tags
+                    ):
                         packages[wheel] = name
                 config = {
                     "name": app.formal_name,

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -184,7 +184,6 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
                 }
                 # Ensure that non-pyodide-compatible wheels are passed as package names
                 # so that micropip can try to install it from the pyodide index.
-                # TODO: get pyodide whl so it can be bundled
                 for wheel in packages:
                     name, version, build, tags = parse_wheel_filename(wheel.name)
                     if not any(

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -183,6 +183,7 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
                 }
                 # Ensure that non-pyodide-compatible wheels are passed as package names
                 # so that micropip can try to install it from the pyodide index.
+                # TODO: get pyodide whl and bundle it instead of relying on micropip
                 for wheel in packages:
                     name, version, build, tags = parse_wheel_filename(wheel.name)
                     if not any(tag.platform == "any" for tag in tags):

--- a/tests/platforms/web/static/test_build.py
+++ b/tests/platforms/web/static/test_build.py
@@ -45,7 +45,7 @@ def test_build_app(build_command, first_app_generated, tmp_path):
                 extra_content=[
                     ("dependency/static/style.css", "span { margin: 10px; }\n"),
                 ],
-            ),
+            )
         elif args[0][3] == "pip":
             create_wheel(
                 bundle_path / "www" / "static" / "wheels",
@@ -53,14 +53,30 @@ def test_build_app(build_command, first_app_generated, tmp_path):
                 extra_content=[
                     ("dependency/static/style.css", "div { margin: 10px; }\n"),
                 ],
-            ),
+            )
+            create_wheel(
+                bundle_path / "www" / "static" / "wheels",
+                "wasm_dep",
+                extra_content=[
+                    ("dependency/static/style.css", "div { margin: 10px; }\n"),
+                ],
+                platform="emscripten_3_1_14_wasm32",
+            )
+            create_wheel(
+                bundle_path / "www" / "static" / "wheels",
+                "macos_dep",
+                extra_content=[
+                    ("dependency/static/style.css", "div { margin: 10px; }\n"),
+                ],
+                platform="macosx_10_9_x86_64",
+            )
             create_wheel(
                 bundle_path / "www" / "static" / "wheels",
                 "other",
                 extra_content=[
                     ("other/static/style.css", "div { padding: 10px; }\n"),
                 ],
-            ),
+            )
         else:
             raise ValueError("Unknown command")
 
@@ -121,7 +137,9 @@ def test_build_app(build_command, first_app_generated, tmp_path):
             "packages": [
                 "/static/wheels/dependency-1.2.3-py3-none-any.whl",
                 "/static/wheels/first_app-1.2.3-py3-none-any.whl",
+                "macos-dep",
                 "/static/wheels/other-1.2.3-py3-none-any.whl",
+                "/static/wheels/wasm_dep-1.2.3-py3-none-emscripten_3_1_14_wasm32.whl",
             ],
         }
 
@@ -157,6 +175,12 @@ def test_build_app(build_command, first_app_generated, tmp_path):
                     " *******************************************************/",
                     "",
                     "div { padding: 10px; }",
+                    "",
+                    "/*******************************************************",
+                    " * wasm_dep 1.2.3::style.css",
+                    " *******************************************************/",
+                    "",
+                    "div { margin: 10px; }",
                 ]
             )
             + "\n"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -150,16 +150,17 @@ def mock_tgz_download(filename, content, role=None):
     return _download_file
 
 
-def create_wheel(path, package="dummy", version="1.2.3", extra_content=None):
+def create_wheel(path, package="dummy", version="1.2.3", lang="py3", abi="none",
+                 platform="any", extra_content=None):
     """Create a sample wheel file.
 
-    :param path: The folder where the wheel should be writter.
+    :param path: The folder where the wheel should be written.
     :param package: The name of the package in the wheel. Defaults to ``dummy``
     :param version: The version number of the package. Defaults to ``1.2.3``
     :param extra_content: Optional. A list of tuples of ``(path, content)`` that
         will be added to the wheel.
     """
-    wheel_filename = path / f"{package}-{version}-py3-none-any.whl"
+    wheel_filename = path / f"{package}-{version}-{lang}-{abi}-{platform}.whl"
 
     create_zip_file(
         wheel_filename,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -150,13 +150,23 @@ def mock_tgz_download(filename, content, role=None):
     return _download_file
 
 
-def create_wheel(path, package="dummy", version="1.2.3", lang="py3", abi="none",
-                 platform="any", extra_content=None):
+def create_wheel(
+    path,
+    package="dummy",
+    version="1.2.3",
+    lang="py3",
+    abi="none",
+    platform="any",
+    extra_content=None,
+):
     """Create a sample wheel file.
 
     :param path: The folder where the wheel should be written.
     :param package: The name of the package in the wheel. Defaults to ``dummy``
     :param version: The version number of the package. Defaults to ``1.2.3``
+    :param lang: The language implementation and version. Defaults to ``py3``
+    :param abi: The ABI tag. Defaults to ``none``
+    :param platform: The platform tag. Defaults to ``any``
     :param extra_content: Optional. A list of tuples of ``(path, content)`` that
         will be added to the wheel.
     """


### PR DESCRIPTION
Currently, briefcase tries to load compiled wheels from the host platform, which leads to errors when loading in the browser. This PR parses the whl filename and any wheels that are not pure python or wasm32 are replaced with simply the package name, so that micropip can install it. We do not attempt to bundle the whl file compiled for the host platform.

In the future, when Pyodide starts hosting an index, we should download the pyodide wheel and bundle that wheel.
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
