### PR TITLE
Use wheels in `tox` instead of sdists

### DIFF
--- a/changes/1376.misc.rst
+++ b/changes/1376.misc.rst
@@ -1,0 +1,1 @@
+When running tests or building docs in tox, Briefcase is now installed as a wheel instead of an sdist.

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ commands_pre = python -m install_requirement --extra dev --project-root "{tox_ro
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
 [testenv:py{,38,39,310,311,312}{,-fast}]
+package = wheel
+wheel_build_env = .pkg
 depends: pre-commit
 use_develop = fast: True
 # Needed on Windows to test data directory creation
@@ -90,6 +92,8 @@ sphinx_args = -W --keep-going -j auto -n
 sphinx_args_extra = {[docs]sphinx_args} -v -E -T -a -d {envtmpdir}/doctrees
 
 [testenv:docs{,-lint,-all}]
+package = wheel
+wheel_build_env = .pkg
 change_dir = docs
 extras = docs
 passenv =


### PR DESCRIPTION
## Changes
- Inspired by Hynek's recent [post](https://hynek.me/articles/turbo-charge-tox/), update `tox` to install Briefcase as a wheel instead of an sdist; it's much faster (although, in fairness, it was already pretty fast).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
