### PR TITLE
Cache image prior to checking docker user mapping

### DIFF
--- a/changes/1368.bugfix.rst
+++ b/changes/1368.bugfix.rst
@@ -1,0 +1,1 @@
+When the target Docker image name is not valid when building Linux System packages, the error message now mentions the invalid image name instead of an error for Docker user mapping.

--- a/changes/1368.bugfix.rst
+++ b/changes/1368.bugfix.rst
@@ -1,1 +1,1 @@
-When the target Docker image name is not valid when building Linux System packages, the error message now mentions the invalid image name instead of an error for Docker user mapping.
+Error reporting has been improved when the target Docker image name is invalid.

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -344,6 +344,10 @@ Delete this file and run Briefcase again.
         ).strip()
 
         if not image_id:
+            self.tools.logger.info(
+                f"Downloading Docker base image for {image_tag}...",
+                prefix="Docker",
+            )
             try:
                 # disable streaming so image download progress bar is shown
                 self.tools.subprocess.run(

--- a/tests/integrations/docker/conftest.py
+++ b/tests/integrations/docker/conftest.py
@@ -91,7 +91,6 @@ def user_mapping_run_calls(tmp_path, monkeypatch) -> list:
                 PurePosixPath("/host_write_test/mock_write_test"),
             ],
             check=True,
-            stream_output=False,
         ),
         call(
             [
@@ -106,6 +105,5 @@ def user_mapping_run_calls(tmp_path, monkeypatch) -> list:
                 PurePosixPath("/host_write_test/mock_write_test"),
             ],
             check=True,
-            stream_output=False,
         ),
     ]

--- a/tests/integrations/docker/test_DockerAppContext__verify.py
+++ b/tests/integrations/docker/test_DockerAppContext__verify.py
@@ -50,6 +50,7 @@ def test_success(mock_tools, first_app_config, verify_kwargs):
         "Docker version 19.03.8, build afacb8b\n",
         "docker info return value",
         "github.com/docker/buildx v0.10.2 00ed17d\n",
+        "1ed313b0551f",  # cached image check
     ]
 
     DockerAppContext.verify(mock_tools, first_app_config, **verify_kwargs)
@@ -97,6 +98,7 @@ def test_docker_image_build_fail(mock_tools, first_app_config, verify_kwargs):
         "Docker version 19.03.8, build afacb8b\n",
         "docker info return value",
         "github.com/docker/buildx v0.10.2 00ed17d\n",
