### PR TITLE
No Sleeping on the Job

### DIFF
--- a/changes/1246.misc.rst
+++ b/changes/1246.misc.rst
@@ -1,0 +1,1 @@
+Tests that caused Briefcase to sleep were updated to short circuit the sleep.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import inspect
 import subprocess
+import time
 from unittest.mock import ANY, MagicMock
 
 import git as git_
@@ -47,6 +48,15 @@ def monkeypatched_print(*args, **kwargs):
 def no_print(monkeypatch):
     """Replace builtin print function for ALL tests."""
     monkeypatch.setattr("builtins.print", monkeypatched_print)
+
+
+_sleep = time.sleep
+
+
+@pytest.fixture
+def sleep_zero(monkeypatch):
+    """Replace all calls to ``time.sleep(x)`` with ``time.sleep(0)."""
+    monkeypatch.setattr(time, "sleep", lambda x: _sleep(0))
 
 
 @pytest.fixture

--- a/tests/integrations/subprocess/test_Subprocess__run__controlled_console.py
+++ b/tests/integrations/subprocess/test_Subprocess__run__controlled_console.py
@@ -6,7 +6,7 @@ from unittest.mock import ANY
 import pytest
 
 
-def test_call(mock_sub, capsys, sub_stream_kw):
+def test_call(mock_sub, sub_stream_kw, sleep_zero, capsys):
     """A simple call will be invoked."""
 
     with mock_sub.tools.input.wait_bar():
@@ -24,7 +24,7 @@ def test_call(mock_sub, capsys, sub_stream_kw):
     assert capsys.readouterr().out == expected_output
 
 
-def test_call_with_arg(mock_sub, capsys, sub_stream_kw):
+def test_call_with_arg(mock_sub, sub_stream_kw, sleep_zero, capsys):
     """Any extra keyword arguments are passed through as-is."""
 
     with mock_sub.tools.input.wait_bar():
@@ -47,7 +47,7 @@ def test_call_with_arg(mock_sub, capsys, sub_stream_kw):
     assert capsys.readouterr().out == expected_output
 
 
-def test_debug_call(mock_sub, capsys, sub_stream_kw):
+def test_debug_call(mock_sub, sub_stream_kw, sleep_zero, capsys):
     """If verbosity is turned up, there is debug output."""
     mock_sub.tools.logger.verbosity = 2
 
@@ -70,7 +70,7 @@ def test_debug_call(mock_sub, capsys, sub_stream_kw):
     assert capsys.readouterr().out == expected_output
 
 
-def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_stream_kw):
+def test_debug_call_with_env(mock_sub, sub_stream_kw, sleep_zero, capsys, tmp_path):
     """If verbosity is turned up, injected env vars are included in debug output."""
     mock_sub.tools.logger.verbosity = 2
 
@@ -133,7 +133,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_stream_kw):
         ),
     ],
 )
-def test_text_eq_true_default_overriding(mock_sub, in_kwargs, kwargs):
+def test_text_eq_true_default_overriding(mock_sub, in_kwargs, kwargs, sleep_zero):
     """if text or universal_newlines is explicitly provided, those should override
     text=true default."""
     with mock_sub.tools.input.wait_bar():
@@ -147,7 +147,13 @@ def test_text_eq_true_default_overriding(mock_sub, in_kwargs, kwargs):
     )
 
 
-def test_stderr_is_redirected(mock_sub, streaming_process, sub_stream_kw, capsys):
+def test_stderr_is_redirected(
+    mock_sub,
+    streaming_process,
+    sub_stream_kw,
+    sleep_zero,
+    capsys,
+):
     """When stderr is redirected, it should be included in the result."""
     stderr_output = "stderr output\nline 2"
     streaming_process.stderr.read.return_value = stderr_output
