### PR TITLE
`pytest` and `pre-commit` cannot run concurrently in `tox`

### DIFF
--- a/changes/1258.misc.rst
+++ b/changes/1258.misc.rst
@@ -1,0 +1,1 @@
+Running ``pytest`` via ``tox`` now depends on the ``pre-commit`` environment to avoid errors in ``pytest``.

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,14 @@ skip_missing_interpreters = True
 # need to force pip to be updated.
 download = True
 
-[testenv]
+[testenv:pre-commit]
+extras = dev
+# 2023-04-22 see pkgenv ↑
+download = {[pkgenv]download}
+commands = pre-commit run --all-files --show-diff-on-failure --color=always
+
+[testenv:py{,38,39,310,311,312}{,-fast}]
+depends: pre-commit
 use_develop = fast: True
 skip_sdist = fast: True
 # Needed on Windows to test data directory creation
@@ -24,7 +31,7 @@ commands =
 [testenv:coverage{,-html}{,-fail}]
 depends = py{,38,39,310,311,312}
 parallel_show_output = True
-extras = {[testenv]extras}
+extras = dev
 # 2023-04-22 see pkgenv ↑
 download = {[pkgenv]download}
 commands =
@@ -32,12 +39,6 @@ commands =
     html : python -m coverage html --skip-covered --skip-empty
     !fail : python -m coverage report
     fail : python -m coverage report --fail-under=100
-
-[testenv:pre-commit]
-extras = {[testenv]extras}
-# 2023-04-22 see pkgenv ↑
-download = {[pkgenv]download}
-commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
 [testenv:towncrier-check]
 package_env = none


### PR DESCRIPTION
- Checks like `isort` can create temporary files in the `src` or `tests` and this can cause `pytest` to fail to load properly.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
