### PR TITLE
Ensure acceptable `DEBIAN` directory permissions for `dpkg-deb`

### DIFF
--- a/changes/1369.bugfix.rst
+++ b/changes/1369.bugfix.rst
@@ -1,0 +1,1 @@
+Creating Debian packages no longer fails due to a permission error for certain umask values such as ``0077``.

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -861,6 +861,8 @@ class LinuxSystemPackageCommand(LinuxSystemMixin, PackageCommand):
                 self.tools.shutil.rmtree(DEBIAN_path)
 
             DEBIAN_path.mkdir()
+            # dpkg-dep requires "DEBIAN" directory is >=0755 and <=0775
+            DEBIAN_path.chmod(0o755)
 
             # Add runtime package dependencies. App config has been finalized,
             # so this will be the target-specific definition, if one exists.


### PR DESCRIPTION
## Changes
- Manually set the permissions for `DEBIAN` to `755`
- `pathlib.Path.mkdir()` respects the process' umask; so, for instance, a umask of `0077` gives `DEBIAN` perms for `700`
- Fixes #1369 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
