### PR TITLE
Ensure that the run command populates the target_image.

### DIFF
--- a/changes/1243.misc.rst
+++ b/changes/1243.misc.rst
@@ -1,0 +1,1 @@
+The target image is populated correctly when a run command infers a build.

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -41,7 +41,18 @@ class LinuxSystemPassiveMixin(LinuxMixin):
 
     @property
     def use_docker(self):
+        # The passive mixing doesn't expose the `--target` option, as it can't use
+        # Docker. However, we need the use_docker property to exist so that the
+        # app config can be finalized in the general case.
         return False
+
+    def parse_options(self, extra):
+        # The passive mixin doesn't expose the `--target` option, but if run infers
+        # build, we need target image to be defined.
+        options = super().parse_options(extra)
+        self.target_image = None
+
+        return options
 
     @property
     def linux_arch(self):

--- a/tests/platforms/linux/system/test_run.py
+++ b/tests/platforms/linux/system/test_run.py
@@ -1,5 +1,7 @@
 import os
 import subprocess
+import sys
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -7,7 +9,10 @@ import pytest
 from briefcase.console import Console, Log
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.subprocess import Subprocess
+from briefcase.platforms.linux import parse_freedesktop_os_release, system
 from briefcase.platforms.linux.system import LinuxSystemRunCommand
+
+from ....utils import create_file
 
 
 @pytest.fixture
@@ -31,17 +36,101 @@ def run_command(tmp_path):
 
 
 @pytest.mark.parametrize("host_os", ["Darwin", "Windows", "WeirdOS"])
-def test_unsupported_host_os(run_command, host_os):
+def test_unsupported_host_os(run_command, first_app, host_os):
     """Error raised for an unsupported OS."""
     run_command.tools.host_os = host_os
     # Mock the existence of a single app
-    run_command.apps = {"app": None}
+    run_command.apps = {"app": first_app}
+
+    # Parse the command line
+    run_command.parse_options([])
 
     with pytest.raises(
         UnsupportedHostError,
         match="Linux system projects can only be executed on Linux.",
     ):
         run_command()
+
+
+def test_supported_host_os(monkeypatch, run_command, first_app, tmp_path):
+    """A supported OS (linux) can invoke run."""
+    # This also verifies that Run (which is a passive command) can generate
+    # build/create commands (which are not passive).
+
+    # Set up the log streamer to return a known stream
+    log_popen = mock.MagicMock()
+    run_command.tools.subprocess.Popen.return_value = log_popen
+
+    # Mock the freedesktop ID environment
+    os_release = "\n".join(
+        [
+            "ID=somevendor",
+            "VERSION_CODENAME=surprising",
+            "ID_LIKE=debian",
+        ]
+    )
+    if sys.version_info >= (3, 10):
+        # mock platform.freedesktop_os_release()
+        run_command.tools.platform.freedesktop_os_release = mock.MagicMock(
+            return_value=parse_freedesktop_os_release(os_release)
+        )
+    else:
+        # For Pre Python3.10, mock the /etc/release file
+        create_file(tmp_path / "os-release", os_release)
+        run_command.tools.ETC_OS_RELEASE = tmp_path / "os-release"
+
+    # Mock the glibc version
+    run_command.target_glibc_version = mock.MagicMock(return_value="2.42")
+
+    # Mock the existence of a valid non-docker system Python
+    # with the same major/minor as the current Python
+    python3 = mock.MagicMock()
+    python3.resolve.return_value = Path(
+        f"/usr/bin/python{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    mock_Path = mock.MagicMock(return_value=python3)
+    monkeypatch.setattr(system, "Path", mock_Path)
+
+    run_command.tools.host_os = "Linux"
+
+    # Mock the existence of a single app
+    run_command.apps = {"app": first_app}
+
+    # Parse the command line
+    run_command.parse_options([])
+
+    # The command runs without error
+    run_command()
+
+    # The process was started
+    run_command.tools.subprocess.Popen.assert_called_with(
+        [
+            os.fsdecode(
+                tmp_path
+                / "base_path"
+                / "build"
+                / "first-app"
+                / "somevendor"
+                / "surprising"
+                / "first-app-0.0.1"
+                / "usr"
+                / "bin"
+                / "first-app"
+            )
+        ],
+        cwd=tmp_path / "home",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+    )
+
+    # The streamer was started
+    run_command._stream_app_logs.assert_called_once_with(
+        first_app,
+        popen=log_popen,
+        test_mode=False,
+        clean_output=False,
+    )
 
 
 def test_run_app(run_command, first_app, tmp_path):


### PR DESCRIPTION
Follow up to #1239; #1222 removed the `--target` option from the Run command. However, when run infers a build, the base command needs to have some options describing that docker is not being used.

This has manifested as CI failures in Toga (e.g. [this failed run](https://github.com/beeware/toga/actions/runs/4803945790/jobs/8549026939))

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
