### PR TITLE
Added `bundle_identifier` for consistent bundle/app IDs across platforms

### DIFF
--- a/changes/1234.bugfix.rst
+++ b/changes/1234.bugfix.rst
@@ -1,0 +1,1 @@
+Application/Bundle IDs are normalized to replace underscores with dashes when possible

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -234,6 +234,7 @@ class CreateCommand(BaseCommand):
                 "class_name": app.class_name,
                 "module_name": app.module_name,
                 "package_name": app.package_name,
+                "bundle_identifier": app.bundle_identifier,
                 # Properties that are a function of the execution
                 "year": date.today().strftime("%Y"),
                 "month": date.today().strftime("%B"),

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -63,7 +63,7 @@ def write_dist_info(app: BaseConfig, dist_info_path: Path):
         f.write(f"Briefcase-Version: {briefcase.__version__}\n")
         f.write(f"Name: {app.app_name}\n")
         f.write(f"Formal-Name: {app.formal_name}\n")
-        f.write(f"App-ID: {app.bundle}.{app.app_name}\n")
+        f.write(f"App-ID: {app.bundle_identifier}\n")
         f.write(f"Version: {app.version}\n")
         if app.url:
             f.write(f"Home-page: {app.url}\n")

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -431,6 +431,23 @@ class AppConfig(BaseConfig):
         return self.app_name.replace("-", "_")
 
     @property
+    def bundle_name(self):
+        """The bundle name for the app.
+
+        This is derived from the app name, but:
+        * all `_` have been replaced with `-`.
+        """
+        return self.app_name.replace("_", "-")
+
+    @property
+    def bundle_identifier(self):
+        """The bundle identifier for the app.
+
+        This is derived from the bundle and the bundle name, joined by a `.`.
+        """
+        return f"{self.bundle}.{self.bundle_name}"
+
+    @property
     def class_name(self):
         """The class name for the app.
 

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -419,7 +419,7 @@ class AppConfig(BaseConfig):
             )
 
     def __repr__(self):
-        return f"<{self.bundle}.{self.app_name} v{self.version} AppConfig>"
+        return f"<{self.bundle_identifier} v{self.version} AppConfig>"
 
     @property
     def module_name(self):

--- a/src/briefcase/integrations/flatpak.py
+++ b/src/briefcase/integrations/flatpak.py
@@ -194,7 +194,7 @@ You must install both flatpak and flatpak-builder.
                 f"and SDK {sdk}/{self.tools.host_arch}/{runtime_version} from repo {repo_alias}."
             ) from e
 
-    def build(self, bundle, app_name, path):
+    def build(self, bundle_identifier, app_name, path):
         """Build a Flatpak manifest.
 
         On success, the app is installed into the user's local Flatpak install,
@@ -202,7 +202,7 @@ You must install both flatpak and flatpak-builder.
         shell file isn't really needed to start the app, but it serves as a
         marker for a successful build that Briefcase can use.
 
-        :param bundle: The bundle identifier for the app being built.
+        :param bundle_identifier: The bundle identifier for the app being built.
         :param app_name: The app name.
         :param path: The path to the folder containing the app's Flatpak
             manifest file.
@@ -229,23 +229,23 @@ You must install both flatpak and flatpak-builder.
             # For bonus points, the marker file also is executable
             # and is an alias for the command that would actually start
             # the flatpak.
-            bin_path = path / f"{bundle}.{app_name}"
+            bin_path = path / bundle_identifier
             with bin_path.open("w", encoding="utf-8") as f:
                 f.write(
                     f"""\
 #!/bin/sh
 # echo To run this flatpak, run:
-flatpak run {bundle}.{app_name}
+flatpak run {bundle_identifier}
 """
                 )
                 self.tools.os.chmod(bin_path, 0o755)
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(f"Error while building app {app_name}.") from e
 