@@ -176,7 +182,13 @@ def test_stderr_is_redirected(mock_sub, streaming_process, sub_stream_kw, capsys
     assert run_result.stderr == stderr_output
 
 
-def test_stderr_dev_null(mock_sub, streaming_process, capsys, sub_stream_kw):
+def test_stderr_dev_null(
+    mock_sub,
+    streaming_process,
+    sub_stream_kw,
+    sleep_zero,
+    capsys,
+):
     """When stderr is discarded, it should be None in the result."""
     streaming_process.stderr = None
 
@@ -204,7 +216,7 @@ def test_stderr_dev_null(mock_sub, streaming_process, capsys, sub_stream_kw):
     assert run_result.stderr is None
 
 
-def test_calledprocesserror(mock_sub, streaming_process, capsys):
+def test_calledprocesserror(mock_sub, streaming_process, sleep_zero, capsys):
     """CalledProcessError is raised with check=True and non-zero return value."""
     stderr_output = "stderr output\nline 2"
     streaming_process.stderr.read.return_value = stderr_output

--- a/tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py
+++ b/tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py
@@ -10,7 +10,7 @@ from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW
 
 
 @pytest.mark.parametrize("platform", ["Linux", "Darwin", "Windows"])
-def test_call(mock_sub, capsys, platform, sub_stream_kw):
+def test_call(mock_sub, capsys, platform, sub_stream_kw, sleep_zero):
     """A simple call will be invoked."""
 
     mock_sub.tools.sys.platform = platform
@@ -27,7 +27,7 @@ def test_call(mock_sub, capsys, platform, sub_stream_kw):
     assert capsys.readouterr().out == expected_output
 
 
-def test_call_with_arg(mock_sub, capsys, sub_stream_kw):
+def test_call_with_arg(mock_sub, capsys, sub_stream_kw, sleep_zero):
     """Any extra keyword arguments are passed through as-is."""
 
     mock_sub.run(["hello", "world"], universal_newlines=True)
@@ -48,7 +48,7 @@ def test_call_with_arg(mock_sub, capsys, sub_stream_kw):
     assert capsys.readouterr().out == expected_output
 
 
-def test_call_with_path_arg(mock_sub, capsys, tmp_path, sub_stream_kw):
+def test_call_with_path_arg(mock_sub, capsys, tmp_path, sub_stream_kw, sleep_zero):
     """Path-based arguments are converted to strings and passed in as-is."""
 
     mock_sub.run(["hello", tmp_path / "location"], cwd=tmp_path / "cwd")
@@ -93,6 +93,7 @@ def test_call_with_start_new_session(
     start_new_session,
     run_kwargs,
     sub_stream_kw,
+    sleep_zero,
 ):
     """start_new_session is passed thru on Linux and macOS but converted for Windows."""
 
@@ -135,6 +136,7 @@ def test_call_windows_with_start_new_session_and_creationflags(
     capsys,
     creationflags,
     final_creationflags,
+    sleep_zero,
 ):
     """creationflags used to simulate start_new_session=True should be merged with any
     existing flags."""
@@ -153,7 +155,7 @@ def test_call_windows_with_start_new_session_and_creationflags(
         )
 
 
-def test_debug_call(mock_sub, capsys, sub_stream_kw):
+def test_debug_call(mock_sub, capsys, sub_stream_kw, sleep_zero):
     """If verbosity is turned up, there is output."""
     mock_sub.tools.logger.verbosity = 2
 
@@ -177,7 +179,7 @@ def test_debug_call(mock_sub, capsys, sub_stream_kw):
     assert capsys.readouterr().out == expected_output
 
 
-def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_stream_kw):
+def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_stream_kw, sleep_zero):
     """If verbosity is turned up, injected env vars are included output."""
     mock_sub.tools.logger.verbosity = 2
 
@@ -209,7 +211,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_stream_kw):
     assert capsys.readouterr().out == expected_output
 
 
-def test_calledprocesserror_exception_logging(mock_sub, capsys):
+def test_calledprocesserror_exception_logging(mock_sub, sleep_zero, capsys):
     mock_sub.tools.logger.verbosity = 2
 
     with pytest.raises(CalledProcessError):
@@ -244,7 +246,7 @@ def test_calledprocesserror_exception_logging(mock_sub, capsys):
         ),
     ],
 )
