### PR TITLE
Doc: update the size of the image for iOS splash images

### DIFF
--- a/changes/1371.removal.rst
+++ b/changes/1371.removal.rst
@@ -1,1 +1,1 @@
-Update documentation about the iOS splash images sizes to reflect the changes in the template
+The size of iOS splash images have changed. iOS apps should now provide 800px, 1600px and 2400px images (previously, this as 1024px, 2048px and 3072px). This is because iOS 14 added a hard limit on the size of image resources.

--- a/changes/1371.removal.rst
+++ b/changes/1371.removal.rst
@@ -1,0 +1,1 @@
+Update documentation about the iOS splash images sizes to reflect the changes in the template

--- a/docs/reference/platforms/iOS.rst
+++ b/docs/reference/platforms/iOS.rst
@@ -30,9 +30,9 @@ Splash Image format
 iOS projects use ``.png`` format splash screen images. A splash screen should
 be a square, transparent image, provided in the following sizes:
 
-* 1024px
-* 2048px
-* 3072px
+* 800px
+* 1600px
+* 2400px
 
 You can specify a background color for the splash screen using the
 ``splash_background_color`` configuration setting.


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Update docs for the new splash image size for iOS, see https://github.com/beeware/briefcase-iOS-Xcode-template/pull/21

<!--- What problem does this change solve? -->

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
