### PR TITLE
Rename template info key names in cookiecutter context

### DIFF
--- a/changes/1347.bugfix.rst
+++ b/changes/1347.bugfix.rst
@@ -1,0 +1,1 @@
+An error no longer occurs when creating a new Briefcase project while ``cookiecutter>=2.2.0`` is installed.

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -468,8 +468,8 @@ What GUI toolkit do you want to use for this project?""",
         # include the version of Briefcase as well as the source of the template.
         context.update(
             {
-                "template": template,
-                "branch": branch,
+                "template_source": template,
+                "template_branch": branch,
                 "briefcase_version": briefcase.__version__,
             }
         )

--- a/tests/commands/new/test_new_app.py
+++ b/tests/commands/new/test_new_app.py
@@ -76,8 +76,8 @@ def test_new_app(
             # The expected app context
             # should now also contain the
             # default template and branch
-            "template": "https://github.com/beeware/briefcase-template",
-            "branch": expected_branch,
+            "template_source": "https://github.com/beeware/briefcase-template",
+            "template_branch": expected_branch,
             "briefcase_version": briefcase_version,
         },
     )
@@ -129,8 +129,8 @@ def test_new_app_missing_template(monkeypatch, new_command, tmp_path):
             # The expected app context
             # should now also contain the
             # default template and branch
-            "template": "https://github.com/beeware/briefcase-template",
-            "branch": "v37.42.7",
+            "template_source": "https://github.com/beeware/briefcase-template",
+            "template_branch": "v37.42.7",
             "briefcase_version": "37.42.7",
         },
     )
@@ -196,8 +196,8 @@ def test_new_app_dev(monkeypatch, new_command, tmp_path, briefcase_version):
                     # The expected app context
                     # should now also contain the
                     # default template and branch
-                    "template": "https://github.com/beeware/briefcase-template",
-                    "branch": "v37.42.7",
+                    "template_source": "https://github.com/beeware/briefcase-template",
+                    "template_branch": "v37.42.7",
                     "briefcase_version": briefcase_version,
                 },
             ),
@@ -213,8 +213,8 @@ def test_new_app_dev(monkeypatch, new_command, tmp_path, briefcase_version):
                     # The expected app context
                     # should now also contain the
                     # default template and branch
-                    "template": "https://github.com/beeware/briefcase-template",
-                    "branch": "v37.42.7",
+                    "template_source": "https://github.com/beeware/briefcase-template",
+                    "template_branch": "v37.42.7",
                     "briefcase_version": briefcase_version,
                 },
             ),
@@ -261,8 +261,8 @@ def test_new_app_with_template(monkeypatch, new_command, tmp_path):
             # The expected app context
             # should now also contain the
             # template and branch
-            "template": "https://example.com/other.git",
-            "branch": "v37.42.7",
+            "template_source": "https://example.com/other.git",
+            "template_branch": "v37.42.7",
             "briefcase_version": "37.42.7",
         },
     )
@@ -313,8 +313,8 @@ def test_new_app_with_invalid_template(monkeypatch, new_command, tmp_path):
             # The expected app context
             # should now also contain the
             # template and branch
-            "template": "https://example.com/other.git",
-            "branch": "v37.42.7",
+            "template_source": "https://example.com/other.git",
+            "template_branch": "v37.42.7",
             "briefcase_version": "37.42.7",
         },
     )
@@ -368,8 +368,8 @@ def test_new_app_with_invalid_template_branch(monkeypatch, new_command, tmp_path
             # The expected app context
             # should now also contain the
             # template and branch
-            "template": "https://example.com/other.git",
-            "branch": "v37.42.7",
+            "template_source": "https://example.com/other.git",
+            "template_branch": "v37.42.7",
             "briefcase_version": "37.42.7",
         },
     )
@@ -414,8 +414,8 @@ def test_new_app_with_branch(monkeypatch, new_command, tmp_path):
             # The expected app context
             # should now also contain the
             # template and branch
-            "template": "https://github.com/beeware/briefcase-template",
-            "branch": "experimental",
+            "template_source": "https://github.com/beeware/briefcase-template",
+            "template_branch": "experimental",
             "briefcase_version": "37.42.7",
         },
     )


### PR DESCRIPTION
- In cookiecutter>=2.2.0, the template key in context has special meaning for nested templates and must be renamed.
- Fixes #1347 

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
