### PR TITLE
Hotfix for linux system packaging use_docker issue.

### DIFF
--- a/changes/1239.misc.rst
+++ b/changes/1239.misc.rst
@@ -1,0 +1,1 @@
+An edge case of use_docker was corrected.

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -40,6 +40,10 @@ class LinuxSystemPassiveMixin(LinuxMixin):
     )
 
     @property
+    def use_docker(self):
+        return False
+
+    @property
     def linux_arch(self):
         # Linux uses different architecture identifiers for some platforms
         return {

--- a/tests/platforms/linux/system/test_mixin__finalize_app_config.py
+++ b/tests/platforms/linux/system/test_mixin__finalize_app_config.py
@@ -3,8 +3,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux import parse_freedesktop_os_release
+from briefcase.platforms.linux.system import LinuxSystemRunCommand
 
 from ....utils import create_file
 
@@ -412,3 +414,46 @@ def test_properties_no_version(create_command, first_app_config):
 
     # Since it's system python, the python version is 3
     assert first_app_config.python_version_tag == "3"
+
+
+def test_passive_mixin(first_app_config, tmp_path):
+    "An app using the PassiveMixin can be finalized"
+    run_command = LinuxSystemRunCommand(
+        logger=Log(),
+        console=Console(),
+        base_path=tmp_path / "base_path",
+        data_path=tmp_path / "briefcase",
+    )
+
+    # Build the app without docker
+    run_command.target_image = None
+    run_command.target_glibc_version = MagicMock(return_value="2.42")
+
+    os_release = "\n".join(
+        [
+            "ID=somevendor",
+            "VERSION_CODENAME=surprising",
+            "ID_LIKE=debian",
+        ]
+    )
+    if sys.version_info >= (3, 10):
+        # mock platform.freedesktop_os_release()
+        run_command.tools.platform.freedesktop_os_release = MagicMock(
+            return_value=parse_freedesktop_os_release(os_release)
+        )
+    else:
+        # For Pre Python3.10, mock the /etc/release file
+        create_file(tmp_path / "os-release", os_release)
+        run_command.tools.ETC_OS_RELEASE = tmp_path / "os-release"
+
+    # Finalize the app config
+    run_command.finalize_app_config(first_app_config)
+
+    # The app's image, vendor and codename have been constructed from the target image
+    assert first_app_config.target_image == "somevendor:surprising"
+    assert first_app_config.target_vendor == "somevendor"
+    assert first_app_config.target_codename == "surprising"
+    assert first_app_config.target_vendor_base == "debian"
+
+    # For tests of other properties merged in finalization, see
+    # test_properties


### PR DESCRIPTION
#1222 refactored the use of options on Linux system packaging to avoid invoking `run` with the `--target` option.

However, the CI on beeware/toga#1901 has shown that there is a stray usage of `use_docker` when finalising the app config.

There is almost certainly a cleanup of Passive/MostlyPassive mixins that can be done; however, we need an immediate fix to allow Toga's CI to pass.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
