### PR TITLE
Use Date/Time on Android Device for Fallback Logging

### DIFF
--- a/changes/1146.bugfix.rst
+++ b/changes/1146.bugfix.rst
@@ -1,0 +1,1 @@
+The run command now ensures Android logging is shown when the datetime on the device is different from the host machine.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1517,9 +1517,15 @@ Activity class not found while starting app.
             raise BriefcaseCommandError("Error stopping the Android emulator.") from e
 
     def datetime(self) -> datetime:
-        """Obtain the device's current date/time."""
+        """Obtain the device's current date/time.
+
+        This date/time is naive (i.e. not timezone aware) and in the device's "local"
+        time. Therefore, it may be quite different from the date/time for Briefcase and
+        caution should be used if comparing it to machine's "local" time.
+        """
+        datetime_format = "%Y-%m-%d %H:%M:%S"
         try:
-            # request datetime in seconds since Unix epoch
-            return datetime.fromtimestamp(int(self.run("shell", "date", "+%s")))
+            device_datetime = self.run("shell", "date", f"+'{datetime_format}'").strip()
+            return datetime.strptime(device_datetime, datetime_format)
         except (ValueError, subprocess.CalledProcessError) as e:
             raise BriefcaseCommandError("Error obtaining device date/time.") from e

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1293,10 +1293,10 @@ class ADB:
                     f"Unable to interrogate AVD name of device {self.device}"
                 ) from e
 
-    def has_booted(self):
+    def has_booted(self) -> bool:
         """Determine if the device has completed booting.
 
-        :returns True if it has booted; False otherwise.
+        :returns: True if it has booted; False otherwise.
         """
         try:
             # When the sys.boot_completed property of the device
@@ -1326,8 +1326,6 @@ class ADB:
         # checking that they are valid, then parsing output to notice errors.
         # This keeps performance good in the success case.
         try:
-            # Capture `stderr` so that if the process exits with failure, the
-            # stderr data is in `e.output`.
             return self.tools.subprocess.check_output(
                 [
                     os.fsdecode(self.tools.android_sdk.adb_path),
@@ -1349,8 +1347,7 @@ class ADB:
         """Install an APK file on an Android device.
 
         :param apk_path: The path of the Android APK file to install.
-
-        Returns `None` on success; raises an exception on failure.
+        :returns: `None` on success; raises an exception on failure.
         """
         try:
             self.run("install", "-r", apk_path)
@@ -1363,8 +1360,7 @@ class ADB:
         """Force-stop an app, specified as a package name.
 
         :param package: The name of the Android package, e.g., com.username.myapp.
-
-        Returns `None` on success; raises an exception on failure.
+        :returns: `None` on success; raises an exception on failure.
         """
         # In my testing, `force-stop` exits with status code 0 (success) so long
         # as you pass a package name, even if the package does not exist, or the
@@ -1379,15 +1375,14 @@ class ADB:
     def start_app(self, package: str, activity: str, passthrough: list[str]):
         """Start an app, specified as a package name & activity name.
 
-        :param package: The name of the Android package, e.g., com.username.myapp.
-        :param activity: The activity of the APK to start.
-        :param passthrough: Arguments to pass to the app.
-
-        Returns `None` on success; raises an exception on failure.
-
         If you have an APK file, and you are not sure of the package or activity
         name, you can find it using `aapt dump badging filename.apk` and looking
         for "package" and "launchable-activity" in the output.
+
+        :param package: The name of the Android package, e.g., com.username.myapp.
+        :param activity: The activity of the APK to start.
+        :param passthrough: Arguments to pass to the app.
+        :returns: `None` on success; raises an exception on failure.
         """
         try:
             # `am start` also accepts string array extras, but we pass the arguments as a
@@ -1429,7 +1424,7 @@ Activity class not found while starting app.
                 f"Unable to start {package}/{activity} on {self.device}"
             ) from e
 
-    def logcat(self, pid: str):
+    def logcat(self, pid: str) -> subprocess.Popen:
         """Start following the adb log for the device.
 
         :param pid: The PID whose logs you want to display.
@@ -1519,4 +1514,12 @@ Activity class not found while starting app.
         try:
             self.run("emu", "kill")
         except subprocess.CalledProcessError as e:
-            raise BriefcaseCommandError("Error starting ADB logcat.") from e
+            raise BriefcaseCommandError("Error stopping the Android emulator.") from e
+
+    def datetime(self) -> datetime:
+        """Obtain the device's current date/time."""
+        try:
+            # request datetime in seconds since Unix epoch
+            return datetime.fromtimestamp(int(self.run("shell", "date", "+%s")))
+        except (ValueError, subprocess.CalledProcessError) as e:
+            raise BriefcaseCommandError("Error obtaining device date/time.") from e

--- a/tests/integrations/android_sdk/ADB/test_avd_name.py
+++ b/tests/integrations/android_sdk/ADB/test_avd_name.py
@@ -4,13 +4,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
-from briefcase.integrations.android_sdk import ADB
 
 
-def test_emulator(mock_tools, capsys):
+def test_emulator(adb, capsys):
     """Invoking `avd_name()` on an emulator returns the AVD."""
     # Mock out the adb response for an emulator
-    adb = ADB(mock_tools, "deafbeefcafe")
     adb.run = MagicMock(return_value="exampledevice\nOK\n")
 
     # Invoke avd_name
@@ -20,10 +18,9 @@ def test_emulator(mock_tools, capsys):
     adb.run.assert_called_once_with("emu", "avd", "name")
 
 
-def test_device(mock_tools, capsys):
+def test_device(adb, capsys):
     """Invoking `avd_name()` on a device returns None."""
     # Mock out the adb response for a physical device
-    adb = ADB(mock_tools, "deafbeefcafe")
     adb.run = MagicMock(
         side_effect=subprocess.CalledProcessError(returncode=1, cmd="emu avd name")
     )
@@ -35,10 +32,9 @@ def test_device(mock_tools, capsys):
     adb.run.assert_called_once_with("emu", "avd", "name")
 
 
-def test_adb_failure(mock_tools, capsys):
+def test_adb_failure(adb, capsys):
     """If `adb()` fails for a miscellaneous reason, an error is raised."""
     # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = MagicMock(
         side_effect=subprocess.CalledProcessError(returncode=69, cmd="emu avd name")
     )
