### PR TITLE
Remove pytest-tldr

### DIFF
--- a/changes/1226.misc.rst
+++ b/changes/1226.misc.rst
@@ -1,0 +1,1 @@
+Remove pytest-tldr from dev requirements

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,6 @@ dev =
     coverage[toml] == 7.2.3
     pre-commit == 3.2.2
     pytest == 7.3.1
-    pytest-tldr == 0.2.5
     setuptools_scm[toml] == 7.1.0
     tox == 4.4.12
 docs =


### PR DESCRIPTION
I've worked with a couple of people today who were trying to debug their tests by adding print statements. Normally you can get pytest to show you captured stdout using the `-r` option (e.g. `-rP`), but it looks like pytest-tldr breaks that, so we had to uninstall it. I've hit the same issue myself in the past.

pytest-tldr also loses the nicely-formatted progress indicator, which should look like this:
```
tests/test_cmdline.py ......................................s.s.............           [  2%]
tests/test_mainline.py ........                                                        [  2%]
tests/commands/base/test_app_module_path.py ........                                   [  3%]
tests/commands/base/test_finalize.py ....                                              [  3%]
```

So overall I think it's more trouble than it's worth, and it's better to remove it from the dev requirements. People who like it can still install it manually.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
