### PR TITLE
Capture `GitCommandError` in log file

### DIFF
--- a/changes/1232.misc.rst
+++ b/changes/1232.misc.rst
@@ -1,0 +1,1 @@
+If `git` fails to update a template in the cookiecutter cache, the `git` command and output are now captured in the Briefcase log file.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -772,10 +772,12 @@ Did you run Briefcase in a project directory that contains {filename.name!r}?"""
                     # Attempt to update the repository
                     remote = repo.remote(name="origin")
                     remote.fetch()
-                except self.tools.git.exc.GitCommandError:
+                except self.tools.git.exc.GitCommandError as e:
                     # We are offline, or otherwise unable to contact
-                    # the origin git repo. It's OK to continue; but warn
-                    # the user that the template may be stale.
+                    # the origin git repo. It's OK to continue; but
+                    # capture the error in the log and warn the user
+                    # that the template may be stale.
+                    self.logger.debug(str(e))
                     self.logger.warning(
                         """
 *************************************************************************
@@ -789,6 +791,7 @@ Did you run Briefcase in a project directory that contains {filename.name!r}?"""
 *************************************************************************
 """
                     )
+
                 try:
                     # Check out the branch for the required version tag.
                     head = remote.refs[branch]


### PR DESCRIPTION
## Changes
- Captures the underlying cause of `git` failures in the log file
- Example where the underlying issue was not a transient network problem:
  - https://github.com/beeware/briefcase/issues/1114

Example of new log entry
```
           [helloworld] Generating application template...                                                                                                             create.py:755
           Assigning helloworld an application GUID of 93bbf2ae-12d0-580c-aeb0-965dc4c04b69                                                                           __init__.py:69
           Using app template: https://github.com/beeware/briefcase-windows-VisualStudio-template.git, branch v0.3.15                                                  create.py:251
           >>> Cmd('git') failed due to: exit code(128)                                                                                                                  base.py:776
           >>>   cmdline: git fetch -v -- origin                                                                                                                         base.py:776
           >>>   stderr: 'fatal: unable to access 'https://github.com/beeware/briefcase-windows-VisualStudio-template.git/': Could not resolve host: github.com'         base.py:776
                                                                                                                                                                         base.py:780
           *************************************************************************                                                                                     base.py:780
           ** WARNING: Unable to update template                                  **                                                                                     base.py:780
           *************************************************************************                                                                                     base.py:780
                                                                                                                                                                         base.py:780
              Briefcase is unable the update the application template. This                                                                                              base.py:780
              may be because your computer is currently offline. Briefcase will                                                                                          base.py:780
              use existing template without updating.                                                                                                                    base.py:780
                                                                                                                                                                         base.py:780
           *************************************************************************                                                                                     base.py:780
           Template branch v0.3.15 not found; falling back to development template                                                                                     create.py:266
           >>> Cmd('git') failed due to: exit code(128)                                                                                                                  base.py:776
           >>>   cmdline: git fetch -v -- origin                                                                                                                         base.py:776
           >>>   stderr: 'fatal: unable to access 'https://github.com/beeware/briefcase-windows-VisualStudio-template.git/': Could not resolve host: github.com'         base.py:776
                                                                                                                                                                         base.py:780
           *************************************************************************                                                                                     base.py:780
           ** WARNING: Unable to update template                                  **                                                                                     base.py:780
           *************************************************************************                                                                                     base.py:780
                                                                                                                                                                         base.py:780
              Briefcase is unable the update the application template. This                                                                                              base.py:780
              may be because your computer is currently offline. Briefcase will                                                                                          base.py:780
              use existing template without updating.                                                                                                                    base.py:780
                                                                                                                                                                         base.py:780
           *************************************************************************                                                                                     base.py:780
           Using existing template (sha 3c5ea03b6a703981ed328f29eb17311b8f3e0573, updated Fri Mar 10 20:09:30 2023)                                                      base.py:797
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