@@ -51,10 +47,9 @@ def test_adb_failure(mock_tools, capsys):
     adb.run.assert_called_once_with("emu", "avd", "name")
 
 
-def test_invalid_device(mock_tools, capsys):
+def test_invalid_device(adb, capsys):
     """Invoking `avd_name()` on an invalid device raises an error."""
     # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = MagicMock(side_effect=InvalidDeviceError("device", "exampleDevice"))
 
     # Invoke install

--- a/tests/integrations/android_sdk/ADB/test_datetime.py
+++ b/tests/integrations/android_sdk/ADB/test_datetime.py
@@ -7,15 +7,21 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError
 
 
-def test_datetime_success(adb):
+@pytest.mark.parametrize(
+    "device_output, expected_datetime",
+    [
+        ("2023-07-12 09:28:04", datetime(2023, 7, 12, 9, 28, 4)),
+        ("2023-07-12 09:28:04\n", datetime(2023, 7, 12, 9, 28, 4)),
+        ("2023-7-12 9:28:04", datetime(2023, 7, 12, 9, 28, 4)),
+        ("2023-12-2 14:28:04", datetime(2023, 12, 2, 14, 28, 4)),
+    ],
+)
+def test_datetime_success(adb, device_output, expected_datetime):
     """adb.datetime() returns `datetime` for device."""
-    adb.run = Mock(return_value="1689098555\n")
+    adb.run = Mock(return_value=device_output)
 
-    # Cannot hardcode the actual datetime of 1689098555 since
-    # it is dependent on the timezone of the host system
-    expected_datetime = datetime.fromtimestamp(1689098555)
     assert adb.datetime() == expected_datetime
-    adb.run.assert_called_once_with("shell", "date", "+%s")
+    adb.run.assert_called_once_with("shell", "date", "+'%Y-%m-%d %H:%M:%S'")
 
 
 def test_datetime_failure_call(adb):

--- a/tests/integrations/android_sdk/ADB/test_datetime.py
+++ b/tests/integrations/android_sdk/ADB/test_datetime.py
@@ -1,0 +1,44 @@
+import subprocess
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError
+from briefcase.integrations.android_sdk import ADB
+
+
+def test_datetime_success(mock_tools):
+    """adb.datetime() returns `datetime` for device."""
+    adb = ADB(mock_tools, "exampleDevice")
+    adb.run = Mock(return_value="1689098555\n")
+
+    expected_datetime = datetime(2023, 7, 11, 14, 2, 35)
+    assert adb.datetime() == expected_datetime
+    adb.run.assert_called_once_with("shell", "date", "+%s")
+
+
+def test_datetime_failure_call(mock_tools):
+    """adb.datetime() fails in subprocess call."""
+    adb = ADB(mock_tools, "exampleDevice")
+    adb.run = Mock(
+        side_effect=subprocess.CalledProcessError(returncode=1, cmd="adb shell ...")
+    )
+
+    with pytest.raises(
+        BriefcaseCommandError,
+        match="Error obtaining device date/time.",
+    ):
+        adb.datetime()
+
+
+def test_datetime_failure_bad_value(mock_tools):
+    """adb.datetime() fails in output conversion."""
+    adb = ADB(mock_tools, "exampleDevice")
+    adb.run = Mock(return_value="this date is jan 1 1970")
+
+    with pytest.raises(
+        BriefcaseCommandError,
+        match="Error obtaining device date/time.",
+    ):
+        adb.datetime()

--- a/tests/integrations/android_sdk/ADB/test_datetime.py
+++ b/tests/integrations/android_sdk/ADB/test_datetime.py
@@ -11,7 +11,9 @@ def test_datetime_success(adb):
     """adb.datetime() returns `datetime` for device."""
     adb.run = Mock(return_value="1689098555\n")
 
-    expected_datetime = datetime(2023, 7, 11, 14, 2, 35)
+    # Cannot hardcode the actual datetime of 1689098555 since
+    # it is dependent on the timezone of the host system
+    expected_datetime = datetime.fromtimestamp(1689098555)
     assert adb.datetime() == expected_datetime
     adb.run.assert_called_once_with("shell", "date", "+%s")
 

--- a/tests/integrations/android_sdk/ADB/test_datetime.py
+++ b/tests/integrations/android_sdk/ADB/test_datetime.py
@@ -5,12 +5,10 @@ from unittest.mock import Mock
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
-from briefcase.integrations.android_sdk import ADB
 
 
-def test_datetime_success(mock_tools):
+def test_datetime_success(adb):
     """adb.datetime() returns `datetime` for device."""
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = Mock(return_value="1689098555\n")
 
     expected_datetime = datetime(2023, 7, 11, 14, 2, 35)
@@ -18,9 +16,8 @@ def test_datetime_success(mock_tools):
     adb.run.assert_called_once_with("shell", "date", "+%s")
 
 
-def test_datetime_failure_call(mock_tools):
+def test_datetime_failure_call(adb):
     """adb.datetime() fails in subprocess call."""
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = Mock(
         side_effect=subprocess.CalledProcessError(returncode=1, cmd="adb shell ...")
     )
@@ -32,10 +29,9 @@ def test_datetime_failure_call(mock_tools):
         adb.datetime()
 
 
-def test_datetime_failure_bad_value(mock_tools):
+def test_datetime_failure_bad_value(adb):
     """adb.datetime() fails in output conversion."""
-    adb = ADB(mock_tools, "exampleDevice")
-    adb.run = Mock(return_value="this date is jan 1 1970")
+    adb.run = Mock(return_value="the date is jan 1 1970")
 
     with pytest.raises(
         BriefcaseCommandError,

--- a/tests/integrations/android_sdk/ADB/test_force_stop_app.py
+++ b/tests/integrations/android_sdk/ADB/test_force_stop_app.py
@@ -4,13 +4,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
-from briefcase.integrations.android_sdk import ADB
 
 
-def test_force_stop_app(mock_tools, capsys):
+def test_force_stop_app(adb, capsys):
     """Invoking `force_stop_app()` calls `run()` with the appropriate parameters."""
     # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = MagicMock(return_value="example normal adb output")
 
     # Invoke force_stop_app
@@ -26,10 +24,9 @@ def test_force_stop_app(mock_tools, capsys):
     assert "normal adb output" not in capsys.readouterr()
 
 
-def test_force_top_fail(mock_tools, capsys):
+def test_force_top_fail(adb, capsys):
     """If `force_stop_app()` fails, an error is raised."""
     # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = MagicMock(
         side_effect=subprocess.CalledProcessError(returncode=69, cmd="force-stop")
     )
