### PR TITLE
Drop root prompt `#` from copybutton regex to avoid false detection with comments

### DIFF
--- a/changes/1242.misc.rst
+++ b/changes/1242.misc.rst
@@ -1,0 +1,1 @@
+The root user prompt ``#`` has been removed as a prompt match for copying commands from code blocks.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,8 +109,8 @@ linkcheck_anchors_ignore = [
 
 # virtual env prefix: (venv), (beeware-venv), (testenv)
 venv = r"\((?:(?:beeware-)?venv|testvenv)\)"
-# macOS and Linux shell prompt: $, #
-shell = r"\$|#"
+# macOS and Linux shell prompt: $
+shell = r"\$"
 # win CMD prompt: C:\>, C:\...>
 cmd = r"C:\\>|C:\\\.\.\.>"
 # PowerShell prompt: PS C:\>, PS C:\...>


### PR DESCRIPTION
## Note
- Found [an example](https://briefcase.readthedocs.io/en/latest/how-to/access-packaging-metadata.html) where this is already a problem...so definitely right move to drop it.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
