### PR TITLE
Bump docformatter from v1.7.2 to v1.7.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.2
+    rev: v1.7.3
     hooks:
       - id: docformatter
         args: [--in-place, --black]

--- a/changes/1333.misc.rst
+++ b/changes/1333.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``docformatter`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `docformatter` from v1.7.2 to v1.7.3 and ran the update against the repo.