### PR TITLE
Use docformatter's new forward compatible setting for Black in v1.7.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,10 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.6.5
+    rev: v1.7.0
     hooks:
       - id: docformatter
-        args: [--in-place, --wrap-descriptions=88, --wrap-summaries=88]
+        args: [--in-place, --black]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/changes/1279.misc.rst
+++ b/changes/1279.misc.rst
@@ -1,0 +1,1 @@
+The version of docformatter was updated to v1.7.0 and now uses a specific setting for compatibility with Black.


### PR DESCRIPTION
## Changes
- Updated docformatter to v1.7.0
- Replaced current settings for line length with [`--black`](https://docformatter.readthedocs.io/en/latest/configuration.html#a-note-on-options-to-control-styles)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
