### PR TITLE
Run `tox` tests in parallel

### DIFF
--- a/changes/1247.misc.rst
+++ b/changes/1247.misc.rst
@@ -1,0 +1,1 @@
+Python tests are now run in parallel via ``tox``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,9 @@ requires = ["setuptools>=60", "setuptools_scm[toml]>=7.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]
+concurrency = ["multiprocessing", "thread"]
 parallel = true
+sigterm = true
 branch = true
 relative_files = true
 source_pkgs = ["briefcase"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,8 +91,10 @@ install_requires =
 # ensure environment consistency.
 dev =
     coverage[toml] == 7.2.3
+    coverage-enable-subprocess == 1.0
     pre-commit == 3.2.2
     pytest == 7.3.1
+    pytest-xdist == 3.2.1
     setuptools_scm[toml] == 7.1.0
     tox == 4.4.12
 docs =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ _sleep = time.sleep
 
 @pytest.fixture
 def sleep_zero(monkeypatch):
-    """Replace all calls to ``time.sleep(x)`` with ``time.sleep(0)."""
+    """Replace all calls to ``time.sleep(x)`` with ``time.sleep(0)``."""
     monkeypatch.setattr(time, "sleep", lambda x: _sleep(0))
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,11 @@ download = True
 # The leading comma generates the "py" environment.
 [testenv:py{,38,39,310,311,312}{,-coverage}]
 passenv =
-    # LOCALAPPDATA is needed to test data directory creation on Windows.
+    # Needed on Windows to test data directory creation
     LOCALAPPDATA
+setenv =
+    # Start Python such that coverage is possible in subprocesses
+    COVERAGE_PROCESS_START = {toxinidir}/pyproject.toml
 extras =
     dev
 # 2023-04-22 The virtualenv used by Tox has pip 23.1 pinned into it
@@ -16,7 +19,7 @@ extras =
 # need to force pip to be updated.
 download = True
 commands =
-    python -m coverage run -m pytest -vv {posargs}
+    python -m coverage run -m pytest {posargs:-n auto -vv}
     coverage : python -m coverage combine
     coverage : python -m coverage report
 


### PR DESCRIPTION
## Changes
- The `tox -e py` command now runs `pytest` tests in parallel
- Use `tox -e py --` to run tests sequentially in process

## Notes
- This took way longer to get working than I'd like to say...
- There are....[some](https://github.com/nedbat/coveragepy/issues/1341#issuecomment-1302863172) [complications](https://github.com/nedbat/coveragepy/issues/367) with getting `coverage.py` working with distributed tests
  - Not least of which is using an ostensibly bizarre pypi [package](https://pypi.org/project/coverage_enable_subprocess/) that was uploaded 7 years ago..
  - I tried to get `pytest-cov` to work....but I couldn't stop some innocuous errors....and it seems possible from Ned's documentation he doesn't have much love for it.
  - At any rate, one of those two packages (or some black magic) is necessary to get Python loaded correctly for `coverage.py` to work

I was about to abandon this effort but I did finally get it working. That said, I'm not sure this is the form it should necessarily take. A competing PR will be created shortly.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
