### PR TITLE
Remove timestamp and PID from Android log format

### DIFF
--- a/changes/1286.bugfix.rst
+++ b/changes/1286.bugfix.rst
@@ -1,0 +1,1 @@
+Android logs no longer include timestamp and PID, making them easier to read on narrow screens.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1354,6 +1354,7 @@ Activity class not found while starting app.
                 "-s",
                 self.device,
                 "logcat",
+                "--format=tag",
                 "--pid",  # This option is available since API level 24.
                 pid,
             ]
@@ -1378,6 +1379,7 @@ Activity class not found while starting app.
                     "-s",
                     self.device,
                     "logcat",
+                    "--format=tag",
                     "-t",
                     since.strftime("%m-%d %H:%M:%S.000000"),
                     "-s",

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -33,9 +33,7 @@ def safe_formal_name(name):
     return re.sub(r"\s+", " ", re.sub(r'[!/\\:<>"\?\*\|]', "", name)).strip()
 
 
-ANDROID_LOG_PREFIX_REGEX = re.compile(
-    r"\d{2}-\d{2} (?P<timestamp>\d{2}:\d{2}:\d{2}.\d{3})\s+\d+\s+\d+ [A-Z] (?P<component>.*?): (?P<content>.*)"
-)
+ANDROID_LOG_PREFIX_REGEX = re.compile(r"[A-Z]/(?P<tag>.*?): (?P<content>.*)")
 
 
 def android_log_clean_filter(line):
@@ -53,7 +51,7 @@ def android_log_clean_filter(line):
     match = ANDROID_LOG_PREFIX_REGEX.match(line)
     if match:
         groups = match.groupdict()
-        include = groups["component"] in {"python.stdout", "python.stderr"}
+        include = groups["tag"] in {"python.stdout", "python.stderr"}
         return groups["content"], include
 
     return line, False

--- a/tests/integrations/android_sdk/ADB/test_logcat.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat.py
@@ -24,6 +24,7 @@ def test_logcat(mock_tools):
             "-s",
             "exampleDevice",
             "logcat",
+            "--format=tag",
             "--pid",
             "1234",
             "EGL_emulation:S",

--- a/tests/integrations/android_sdk/ADB/test_logcat_tail.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat_tail.py
@@ -24,6 +24,7 @@ def test_logcat_tail(mock_tools):
             "-s",
             "exampleDevice",
             "logcat",
+            "--format=tag",
             "-t",
             "11-10 09:08:07.000000",
             "-s",

--- a/tests/platforms/android/gradle/test_android_log_clean_filter.py
+++ b/tests/platforms/android/gradle/test_android_log_clean_filter.py
@@ -13,35 +13,35 @@ from briefcase.platforms.android.gradle import android_log_clean_filter
         ),
         # System messages log
         (
-            "11-16 14:32:57.866  4041  4041 D libEGL  : loaded /vendor/lib64/egl/libEGL_emulation.so",
+            "D/libEGL  : loaded /vendor/lib64/egl/libEGL_emulation.so",
             (
                 "loaded /vendor/lib64/egl/libEGL_emulation.so",
                 False,
             ),
         ),
         (
-            "11-16 14:32:57.967  4041  4067 D stdio   : Could not find platform independent libraries <prefix>",
+            "D/stdio   : Could not find platform independent libraries <prefix>",
             ("Could not find platform independent libraries <prefix>", False),
         ),
         (
-            "11-16 14:32:58.218  4041  4041 D MainActivity: onStart() start",
+            "D/MainActivity: onStart() start",
             ("onStart() start", False),
         ),
         # Python App messages
         (
-            "11-16 14:32:58.195  4041  4041 I python.stdout: Python app launched & stored in Android Activity class",
+            "I/python.stdout: Python app launched & stored in Android Activity class",
             ("Python app launched & stored in Android Activity class", True),
         ),
         (
-            "11-16 14:32:58.195  4041  4041 I python.stdout: ",
+            "I/python.stdout: ",
             ("", True),
         ),
         (
-            "11-16 14:32:58.195  4041  4041 I python.stderr: test_case (tests.foobar.test_other.TestOtherMethods)",
+            "I/python.stderr: test_case (tests.foobar.test_other.TestOtherMethods)",
             ("test_case (tests.foobar.test_other.TestOtherMethods)", True),
         ),
         (
-            "11-16 14:32:58.195  4041  4041 I python.stderr: ",
+            "I/python.stderr: ",
             ("", True),
         ),
         # Unknown content


### PR DESCRIPTION
This information is rarely helpful, and the added line length makes the log difficult to follow even in a moderately wide terminal.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