@@ -44,10 +41,9 @@ def test_force_top_fail(mock_tools, capsys):
     )
 
 
-def test_invalid_device(mock_tools, capsys):
+def test_invalid_device(adb, capsys):
     """Invoking `force_stop_app()` on an invalid device raises an error."""
     # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = MagicMock(side_effect=InvalidDeviceError("device", "exampleDevice"))
 
     # Invoke force_stop_app

--- a/tests/integrations/android_sdk/ADB/test_has_booted.py
+++ b/tests/integrations/android_sdk/ADB/test_has_booted.py
@@ -4,13 +4,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
-from briefcase.integrations.android_sdk import ADB
 
 
-def test_booted(mock_tools, capsys):
+def test_booted(adb, capsys):
     """A booted device returns true."""
     # Mock out the adb response for an emulator
-    adb = ADB(mock_tools, "deafbeefcafe")
     adb.run = MagicMock(return_value="1\n")
 
     # Invoke avd_name
@@ -20,10 +18,9 @@ def test_booted(mock_tools, capsys):
     adb.run.assert_called_once_with("shell", "getprop", "sys.boot_completed")
 
 
-def test_not_booted(mock_tools, capsys):
+def test_not_booted(adb, capsys):
     """A non-booted device returns False."""
     # Mock out the adb response for an emulator
-    adb = ADB(mock_tools, "deafbeefcafe")
     adb.run = MagicMock(return_value="\n")
 
     # Invoke avd_name
@@ -33,10 +30,9 @@ def test_not_booted(mock_tools, capsys):
     adb.run.assert_called_once_with("shell", "getprop", "sys.boot_completed")
 
 
-def test_adb_failure(mock_tools, capsys):
+def test_adb_failure(adb, capsys):
     """If ADB fails, an error is raised."""
     # Mock out the adb response for an emulator
-    adb = ADB(mock_tools, "deafbeefcafe")
     adb.run = MagicMock(
         side_effect=subprocess.CalledProcessError(returncode=69, cmd="emu avd name")
     )
@@ -49,10 +45,9 @@ def test_adb_failure(mock_tools, capsys):
     adb.run.assert_called_once_with("shell", "getprop", "sys.boot_completed")
 
 
-def test_invalid_device(mock_tools, capsys):
+def test_invalid_device(adb, capsys):
     """If the device ID is invalid, an error is raised."""
     # Mock out the adb response for an emulator
-    adb = ADB(mock_tools, "not-a-device")
     adb.run = MagicMock(side_effect=InvalidDeviceError("device", "exampleDevice"))
 
     # Invoke avd_name

--- a/tests/integrations/android_sdk/ADB/test_install_apk.py
+++ b/tests/integrations/android_sdk/ADB/test_install_apk.py
@@ -4,13 +4,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
-from briefcase.integrations.android_sdk import ADB
 
 
-def test_install_apk(mock_tools, capsys):
+def test_install_apk(adb, capsys):
     """Invoking `install_apk()` calls `run()` with the appropriate parameters."""
     # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = MagicMock(return_value="example normal adb output")
 
     # Invoke install
@@ -24,10 +22,9 @@ def test_install_apk(mock_tools, capsys):
     assert "normal adb output" not in capsys.readouterr()
 
 
-def test_install_failure(mock_tools, capsys):
+def test_install_failure(adb, capsys):
     """If `install_apk()` fails, an error is raised."""
     # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = MagicMock(
         side_effect=subprocess.CalledProcessError(returncode=2, cmd="install")
     )
@@ -40,10 +37,9 @@ def test_install_failure(mock_tools, capsys):
     adb.run.assert_called_once_with("install", "-r", "example.apk")
 
 
-def test_invalid_device(mock_tools, capsys):
+def test_invalid_device(adb, capsys):
     """Invoking `install_apk()` on an invalid device raises an error."""
     # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = MagicMock(side_effect=InvalidDeviceError("device", "exampleDevice"))
 
     # Invoke install

--- a/tests/integrations/android_sdk/ADB/test_kill.py
+++ b/tests/integrations/android_sdk/ADB/test_kill.py
@@ -5,14 +5,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
-from briefcase.integrations.android_sdk import ADB
 
 
-def test_kill(mock_tools):
+def test_kill(mock_tools, adb):
     """An emulator can be killed."""
