### PR TITLE
Updates after dropping Python 3.6 and 3.7

### DIFF
--- a/changes/1372.misc.rst
+++ b/changes/1372.misc.rst
@@ -1,0 +1,1 @@
+Updates after dropping Python 3.6 and 3.7.

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -262,10 +262,9 @@ class JDK(ManagedTool):
 
         with self.tools.input.wait_bar("Installing OpenJDK..."):
             try:
-                # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
                 self.tools.shutil.unpack_archive(
-                    os.fsdecode(jdk_zip_path),
-                    extract_dir=os.fsdecode(self.tools.base_path),
+                    str(jdk_zip_path),
+                    extract_dir=str(self.tools.base_path),
                 )
             except (shutil.ReadError, EOFError) as e:
                 raise BriefcaseCommandError(

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -263,8 +263,8 @@ class JDK(ManagedTool):
         with self.tools.input.wait_bar("Installing OpenJDK..."):
             try:
                 self.tools.shutil.unpack_archive(
-                    str(jdk_zip_path),
-                    extract_dir=str(self.tools.base_path),
+                    os.fsdecode(jdk_zip_path),
+                    extract_dir=os.fsdecode(self.tools.base_path),
                 )
             except (shutil.ReadError, EOFError) as e:
                 raise BriefcaseCommandError(

--- a/src/briefcase/integrations/wix.py
+++ b/src/briefcase/integrations/wix.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import shutil
 from pathlib import Path
 
@@ -138,10 +137,9 @@ does not point to an install of the WiX Toolset.
 
         try:
             with self.tools.input.wait_bar("Installing WiX..."):
-                # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
                 self.tools.shutil.unpack_archive(
-                    os.fsdecode(wix_zip_path),
-                    extract_dir=os.fsdecode(self.wix_home),
+                    str(wix_zip_path),
+                    extract_dir=str(self.wix_home),
                 )
         except (shutil.ReadError, EOFError) as e:
             raise BriefcaseCommandError(

--- a/src/briefcase/integrations/wix.py
+++ b/src/briefcase/integrations/wix.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import shutil
 from pathlib import Path
 
@@ -138,8 +139,8 @@ does not point to an install of the WiX Toolset.
         try:
             with self.tools.input.wait_bar("Installing WiX..."):
                 self.tools.shutil.unpack_archive(
-                    str(wix_zip_path),
-                    extract_dir=str(self.wix_home),
+                    os.fsdecode(wix_zip_path),
+                    extract_dir=os.fsdecode(self.wix_home),
                 )
         except (shutil.ReadError, EOFError) as e:
             raise BriefcaseCommandError(

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
@@ -20,8 +20,6 @@ def test_existing_skin(mock_tools, android_sdk):
 
 def test_new_skin(mock_tools, android_sdk):
     """If the skin doesn't exist, an attempt is made to download it."""
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    # Remove if block when we drop py3.7 support.
     skin_tgz_path = MagicMock(spec_set=Path)
     skin_tgz_path.__fspath__.return_value = "/path/to/skin.tgz"
     mock_tools.download.file.return_value = skin_tgz_path
@@ -50,8 +48,6 @@ def test_new_skin(mock_tools, android_sdk):
 
 def test_skin_download_failure(mock_tools, android_sdk, tmp_path):
     """If the skin download fails, an error is raised."""
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
-    # Remove if block when we drop py3.7 support.
     skin_tgz_path = MagicMock(spec_set=Path)
     skin_tgz_path.__fspath__.return_value = "/path/to/skin.tgz"
     mock_tools.download.file.return_value = skin_tgz_path
@@ -79,8 +75,6 @@ def test_skin_download_failure(mock_tools, android_sdk, tmp_path):
 def test_unpack_failure(mock_tools, android_sdk, tmp_path):
     """If the download is corrupted and unpacking fails, an error is raised."""
     # Mock the result of the download of a skin
-    # Consider to remove if block when we drop py3.7 support, only keep statements from else.
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
     skin_tgz_path = MagicMock(spec_set=Path)
     skin_tgz_path.__fspath__.return_value = "/path/to/skin.tgz"
     mock_tools.download.file.return_value = skin_tgz_path

--- a/tests/integrations/java/test_JDK__upgrade.py
+++ b/tests/integrations/java/test_JDK__upgrade.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 from unittest.mock import MagicMock
 
@@ -60,10 +59,9 @@ def test_existing_install(mock_tools, tmp_path):
     mock_tools.shutil.rmtree.side_effect = rmtree
 
     # Mock the cached download path.
-    # Consider to remove if block when we drop py3.7 support, only keep statements from else.
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
     archive = MagicMock()
     archive.__fspath__.return_value = "/path/to/download.zip"
+    archive.__str__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Create a directory to make it look like Java was downloaded and unpacked.
@@ -87,9 +85,8 @@ def test_existing_install(mock_tools, tmp_path):
     )
 
     # The archive was unpacked.
-    # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
     mock_tools.shutil.unpack_archive.assert_called_with(
-        "/path/to/download.zip", extract_dir=os.fsdecode(tmp_path / "tools")
+        "/path/to/download.zip", extract_dir=str(tmp_path / "tools")
     )
     # The original archive was deleted
     archive.unlink.assert_called_once_with()
@@ -112,10 +109,9 @@ def test_macOS_existing_install(mock_tools, tmp_path):
     mock_tools.shutil.rmtree.side_effect = rmtree
 
     # Mock the cached download path.
-    # Consider to remove if block when we drop py3.7 support, only keep statements from else.
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
     archive = MagicMock()
     archive.__fspath__.return_value = "/path/to/download.zip"
+    archive.__str__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Create a directory to make it look like Java was downloaded and unpacked.
@@ -139,10 +135,9 @@ def test_macOS_existing_install(mock_tools, tmp_path):
     )
 
     # The archive was unpacked.
-    # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
     mock_tools.shutil.unpack_archive.assert_called_with(
         "/path/to/download.zip",
-        extract_dir=os.fsdecode(tmp_path / "tools"),
+        extract_dir=str(tmp_path / "tools"),
     )
     # The original archive was deleted
     archive.unlink.assert_called_once_with()
@@ -198,10 +193,9 @@ def test_unpack_fail(mock_tools, tmp_path):
     mock_tools.shutil.rmtree.side_effect = rmtree
 
     # Mock the cached download path
-    # Consider to remove if block when we drop py3.7 support, only keep statements from else.
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
     archive = MagicMock()
     archive.__fspath__.return_value = "/path/to/download.zip"
+    archive.__str__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Mock an unpack failure due to an invalid archive
@@ -226,10 +220,9 @@ def test_unpack_fail(mock_tools, tmp_path):
     )
 
     # The archive was unpacked.
-    # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
     mock_tools.shutil.unpack_archive.assert_called_with(
         "/path/to/download.zip",
-        extract_dir=os.fsdecode(tmp_path / "tools"),
+        extract_dir=str(tmp_path / "tools"),
     )
     # The original archive was not deleted
     assert archive.unlink.call_count == 0

--- a/tests/integrations/java/test_JDK__upgrade.py
+++ b/tests/integrations/java/test_JDK__upgrade.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from unittest.mock import MagicMock
 
@@ -61,7 +62,6 @@ def test_existing_install(mock_tools, tmp_path):
     # Mock the cached download path.
     archive = MagicMock()
     archive.__fspath__.return_value = "/path/to/download.zip"
-    archive.__str__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Create a directory to make it look like Java was downloaded and unpacked.
@@ -86,7 +86,7 @@ def test_existing_install(mock_tools, tmp_path):
 
     # The archive was unpacked.
     mock_tools.shutil.unpack_archive.assert_called_with(
-        "/path/to/download.zip", extract_dir=str(tmp_path / "tools")
+        "/path/to/download.zip", extract_dir=os.fsdecode(tmp_path / "tools")
     )
     # The original archive was deleted
     archive.unlink.assert_called_once_with()
@@ -111,7 +111,6 @@ def test_macOS_existing_install(mock_tools, tmp_path):
     # Mock the cached download path.
     archive = MagicMock()
     archive.__fspath__.return_value = "/path/to/download.zip"
-    archive.__str__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Create a directory to make it look like Java was downloaded and unpacked.
@@ -137,7 +136,7 @@ def test_macOS_existing_install(mock_tools, tmp_path):
     # The archive was unpacked.
     mock_tools.shutil.unpack_archive.assert_called_with(
         "/path/to/download.zip",
-        extract_dir=str(tmp_path / "tools"),
+        extract_dir=os.fsdecode(tmp_path / "tools"),
     )
     # The original archive was deleted
     archive.unlink.assert_called_once_with()
@@ -195,7 +194,6 @@ def test_unpack_fail(mock_tools, tmp_path):
     # Mock the cached download path
     archive = MagicMock()
     archive.__fspath__.return_value = "/path/to/download.zip"
-    archive.__str__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Mock an unpack failure due to an invalid archive
@@ -222,7 +220,7 @@ def test_unpack_fail(mock_tools, tmp_path):
     # The archive was unpacked.
     mock_tools.shutil.unpack_archive.assert_called_with(
         "/path/to/download.zip",
-        extract_dir=str(tmp_path / "tools"),
+        extract_dir=os.fsdecode(tmp_path / "tools"),
     )
     # The original archive was not deleted
     assert archive.unlink.call_count == 0

--- a/tests/integrations/java/test_JDK__verify.py
+++ b/tests/integrations/java/test_JDK__verify.py
@@ -451,10 +451,9 @@ def test_successful_jdk_download(
     mock_tools.os.environ = {"JAVA_HOME": "/does/not/exist"}
 
     # Mock the cached download path
-    # Consider to remove if block when we drop py3.7 support, only keep statements from else.
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
     archive = mock.MagicMock()
     archive.__fspath__.return_value = "/path/to/download.zip"
+    archive.__str__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Create a directory to make it look like Java was downloaded and unpacked.
@@ -477,9 +476,8 @@ def test_successful_jdk_download(
         role="Java 17 JDK",
     )
     # The archive was unpacked
-    # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
     mock_tools.shutil.unpack_archive.assert_called_with(
-        "/path/to/download.zip", extract_dir=os.fsdecode(tmp_path / "tools")
+        "/path/to/download.zip", extract_dir=str(tmp_path / "tools")
     )
     # The original archive was deleted
     archive.unlink.assert_called_once_with()
@@ -529,10 +527,9 @@ def test_invalid_jdk_archive(mock_tools, tmp_path):
     mock_tools.host_arch = "x86_64"
 
     # Mock the cached download path
-    # Consider to remove if block when we drop py3.7 support, only keep statements from else.
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
     archive = mock.MagicMock()
     archive.__fspath__.return_value = "/path/to/download.zip"
+    archive.__str__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Mock an unpack failure due to an invalid archive
@@ -549,10 +546,9 @@ def test_invalid_jdk_archive(mock_tools, tmp_path):
         role="Java 17 JDK",
     )
     # An attempt was made to unpack the archive.
-    # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
     mock_tools.shutil.unpack_archive.assert_called_with(
         "/path/to/download.zip",
-        extract_dir=os.fsdecode(tmp_path / "tools"),
+        extract_dir=str(tmp_path / "tools"),
     )
     # The original archive was not deleted
     assert archive.unlink.call_count == 0

--- a/tests/integrations/java/test_JDK__verify.py
+++ b/tests/integrations/java/test_JDK__verify.py
@@ -453,7 +453,6 @@ def test_successful_jdk_download(
     # Mock the cached download path
     archive = mock.MagicMock()
     archive.__fspath__.return_value = "/path/to/download.zip"
-    archive.__str__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Create a directory to make it look like Java was downloaded and unpacked.
@@ -477,7 +476,7 @@ def test_successful_jdk_download(
     )
     # The archive was unpacked
     mock_tools.shutil.unpack_archive.assert_called_with(
-        "/path/to/download.zip", extract_dir=str(tmp_path / "tools")
+        "/path/to/download.zip", extract_dir=os.fsdecode(tmp_path / "tools")
     )
     # The original archive was deleted
     archive.unlink.assert_called_once_with()
@@ -529,7 +528,6 @@ def test_invalid_jdk_archive(mock_tools, tmp_path):
     # Mock the cached download path
     archive = mock.MagicMock()
     archive.__fspath__.return_value = "/path/to/download.zip"
-    archive.__str__.return_value = "/path/to/download.zip"
     mock_tools.download.file.return_value = archive
 
     # Mock an unpack failure due to an invalid archive
@@ -548,7 +546,7 @@ def test_invalid_jdk_archive(mock_tools, tmp_path):
     # An attempt was made to unpack the archive.
     mock_tools.shutil.unpack_archive.assert_called_with(
         "/path/to/download.zip",
-        extract_dir=str(tmp_path / "tools"),
+        extract_dir=os.fsdecode(tmp_path / "tools"),
     )
     # The original archive was not deleted
     assert archive.unlink.call_count == 0

--- a/tests/integrations/wix/test_WiX__upgrade.py
+++ b/tests/integrations/wix/test_WiX__upgrade.py
@@ -51,10 +51,9 @@ def test_existing_wix_install(mock_tools, tmp_path):
     wix_path = tmp_path / "tools" / "wix"
 
     wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
-    # Consider to remove if block when we drop py3.7 support, only keep statements from else.
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
     wix_zip = MagicMock()
     wix_zip.__fspath__.return_value = wix_zip_path
+    wix_zip.__str__.return_value = wix_zip_path
 
     mock_tools.download.file.return_value = wix_zip
 
@@ -75,9 +74,8 @@ def test_existing_wix_install(mock_tools, tmp_path):
     )
 
     # The download was unpacked
-    # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
     mock_tools.shutil.unpack_archive.assert_called_with(
-        os.fsdecode(wix_zip_path), extract_dir=os.fsdecode(wix_path)
+        str(wix_zip_path), extract_dir=str(wix_path)
     )
 
     # The zip file was removed
@@ -125,10 +123,9 @@ def test_unpack_fail(mock_tools, tmp_path):
 
     # Mock the download
     wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
-    # Consider to remove if block when we drop py3.7 support, only keep statements from else.
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
     wix_zip = MagicMock()
     wix_zip.__fspath__.return_value = wix_zip_path
+    wix_zip.__str__.return_value = wix_zip_path
 
     mock_tools.download.file.return_value = wix_zip
 
@@ -151,9 +148,8 @@ def test_unpack_fail(mock_tools, tmp_path):
     )
 
     # The download was unpacked.
