### PR TITLE
Resolve naming ambiguity

### DIFF
--- a/changes/1379.misc.rst
+++ b/changes/1379.misc.rst
@@ -1,0 +1,1 @@
+The inadvertent override of the build_method introduced by #1377 was resolved.


### PR DESCRIPTION
Refs #1379

#1377 added support for Android APK builds. It fully passed CI, and was merged. 

However, the change caused problems as soon as it was used by others (e.g., [this CI build in Toga](https://github.com/beeware/toga/actions/runs/5637111334/job/15269929634?pr=2051)).

The problem is that it added a `build_command()` method which overrode the `build_command()` that... does actual builds. 

This PR is a hotfix to get mainline working. There is an underlying issue with CI that needs to be resolved.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
