### PR TITLE
Bump docformatter from v1.7.3 to v1.7.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.3
+    rev: v1.7.5
     hooks:
       - id: docformatter
         args: [--in-place, --black]

--- a/changes/1364.misc.rst
+++ b/changes/1364.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``docformatter`` was updated to its latest version.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -365,10 +365,10 @@ a custom location for Briefcase's tools.
     def template_target_version(self, app: AppConfig) -> str | None:
         """The target version of Briefcase for the app from ``briefcase.toml``.
 
-        This value represents a version epoch specific to the platform. An epoch
-        begins when a breaking change is introduced. Therefore, this value would
-        remain the version of Briefcase that introduced a breaking change for a
-        template until another such change requires a new epoch.
+        This value represents a version epoch specific to the platform. An epoch begins
+        when a breaking change is introduced. Therefore, this value would remain the
+        version of Briefcase that introduced a breaking change for a template until
+        another such change requires a new epoch.
 
         :param app: The config object for the app
         :return: target version or None if one isn't specified

--- a/tests/integrations/base/test_tool_registry.py
+++ b/tests/integrations/base/test_tool_registry.py
@@ -20,8 +20,8 @@ def integrations_modules() -> Set[str]:
 
 
 def tools_for_module(tool_module_name: str) -> Dict[str, Type[Tool]]:
-    """Return classes that subclass Tool in a module in
-    ``briefcase.integrations``, e.g. {"android_sdk": AndroidSDK}."""
+    """Return classes that subclass Tool in a module in ``briefcase.integrations``, e.g.
+    {"android_sdk": AndroidSDK}."""
     return dict(
         inspect.getmembers(
             sys.modules[f"briefcase.integrations.{tool_module_name}"],


### PR DESCRIPTION
Bumps `pre-commit` hook for `docformatter` from v1.7.3 to v1.7.5 and ran the update against the repo.