### PR TITLE
No warning if JDK referred by macOS is invalid

### DIFF
--- a/changes/1305.bugfix.rst
+++ b/changes/1305.bugfix.rst
@@ -1,0 +1,1 @@
+An warning is no longer logged if the Java identified by macOS is not usable by Briefcase.

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -121,7 +121,6 @@ class JDK(ManagedTool):
     Briefcase will use its own JDK instance.
 
 *************************************************************************
-
 """
 
             except OSError:
@@ -139,7 +138,6 @@ class JDK(ManagedTool):
     Briefcase will use its own JDK instance.
 
 *************************************************************************
-
 """
 
             except subprocess.CalledProcessError:
@@ -166,7 +164,6 @@ class JDK(ManagedTool):
     from the command prompt.
 
 *************************************************************************
-
 """
 
             except IndexError:
@@ -193,7 +190,6 @@ class JDK(ManagedTool):
     from the command prompt.
 
 *************************************************************************
-
 """
 
         # macOS has a helpful system utility to determine JAVA_HOME. Try it.
@@ -215,8 +211,11 @@ class JDK(ManagedTool):
                     pass  # do not alert user if macOS found an unqualified JDK
 
         if java is None:
-            # If we've reached this point, any user-provided JAVA_HOME is broken;
-            # use the Briefcase one.
+            # Inform the user if the user-specified JDK wasn't valid
+            if install_message:
+                tools.logger.warning(install_message)
+
+            # Use the Briefcase JDK install
             java_home = tools.base_path / cls.JDK_INSTALL_DIR_NAME
 
             # The macOS download has a weird layout (inherited from the official Oracle
@@ -228,10 +227,6 @@ class JDK(ManagedTool):
 
             if not java.exists():
                 if install:
-                    # We only display the warning messages on the pass where we actually
-                    # install the JDK.
-                    if install_message:
-                        tools.logger.warning(install_message)
                     tools.logger.info(
                         f"A Java {cls.JDK_MAJOR_VER} JDK was not found; downloading and installing...",
                         prefix=cls.name,

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -72,7 +72,7 @@ class JDK(ManagedTool):
                 "-version",
             ],
         )
-        # This should be a string of the form "javac 17.0.7\n"
+        # javac's output should look like "javac 17.0.7\n"
         return output.strip("\n").split(" ")[1]
 
     @classmethod

--- a/tests/integrations/java/test_JDK__verify.py
+++ b/tests/integrations/java/test_JDK__verify.py
@@ -246,9 +246,10 @@ def test_invalid_jdk_version(mock_tools, host_os, java_home, tmp_path, capsys):
         [os.fsdecode(Path("/path/to/java/bin/javac")), "-version"],
     )
 
-    # No console output (because Briefcase JDK exists)
+    # Warning is shown for invalid JAVA_HOME
     output = capsys.readouterr()
-    assert output.out == ""
+    assert "WARNING: JAVA_HOME does not point to a Java 17 JDK" in output.out
+    assert output.out.endswith("****\n")
     assert output.err == ""
 
 
@@ -292,9 +293,10 @@ def test_no_javac(mock_tools, host_os, java_home, error_type, tmp_path, capsys):
         [os.fsdecode(Path("/path/to/nowhere/bin/javac")), "-version"],
     ),
 
-    # No console output (because Briefcase JDK exists)
+    # Warning is shown for invalid JAVA_HOME
     output = capsys.readouterr()
-    assert output.out == ""
+    assert "WARNING: JAVA_HOME does not point to a JDK" in output.out
+    assert output.out.endswith("****\n")
     assert output.err == ""
 
 
@@ -333,9 +335,10 @@ def test_javac_error(mock_tools, host_os, java_home, tmp_path, capsys):
         [os.fsdecode(Path("/path/to/nowhere/bin/javac")), "-version"],
     ),
 
-    # No console output (because Briefcase JDK exists)
+    # Warning is shown for invalid JAVA_HOME
     output = capsys.readouterr()
-    assert output.out == ""
+    assert "WARNING: Unable to invoke the Java compiler" in output.out
+    assert output.out.endswith("****\n")
     assert output.err == ""
 
 
@@ -374,7 +377,11 @@ def test_unparseable_javac_version(mock_tools, host_os, java_home, tmp_path, cap
 
     # No console output (because Briefcase JDK exists)
     output = capsys.readouterr()
-    assert output.out == ""
+    assert (
+        "WARNING: Unable to determine the version of Java that is installed"
+        in output.out
+    )
+    assert output.out.endswith("****\n")
     assert output.err == ""
 
 


### PR DESCRIPTION
## Changes
- The user is no longer warned about any issues detected with the JDK referred by macOS via `/usr/libexec/java_home`
- Fixes #1305

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
