### PR TITLE
Disable progress bar and wait bar if `stdout` is not attached to a tty

### DIFF
--- a/changes/1267.bugfix.rst
+++ b/changes/1267.bugfix.rst
@@ -1,0 +1,1 @@
+Briefcase's Progress Bar and Wait Bar will no longer be rendered if the ``FORCE_COLOR`` environment variable is set.

--- a/tests/console/Console/test_progress_bar.py
+++ b/tests/console/Console/test_progress_bar.py
@@ -1,0 +1,10 @@
+def test_wait_bar_always_interactive(interactive_console):
+    """Progress Bar is not disabled when console is interactive."""
+    with interactive_console.progress_bar() as bar:
+        assert bar.disable is False
+
+
+def test_wait_bar_non_interactive(non_interactive_console):
+    """Progress Bar is disabled when console is non-interactive."""
+    with non_interactive_console.progress_bar() as bar:
+        assert bar.disable is True

--- a/tests/console/Console/test_properties.py
+++ b/tests/console/Console/test_properties.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 from briefcase.console import Console
 
 
@@ -31,3 +34,18 @@ def test_disable():
     console.enabled = False
 
     assert not console.enabled
+
+
+def test_is_interactive_is_tty(console):
+    """Interactivity should match whether a tty is attached to stdout."""
+    assert console.is_interactive is os.isatty(sys.stdout.fileno())
+
+
+def test_is_interactive_non_interactive(non_interactive_console):
+    """Console is non-interactive when stdout has no tty."""
+    assert non_interactive_console.is_interactive is False
+
+
+def test_is_interactive_always_interactive(interactive_console):
+    """Console is interactive when stdout has a tty."""
+    assert interactive_console.is_interactive is True

--- a/tests/console/Console/test_release_console_control.py
+++ b/tests/console/Console/test_release_console_control.py
@@ -27,12 +27,13 @@ def test_console_is_not_controlled():
     assert console.is_console_controlled is False
 
 
-def test_wait_bar_is_active():
+def test_wait_bar_is_active(interactive_console):
     """An active Wait Bar is stopped."""
-    console = Console()
+    # Always run in interactive mode; otherwise, is_started is will never be True
+    console = interactive_console
 
     with console.wait_bar("Testing..."):
-        # Mock the Wait Bar stop and start methods
+        # Wrap the Wait Bar stop and start methods
         console._wait_bar.stop = Mock(wraps=console._wait_bar.stop)
         console._wait_bar.start = Mock(wraps=console._wait_bar.start)
 

--- a/tests/console/Console/test_wait_bar.py
+++ b/tests/console/Console/test_wait_bar.py
@@ -115,3 +115,19 @@ def test_wait_bar_keyboard_interrupt_nested(
                 raise KeyboardInterrupt
 
     assert capsys.readouterr().out == output
+
+
+def test_wait_bar_always_interactive(interactive_console):
+    """Wait Bar is not disabled when console is interactive."""
+    with interactive_console.wait_bar():
+        assert interactive_console._wait_bar.disable is False
+        with interactive_console.wait_bar():
+            assert interactive_console._wait_bar.disable is False
+
+
+def test_wait_bar_non_interactive(non_interactive_console):
+    """Wait Bar is disabled when console is non-interactive."""
+    with non_interactive_console.wait_bar():
+        assert non_interactive_console._wait_bar.disable is True
+        with non_interactive_console.wait_bar():
+            assert non_interactive_console._wait_bar.disable is True

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -1,3 +1,4 @@
+import sys
 from unittest import mock
 
 import pytest
@@ -6,14 +7,26 @@ from briefcase.console import Console
 
 
 @pytest.fixture
-def console():
+def console() -> Console:
     console = Console()
-    console.input = mock.MagicMock()
+    console.input = mock.MagicMock(spec_set=input)
     return console
 
 
 @pytest.fixture
-def disabled_console():
+def disabled_console() -> Console:
     console = Console(enabled=False)
-    console.input = mock.MagicMock()
+    console.input = mock.MagicMock(spec_set=input)
     return console
+
+
+@pytest.fixture
+def non_interactive_console(console, monkeypatch) -> Console:
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+    yield console
+
+
+@pytest.fixture
+def interactive_console(console, monkeypatch) -> Console:
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    yield console


### PR DESCRIPTION
## Changes
- Disables the Progress Bar and Wait Bar if `stdout` if not attached to a tty

## Notes
- It was discovered in beeware/.github#36 that when `FORCE_COLOR` is set, Rich not only enables ANSI color and styling, but also turns on "live" elements like the Progress Bar
- Allowing the Progress Bar to run in CI can create really ugly [logs](https://github.com/beeware/.github/actions/runs/4902657729/jobs/8754641453)
- I initially considered disabling these dynamic elements when the `--no-input` switch is used....but I decided against it because:
  - It's a weak proxy for "non-interactive session"
  - It can disable the dynamic elements when they are still desired and reasonable to show
  - When users encounter the problem of polluted CI logs, they would be required to add an un-intuitive switch to _all_ invocations of Briefcase
- Rich's [recommendation](https://rich.readthedocs.io/en/stable/console.html#interactive-mode) for this situation is to instantiate `Console` with `force_terminal=True` and `force_interactive=False`
  - However, this recommendation is qualified with "you might want to do this in some CI environments"....and this only seems to make sense if the application using Rich is only really used in CI by the application developer
  - In Briefcase's case, we would need to establish some process for users to implement in their CI in order to activate these overrides for `Console`
  - Alternatively, we could always connect `sys.stdout.isatty()` to these overrides....although, I think I'd rather just let Rich do what it does by default and just target our known issues
    - After all, Rich has all the battle-tested logic for when terminal and interactive things should happen
- Thus, just disabling the specific uses of Rich's dynamic elements in Briefcase when a tty isn't available seems like the best way to use default functionality while avoiding known issues

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct