### PR TITLE
Ensure repo checkout is unshallow in RTD builds for SCM versioning

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,15 +2,17 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
     python: "3"
   jobs:
+    post_checkout:
+      # RTD defaults to a depth of 50 but Briefcase versioning may require
+      # much more git history to accurately determine the SCM version
+      - git fetch --unshallow
     pre_build:
       - tox -e docs-lint
 
@@ -24,7 +26,7 @@ sphinx:
 formats:
    - pdf
 
-# Optionally declare the Python requirements required to build your docs
+# Install extras for build - dev is needed to run tox
 python:
   install:
   - method: pip

--- a/changes/1339.misc.rst
+++ b/changes/1339.misc.rst
@@ -1,0 +1,1 @@
+The Briefcase repository checkout for Read the Docs builds is now made unshallow to ensure accurate SCM versioning.


### PR DESCRIPTION
- Fixes #1339

RTD build for this PR: https://readthedocs.org/projects/briefcase/builds/21175717/
RTD build for #1331 showing issue: https://briefcase--1331.org.readthedocs.build/en/1331/

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
