### PR TITLE
Bump flake8 from

### DIFF
--- a/update.log
+++ b/update.log
@@ -1,0 +1,1 @@
+[https://github.com/PyCQA/flake8] already up to date!


### PR DESCRIPTION
Bumps `pre-commit` hook for `flake8` from  and ran the update against the repo.