-    # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
     mock_tools.shutil.unpack_archive.assert_called_with(
-        os.fsdecode(wix_zip_path), extract_dir=os.fsdecode(wix_path)
+        str(wix_zip_path), extract_dir=str(wix_path)
     )
 
     # The zip file was not removed

--- a/tests/integrations/wix/test_WiX__upgrade.py
+++ b/tests/integrations/wix/test_WiX__upgrade.py
@@ -53,7 +53,6 @@ def test_existing_wix_install(mock_tools, tmp_path):
     wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
     wix_zip = MagicMock()
     wix_zip.__fspath__.return_value = wix_zip_path
-    wix_zip.__str__.return_value = wix_zip_path
 
     mock_tools.download.file.return_value = wix_zip
 
@@ -75,7 +74,7 @@ def test_existing_wix_install(mock_tools, tmp_path):
 
     # The download was unpacked
     mock_tools.shutil.unpack_archive.assert_called_with(
-        str(wix_zip_path), extract_dir=str(wix_path)
+        os.fsdecode(wix_zip_path), extract_dir=os.fsdecode(wix_path)
     )
 
     # The zip file was removed
@@ -125,7 +124,6 @@ def test_unpack_fail(mock_tools, tmp_path):
     wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
     wix_zip = MagicMock()
     wix_zip.__fspath__.return_value = wix_zip_path
