### PR TITLE
Bump pyupgrade from v3.4.0 to v3.6.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.4.0
+    rev: v3.6.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]

--- a/update.log
+++ b/update.log
@@ -1,0 +1,1 @@
+[https://github.com/asottile/pyupgrade] updating v3.4.0 -> v3.6.0


### PR DESCRIPTION
Bumps `pre-commit` hook for `pyupgrade` from v3.4.0 to v3.6.0 and ran the update against the repo.