### PR TITLE
Fix up support for Python 3.12

### DIFF
--- a/changes/1290.misc.rst
+++ b/changes/1290.misc.rst
@@ -1,0 +1,1 @@
+The test suite is now compatible with Python 3.12.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ no-cover-if-is-macos = "'darwin' == os_environ.get('COVERAGE_PLATFORM', sys_plat
 no-cover-if-not-macos = "'darwin' != os_environ.get('COVERAGE_PLATFORM', sys_platform) and os_environ.get('COVERAGE_EXCLUDE_PLATFORM') != 'disable'"
 no-cover-if-is-windows = "'win32' == os_environ.get('COVERAGE_PLATFORM', sys_platform) and os_environ.get('COVERAGE_EXCLUDE_PLATFORM') != 'disable'"
 no-cover-if-not-windows = "'win32' != os_environ.get('COVERAGE_PLATFORM', sys_platform) and os_environ.get('COVERAGE_EXCLUDE_PLATFORM') != 'disable'"
+no-cover-if-lt-py312 = "sys_version_info < (3, 12) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-is-py310 = "python_version == '3.10' and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-lt-py310 = "sys_version_info < (3, 10) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-gte-py310 = "sys_version_info > (3, 10) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ no-cover-if-is-macos = "'darwin' == os_environ.get('COVERAGE_PLATFORM', sys_plat
 no-cover-if-not-macos = "'darwin' != os_environ.get('COVERAGE_PLATFORM', sys_platform) and os_environ.get('COVERAGE_EXCLUDE_PLATFORM') != 'disable'"
 no-cover-if-is-windows = "'win32' == os_environ.get('COVERAGE_PLATFORM', sys_platform) and os_environ.get('COVERAGE_EXCLUDE_PLATFORM') != 'disable'"
 no-cover-if-not-windows = "'win32' != os_environ.get('COVERAGE_PLATFORM', sys_platform) and os_environ.get('COVERAGE_EXCLUDE_PLATFORM') != 'disable'"
+no-cover-if-is-py312 = "python_version == '3.12' and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-lt-py312 = "sys_version_info < (3, 12) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-is-py310 = "python_version == '3.10' and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-lt-py310 = "sys_version_info < (3, 10) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
@@ -52,6 +53,8 @@ multi_line_output = 3
 testpaths = ["tests"]
 filterwarnings = [
     "error",
+    # suppress until python-dateutil>2.8.2 is released (https://github.com/dateutil/dateutil/issues/1284)
+    "ignore:.*datetime.utcfromtimestamp\\(\\) is deprecated.*:DeprecationWarning:",
 ]
 
 # need to ensure build directories aren't excluded from recursion

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -6,6 +6,7 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 from contextlib import suppress
 from datetime import datetime
@@ -806,7 +807,11 @@ connection.
         # Unpack skin archive
         with self.tools.input.wait_bar("Installing device skin..."):
             try:
-                self.tools.shutil.unpack_archive(skin_tgz_path, extract_dir=skin_path)
+                self.tools.shutil.unpack_archive(
+                    skin_tgz_path,
+                    extract_dir=skin_path,
+                    **({"filter": "data"} if sys.version_info >= (3, 12) else {}),
+                )
             except (shutil.ReadError, EOFError) as err:
                 raise BriefcaseCommandError(
                     f"Unable to unpack {skin} device skin."

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -575,7 +575,8 @@ password:
         finally:
             # Clean up house; we don't need the archive anymore.
             if archive_filename != filename:
-                self.tools.os.unlink(archive_filename)
+                # coverage exclusion required for https://github.com/python/cpython/issues/105658
+                self.tools.os.unlink(archive_filename)  # no-cover-if-is-py312
 
         try:
             self.logger.info()

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 from unittest import mock
 
 import pytest
@@ -55,6 +56,7 @@ def test_install_app_support_package(
     create_command.tools.shutil.unpack_archive.assert_called_with(
         tmp_path / "data" / "support" / "Python-3.X-tester-support.b37.tar.gz",
         extract_dir=support_path,
+        **({"filter": "data"} if sys.version_info >= (3, 12) else {}),
     )
 
     # Confirm that the full path to the support file
@@ -100,6 +102,7 @@ def test_install_pinned_app_support_package(
     create_command.tools.shutil.unpack_archive.assert_called_with(
         tmp_path / "data" / "support" / "Python-3.X-Tester-support.b42.tar.gz",
         extract_dir=support_path,
+        **({"filter": "data"} if sys.version_info >= (3, 12) else {}),
     )
 
     # Confirm that the full path to the support file

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -40,6 +41,7 @@ def test_new_skin(mock_tools, android_sdk):
     mock_tools.shutil.unpack_archive.assert_called_once_with(
         skin_tgz_path,
         extract_dir=android_sdk.root_path / "skins" / "pixel_X",
+        **({"filter": "data"} if sys.version_info >= (3, 12) else {}),
     )
 
     # Original file was deleted.
@@ -102,6 +104,7 @@ def test_unpack_failure(mock_tools, android_sdk, tmp_path):
     mock_tools.shutil.unpack_archive.assert_called_once_with(
         skin_tgz_path,
         extract_dir=android_sdk.root_path / "skins" / "pixel_X",
+        **({"filter": "data"} if sys.version_info >= (3, 12) else {}),
     )
 
     # Original file wasn't deleted.


### PR DESCRIPTION
## Changes
- Enable new tarfile extraction protections in Python 3.12
  - https://docs.python.org/3.12/whatsnew/3.12.html#other-language-changes
  - This applies the new ["data" filter](https://docs.python.org/3.12/library/tarfile.html#tarfile.data_filter) to unpacking tar files
  - This prevents the unpacked files from using absolute filepaths or symlinks from referencing absolute filepaths or filepaths outside of the target directory
  - Additionally, the permissions are sanitized to basically ensure they are sane; e.g. world execute permissions are removed if the owner doesn't have execute permissions.

## Notes
- `DeprecationWarning` from pytest for `ast` constants
  - https://github.com/pytest-dev/pytest/issues/10977
- `DeprecationWarning` from dateutil for `datetime.utcfromtimestamp()` usage
  - https://github.com/dateutil/dateutil/issues/1284

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