-    def run(self, bundle, app_name, args=None, main_module=None):
+    def run(self, bundle_identifier, app_name, args=None, main_module=None):
         """Run a Flatpak in a way that allows for log streaming.
 
-        :param bundle: The bundle identifier for the app being built.
+        :param bundle_identifier: The bundle identifier for the app being built.
         :param app_name: The app name.
         :param args: (Optional) The list of arguments to pass to the app
         :param main_module: (Optional) The main module to run. Only required if you
@@ -267,7 +267,7 @@ flatpak run {bundle}.{app_name}
             [
                 "flatpak",
                 "run",
-                f"{bundle}.{app_name}",
+                bundle_identifier,
             ]
             + ([] if args is None else args),
             stdout=subprocess.PIPE,
@@ -276,7 +276,9 @@ flatpak run {bundle}.{app_name}
             **kwargs,
         )
 
-    def bundle(self, repo_url, bundle, app_name, version, build_path, output_path):
+    def bundle(
+        self, repo_url, bundle_identifier, app_name, version, build_path, output_path
+    ):
         """Bundle a Flatpak for distribution.
 
         Generates a standalone .flatpak file that can be installed into another user's
@@ -284,7 +286,7 @@ flatpak run {bundle}.{app_name}
 
         :param repo_url: The URL of the repository that contains the runtime
             used by the app.
-        :param bundle: The bundle identifier for the app being built.
+        :param bundle_identifier: The bundle identifier for the app being built.
         :param app_name: The app name.
         :param version: The version of the app being built.
         :param build_path: The path where the flatpak was built. This path will
@@ -303,7 +305,7 @@ flatpak run {bundle}.{app_name}
                     # "--gpg-sign", "..."
                     "repo",
                     output_path,
-                    f"{bundle}.{app_name}",
+                    bundle_identifier,
                     version,
                 ],
                 check=True,

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -431,11 +431,10 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         # Try to uninstall the app first. If the app hasn't been installed
         # before, this will still succeed.
         self.logger.info(f"Installing {label}...", prefix=app.app_name)
-        app_identifier = ".".join([app.bundle, app.app_name])
         try:
             with self.input.wait_bar("Uninstalling any existing app version..."):
                 self.tools.subprocess.run(
-                    ["xcrun", "simctl", "uninstall", udid, app_identifier],
+                    ["xcrun", "simctl", "uninstall", udid, app.bundle_identifier],
                     check=True,
                 )
         except subprocess.CalledProcessError as e:
@@ -496,7 +495,8 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
             self.logger.info(f"Starting {label}...", prefix=app.app_name)
             with self.input.wait_bar(f"Launching {label}..."):
                 output = self.tools.subprocess.check_output(
-                    ["xcrun", "simctl", "launch", udid, app_identifier] + passthrough
+                    ["xcrun", "simctl", "launch", udid, app.bundle_identifier]
+                    + passthrough
                 )
                 try:
                     app_pid = int(output.split(":")[1].strip())

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -97,9 +97,9 @@ class LinuxAppImageMostlyPassiveMixin(LinuxAppImagePassiveMixin):
     def docker_image_tag(self, app):
         """The Docker image tag for an app."""
         try:
-            return f"briefcase/{app.bundle}.{app.app_name.lower()}:{app.manylinux}-appimage"
+            return f"briefcase/{app.bundle_identifier.lower()}:{app.manylinux}-appimage"
         except AttributeError:
-            return f"briefcase/{app.bundle}.{app.app_name.lower()}:appimage"
+            return f"briefcase/{app.bundle_identifier.lower()}:appimage"
 
     def verify_tools(self):
         """If we're using docker, verify that it is available."""
@@ -268,8 +268,7 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
                         os.fsdecode(self.appdir_path(app)),
                         "--desktop-file",
                         os.fsdecode(
-                            self.appdir_path(app)
-                            / f"{app.bundle}.{app.app_name}.desktop"
+                            self.appdir_path(app) / f"{app.bundle_identifier}.desktop"
                         ),
                         "--output",
                         "appimage",

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -145,7 +145,7 @@ class LinuxFlatpakBuildCommand(LinuxFlatpakMixin, BuildCommand):
         self.logger.info("Building Flatpak...", prefix=app.app_name)
         with self.input.wait_bar("Building..."):
             self.tools.flatpak.build(
-                bundle=app.bundle,
+                bundle_identifier=app.bundle_identifier,
                 app_name=app.app_name,
                 path=self.bundle_path(app),
             )
