### PR TITLE
Add support to specify an Android SDK in `ANDROID_HOME` (fixes #463)

### DIFF
--- a/changes/463.feature.rst
+++ b/changes/463.feature.rst
@@ -1,0 +1,1 @@
+An Android SDK specified in ``ANDROID_HOME`` is respected now and will take precedence over the setting of ``ANDROID_SDK_ROOT``.

--- a/docs/reference/platforms/android.rst
+++ b/docs/reference/platforms/android.rst
@@ -4,6 +4,21 @@ Android
 
 When generating an Android project, Briefcase produces a Gradle project.
 
+Gradle requires an installation of the Android SDK and a Java JDK.
+
+An existing installation of the Android SDK will be used by Briefcase if its
+file path is specified in the ``ANDROID_HOME`` environment variable.
+The environment variable ``ANDROID_SDK_ROOT`` can also specify the file path to
+the SDK but it is considered deprecated by Android.
+
+An existing Java JDK will be used by Briefcase if its file path is specified in
+the ``JAVA_HOME`` environment variable. Briefcase requires the JDK to be
+version 17. On macOS, Briefcase will use the ``/usr/libexec/java_home`` tool to
+actively find an existing JDK installation for use if ``JAVA_HOME`` is not set.
+
+If the above methods fail to find an Android SDK or Java JDK, Briefcase will
+install an isolated copy in its data directory.
+
 Icon format
 ===========
 

--- a/docs/reference/platforms/android.rst
+++ b/docs/reference/platforms/android.rst
@@ -8,8 +8,8 @@ Gradle requires an install of the Android SDK and a Java 17 JDK.
 
 If you have an existing install of the Android SDK, it will be used by Briefcase
 if the ``ANDROID_HOME`` environment variable is set. If ``ANDROID_HOME`` is not
-present in the environment, Briefcase will honor the ``ANDROID_SDK_ROOT``
-environment variable (the use of variable has been deprecated by Android).
+present in the environment, Briefcase will honor the deprecated
+``ANDROID_SDK_ROOT`` environment variable.
 
 If you have an existing install of a Java 17 JDK, it will be used by Briefcase
 if the ``JAVA_HOME`` environment variable is set. On macOS, if ``JAVA_HOME`` is

--- a/docs/reference/platforms/android.rst
+++ b/docs/reference/platforms/android.rst
@@ -4,20 +4,20 @@ Android
 
 When generating an Android project, Briefcase produces a Gradle project.
 
-Gradle requires an installation of the Android SDK and a Java JDK.
+Gradle requires an install of the Android SDK and a Java 17 JDK.
 
-An existing installation of the Android SDK will be used by Briefcase if its
-file path is specified in the ``ANDROID_HOME`` environment variable.
-The environment variable ``ANDROID_SDK_ROOT`` can also specify the file path to
-the SDK but it is considered deprecated by Android.
+If you have an existing install of the Android SDK, it will be used by Briefcase
+if the ``ANDROID_HOME`` environment variable is set. If ``ANDROID_HOME`` is not
+present in the environment, Briefcase will honor the ``ANDROID_SDK_ROOT``
+environment variable (the use of variable has been deprecated by Android).
 
-An existing Java JDK will be used by Briefcase if its file path is specified in
-the ``JAVA_HOME`` environment variable. Briefcase requires the JDK to be
-version 17. On macOS, Briefcase will use the ``/usr/libexec/java_home`` tool to
-actively find an existing JDK installation for use if ``JAVA_HOME`` is not set.
+If you have an existing install of a Java 17 JDK, it will be used by Briefcase
+if the ``JAVA_HOME`` environment variable is set. On macOS, if ``JAVA_HOME`` is
+not set, Briefcase will use the ``/usr/libexec/java_home`` tool to find an
+existing JDK install.
 
 If the above methods fail to find an Android SDK or Java JDK, Briefcase will
-install an isolated copy in its data directory.
+download and install an isolated copy in its data directory.
 
 Icon format
 ===========

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -173,16 +173,17 @@ class AndroidSDK(ManagedTool):
 *************************************************************************
 
     The ANDROID_HOME and ANDROID_SDK_ROOT environment variables are set
-    to different file paths:
+    to different paths:
 
         ANDROID_HOME:     {android_home}
         ANDROID_SDK_ROOT: {android_sdk_root}
 
-    Briefcase will ignore ANDROID_SDK_ROOT and only use the SDK file path
+    Briefcase will ignore ANDROID_SDK_ROOT and only use the path
     specified by ANDROID_HOME.
 
-    Update your environment configuration to not set ANDROID_SDK_ROOT or
-    set both environment variables to the same SDK file path.
+    You should update your environment configuration to either not set
+    ANDROID_SDK_ROOT, or set both environment variables to the same
+    path.
 
 *************************************************************************
 """
@@ -241,8 +242,8 @@ class AndroidSDK(ManagedTool):
     Briefcase is using the Android SDK specified by the ANDROID_SDK_ROOT
     environment variable.
 
-    Android has replaced this configuration with the ANDROID_HOME
-    environment variable and deprecated ANDROID_SDK_ROOT.
+    Android has deprecated ANDROID_SDK_ROOT in favor of the
+    ANDROID_HOME environment variable.
 
     Update your environment configuration to set ANDROID_HOME instead of
     ANDROID_SDK_ROOT to ensure future compatibility.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -257,7 +257,7 @@ class AndroidSDK(ManagedTool):
                 tools.logger.warning(
                     f"""
 *************************************************************************
-** WARNING: {sdk_env_source} does not point to an Android SDK{" " * (26 - len(sdk_env_source))}**
+** {f"WARNING: {sdk_env_source} does not point to an Android SDK":67} **
 *************************************************************************
 
     The location pointed to by the {sdk_env_source} environment

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -118,6 +118,7 @@ class AndroidSDK(ManagedTool):
     @property
     def env(self) -> dict[str, str]:
         return {
+            "ANDROID_HOME": os.fsdecode(self.root_path),
             "ANDROID_SDK_ROOT": os.fsdecode(self.root_path),
             "JAVA_HOME": str(self.tools.java.java_home),
         }
@@ -148,6 +149,56 @@ class AndroidSDK(ManagedTool):
         return f"system-images;android-31;default;{self.emulator_abi}"
 
     @classmethod
+    def sdk_path_from_env(cls, tools: ToolCache) -> tuple[str | None, str | None]:
+        """Determine the file path to an Android SDK from the environment.
+
+        Android has historically supported several env vars to set the location of an
+        Android SDK for build tools. The currently preferred source is ANDROID_HOME;
+        however, ANDROID_SDK_ROOT is also supported as a deprecated setting.
+
+        These values must be same if both set; otherwise, Gradle will error.
+
+        :param tools: ToolCache of available tools
+        :returns: Tuple of path to SDK and the env var name that provided that path
+        """
+        android_home = tools.os.environ.get("ANDROID_HOME")
+        android_sdk_root = tools.os.environ.get("ANDROID_SDK_ROOT")
+
+        if android_home:
+            if android_sdk_root and android_sdk_root != android_home:
+                tools.logger.warning(
+                    f"""
+*************************************************************************
+** WARNING: ANDROID_HOME and ANDROID_SDK_ROOT are inconsistent         **
+*************************************************************************
+
+    The ANDROID_HOME and ANDROID_SDK_ROOT environment variables are set
+    to different file paths:
+
+        ANDROID_HOME:     {android_home}
+        ANDROID_SDK_ROOT: {android_sdk_root}
+
+    Briefcase will ignore ANDROID_SDK_ROOT and only use the SDK file path
+    specified by ANDROID_HOME.
+
+    Update your environment configuration to not set ANDROID_SDK_ROOT or
+    set both environment variables to the same SDK file path.
+
+*************************************************************************
+"""
+                )
+            sdk_root = android_home
+            sdk_source = "ANDROID_HOME"
+        elif android_sdk_root:
+            sdk_root = android_sdk_root
+            sdk_source = "ANDROID_SDK_ROOT"
+        else:
+            sdk_root = None
+            sdk_source = None
+
+        return sdk_root, sdk_source
+
+    @classmethod
     def verify_install(
         cls,
         tools: ToolCache,
@@ -156,11 +207,11 @@ class AndroidSDK(ManagedTool):
     ) -> AndroidSDK:
         """Verify an Android SDK is available.
 
-        If the ANDROID_SDK_ROOT environment variable is set, that location will
+        The file paths in ANDROID_HOME and ANDROID_SDK_ROOT environment variables will
         be checked for a valid SDK.
 
-        If the location provided doesn't contain an SDK, or no location is provided,
-        an SDK is downloaded.
+        If those file paths do not contain an SDK, or no file path is provided, an SDK
+        is downloaded.
 
         :param tools: ToolCache of available tools
         :param install: Should the tool be installed if it is not found?
@@ -174,21 +225,41 @@ class AndroidSDK(ManagedTool):
         JDK.verify(tools=tools, install=install)
 
         sdk = None
-        sdk_root = tools.os.environ.get("ANDROID_SDK_ROOT")
+        sdk_root, sdk_env_source = cls.sdk_path_from_env(tools=tools)
+
         if sdk_root:
             sdk = AndroidSDK(tools=tools, root_path=Path(sdk_root))
 
             if sdk.exists():
+                if sdk_env_source == "ANDROID_SDK_ROOT":
+                    tools.logger.warning(
+                        """
+*************************************************************************
+** WARNING: Using Android SDK from ANDROID_SDK_ROOT                    **
+*************************************************************************
+
+    Briefcase is using the Android SDK specified by the ANDROID_SDK_ROOT
+    environment variable.
+
+    Android has replaced this configuration with the ANDROID_HOME
+    environment variable and deprecated ANDROID_SDK_ROOT.
+
+    Update your environment configuration to set ANDROID_HOME instead of
+    ANDROID_SDK_ROOT to ensure future compatibility.
+
+*************************************************************************
+"""
+                    )
                 sdk.verify_license()
             else:
                 sdk = None
                 tools.logger.warning(
                     f"""
 *************************************************************************
-** WARNING: ANDROID_SDK_ROOT does not point to an Android SDK          **
+** WARNING: {sdk_env_source} does not point to an Android SDK{" " * (26 - len(sdk_env_source))}**
 *************************************************************************
 
-    The location pointed to by the ANDROID_SDK_ROOT environment
+    The location pointed to by the {sdk_env_source} environment
     variable:
 
     {sdk_root}

--- a/tests/console/test_Log.py
+++ b/tests/console/test_Log.py
@@ -89,7 +89,7 @@ def test_save_log_to_file_no_exception(mock_now, command, tmp_path):
     stacktrace if one is not captured."""
     command.tools.os.environ = {
         "GITHUB_KEY": "super-secret-key",
-        "ANDROID_SDK_ROOT": "/androidsdk",
+        "ANDROID_HOME": "/androidsdk",
     }
 
     logger = Log(verbosity=2)
@@ -131,11 +131,11 @@ def test_save_log_to_file_no_exception(mock_now, command, tmp_path):
     assert "this is log output" in log_contents
     assert "this is console output" not in log_contents
     # Environment variables are in the output
-    assert "ANDROID_SDK_ROOT=/androidsdk" in log_contents
+    assert "ANDROID_HOME=/androidsdk" in log_contents
     assert "GITHUB_KEY=********************" in log_contents
     assert "GITHUB_KEY=super-secret-key" not in log_contents
     # Environment variables are sorted
-    assert log_contents.index("ANDROID_SDK_ROOT") < log_contents.index("GITHUB_KEY")
+    assert log_contents.index("ANDROID_HOME") < log_contents.index("GITHUB_KEY")
 
     assert TRACEBACK_HEADER not in log_contents
     assert EXTRA_HEADER not in log_contents

--- a/tests/integrations/android_sdk/AndroidSDK/test_properties.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_properties.py
@@ -89,6 +89,7 @@ def test_simple_env(mock_tools, android_sdk, tmp_path):
     """The SDK Environment can be constructed."""
     assert android_sdk.env == {
         "JAVA_HOME": os.fsdecode(Path("/path/to/jdk")),
+        "ANDROID_HOME": os.fsdecode(tmp_path / "sdk"),
         "ANDROID_SDK_ROOT": os.fsdecode(tmp_path / "sdk"),
     }
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -113,8 +113,49 @@ def test_succeeds_immediately_in_happy_path(mock_tools, tmp_path):
     assert sdk.root_path == android_sdk_root_path
 
 
-def test_user_provided_sdk(mock_tools, tmp_path):
-    """If the user specifies a valid ANDROID_SDK_ROOT, it is used."""
+@pytest.mark.parametrize("env_var", ["ANDROID_HOME", "ANDROID_SDK_ROOT"])
+def test_user_provided_sdk(mock_tools, env_var, tmp_path, capsys):
+    """If the user environment specifies a valid Android SDK, it is used."""
+    # Increase the log level.
+    mock_tools.logger.verbosity = 2
+
+    # Create `sdkmanager` and the license file.
+    existing_android_sdk_root_path = tmp_path / "other_sdk"
+    tools_bin = existing_android_sdk_root_path / "cmdline-tools" / "latest" / "bin"
+    tools_bin.mkdir(parents=True, mode=0o755)
+    if platform.system() == "Windows":
+        sdk_manager = tools_bin / "sdkmanager.bat"
+        sdk_manager.touch()
+    else:
+        sdk_manager = tools_bin / "sdkmanager"
+        sdk_manager.touch(mode=0o755)
+
+    # Pre-accept the license
+    accept_license(existing_android_sdk_root_path)()
+
+    # Set the environment to specify ANDROID_SDK_ROOT
+    mock_tools.os.environ = {env_var: os.fsdecode(existing_android_sdk_root_path)}
+
+    # Expect verify() to succeed
+    sdk = AndroidSDK.verify(mock_tools)
+
+    # No calls to download or unpack anything.
+    mock_tools.download.file.assert_not_called()
+    mock_tools.shutil.unpack_archive.assert_not_called()
+
+    # The returned SDK has the expected root path.
+    assert sdk.root_path == existing_android_sdk_root_path
+
+    # User is warned about using ANDROID_SDK_ROOT
+    if env_var == "ANDROID_SDK_ROOT":
+        assert "Using Android SDK from ANDROID_SDK_ROOT" in capsys.readouterr().out
+    else:
+        assert capsys.readouterr().out == ""
+
+
+def test_consistent_user_provided_sdk(mock_tools, tmp_path, capsys):
+    """If the user environment specifies a valid Android SDK in both ANDROID_HOME and
+    ANDROID_SDK_ROOT, it is used."""
     # Increase the log level.
     mock_tools.logger.verbosity = 2
 
@@ -134,7 +175,8 @@ def test_user_provided_sdk(mock_tools, tmp_path):
 
     # Set the environment to specify ANDROID_SDK_ROOT
     mock_tools.os.environ = {
-        "ANDROID_SDK_ROOT": os.fsdecode(existing_android_sdk_root_path)
+        "ANDROID_HOME": os.fsdecode(existing_android_sdk_root_path),
+        "ANDROID_SDK_ROOT": os.fsdecode(existing_android_sdk_root_path),
     }
 
     # Expect verify() to succeed
@@ -147,9 +189,54 @@ def test_user_provided_sdk(mock_tools, tmp_path):
     # The returned SDK has the expected root path.
     assert sdk.root_path == existing_android_sdk_root_path
 
+    # User is not warned about configuration
+    assert capsys.readouterr().out == ""
 
-def test_invalid_user_provided_sdk(mock_tools, tmp_path):
-    """If the user specifies an invalid ANDROID_SDK_ROOT, it is ignored."""
+
+def test_inconsistent_user_provided_sdk(mock_tools, tmp_path, capsys):
+    """A warning is logged if ANDROID_HOME and ANDROID_SDK_ROOT are not the same."""
+    # Increase the log level.
+    mock_tools.logger.verbosity = 2
+
+    # Create `sdkmanager` and the license file.
+    existing_android_sdk_root_path = tmp_path / "other_sdk"
+    tools_bin = existing_android_sdk_root_path / "cmdline-tools" / "latest" / "bin"
+    tools_bin.mkdir(parents=True, mode=0o755)
+    if platform.system() == "Windows":
+        sdk_manager = tools_bin / "sdkmanager.bat"
+        sdk_manager.touch()
+    else:
+        sdk_manager = tools_bin / "sdkmanager"
+        sdk_manager.touch(mode=0o755)
+
+    # Pre-accept the license
+    accept_license(existing_android_sdk_root_path)()
+
+    # Set the environment to specify ANDROID_HOME and ANDROID_SDK_ROOT
+    mock_tools.os.environ = {
+        "ANDROID_HOME": os.fsdecode(existing_android_sdk_root_path),
+        "ANDROID_SDK_ROOT": "/opt/sdk2",
+    }
+
+    # Expect verify() to succeed
+    sdk = AndroidSDK.verify(mock_tools)
+
+    # No calls to download or unpack anything.
+    mock_tools.download.file.assert_not_called()
+    mock_tools.shutil.unpack_archive.assert_not_called()
+
+    # The returned SDK has the expected root path.
+    assert sdk.root_path == existing_android_sdk_root_path
+
+    # User is warned about using ANDROID_SDK_ROOT
+    assert (
+        "ANDROID_HOME and ANDROID_SDK_ROOT are inconsistent" in capsys.readouterr().out
+    )
+
+
+@pytest.mark.parametrize("env_var", ["ANDROID_HOME", "ANDROID_SDK_ROOT"])
+def test_invalid_user_provided_sdk(mock_tools, env_var, tmp_path, capsys):
+    """If the user's environment specifies an invalid Android SDK, it is ignored."""
 
     # Create `sdkmanager` and the license file
     # for the *briefcase* managed version of the SDK.
@@ -167,7 +254,7 @@ def test_invalid_user_provided_sdk(mock_tools, tmp_path):
     accept_license(android_sdk_root_path)()
 
     # Set the environment to specify an ANDROID_SDK_ROOT that doesn't exist
-    mock_tools.os.environ = {"ANDROID_SDK_ROOT": os.fsdecode(tmp_path / "other_sdk")}
+    mock_tools.os.environ = {env_var: os.fsdecode(tmp_path / "other_sdk")}
 
     # Expect verify() to succeed
     sdk = AndroidSDK.verify(mock_tools)
@@ -179,6 +266,91 @@ def test_invalid_user_provided_sdk(mock_tools, tmp_path):
 
     # The returned SDK has the expected root path.
     assert sdk.root_path == android_sdk_root_path
+
+    # User is informed about invalid env var setting
+    assert f"{env_var} does not point to an Android SDK" in capsys.readouterr().out
+
+
+def test_consistent_invalid_user_provided_sdk(mock_tools, tmp_path, capsys):
+    """If the user's environment specifies an invalid Android SDK in both ANDROID_HOME
+    and ANDROID_SDK_ROOT, they are ignored."""
+
+    # Create `sdkmanager` and the license file
+    # for the *briefcase* managed version of the SDK.
+    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    tools_bin = android_sdk_root_path / "cmdline-tools" / "latest" / "bin"
+    tools_bin.mkdir(parents=True, mode=0o755)
+    if platform.system() == "Windows":
+        sdk_manager = tools_bin / "sdkmanager.bat"
+        sdk_manager.touch()
+    else:
+        sdk_manager = tools_bin / "sdkmanager"
+        sdk_manager.touch(mode=0o755)
+
+    # Pre-accept the license
+    accept_license(android_sdk_root_path)()
+
+    # Set the environment to specify an ANDROID_SDK_ROOT that doesn't exist
+    mock_tools.os.environ = {
+        "ANDROID_HOME": os.fsdecode(tmp_path / "other_sdk"),
+        "ANDROID_SDK_ROOT": os.fsdecode(tmp_path / "other_sdk"),
+    }
+
+    # Expect verify() to succeed
+    sdk = AndroidSDK.verify(mock_tools)
+
+    # No calls to download, run or unpack anything.
+    mock_tools.download.file.assert_not_called()
+    mock_tools.subprocess.run.assert_not_called()
+    mock_tools.shutil.unpack_archive.assert_not_called()
+
+    # The returned SDK has the expected root path.
+    assert sdk.root_path == android_sdk_root_path
+
+    # User is informed about invalid env var setting
+    assert "ANDROID_HOME does not point to an Android SDK" in capsys.readouterr().out
+
+
+def test_inconsistent_invalid_user_provided_sdk(mock_tools, tmp_path, capsys):
+    """If the user's environment specifies an invalid Android SDK in both ANDROID_HOME
+    and ANDROID_SDK_ROOT...and they are both different, they are ignored."""
+
+    # Create `sdkmanager` and the license file
+    # for the *briefcase* managed version of the SDK.
+    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    tools_bin = android_sdk_root_path / "cmdline-tools" / "latest" / "bin"
+    tools_bin.mkdir(parents=True, mode=0o755)
+    if platform.system() == "Windows":
+        sdk_manager = tools_bin / "sdkmanager.bat"
+        sdk_manager.touch()
+    else:
+        sdk_manager = tools_bin / "sdkmanager"
+        sdk_manager.touch(mode=0o755)
+
+    # Pre-accept the license
+    accept_license(android_sdk_root_path)()
+
+    # Set the environment to specify an ANDROID_SDK_ROOT that doesn't exist
+    mock_tools.os.environ = {
+        "ANDROID_HOME": os.fsdecode(tmp_path / "other_sdk1"),
+        "ANDROID_SDK_ROOT": os.fsdecode(tmp_path / "other_sdk2"),
+    }
+
+    # Expect verify() to succeed
+    sdk = AndroidSDK.verify(mock_tools)
+
+    # No calls to download, run or unpack anything.
+    mock_tools.download.file.assert_not_called()
+    mock_tools.subprocess.run.assert_not_called()
+    mock_tools.shutil.unpack_archive.assert_not_called()
+
+    # The returned SDK has the expected root path.
+    assert sdk.root_path == android_sdk_root_path
+
+    # User is informed about invalid env var setting
+    output = capsys.readouterr().out
+    assert "ANDROID_HOME and ANDROID_SDK_ROOT are inconsistent" in output
+    assert "ANDROID_HOME does not point to an Android SDK" in output
 
 
 def test_download_sdk(mock_tools, tmp_path):

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -542,6 +542,7 @@ def test_log_file_extra(run_command, monkeypatch):
     run_command.tools.subprocess.check_output.assert_called_once_with(
         [normpath(sdk_manager), "--list_installed"],
         env={
+            "ANDROID_HOME": str(run_command.tools.android_sdk.root_path),
             "ANDROID_SDK_ROOT": str(run_command.tools.android_sdk.root_path),
             "JAVA_HOME": str(run_command.tools.java.java_home),
         },


### PR DESCRIPTION
## Changes
- Fixes #463
- The file path in `ANDROID_HOME` now takes precedence over `ANDROID_SDK_ROOT`
- The eventual file path for the SDK used is passed both as `ANDROID_HOME` and `ANDROID_SDK_ROOT` when Android commands are run in the shell.
- Behavior summary:
  - No environment variables set
    - Briefcase's SDK is used
  - Only `ANDROID_HOME` is set
    - If it's an SDK, it is silently used
    - If it's not an SDK, a warning is issued it isn't an SDK and Briefcase's SDK is used
  - Only `ANDROID_SDK_ROOT` is set
    - If it's an SDK, a warning is issued that `ANDROID_SDK_ROOT` is deprecated but it is used
    - If it's not an SDK, a warning is issued it isn't an SDK and Briefcase's SDK is used
  - Both `ANDROID_HOME` and `ANDROID_SDK_ROOT` are set to the same value
    - Falls back to as if only `ANDROID_HOME` was set
  - Both `ANDROID_HOME` and `ANDROID_SDK_ROOT` are set to _different_ values
    - A warning is issued that `ANDROID_HOME` takes precedence over `ANDROID_SDK_ROOT`
    - If `ANDROID_HOME` is a valid SDK, it is used
    - If `ANDROID_HOME` is _not_ a valid SDK, a warning is issued it isn't an SDK and Briefcase's SDK is used

## Notes
- I broke with the [recommended implementation](https://github.com/beeware/briefcase/issues/463#issuecomment-1217891624) because I think it can imposition the user too much.
- For instance, erroring if `ANDROID_HOME` and `ANDROID_SDK_ROOT` are set to different file paths.
  - This isn't inherently problematic for Briefcase...at least based on my implementation.
  - However, erroring like this would _require_ users to change their environment just to run Briefcase.
- As part of this, I am also setting the SDK file path in both `ANDROID_HOME` and `ANDROID_SDK_ROOT` for subprocess calls
  - This is primarily because if the user has a bad setting for `ANDROID_SDK_ROOT` and Briefcase only sets `ANDROID_HOME`, the `ANDROID_SDK_ROOT` setting will leak in to subprocess calls.....therefore, the user would need to unset `ANDROID_SDK_ROOT` to be able to run Briefcase.
  - So, it seems reasonable to me for Briefcase to simply mask this scenario since we already have a known valid SDK.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