-def test_text_eq_true_default_overriding(mock_sub, in_kwargs, kwargs):
+def test_text_eq_true_default_overriding(mock_sub, in_kwargs, kwargs, sleep_zero):
     """If text or universal_newlines is explicitly provided, those should override
     text=true default."""
     mock_sub.run(["hello", "world"], **in_kwargs)

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -15,7 +15,7 @@ def mock_sub(mock_sub):
     return mock_sub
 
 
-def test_output(mock_sub, streaming_process, capsys):
+def test_output(mock_sub, streaming_process, sleep_zero, capsys):
     """Process output is printed."""
     mock_sub.stream_output("testing", streaming_process)
 
@@ -29,7 +29,7 @@ def test_output(mock_sub, streaming_process, capsys):
     mock_sub.cleanup.assert_called_once_with("testing", streaming_process)
 
 
-def test_output_debug(mock_sub, streaming_process, capsys):
+def test_output_debug(mock_sub, streaming_process, sleep_zero, capsys):
     """Process output is printed; no debug output for only stream_output."""
     mock_sub.tools.logger.verbosity = 2
 
@@ -66,7 +66,12 @@ def test_keyboard_interrupt(mock_sub, streaming_process, capsys):
     mock_sub.cleanup.assert_called_once_with("testing", streaming_process)
 
 
-def test_process_exit_with_queued_output(mock_sub, streaming_process, capsys):
+def test_process_exit_with_queued_output(
+    mock_sub,
+    streaming_process,
+    sleep_zero,
+    capsys,
+):
     """All output is printed despite the process exiting early."""
     streaming_process.poll.side_effect = [None, -3, -3, -3]
 
@@ -82,7 +87,7 @@ def test_process_exit_with_queued_output(mock_sub, streaming_process, capsys):
 
 
 @pytest.mark.parametrize("stop_func_ret_val", (True, False))