-    # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
-
     # Invoke kill
     adb.kill()
 
@@ -29,10 +25,9 @@ def test_kill(mock_tools):
     )
 
 
-def test_kill_failure(mock_tools):
+def test_kill_failure(adb):
     """If emu kill fails, the error is caught."""
     # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = MagicMock(
         side_effect=subprocess.CalledProcessError(returncode=1, cmd="adb emu kill")
     )

--- a/tests/integrations/android_sdk/ADB/test_logcat.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat.py
@@ -2,14 +2,9 @@ import os
 import subprocess
 from unittest import mock
 
-from briefcase.integrations.android_sdk import ADB
 
-
-def test_logcat(mock_tools):
+def test_logcat(mock_tools, adb):
     """Invoking `logcat()` calls `Popen()` with the appropriate parameters."""
-    # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
-
     # Mock the result of calling Popen so we can compare against this return value
     popen = mock.MagicMock()
     mock_tools.subprocess.Popen.return_value = popen

--- a/tests/integrations/android_sdk/ADB/test_logcat_tail.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat_tail.py
@@ -6,14 +6,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
-from briefcase.integrations.android_sdk import ADB
 
 
-def test_logcat_tail(mock_tools):
+def test_logcat_tail(mock_tools, adb):
     """Invoking `logcat_tail()` calls `run()` with the appropriate parameters."""
-    # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
-
     # Invoke logcat_tail with a specific timestamp
     adb.logcat_tail(since=datetime(2022, 11, 10, 9, 8, 7))
 
@@ -38,10 +34,9 @@ def test_logcat_tail(mock_tools):
     )
 
 
-def test_adb_failure(mock_tools):
+def test_adb_failure(mock_tools, adb):
     """If adb logcat fails, the error is caught."""
     # Mock out the run command on an adb instance
-    adb = ADB(mock_tools, "exampleDevice")
     mock_tools.subprocess.run = MagicMock(
         side_effect=subprocess.CalledProcessError(returncode=1, cmd="adb logcat")
     )

--- a/tests/integrations/android_sdk/ADB/test_pid_exists.py
+++ b/tests/integrations/android_sdk/ADB/test_pid_exists.py
@@ -1,29 +1,27 @@
 import subprocess
 from unittest.mock import Mock
 
-from briefcase.integrations.android_sdk import ADB
 
-
-def test_pid_exists_succeed(mock_tools):
+def test_pid_exists_succeed(adb):
     """adb.pid_exists() can be called on a process that exists."""
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = Mock(return_value="")
+
     assert adb.pid_exists("1234")
     adb.run.assert_called_once_with("shell", "test", "-e", "/proc/1234")
 
 
-def test_pid_exists_quiet(mock_tools):
+def test_pid_exists_quiet(adb):
     """adb.pid_exists() can be called in quiet mode on a process that exists."""
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = Mock(return_value="")
+
     assert adb.pid_exists("1234", quiet=True)
     adb.run.assert_called_once_with("shell", "test", "-e", "/proc/1234", quiet=True)
 
 
-def test_pid_does_not_exist(mock_tools):
+def test_pid_does_not_exist(adb):
     """If adb.pid_exists() returns a status code of 1, it is interpreted as the process
     not existing."""
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = Mock(side_effect=subprocess.CalledProcessError(returncode=1, cmd="test"))
+
     assert not adb.pid_exists("9999") is None
     adb.run.assert_called_once_with("shell", "test", "-e", "/proc/9999")

--- a/tests/integrations/android_sdk/ADB/test_pidof.py
+++ b/tests/integrations/android_sdk/ADB/test_pidof.py
@@ -1,37 +1,35 @@
 import subprocess
 from unittest.mock import Mock
 
-from briefcase.integrations.android_sdk import ADB
 
-
-def test_pidof_succeed(mock_tools):
+def test_pidof_succeed(adb):
     """adb.pidof() can be called on a process that exists."""
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = Mock(return_value="5678\n")
+
     assert adb.pidof("com.example") == "5678"
     adb.run.assert_called_once_with("shell", "pidof", "-s", "com.example")
 
 