@@ -178,7 +178,7 @@ class LinuxFlatpakRunCommand(LinuxFlatpakMixin, RunCommand):
 
         # Start the app in a way that lets us stream the logs
         app_popen = self.tools.flatpak.run(
-            bundle=app.bundle,
+            bundle_identifier=app.bundle_identifier,
             app_name=app.app_name,
             args=passthrough,
             **kwargs,
@@ -206,7 +206,7 @@ class LinuxFlatpakPackageCommand(LinuxFlatpakMixin, PackageCommand):
             _, flatpak_repo_url = self.flatpak_runtime_repo(app)
             self.tools.flatpak.bundle(
                 repo_url=flatpak_repo_url,
-                bundle=app.bundle,
+                bundle_identifier=app.bundle_identifier,
                 app_name=app.app_name,
                 version=app.version,
                 build_path=self.bundle_path(app),

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -25,7 +25,7 @@ class LinuxFlatpakMixin(LinuxMixin):
         # build process, so the SDK wrapper creates a file that can use to identify
         # if run has been invoked. As a neat side effect, it's also a shell script
         # that can invoke the flatpak.
-        return self.bundle_path(app) / f"{app.bundle}.{app.app_name}"
+        return self.bundle_path(app) / app.bundle_identifier
 
     def project_path(self, app):
         return self.bundle_path(app)

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -287,7 +287,7 @@ class LinuxSystemMostlyPassiveMixin(LinuxSystemPassiveMixin):
 
     def docker_image_tag(self, app):
         """The Docker image tag for an app."""
-        return f"briefcase/{app.bundle}.{app.app_name.lower()}:{app.target_vendor}-{app.target_codename}"
+        return f"briefcase/{app.bundle_identifier.lower()}:{app.target_vendor}-{app.target_codename}"
 
     def verify_tools(self):
         """If we're using Docker, verify that it is available."""

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -64,7 +64,7 @@ class WindowsCreateCommand(CreateCommand):
             guid = app.guid
         except AttributeError:
             # Create a DNS domain by reversing the bundle identifier
-            domain = ".".join([app.app_name] + app.bundle.split(".")[::-1])
+            domain = ".".join(app.bundle_identifier.split(".")[::-1])
             guid = uuid.uuid5(uuid.NAMESPACE_DNS, domain)
             self.logger.info(f"Assigning {app.app_name} an application GUID of {guid}")
 

--- a/tests/commands/create/test_generate_app_template.py
+++ b/tests/commands/create/test_generate_app_template.py
@@ -24,6 +24,7 @@ def full_context():
         "app_name": "my-app",
         "formal_name": "My App",
         "bundle": "com.example",
+        "bundle_identifier": "com.example.my-app",
         "version": "1.2.3",
         "description": "This is a simple app",
         "long_description": None,

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -254,6 +254,46 @@ def test_package_name(bundle, package_name):
 
 
 @pytest.mark.parametrize(
+    "app_name, bundle_name",
+    [
+        ("my-app", "my-app"),
+        ("my_app", "my-app"),
+    ],
+)
+def test_bundle_name(app_name, bundle_name):
+    config = AppConfig(
+        app_name=app_name,
+        version="1.2.3",
+        bundle="com.example",
+        description="A simple app",
+        sources=["src/my_app"],
+    )
+
+    assert config.bundle_name == bundle_name
+
+
+@pytest.mark.parametrize(
+    "app_name, bundle_name",
+    [
+        ("my-app", "my-app"),
+        ("my_app", "my-app"),
+    ],
+)
+def test_bundle_identifier(app_name, bundle_name):
+    bundle = "com.example"
+
+    config = AppConfig(
+        app_name=app_name,
+        version="1.2.3",
+        bundle=bundle,
+        description="A simple app",
+        sources=["src/my_app"],
+    )
+
+    assert config.bundle_identifier == f"{bundle}.{bundle_name}"
+
+
+@pytest.mark.parametrize(
     "sources",
     [
         ["src/dupe", "src/dupe"],

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -22,6 +22,8 @@ def test_minimal_AppConfig():
     assert config.requires is None
 
     # Derived properties have been set.
+    assert config.bundle_name == "myapp"
+    assert config.bundle_identifier == "org.beeware.myapp"
     assert config.formal_name == "myapp"
     assert config.class_name == "myapp"
     assert config.document_types == {}

--- a/tests/integrations/flatpak/test_Flatpak__build.py
+++ b/tests/integrations/flatpak/test_Flatpak__build.py
@@ -8,7 +8,7 @@ from briefcase.exceptions import BriefcaseCommandError
 def test_build(flatpak, tmp_path):
     """A Flatpak project can be built."""
     flatpak.build(
-        bundle="com.example",
+        bundle_identifier="com.example.my-app",
         app_name="my-app",
         path=tmp_path,
     )
@@ -47,7 +47,7 @@ def test_build_fail(flatpak, tmp_path):
         match=r"Error while building app my-app.",
     ):
         flatpak.build(
-            bundle="com.example",
+            bundle_identifier="com.example.my-app",
             app_name="my-app",
             path=tmp_path / "bundle",
         )

--- a/tests/integrations/flatpak/test_Flatpak__bundle.py
+++ b/tests/integrations/flatpak/test_Flatpak__bundle.py
@@ -10,7 +10,7 @@ def test_bundle(flatpak, tmp_path):
 
     flatpak.bundle(
         repo_url="https://example.com/flatpak",
-        bundle="com.example",
+        bundle_identifier="com.example.my-app",
         app_name="my-app",
         version="1.2.3",
         build_path=tmp_path / "build",
@@ -46,7 +46,7 @@ def test_bundle_fail(flatpak, tmp_path):
     ):
         flatpak.bundle(
             repo_url="https://example.com/flatpak",
-            bundle="com.example",
+            bundle_identifier="com.example.my-app",
             app_name="my-app",
             version="1.2.3",
             build_path=tmp_path / "build",

--- a/tests/integrations/flatpak/test_Flatpak__run.py
+++ b/tests/integrations/flatpak/test_Flatpak__run.py
@@ -10,7 +10,7 @@ def test_run(flatpak):
 
     # Call run()
     result = flatpak.run(
-        bundle="com.example",
+        bundle_identifier="com.example.my-app",
         app_name="my-app",
     )
 
@@ -38,7 +38,7 @@ def test_run_with_args(flatpak):
 
     # Call run()
     result = flatpak.run(
-        bundle="com.example",
+        bundle_identifier="com.example.my-app",
         app_name="my-app",
         args=["foo", "bar"],
     )
@@ -69,7 +69,7 @@ def test_main_module_override(flatpak):
 
     # Call run()
     result = flatpak.run(
-        bundle="com.example",
+        bundle_identifier="com.example.my-app",
         app_name="my-app",
         main_module="org.beeware.test-case",
     )

--- a/tests/platforms/conftest.py
+++ b/tests/platforms/conftest.py
@@ -33,3 +33,21 @@ def uppercase_app_config():
         description="The first simple app",
         sources=["src/First_App"],
     )
+
+
+@pytest.fixture()
+def underscore_app_config(first_app_config):
+    return AppConfig(
+        app_name="first_app",
+        project_name="First Project",
+        formal_name="First App",
+        author="Megacorp",
+        author_email="maintainer@example.com",
+        url="https://example.com/first-app",
+        bundle="com.example",
+        version="0.0.1",
+        description="The first simple app \\ demonstration",
+        sources=["src/first_app"],
+        requires=["foo==1.2.3", "bar>=4.5"],
+        test_requires=["pytest"],
+    )

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -72,7 +72,7 @@ def test_run_multiple_devices_input_disabled(run_command, first_app_config):
         run_command.run_app(first_app_config, test_mode=False, passthrough=[])
 
 
-def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
+def test_run_app_simulator_booted(run_command, underscore_app_config, tmp_path):
     """An iOS App can be started when the simulator is already booted."""
     # A valid target device will be selected.
     run_command.select_target_device = mock.MagicMock(
@@ -92,7 +92,7 @@ def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
     run_command.tools.subprocess.Popen.return_value = log_stream_process
 
     # Run the app
-    run_command.run_app(first_app_config, test_mode=False, passthrough=[])
+    run_command.run_app(underscore_app_config, test_mode=False, passthrough=[])
 
     # The correct sequence of commands was issued.
     run_command.tools.subprocess.run.assert_has_calls(
@@ -130,7 +130,7 @@ def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
                     tmp_path
                     / "base_path"
                     / "build"
-                    / "first-app"
+                    / "first_app"
                     / "ios"
                     / "xcode"
                     / "build"
@@ -175,7 +175,7 @@ def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
 
     # Log stream monitoring was started
     run_command._stream_app_logs.assert_called_with(
-        first_app_config,
+        underscore_app_config,
         popen=log_stream_process,
         test_mode=False,
         clean_filter=macOS_log_clean_filter,

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -72,8 +72,127 @@ def test_run_multiple_devices_input_disabled(run_command, first_app_config):
         run_command.run_app(first_app_config, test_mode=False, passthrough=[])
 
 
-def test_run_app_simulator_booted(run_command, underscore_app_config, tmp_path):
+def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
     """An iOS App can be started when the simulator is already booted."""
+    # A valid target device will be selected.
+    run_command.select_target_device = mock.MagicMock(
+        return_value=("2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D", "13.2", "iPhone 11")
+    )
+
+    # Simulator is already booted
+    run_command.get_device_state = mock.MagicMock(return_value=DeviceState.BOOTED)
+
+    # Mock a process ID for the app
+    run_command.tools.subprocess.check_output.return_value = (
+        "com.example.first-app: 1234\n"
+    )
+
+    # Mock the log stream
+    log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
+    run_command.tools.subprocess.Popen.return_value = log_stream_process
+
+    # Run the app
+    run_command.run_app(first_app_config, test_mode=False, passthrough=[])
+
+    # The correct sequence of commands was issued.
+    run_command.tools.subprocess.run.assert_has_calls(
+        [
+            # Open the simulator
+            mock.call(
+                [
+                    "open",
+                    "-a",
+                    "Simulator",
+                    "--args",
+                    "-CurrentDeviceUDID",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                ],
+                check=True,
+            ),
+            # Uninstall the old app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "uninstall",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "com.example.first-app",
+                ],
+                check=True,
+            ),
+            # Install the new app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "install",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    tmp_path
+                    / "base_path"
+                    / "build"
+                    / "first-app"
+                    / "ios"
+                    / "xcode"
+                    / "build"
+                    / "Debug-iphonesimulator"
+                    / "First App.app",
+                ],
+                check=True,
+            ),
+        ]
+    )
+    # Launch the new app
+    run_command.tools.subprocess.check_output.assert_called_once_with(
+        [
+            "xcrun",
+            "simctl",
+            "launch",
+            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+            "com.example.first-app",
+        ],
+    )
+
+    # Start the log stream
+    run_command.tools.subprocess.Popen.assert_called_once_with(
+        [
+            "xcrun",
+            "simctl",
+            "spawn",
+            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+            "log",
+            "stream",
+            "--style",
+            "compact",
+            "--predicate",
+            'senderImagePath ENDSWITH "/First App"'
+            ' OR (processImagePath ENDSWITH "/First App"'
+            ' AND senderImagePath ENDSWITH "-iphonesimulator.so")',
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+    )
+
+    # Log stream monitoring was started
+    run_command._stream_app_logs.assert_called_with(
+        first_app_config,
+        popen=log_stream_process,
+        test_mode=False,
+        clean_filter=macOS_log_clean_filter,
+        clean_output=True,
+        stop_func=mock.ANY,
+        log_stream=True,
+    )
+
+
+def test_run_app_simulator_booted_underscore(
+    run_command, underscore_app_config, tmp_path
+):
+    """An iOS App can be started when the simulator is already booted.
+
+    This test is specific to app names that have underscores since those are not
+    supported by Apple within app identifiers.
+    """
     # A valid target device will be selected.
     run_command.select_target_device = mock.MagicMock(
         return_value=("2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D", "13.2", "iPhone 11")

--- a/tests/platforms/linux/flatpak/test_build.py
+++ b/tests/platforms/linux/flatpak/test_build.py
@@ -46,7 +46,7 @@ def test_build(build_command, first_app_config, tmp_path):
 
     # The build is invoked
     build_command.tools.flatpak.build.assert_called_once_with(
-        bundle="com.example",
+        bundle_identifier="com.example.first-app",
         app_name="first-app",
         path=tmp_path / "base_path" / "build" / "first-app" / "linux" / "flatpak",
     )

--- a/tests/platforms/linux/flatpak/test_package.py
+++ b/tests/platforms/linux/flatpak/test_package.py
@@ -31,7 +31,7 @@ def test_package(package_command, first_app_config, tmp_path):
     # A flatpak bundle is created
     package_command.tools.flatpak.bundle.assert_called_once_with(
         repo_url="https://example.com/flatpak/repo",
-        bundle="com.example",
+        bundle_identifier="com.example.first-app",
         app_name="first-app",
         version="0.0.1",
         build_path=tmp_path / "base_path" / "build" / "first-app" / "linux" / "flatpak",

--- a/tests/platforms/linux/flatpak/test_run.py
+++ b/tests/platforms/linux/flatpak/test_run.py
@@ -35,7 +35,7 @@ def test_run(run_command, first_app_config):
 
     # App is executed
     run_command.tools.flatpak.run.assert_called_once_with(
-        bundle="com.example",
+        bundle_identifier="com.example.first-app",
         app_name="first-app",
         args=[],
     )
@@ -64,7 +64,7 @@ def test_run_with_passthrough(run_command, first_app_config):
 
     # App is executed with args
     run_command.tools.flatpak.run.assert_called_once_with(
-        bundle="com.example",
+        bundle_identifier="com.example.first-app",
         app_name="first-app",
         args=["foo", "--bar"],
     )
@@ -87,7 +87,7 @@ def test_run_app_failed(run_command, first_app_config, tmp_path):
 
     # The run command was still invoked
     run_command.tools.flatpak.run.assert_called_once_with(
-        bundle="com.example",
+        bundle_identifier="com.example.first-app",
         app_name="first-app",
         args=[],
     )
@@ -107,7 +107,7 @@ def test_run_test_mode(run_command, first_app_config):
 
     # App is executed
     run_command.tools.flatpak.run.assert_called_once_with(
-        bundle="com.example",
+        bundle_identifier="com.example.first-app",
         app_name="first-app",
         args=[],
         main_module="tests.first_app",
@@ -137,7 +137,7 @@ def test_run_test_mode_with_args(run_command, first_app_config):
 
     # App is executed
     run_command.tools.flatpak.run.assert_called_once_with(
-        bundle="com.example",
+        bundle_identifier="com.example.first-app",
         app_name="first-app",
         args=["foo", "--bar"],
         main_module="tests.first_app",


### PR DESCRIPTION
This introduces two new dynamic properties to `AppConfig`:
* `bundle_name` which is a normalized version of `app_name` that replaces underscores with dashes
* `bundle_identifier` which is the combination of `bundle` and `bundle_name` to give a fully qualified identifier

The `bundle_identifier` is shown in the following places:
* `repr(AppConfig())` in addition to the `app_name` (example: `<com.example.first-app (first_app) v1.2.3 AppConfig>`)
* `briefcase create` as the `App-ID` line

The `bundle_identifier` has been propagated to the following platforms:
* iOS for the package name
* Windows for the domain used for apps
* Linux for the binary paths and docker image names

It has not been propagated to Android as that platform requires underscores instead of dashes in their application IDs.

This fixes https://github.com/beeware/briefcase/issues/1155.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