-def test_stop_func(mock_sub, streaming_process, stop_func_ret_val, capsys):
+def test_stop_func(mock_sub, streaming_process, stop_func_ret_val, sleep_zero, capsys):
     """All output is printed whether stop_func aborts streaming or not."""
     mock_sub.stream_output(
         "testing", streaming_process, stop_func=lambda: stop_func_ret_val
@@ -97,7 +102,7 @@ def test_stop_func(mock_sub, streaming_process, stop_func_ret_val, capsys):
     mock_sub.cleanup.assert_called_once_with("testing", streaming_process)
 
 
-def test_stuck_streamer(mock_sub, streaming_process, monkeypatch, capsys):
+def test_stuck_streamer(mock_sub, streaming_process, sleep_zero, monkeypatch, capsys):
     """Following a KeyboardInterrupt, output streaming returns even if the output
     streamer becomes stuck."""
 
@@ -185,7 +190,7 @@ def test_readline_raises_exception(mock_sub, streaming_process, monkeypatch, cap
     )
 
 
-def test_filter_func(mock_sub, streaming_process, capsys):
+def test_filter_func(mock_sub, streaming_process, sleep_zero, capsys):
     """A filter can be added to modify an output stream."""
 
     # Define a filter function that converts "output" into "filtered"
@@ -206,7 +211,7 @@ def test_filter_func(mock_sub, streaming_process, capsys):
     mock_sub.cleanup.assert_called_once_with("testing", streaming_process)
 
 
-def test_filter_func_reject(mock_sub, streaming_process, capsys):
+def test_filter_func_reject(mock_sub, streaming_process, sleep_zero, capsys):
     """A filter that rejects lines can be added to modify an output stream."""
 
     # Define a filter function that ignores blank lines
@@ -228,7 +233,7 @@ def test_filter_func_reject(mock_sub, streaming_process, capsys):
     mock_sub.cleanup.assert_called_once_with("testing", streaming_process)
 
 
-def test_filter_func_line_ends(mock_sub, streaming_process, capsys):
+def test_filter_func_line_ends(mock_sub, streaming_process, sleep_zero, capsys):
     """Filter functions are not provided the newline."""
 
     # Define a filter function that redacts lines that end with 1
@@ -253,7 +258,12 @@ def test_filter_func_line_ends(mock_sub, streaming_process, capsys):
     mock_sub.cleanup.assert_called_once_with("testing", streaming_process)
 
 
-def test_filter_func_line_multiple_output(mock_sub, streaming_process, capsys):
+def test_filter_func_line_multiple_output(
+    mock_sub,
+    streaming_process,
+    sleep_zero,
+    capsys,
+):
     """Filter functions can generate multiple lines from a single input."""
 
     # Define a filter function that adds an extra line of content when the

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -1,4 +1,5 @@
 import subprocess
+import time
 from unittest import mock
 
 import pytest
@@ -22,6 +23,9 @@ def run_command(tmp_path):
     command.tools.home_path = tmp_path / "home"
     command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
     command._stream_app_logs = mock.MagicMock()
+
+    # Disable sleeps
+    command.sleep = mock.MagicMock(side_effect=lambda x: time.sleep(0))
 
     # To satisfy coverage, the stop function must be invoked
     # at least once when streaming app logs.
@@ -186,7 +190,9 @@ def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
 
 
 def test_run_app_simulator_booted_underscore(
-    run_command, underscore_app_config, tmp_path
+    run_command,
+    underscore_app_config,
+    tmp_path,
 ):
     """An iOS App can be started when the simulator is already booted.
 

--- a/tests/platforms/macOS/app/test_run.py
+++ b/tests/platforms/macOS/app/test_run.py
@@ -35,7 +35,7 @@ def run_command(tmp_path):
     return command
 
 
-def test_run_app(run_command, first_app_config, tmp_path, monkeypatch):
+def test_run_app(run_command, first_app_config, sleep_zero, tmp_path, monkeypatch):
     """A macOS app can be started."""
     # Mock a popen object that represents the log stream
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
@@ -87,7 +87,13 @@ def test_run_app(run_command, first_app_config, tmp_path, monkeypatch):
     run_command.tools.os.kill.assert_called_with(100, SIGTERM)
 
 
-def test_run_app_with_passthrough(run_command, first_app_config, tmp_path, monkeypatch):
+def test_run_app_with_passthrough(
+    run_command,
+    first_app_config,
+    sleep_zero,
+    tmp_path,
+    monkeypatch,
+):
     """A macOS app can be started with args."""
     # Mock a popen object that represents the log stream
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
@@ -144,7 +150,7 @@ def test_run_app_with_passthrough(run_command, first_app_config, tmp_path, monke
     run_command.tools.os.kill.assert_called_with(100, SIGTERM)
 
 
-def test_run_app_failed(run_command, first_app_config, tmp_path):
+def test_run_app_failed(run_command, first_app_config, sleep_zero, tmp_path):
     """If there's a problem started the app, an exception is raised."""
     # Mock a failure opening the app
     run_command.tools.subprocess.run.side_effect = subprocess.CalledProcessError(
@@ -185,7 +191,12 @@ def test_run_app_failed(run_command, first_app_config, tmp_path):
 
 
 def test_run_app_find_pid_failed(
-    run_command, first_app_config, tmp_path, monkeypatch, capsys
+    run_command,
+    first_app_config,
+    sleep_zero,
+    tmp_path,
+    monkeypatch,
+    capsys,
 ):
     """If after app is started, its pid is not found, do not stream output."""
     # Mock a failed PID lookup
@@ -229,7 +240,13 @@ def test_run_app_find_pid_failed(
     run_command.tools.os.kill.assert_not_called()
 
 
-def test_run_app_test_mode(run_command, first_app_config, tmp_path, monkeypatch):
+def test_run_app_test_mode(
+    run_command,
+    first_app_config,
+    sleep_zero,
+    tmp_path,
+    monkeypatch,
+):
     """A macOS app can be started in test mode."""
     # Mock a popen object that represents the log stream
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)

--- a/tests/platforms/macOS/xcode/test_run.py
+++ b/tests/platforms/macOS/xcode/test_run.py
@@ -37,7 +37,7 @@ def run_command(tmp_path):
     return command
 
 
-def test_run_app(run_command, first_app_config, tmp_path, monkeypatch):
+def test_run_app(run_command, first_app_config, sleep_zero, tmp_path, monkeypatch):
     """A macOS Xcode app can be started."""
     # Mock a popen object that represents the log stream
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
@@ -89,7 +89,13 @@ def test_run_app(run_command, first_app_config, tmp_path, monkeypatch):
     run_command.tools.os.kill.assert_called_with(100, SIGTERM)
 
 
-def test_run_app_with_passthrough(run_command, first_app_config, tmp_path, monkeypatch):
+def test_run_app_with_passthrough(
+    run_command,
+    first_app_config,
+    sleep_zero,
+    tmp_path,
+    monkeypatch,
+):
     """A macOS Xcode app can be started with args."""
     # Mock a popen object that represents the log stream
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
@@ -146,7 +152,13 @@ def test_run_app_with_passthrough(run_command, first_app_config, tmp_path, monke
     run_command.tools.os.kill.assert_called_with(100, SIGTERM)
 
 
-def test_run_app_test_mode(run_command, first_app_config, tmp_path, monkeypatch):
+def test_run_app_test_mode(
+    run_command,
+    first_app_config,
+    sleep_zero,
+    tmp_path,
+    monkeypatch,
+):
     """A macOS Xcode app can be started in test mode."""
     # Mock a popen object that represents the log stream
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
@@ -202,6 +214,7 @@ def test_run_app_test_mode(run_command, first_app_config, tmp_path, monkeypatch)
 def test_run_app_test_mode_with_passthrough(
     run_command,
     first_app_config,
+    sleep_zero,
     tmp_path,
     monkeypatch,
 ):


### PR DESCRIPTION
## Changes
- Replace any calls to `time.sleep(x)` with `time.sleep(0)`
- I'm seeing ~37% speedup locally from 29s to 18s
- (Note: I'm working on getting `pytest-xdist` working....tests run in <5s then on 8 hyper threaded cores)

## Examples of Slow Tests
<details>
<summary>Top 50 previously slowest tests</summary>

```
0.55s call     tests/integrations/subprocess/test_Subprocess__stream_output.py::test_stuck_streamer
0.35s call     tests/integrations/subprocess/test_Subprocess__stream_output.py::test_keyboard_interrupt
0.33s call     tests/platforms/iOS/xcode/test_run.py::test_run_app_simulator_launch_failure
0.27s call     tests/platforms/iOS/xcode/test_run.py::test_run_app_simulator_booted
0.26s call     tests/platforms/iOS/xcode/test_run.py::test_run_app_simulator_shut_down
0.26s call     tests/platforms/iOS/xcode/test_run.py::test_run_app_with_passthrough
0.26s call     tests/platforms/iOS/xcode/test_run.py::test_run_app_simulator_booted_underscore
0.26s call     tests/platforms/iOS/xcode/test_run.py::test_run_app_simulator_non_integer_pid
0.26s call     tests/platforms/iOS/xcode/test_run.py::test_run_app_simulator_no_pid
0.26s call     tests/platforms/iOS/xcode/test_run.py::test_run_app_test_mode
0.26s call     tests/platforms/iOS/xcode/test_run.py::test_run_app_test_mode_with_passthrough
0.26s call     tests/platforms/macOS/app/test_run.py::test_run_app_find_pid_failed
0.26s call     tests/platforms/macOS/xcode/test_run.py::test_run_app
0.25s call     tests/platforms/macOS/xcode/test_run.py::test_run_app_test_mode_with_passthrough
0.25s call     tests/platforms/macOS/xcode/test_run.py::test_run_app_test_mode
0.25s call     tests/platforms/macOS/app/test_run.py::test_run_app_test_mode
0.25s call     tests/platforms/macOS/app/test_run.py::test_run_app
0.25s call     tests/platforms/macOS/xcode/test_run.py::test_run_app_with_passthrough
0.25s call     tests/platforms/macOS/app/test_run.py::test_run_app_with_passthrough
0.25s call     tests/platforms/macOS/app/test_run.py::test_run_app_failed
0.21s call     tests/integrations/subprocess/test_Subprocess__run__controlled_console.py::test_text_eq_true_default_overriding[in_kwargs3-kwargs3]
0.21s call     tests/integrations/subprocess/test_Subprocess__run__controlled_console.py::test_text_eq_true_default_overriding[in_kwargs2-kwargs2]
0.21s call     tests/integrations/subprocess/test_Subprocess__run__controlled_console.py::test_text_eq_true_default_overriding[in_kwargs4-kwargs4]
0.21s call     tests/integrations/subprocess/test_Subprocess__run__controlled_console.py::test_text_eq_true_default_overriding[in_kwargs5-kwargs5]
0.21s call     tests/integrations/subprocess/test_Subprocess__run__controlled_console.py::test_text_eq_true_default_overriding[in_kwargs0-kwargs0]
0.21s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_text_eq_true_default_overriding[in_kwargs1-kwargs1]
0.21s call     tests/integrations/subprocess/test_Subprocess__run__controlled_console.py::test_text_eq_true_default_overriding[in_kwargs1-kwargs1]
0.21s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_text_eq_true_default_overriding[in_kwargs0-kwargs0]
0.21s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_text_eq_true_default_overriding[in_kwargs2-kwargs2]
0.21s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_text_eq_true_default_overriding[in_kwargs4-kwargs4]
0.21s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_text_eq_true_default_overriding[in_kwargs3-kwargs3]
0.19s call     tests/test_mainline.py::test_interrupted_command_with_log
0.19s call     tests/test_mainline.py::test_unknown_command_error
0.18s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_call_with_start_new_session[Linux-None-run_kwargs0]
0.13s teardown tests/platforms/windows/visualstudio/test_run.py::test_run_app_test_mode_with_args
0.11s call     tests/integrations/subprocess/test_Subprocess__run__controlled_console.py::test_debug_call_with_env
0.11s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_calledprocesserror_exception_logging
0.11s call     tests/integrations/subprocess/test_Subprocess__run__controlled_console.py::test_debug_call
0.11s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_debug_call_with_env
0.11s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_call[Darwin]
0.11s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_call_with_start_new_session[Darwin-True-run_kwargs4]
0.11s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_call_with_start_new_session[Windows-False-run_kwargs8]
0.11s call     tests/integrations/subprocess/test_Subprocess__run__controlled_console.py::test_calledprocesserror
0.11s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_debug_call
0.11s call     tests/integrations/subprocess/test_Subprocess__run__controlled_console.py::test_call
0.11s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_call_with_arg
0.11s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_call_with_start_new_session[Darwin-None-run_kwargs3]
0.11s call     tests/integrations/subprocess/test_Subprocess__run__controlled_console.py::test_call_with_arg
0.11s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_call_with_start_new_session[Windows-True-run_kwargs7]
0.11s call     tests/integrations/subprocess/test_Subprocess__run__controlled_console.py::test_stderr_is_redirected
```
</details>

<details>
<summary>Top 50 currently slowest tests</summary>

```
0.35s call     tests/integrations/subprocess/test_Subprocess__stream_output.py::test_keyboard_interrupt
0.20s call     tests/test_mainline.py::test_unknown_command_error
0.19s call     tests/test_mainline.py::test_interrupted_command_with_log
0.13s teardown tests/platforms/windows/visualstudio/test_run.py::test_run_app_test_mode_with_args
0.09s call     tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py::test_call_with_start_new_session[Linux-None-run_kwargs0]
0.08s call     tests/platforms/iOS/xcode/test_run.py::test_run_app_simulator_uninstall_failure
0.08s call     tests/platforms/web/static/test_run.py::test_cleanup_server_error[localhost-8080-exception3-localhost:8080 is already in use.]
0.07s setup    tests/integrations/linuxdeploy/test_LinuxDeploy__is_elf_file.py::test_is_elf_header_positive_detection
0.07s call     tests/console/test_Log.py::test_save_log_to_file_with_multiple_exceptions
0.06s call     tests/integrations/cookiecutter/test_RGBExtension.py::test_py_tag[#000000-0.0-0.0-0.0]
0.06s setup    tests/commands/upgrade/test_call.py::test_list_specific_tools
0.04s call     tests/platforms/linux/system/test_run.py::test_supported_host_os
0.04s call     tests/test_mainline.py::test_command
0.04s call     tests/test_mainline.py::test_interrupted_command
0.04s call     tests/platforms/linux/appimage/test_build.py::test_build_appimage_with_plugins_in_docker
0.03s call     tests/platforms/linux/flatpak/test_mixin.py::test_verify_linux
0.03s call     tests/test_mainline.py::test_command_warning
0.03s call     tests/platforms/linux/flatpak/test_open.py::test_open
0.03s call     tests/platforms/linux/system/test_build.py::test_build_app
0.03s setup    tests/platforms/windows/app/test_package.py::test_package_formats
0.03s call     tests/platforms/linux/appimage/test_build.py::test_build_appimage_in_docker
0.03s call     tests/integrations/android_sdk/AndroidSDK/test_verify_avd.py::test_unrecognized_emulator_skin
0.02s call     tests/platforms/linux/appimage/test_build.py::test_build_appimage_with_plugin
0.02s setup    tests/integrations/docker/test_DockerAppContext__run.py::test_cwd
0.02s call     tests/test_mainline.py::test_help
0.02s call     tests/test_mainline.py::test_test_failure
0.02s call     tests/config/test_parse_config.py::test_requires
0.02s setup    tests/integrations/docker/test_DockerAppContext__run.py::test_call_with_arg_and_env
0.02s setup    tests/integrations/java/test_JDK__verify.py::test_no_javac[Windows-java_home3-NotADirectoryError]
0.02s call     tests/commands/create/test_call.py::test_create
0.02s call     tests/integrations/linuxdeploy/test_LinuxDeploy__verify_plugins.py::test_complex_plugin_config
0.02s call     tests/test_mainline.py::test_command_error
0.02s call     tests/integrations/xcode/test_confirm_xcode_license_accepted.py::test_license_status_unknown
0.02s setup    tests/integrations/docker/test_DockerAppContext__run.py::test_call_with_path_arg_and_env
0.02s call     tests/test_cmdline.py::test_run_command[run --test -r-expected_options4]
0.02s setup    tests/integrations/docker/test_DockerAppContext__dockerize_path.py::test_dockerize_path[value-value]
0.02s setup    tests/integrations/docker/test_DockerAppContext__dockerize_path.py::test_dockerize_path[/unmodified/path:{tmp_path}/bundle/path/to/file:{tmp_path}/briefcase/path/to/other/file-/unmodified/path:/app/path/to/file:/home/brutus/.cache/briefcase/path/to/other/file]
0.02s call     tests/test_cmdline.py::test_run_command[run -- --test-expected_options7]
0.02s setup    tests/integrations/docker/test_DockerAppContext__run.py::test_simple_verbose_call
0.02s setup    tests/integrations/docker/test_DockerAppContext__check_output.py::test_simple_call
0.02s call     tests/console/test_Log.py::test_save_log_to_file_with_exception
0.02s call     tests/integrations/android_sdk/AndroidSDK/test_verify.py::test_download_sdk_legacy_install
0.02s setup    tests/integrations/docker/test_DockerAppContext__check_output.py::test_extra_mounts
0.02s setup    tests/integrations/docker/test_DockerAppContext__check_output.py::test_call_with_path_arg_and_env
0.02s setup    tests/integrations/docker/test_DockerAppContext__check_output.py::test_simple_verbose_call
0.02s setup    tests/integrations/docker/test_DockerAppContext__check_output.py::test_call_with_arg_and_env
0.02s call     tests/test_cmdline.py::test_bare_command_help
0.02s setup    tests/integrations/docker/test_DockerAppContext__check_output.py::test_cwd
0.02s setup    tests/integrations/docker/test_DockerAppContext__run.py::test_extra_mounts
0.02s call     tests/test_cmdline.py::test_run_command[run --test -- --test-expected_options8]

```
</details>

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
