### PR TITLE
Document WebKit limitation on AppImage.

### DIFF
--- a/changes/1322.doc.rst
+++ b/changes/1322.doc.rst
@@ -1,0 +1,1 @@
+The limitations of using WebKit2 in AppImage were documented.

--- a/docs/reference/platforms/linux/appimage.rst
+++ b/docs/reference/platforms/linux/appimage.rst
@@ -198,7 +198,7 @@ AppImage.
 
 In addition, many of the commonly used ``manylinux`` base images predate the release of
 WebKit2. As a result, system packages providing WebKit2 are not available on these base
-images. ``manylinux2_28`` is the earliest supported ``manylinux`` image that provides
+images. ``manylinux_2_28`` is the earliest supported ``manylinux`` image that provides
 WebKit2 support.
 
 Runtime issues with AppImages

--- a/docs/reference/platforms/linux/appimage.rst
+++ b/docs/reference/platforms/linux/appimage.rst
@@ -188,6 +188,19 @@ Briefcase will unpack the new support package without cleaning up existing
 support package content. This *should* work; however, ensure a reproducible
 release artefacts, it is advisable to perform a clean app build before release.
 
+Apps using WebKit2 are not supported
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+WebKit2, the library that provides web widget support, can't currently be deployed with
+AppImage. WebKit2 uses subprocesses to manage network and rendering requests, but the
+way it packages and launches these subprocesses isn't currently compatible with
+AppImage.
+
+In addition, many of the commonly used ``manylinux`` base images predate the release of
+WebKit2. As a result, system packages providing WebKit2 are not available on these base
+images. ``manylinux2_28`` is the earliest supported ``manylinux`` image that provides
+WebKit2 support.
+
 Runtime issues with AppImages
 =============================
 


### PR DESCRIPTION
Document that Webkit2 doesn't work on AppImage.

Fixes #1322 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