+        "1ed313b0551f",  # cached image check
     ]
 
     mock_tools.subprocess.run.side_effect = [

--- a/tests/integrations/docker/test_Docker__cache_image.py
+++ b/tests/integrations/docker/test_Docker__cache_image.py
@@ -25,13 +25,14 @@ def test_cache_image(mock_tools, user_mapping_run_calls):
     mock_tools.docker.cache_image("ubuntu:jammy")
 
     # Confirms that image is not available
-    mock_tools.subprocess.check_output.assert_called_once_with(
+    mock_tools.subprocess.check_output.assert_called_with(
         ["docker", "images", "-q", "ubuntu:jammy"]
     )
 
     # Image is pulled and cached
     mock_tools.subprocess.run.assert_has_calls(
-        user_mapping_run_calls + [call(["docker", "pull", "ubuntu:jammy"], check=True)]
+        user_mapping_run_calls
+        + [call(["docker", "pull", "ubuntu:jammy"], check=True, stream_output=False)]
     )
 
 
@@ -44,7 +45,7 @@ def test_cache_image_already_cached(mock_tools, user_mapping_run_calls):
     mock_tools.docker.cache_image("ubuntu:jammy")
 
     # Confirms that image is not available
-    mock_tools.subprocess.check_output.assert_called_once_with(
+    mock_tools.subprocess.check_output.assert_called_with(
         ["docker", "images", "-q", "ubuntu:jammy"]
     )
 

--- a/tests/integrations/docker/test_Docker__verify.py
+++ b/tests/integrations/docker/test_Docker__verify.py
@@ -13,6 +13,7 @@ from briefcase.integrations.subprocess import Subprocess
 VALID_DOCKER_VERSION = "Docker version 19.03.8, build afacb8b\n"
 VALID_DOCKER_INFO = "docker info printout"
 VALID_BUILDX_VERSION = "github.com/docker/buildx v0.10.2 00ed17d\n"
+VALID_USER_MAPPING_IMAGE_CACHE = "1ed313b0551f"
 DOCKER_VERIFICATION_CALLS = [
     call(["docker", "--version"]),
     call(["docker", "info"]),
@@ -70,6 +71,7 @@ def test_docker_exists(mock_tools, user_mapping_run_calls, capsys, tmp_path):
         VALID_DOCKER_VERSION,
         VALID_DOCKER_INFO,
         VALID_BUILDX_VERSION,
+        VALID_USER_MAPPING_IMAGE_CACHE,
     ]
 
     # Invoke docker verify
@@ -114,6 +116,7 @@ def test_docker_failure(mock_tools, user_mapping_run_calls, capsys):
         ),
         "Success!",
         VALID_BUILDX_VERSION,
+        VALID_USER_MAPPING_IMAGE_CACHE,
     ]
 
     # Invoke Docker verify
@@ -280,6 +283,7 @@ def test_docker_image_hint(mock_tools):
         VALID_DOCKER_VERSION,
         VALID_DOCKER_INFO,
         VALID_BUILDX_VERSION,
+        VALID_USER_MAPPING_IMAGE_CACHE,
     ]
 
     Docker.verify(mock_tools, image_tag="myimage:tagtorulethemall")
@@ -298,7 +302,6 @@ def test_docker_image_hint(mock_tools):
                     PurePosixPath("/host_write_test/container_write_test"),
                 ],
                 check=True,
-                stream_output=False,
             ),
             call(
                 [
@@ -313,7 +316,6 @@ def test_docker_image_hint(mock_tools):
                     PurePosixPath("/host_write_test/container_write_test"),
                 ],
                 check=True,
-                stream_output=False,
             ),
         ]
     )
@@ -333,6 +335,7 @@ def test_user_mapping_write_file_exists(mock_tools, mock_write_test_path):
         VALID_DOCKER_VERSION,
         VALID_DOCKER_INFO,
         VALID_BUILDX_VERSION,
+        VALID_USER_MAPPING_IMAGE_CACHE,
     ]
 
     # Mock failure for deleting an existing write test file
@@ -353,6 +356,7 @@ def test_user_mapping_write_test_file_creation_fails(mock_tools, mock_write_test
         VALID_DOCKER_VERSION,
         VALID_DOCKER_INFO,
         VALID_BUILDX_VERSION,
+        VALID_USER_MAPPING_IMAGE_CACHE,
     ]
 
     # Mock failure for deleting an existing write test file
@@ -376,6 +380,7 @@ def test_user_mapping_write_test_file_cleanup_fails(mock_tools, mock_write_test_
         VALID_DOCKER_VERSION,
         VALID_DOCKER_INFO,
         VALID_BUILDX_VERSION,
+        VALID_USER_MAPPING_IMAGE_CACHE,
     ]
 
     # Mock failure for deleting an existing write test file
@@ -406,6 +411,7 @@ def test_user_mapping_setting(
         VALID_DOCKER_VERSION,
         VALID_DOCKER_INFO,
         VALID_BUILDX_VERSION,
+        VALID_USER_MAPPING_IMAGE_CACHE,
     ]
 
     stat_result = namedtuple("stat_result", "st_uid")


### PR DESCRIPTION
## Changes
- Closes #1368
- Simply ensuring the image is cached beforehand prints out a much better error message.
- While the docker return code checking may prove useful in the future, it feels like overkill right now.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