-    wix_zip.__str__.return_value = wix_zip_path
 
     mock_tools.download.file.return_value = wix_zip
 
@@ -149,7 +147,7 @@ def test_unpack_fail(mock_tools, tmp_path):
 
     # The download was unpacked.
     mock_tools.shutil.unpack_archive.assert_called_with(
-        str(wix_zip_path), extract_dir=str(wix_path)
+        os.fsdecode(wix_zip_path), extract_dir=os.fsdecode(wix_path)
     )
 
     # The zip file was not removed

--- a/tests/integrations/wix/test_WiX__verify.py
+++ b/tests/integrations/wix/test_WiX__verify.py
@@ -104,10 +104,9 @@ def test_download_wix(mock_tools, tmp_path):
     wix_path = tmp_path / "tools" / "wix"
 
     wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
-    # Consider to remove if block when we drop py3.7 support, only keep statements from else.
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
     wix_zip = MagicMock()
     wix_zip.__fspath__.return_value = wix_zip_path
+    wix_zip.__str__.return_value = wix_zip_path
 
     mock_tools.download.file.return_value = wix_zip
 
@@ -125,9 +124,8 @@ def test_download_wix(mock_tools, tmp_path):
     )
 
     # The download was unpacked.
-    # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
     mock_tools.shutil.unpack_archive.assert_called_with(
-        os.fsdecode(wix_zip_path), extract_dir=os.fsdecode(wix_path)
+        str(wix_zip_path), extract_dir=str(wix_path)
     )
 
     # The zip file was removed
