### PR TITLE
Raising error on Failure [INSTALL_FAILED_OLDER_SDK]

### DIFF
--- a/changes/1157.bugfix.rst
+++ b/changes/1157.bugfix.rst
@@ -1,1 +1,1 @@
-Briefcase will now detect, if you try to launch an version on an android that is too old.
+Briefcase will detect if you attempt to launch an Android app on a device whose OS doesn't meet minimum version requirements.

--- a/changes/1157.bugfix.rst
+++ b/changes/1157.bugfix.rst
@@ -1,0 +1,1 @@
+Briefcase will now detect, if you try to launch an version on an android that is too old.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -706,7 +706,6 @@ connection.
             output = self.tools.subprocess.check_output(
                 [os.fsdecode(self.emulator_path), "-list-avds"]
             ).strip()
-
             # AVD names are returned one per line.
             if len(output) == 0:
                 return []
@@ -720,7 +719,6 @@ connection.
             output = self.tools.subprocess.check_output(
                 [os.fsdecode(self.adb_path), "devices", "-l"]
             ).strip()
-
             # Process the output of `adb devices -l`.
             # The first line is header information.
             # Each subsequent line is a single device descriptor.
@@ -1326,7 +1324,7 @@ class ADB:
         # checking that they are valid, then parsing output to notice errors.
         # This keeps performance good in the success case.
         try:
-            return self.tools.subprocess.check_output(
+            output = self.tools.subprocess.check_output(
                 [
                     os.fsdecode(self.tools.android_sdk.adb_path),
                     "-s",
@@ -1338,6 +1336,11 @@ class ADB:
                 ],
                 quiet=quiet,
             )
+            # Manually raise error if "Failure [INSTALL_FAILED_OLDER_SDK]" occurs,
+            # because this failer results in return code 0
+            if "Failure [INSTALL_FAILED_OLDER_SDK]" in output:
+                raise BriefcaseCommandError("Failed to install older SDK")
+            return output
         except subprocess.CalledProcessError as e:
             if any(DEVICE_NOT_FOUND.match(line) for line in e.output.split("\n")):
                 raise InvalidDeviceError("device id", self.device) from e

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1336,10 +1336,13 @@ class ADB:
                 ],
                 quiet=quiet,
             )
-            # Manually raise error if "Failure [INSTALL_FAILED_OLDER_SDK]" occurs,
-            # because this failer results in return code 0
+            # add returns status code 0 in the case of failure. The only tangible evidence
+            # of failure is the message "Failure [INSTALL_FAILED_OLDER_SDK]" in the,
+            # console output; so if that message exists in the output, raise an exception.
             if "Failure [INSTALL_FAILED_OLDER_SDK]" in output:
-                raise BriefcaseCommandError("Failed to install older SDK")
+                raise BriefcaseCommandError(
+                    "Your device doesn't meet the minimum SDK requirements of this app."
+                )
             return output
         except subprocess.CalledProcessError as e:
             if any(DEVICE_NOT_FOUND.match(line) for line in e.output.split("\n")):

--- a/tests/integrations/android_sdk/ADB/test_run.py
+++ b/tests/integrations/android_sdk/ADB/test_run.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from briefcase.exceptions import InvalidDeviceError
+from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 
 
 def test_simple_command(mock_tools, adb, tmp_path):
@@ -99,3 +99,17 @@ def test_error_handling(mock_tools, adb, name, exception, tmp_path):
         ],
         quiet=False,
     )
+
+
+def test_older_sdk_error(mock_tools, adb):
+    """Failure [INSTALL_FAILED_OLDER_SDK] needs to be catched manually."""
+    mock_tools.subprocess.check_output.return_value = "\n".join(
+        [
+            "Performing Push Install",
+            "C:/.../app-debug.apk: 1 file pushed, 0 skipped. 5.5 MB/s (33125287 bytes in 5.768s)",
+            "         pkg: /data/local/tmp/app-debug.apk",
+            "Failure [INSTALL_FAILED_OLDER_SDK]",
+        ]
+    )
+    with pytest.raises(BriefcaseCommandError):
+        adb.run("example", "command")

--- a/tests/integrations/android_sdk/ADB/test_run.py
+++ b/tests/integrations/android_sdk/ADB/test_run.py
@@ -113,6 +113,6 @@ def test_older_sdk_error(mock_tools, adb):
     )
     with pytest.raises(
         BriefcaseCommandError,
-        r"Your device doesn't meet the minimum SDK requirements of this app.",
+        match=r"Your device doesn't meet the minimum SDK requirements of this app",
     ):
         adb.run("example", "command")

--- a/tests/integrations/android_sdk/ADB/test_run.py
+++ b/tests/integrations/android_sdk/ADB/test_run.py
@@ -111,5 +111,8 @@ def test_older_sdk_error(mock_tools, adb):
             "Failure [INSTALL_FAILED_OLDER_SDK]",
         ]
     )
-    with pytest.raises(BriefcaseCommandError):
+    with pytest.raises(
+        BriefcaseCommandError,
+        r"Your device doesn't meet the minimum SDK requirements of this app.",
+    ):
         adb.run("example", "command")


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Manually raise of error if "Failure [INSTALL_FAILED_OLDER_SDK]"  occurs in ADB.run() added as well as test_older_sdk_error function added to ADB\test_run.py

<!--- What problem does this change solve? -->
 For "Failure [INSTALL_FAILED_OLDER_SDK]", an error is now raised even though the return code is 0

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #1157

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] All new features have been tested
- [ x] All new features have been documented
- [ x] I have read the **CONTRIBUTING.md** file
- [ x] I will abide by the code of conduct
