### PR TITLE
Bump tox to 4.6.0 and remove workarounds to avoid pip 23.1

### DIFF
--- a/changes/1301.misc.rst
+++ b/changes/1301.misc.rst
@@ -1,0 +1,1 @@
+Updated tox from 4.5.2 to 4.6.0 and removed the workarounds to avoid pip 23.1.

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ dev =
     pytest == 7.3.1
     pytest-xdist == 3.3.1
     setuptools_scm[toml] == 7.1.0
-    tox == 4.5.2
+    tox == 4.6.0
 docs =
     furo == 2023.5.20
     pyenchant == 3.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -12,16 +12,7 @@ labels =
     ci = towncrier-check,docs-lint,pre-commit,py{38,39,310,311,312},coverage-platform
 skip_missing_interpreters = True
 
-[pkgenv]
-# 2023-04-22 The virtualenv used by Tox has pip 23.1 pinned into it
-# This version has a bug on winstore installs of Python, so we
-# need to force pip to be updated.
-# Can be removed once tox bumps virtualenv >= v20.23.0
-download = True
-
 [testenv:pre-commit]
-# 2023-04-22 see pkgenv ↑
-download = {[pkgenv]download}
 skip_install = True
 deps = build
 commands_pre = python -m install_requirement --extra dev --project-root "{tox_root}" pre-commit
@@ -34,8 +25,6 @@ use_develop = fast: True
 passenv = LOCALAPPDATA
 setenv = COVERAGE_FILE = {env:COVERAGE_FILE:.coverage}
 extras = dev
-# 2023-04-22 see pkgenv ↑
-download = {[pkgenv]download}
 commands =
     !fast : python -m coverage run -m pytest {posargs:-vv --color yes}
     fast : python -m pytest {posargs:-vv --color yes -n auto}
@@ -52,8 +41,6 @@ base_python =
     coverage310: py310
     coverage311: py311
     coverage312: py312
-# 2023-04-22 see pkgenv ↑
-download = {[pkgenv]download}
 passenv = COVERAGE_FILE
 setenv =
     keep: COMBINE_FLAGS = --keep


### PR DESCRIPTION
## Changes
- Tox [bumped](https://github.com/tox-dev/tox/commit/5ad66c1f86c19f10dd59cbe3b2132d59d2fd3e86) its minimum requirement for virtualenv to 20.23
- Since virtualenv 20.23 embeds pip 23.1.2, the [workarounds](https://github.com/beeware/briefcase/pull/1198) to avoid pip 23.1 are moot
- This restores a small speed improvement to tox environments since they will no longer always download the latest pip and setuptools

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