@@ -191,10 +189,9 @@ def test_unpack_fail(mock_tools, tmp_path):
     wix_path = tmp_path / "tools" / "wix"
 
     wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
-    # Consider to remove if block when we drop py3.7 support, only keep statements from else.
-    # MagicMock below py3.8 doesn't have __fspath__ attribute.
     wix_zip = MagicMock()
     wix_zip.__fspath__.return_value = wix_zip_path
+    wix_zip.__str__.return_value = wix_zip_path
 
     mock_tools.download.file.return_value = wix_zip
 
@@ -217,9 +214,8 @@ def test_unpack_fail(mock_tools, tmp_path):
     )
 
     # The download was unpacked.
-    # TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
     mock_tools.shutil.unpack_archive.assert_called_with(
-        os.fsdecode(wix_zip_path), extract_dir=os.fsdecode(wix_path)
+        str(wix_zip_path), extract_dir=str(wix_path)
     )
 
     # The zip file was not removed

--- a/tests/integrations/wix/test_WiX__verify.py
+++ b/tests/integrations/wix/test_WiX__verify.py
@@ -106,7 +106,6 @@ def test_download_wix(mock_tools, tmp_path):
     wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
     wix_zip = MagicMock()
     wix_zip.__fspath__.return_value = wix_zip_path
