### PR TITLE
Pass the Briefcase version to cookiecutter from `NewCommand`

### DIFF
--- a/changes/1276.bugfix.rst
+++ b/changes/1276.bugfix.rst
@@ -1,0 +1,1 @@
+When creating a new Briefcase project, the header line in ``pyproject.toml`` now contains the version of Briefcase instead of "Unknown".

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -467,10 +467,15 @@ What GUI toolkit do you want to use for this project?""",
                 f"A directory named '{context['app_name']}' already exists."
             )
 
-        # This is to have briefcase template file
-        # mentioning extra context on which template/branch
-        # the project was generated from.
-        context.update({"template": template, "branch": branch})
+        # Additional context for the Briefcase template pyproject.toml header to
+        # include the version of Briefcase as well as the source of the template.
+        context.update(
+            {
+                "template": template,
+                "branch": branch,
+                "briefcase_version": briefcase.__version__,
+            }
+        )
 
         try:
             self.logger.info(f"Using app template: {template}, branch {branch}")

--- a/tests/commands/new/test_new_app.py
+++ b/tests/commands/new/test_new_app.py
@@ -78,6 +78,7 @@ def test_new_app(
             # default template and branch
             "template": "https://github.com/beeware/briefcase-template",
             "branch": expected_branch,
+            "briefcase_version": briefcase_version,
         },
     )
 
@@ -130,6 +131,7 @@ def test_new_app_missing_template(monkeypatch, new_command, tmp_path):
             # default template and branch
             "template": "https://github.com/beeware/briefcase-template",
             "branch": "v37.42.7",
+            "briefcase_version": "37.42.7",
         },
     )
 
@@ -196,6 +198,7 @@ def test_new_app_dev(monkeypatch, new_command, tmp_path, briefcase_version):
                     # default template and branch
                     "template": "https://github.com/beeware/briefcase-template",
                     "branch": "v37.42.7",
+                    "briefcase_version": briefcase_version,
                 },
             ),
             mock.call(
@@ -212,6 +215,7 @@ def test_new_app_dev(monkeypatch, new_command, tmp_path, briefcase_version):
                     # default template and branch
                     "template": "https://github.com/beeware/briefcase-template",
                     "branch": "v37.42.7",
+                    "briefcase_version": briefcase_version,
                 },
             ),
         ]
@@ -259,6 +263,7 @@ def test_new_app_with_template(monkeypatch, new_command, tmp_path):
             # template and branch
             "template": "https://example.com/other.git",
             "branch": "v37.42.7",
+            "briefcase_version": "37.42.7",
         },
     )
 
@@ -310,6 +315,7 @@ def test_new_app_with_invalid_template(monkeypatch, new_command, tmp_path):
             # template and branch
             "template": "https://example.com/other.git",
             "branch": "v37.42.7",
+            "briefcase_version": "37.42.7",
         },
     )
 
@@ -364,6 +370,7 @@ def test_new_app_with_invalid_template_branch(monkeypatch, new_command, tmp_path
             # template and branch
             "template": "https://example.com/other.git",
             "branch": "v37.42.7",
+            "briefcase_version": "37.42.7",
         },
     )
 
@@ -409,6 +416,7 @@ def test_new_app_with_branch(monkeypatch, new_command, tmp_path):
             # template and branch
             "template": "https://github.com/beeware/briefcase-template",
             "branch": "experimental",
+            "briefcase_version": "37.42.7",
         },
     )
 


### PR DESCRIPTION
## Changes
- `briefcase new` now passes `briefcase.__version__` as `briefcase_version` to cookiecutter so `pyproject.toml` contains the Briefcase version instead of `Unknown`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
