### PR TITLE
add coverage report to tox.ini

### DIFF
--- a/changes/1228.misc.rst
+++ b/changes/1228.misc.rst
@@ -1,1 +1,1 @@
-Added coverage report to tox.ini and updated docs to mention it.
+Added coverage command to tox.ini and updated docs to mention it.

--- a/changes/1228.misc.rst
+++ b/changes/1228.misc.rst
@@ -1,0 +1,1 @@
+Added coverage report to tox.ini and updated docs to mention it.

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -321,6 +321,17 @@ substituting the version number that you want to target. You can also specify
 the `towncrier-check`, `docs` or `package` targets to check release notes,
 documentation syntax and packaging metadata, respectively.
 
+Verify test coverage
+--------------------
+
+When you run the test suite, a coverage report is generated and shown at the
+end of the output. Depending on your platform, some lines required by other
+platforms will be skipped and shown as "missing" in the coverage report. You
+can safely ignore those lines. However, make sure that any lines of code that
+you added or modified do not appear in the report. If they do, you need to add
+new tests that will cover those lines. Otherwise, the coverage check will fail
+when you make a PR with your changes.
+
 Add change information for release notes
 ----------------------------------------
 

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -324,8 +324,12 @@ documentation syntax and packaging metadata, respectively.
 Verify test coverage
 --------------------
 
-When you run the test suite, a coverage report is generated and shown at the
-end of the output. Depending on your platform, some lines required by other
+Briefcase requires 100% test coverage, so when you add new code it is expected
+that enough tests are added to cover the new code. You can run ``tox`` with the
+`coverage` target to generate a coverage report. The test suite is then run and
+a coverage report is generated and shown at the end of the output.
+
+Depending on your platform, it's possible that some lines required by other
 platforms will be skipped and shown as "missing" in the coverage report. You
 can safely ignore those lines. However, make sure that any lines of code that
 you added or modified do not appear in the report. If they do, you need to add

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -336,20 +336,22 @@ To run the test suite and generate a coverage report, run:
 
     .. code-block:: console
 
-      (venv) $ tox -e coverage
+      (venv) $ tox -e py-coverage
 
   .. group-tab:: Linux
 
     .. code-block:: console
 
-      (venv) $ tox -e coverage
+      (venv) $ tox -e py-coverage
 
   .. group-tab:: Windows
 
     .. code-block:: doscon
 
-      (venv) C:\...>tox -e coverage
+      (venv) C:\...>tox -e py-coverage
 
+You can use a specific Python version for the coverage report by adding the
+version number to the `py-coverage` command. For example, `py310-coverage`.
 Depending on your platform, it's possible that some lines required by other
 platforms will be skipped and shown as "missing" in the coverage report. You
 can safely ignore those lines. However, make sure that any lines of code that

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -324,10 +324,31 @@ documentation syntax and packaging metadata, respectively.
 Verify test coverage
 --------------------
 
-Briefcase requires 100% test coverage, so when you add new code it is expected
-that enough tests are added to cover the new code. You can run ``tox`` with the
-`coverage` target to generate a coverage report. The test suite is then run and
-a coverage report is generated and shown at the end of the output.
+Briefcase maintains 100% branch coverage in its codebase. When you add or modify
+code in the project, you must add test code to ensure coverage of any
+changes you make.
+
+To run the test suite and generate a coverage report, run:
+
+.. tabs::
+
+  .. group-tab:: macOS
+
+    .. code-block:: console
+
+      (venv) $ tox -e coverage
+
+  .. group-tab:: Linux
+
+    .. code-block:: console
+
+      (venv) $ tox -e coverage
+
+  .. group-tab:: Windows
+
+    .. code-block:: doscon
+
+      (venv) C:\...>tox -e coverage
 
 Depending on your platform, it's possible that some lines required by other
 platforms will be skipped and shown as "missing" in the coverage report. You

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -11,6 +11,7 @@ BeeWare
 Bugfix
 Bugfixes
 checkmarks
+codebase
 cryptographic
 dev
 dialogs

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 download = True
 
 # The leading comma generates the "py" environment.
-[testenv:py{,38,39,310,311,312}]
+[testenv:py{,38,39,310,311,312}-coverage]
 passenv =
     # LOCALAPPDATA is needed to test data directory creation on Windows.
     LOCALAPPDATA
@@ -17,18 +17,8 @@ extras =
 download = True
 commands =
     python -m coverage run -m pytest -vv {posargs}
-
-[testenv:coverage]
-extras =
-    dev
-# 2023-04-22 The virtualenv used by Tox has pip 23.1 pinned into it
-# This version has a bug on winstore installs of Python, so we
-# need to force pip to be updated.
-download = True
-commands =
-    python -m coverage run -m pytest -vv {posargs}
-    python -m coverage combine
-    python -m coverage report
+    coverage : python -m coverage combine
+    coverage : python -m coverage report
 
 [testenv:towncrier-check]
 package_env = none

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 download = True
 
 # The leading comma generates the "py" environment.
-[testenv:py{,38,39,310,311,312}-coverage]
+[testenv:py{,38,39,310,311,312}{,-coverage}]
 passenv =
     # LOCALAPPDATA is needed to test data directory creation on Windows.
     LOCALAPPDATA

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ extras =
 download = True
 commands =
     python -m coverage run -m pytest -vv {posargs}
+    python -m coverage combine
+    python -m coverage report
 
 [testenv:towncrier-check]
 package_env = none

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,12 @@ extras =
 download = True
 commands =
     python -m coverage run -m pytest -vv {posargs}
+
+[testenv:coverage]
+extras =
+    dev
+commands =
+    python -m coverage run -m pytest -vv {posargs}
     python -m coverage combine
     python -m coverage report
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,10 @@ commands =
 [testenv:coverage]
 extras =
     dev
+# 2023-04-22 The virtualenv used by Tox has pip 23.1 pinned into it
+# This version has a bug on winstore installs of Python, so we
+# need to force pip to be updated.
+download = True
 commands =
     python -m coverage run -m pytest -vv {posargs}
     python -m coverage combine


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Added a coverage report at the end of the test output
<!--- What problem does this change solve? -->
it's helpful to have coverage information when there's a coverage check in the CI.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