-    wix_zip.__str__.return_value = wix_zip_path
 
     mock_tools.download.file.return_value = wix_zip
 
@@ -125,7 +124,7 @@ def test_download_wix(mock_tools, tmp_path):
 
     # The download was unpacked.
     mock_tools.shutil.unpack_archive.assert_called_with(
-        str(wix_zip_path), extract_dir=str(wix_path)
+        os.fsdecode(wix_zip_path), extract_dir=os.fsdecode(wix_path)
     )
 
     # The zip file was removed
@@ -191,7 +190,6 @@ def test_unpack_fail(mock_tools, tmp_path):
     wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
     wix_zip = MagicMock()
     wix_zip.__fspath__.return_value = wix_zip_path
-    wix_zip.__str__.return_value = wix_zip_path
 
     mock_tools.download.file.return_value = wix_zip
 
@@ -215,7 +213,7 @@ def test_unpack_fail(mock_tools, tmp_path):
 
     # The download was unpacked.
     mock_tools.shutil.unpack_archive.assert_called_with(
-        str(wix_zip_path), extract_dir=str(wix_path)
+        os.fsdecode(wix_zip_path), extract_dir=os.fsdecode(wix_path)
     )
 
     # The zip file was not removed


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Fix some things left over from the drop of EOL Python 3.6 and 3.7:

```python
# TODO: Py3.6 compatibility; os.fsdecode not required in Py3.7
```

Replace `os.fsdecode()` with `str()`, because they can be pathlib Paths.

Also need things like `archive.__str__.return_value = "/path/to/download.zip"` for the MagicMock objects.

---

```python
    # Consider to remove if block when we drop py3.7 support, only keep statements from else.
    # MagicMock below py3.8 doesn't have __fspath__ attribute.
```

The if/else blocks (they used to look like https://github.com/beeware/briefcase/commit/05c50b999e90d37ed8ebd67543c33c008bd91215) have already been cleaned up (presumably by pyupgrade), so remove these old comments.


<!--- What problem does this change solve? -->



<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [n/a] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