-def test_pidof_quiet(mock_tools):
+def test_pidof_quiet(adb):
     """adb.pidof() can be called in quiet mode on a process that exists."""
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = Mock(return_value="5678\n")
+
     assert adb.pidof("com.example", quiet=True) == "5678"
     adb.run.assert_called_once_with("shell", "pidof", "-s", "com.example", quiet=True)
 
 
-def test_pidof_fail_exit_0(mock_tools):
+def test_pidof_fail_exit_0(adb):
     """If adb.pidof() returns a PID of 0, it is interpreted as the process not
     existing."""
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = Mock(return_value="")
+
     assert adb.pidof("com.example") is None
     adb.run.assert_called_once_with("shell", "pidof", "-s", "com.example")
 
 
-def test_pidof_fail_exit_1(mock_tools):
+def test_pidof_fail_exit_1(adb):
     """If adb.pidof() fails, it is interpreted as the process not existing."""
-    adb = ADB(mock_tools, "exampleDevice")
     adb.run = Mock(side_effect=subprocess.CalledProcessError(1, "adb shell"))
+
     assert adb.pidof("com.example") is None
     adb.run.assert_called_once_with("shell", "pidof", "-s", "com.example")

--- a/tests/integrations/android_sdk/ADB/test_run.py
+++ b/tests/integrations/android_sdk/ADB/test_run.py
@@ -6,14 +6,10 @@ from pathlib import Path
 import pytest
 
 from briefcase.exceptions import InvalidDeviceError
-from briefcase.integrations.android_sdk import ADB
 
 
-def test_simple_command(mock_tools, tmp_path):
+def test_simple_command(mock_tools, adb, tmp_path):
     """ADB.run() invokes adb with the provided arguments."""
-    # Create an ADB instance and invoke command()
-    adb = ADB(mock_tools, "exampleDevice")
-
     adb.run("example", "command")
 
     # Check that adb was invoked with the expected commands
@@ -34,11 +30,8 @@ def test_simple_command(mock_tools, tmp_path):
     )
 
 
-def test_quiet_command(mock_tools, tmp_path):
+def test_quiet_command(mock_tools, adb, tmp_path):
     """ADB.run() can be invoked in quiet mode."""
-    # Create an ADB instance and invoke command()
-    adb = ADB(mock_tools, "exampleDevice")
-
     adb.run("example", "command", quiet=True)
 
     # Check that adb was invoked with the expected commands
@@ -70,7 +63,7 @@ def test_quiet_command(mock_tools, tmp_path):
         ("arbitrary-adb-error-unknown-command", subprocess.CalledProcessError),
     ],
 )
-def test_error_handling(mock_tools, tmp_path, name, exception):
+def test_error_handling(mock_tools, adb, name, exception, tmp_path):
     """ADB.run() can parse errors returned by adb."""
     # Set up a mock command with a subprocess module that has with sample data loaded.
     adb_samples = Path(__file__).parent / "adb_errors"
@@ -86,8 +79,7 @@ def test_error_handling(mock_tools, tmp_path, name, exception):
                 )
             )
 
-    # Create an ADB instance and invoke run()
-    adb = ADB(mock_tools, "exampleDevice")
+    # invoke run()
     with pytest.raises(exception):
         adb.run("example", "command")
 

--- a/tests/integrations/android_sdk/conftest.py
+++ b/tests/integrations/android_sdk/conftest.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.integrations.android_sdk import AndroidSDK
+from briefcase.integrations.android_sdk import ADB, AndroidSDK
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.java import JDK
@@ -30,3 +30,8 @@ def android_sdk(mock_tools, tmp_path) -> AndroidSDK:
     sdk_root.mkdir(parents=True)
 
     return AndroidSDK(mock_tools, root_path=sdk_root)
+
+
+@pytest.fixture
+def adb(mock_tools) -> ADB:
+    return ADB(mock_tools, "exampleDevice")


### PR DESCRIPTION
## Changes
- Fixes #1146
- When the PID for the app on an Android device is not found, the fallback app streaming method will use a datetime from the device instead of the host machine as the start time to show logs.

## Notes
- I'm operating under the assumption that Android's `date` command has supported this formatting for as long as we've needed it to.
- I'm also currently aborting if obtaining the device datetime goes wrong since such a contingency seems really unlikely to be necessary when things are working otherwise.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
