### PR TITLE
Support verbose logging for third-party tools

### DIFF
--- a/changes/1384.feature.rst
+++ b/changes/1384.feature.rst
@@ -1,0 +1,1 @@
+Using the ``-vv`` switch, verbose logging can now be enabled for the third-party tools, such as Gradle, linuxdeploy, etc.

--- a/changes/1384.feature.rst
+++ b/changes/1384.feature.rst
@@ -1,1 +1,1 @@
-Using the ``-vv`` switch, verbose logging can now be enabled for the third-party tools, such as Gradle, linuxdeploy, etc.
+An super verbose logging mode was added (enabled using ``-vv``). This turns on all Briefcase internal logging, but also enables verbose logging for all the third-party tools that Briefcase invokes.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -667,7 +667,7 @@ any compatibility problems, and then add the compatibility declaration.
             "--verbosity",
             action="count",
             default=1,
-            help="set the verbosity of output",
+            help="Set the verbosity of output. Use twice to include verbose logging from third-party tools.",
         )
         parser.add_argument("-V", "--version", action="version", version=__version__)
         parser.add_argument(

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -666,8 +666,8 @@ any compatibility problems, and then add the compatibility declaration.
             "-v",
             "--verbosity",
             action="count",
-            default=1,
-            help="Set the verbosity of output. Use twice to include verbose logging from third-party tools.",
+            default=0,
+            help="Enable verbose logging. -vv enables super verbose mode.",
         )
         parser.add_argument("-V", "--version", action="version", version=__version__)
         parser.add_argument(

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -230,6 +230,14 @@ class Log:
         """Log message at error level; always included in output."""
         self._log(prefix=prefix, message=message, markup=markup, style="bold red")
 
+    @property
+    def is_deep_debug(self):
+        """Is extra verbosity enabled via -vv?
+
+        Enables verbose output from third-party tools.
+        """
+        return self.verbosity >= 3
+
     def capture_stacktrace(self, label="Main thread"):
         """Preserve Rich stacktrace from exception while in except block.
 

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -117,15 +117,15 @@ class Log:
     """Manage logging output driven by verbosity flags."""
 
     # level of verbosity when debug output is shown in the console
-    DEBUG = 2
+    DEBUG = 1
     # printed at the beginning of all debug output
     DEBUG_PREFACE = ">>> "
     # subdirectory of command.base_path to store log files
     LOG_DIR = "logs"
 
-    def __init__(self, printer=Printer(), verbosity=1):
+    def __init__(self, printer=Printer(), verbosity=0):
         self.print = printer
-        # --verbosity flag: 1 for info, 2 for debug
+        # --verbosity flag: 0 for info, 1 for debug, 2 for super-verbose
         self.verbosity = verbosity
         # --log flag to force logfile creation
         self.save_log = False
@@ -236,7 +236,7 @@ class Log:
 
         Enables verbose output from third-party tools.
         """
-        return self.verbosity >= 3
+        return self.verbosity >= 2
 
     def capture_stacktrace(self, label="Main thread"):
         """Preserve Rich stacktrace from exception while in except block.

--- a/src/briefcase/integrations/flatpak.py
+++ b/src/briefcase/integrations/flatpak.py
@@ -154,7 +154,8 @@ You must install both flatpak and flatpak-builder.
                     "--if-not-exists",
                     repo_alias,
                     url,
-                ],
+                ]
+                + (["--verbose"] if self.tools.logger.is_deep_debug else []),
                 check=True,
             )
         except subprocess.CalledProcessError as e:
@@ -186,7 +187,8 @@ You must install both flatpak and flatpak-builder.
                     repo_alias,
                     f"{runtime}/{self.tools.host_arch}/{runtime_version}",
                     f"{sdk}/{self.tools.host_arch}/{runtime_version}",
-                ],
+                ]
+                + (["--verbose"] if self.tools.logger.is_deep_debug else []),
                 check=True,
                 # flatpak install uses many animations that cannot be disabled
                 stream_output=False,
@@ -222,7 +224,8 @@ You must install both flatpak and flatpak-builder.
                     "--user",
                     "build",
                     "manifest.yml",
-                ],
+                ]
+                + (["--verbose"] if self.tools.logger.is_deep_debug else []),
                 check=True,
                 cwd=path,
             )
@@ -269,13 +272,15 @@ flatpak run {bundle_identifier}
         else:
             kwargs = {}
 
+        flatpak_run_cmd = ["flatpak", "run", bundle_identifier]
+        flatpak_run_cmd.extend([] if args is None else args)
+
+        if self.tools.logger.is_deep_debug:
+            # Must come before bundle identifier; otherwise, it's passed as an arg to app
+            flatpak_run_cmd.insert(2, "--verbose")
+
         return self.tools.subprocess.Popen(
-            [
-                "flatpak",
-                "run",
-                bundle_identifier,
-            ]
-            + ([] if args is None else args),
+            flatpak_run_cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             bufsize=1,
@@ -319,7 +324,8 @@ flatpak run {bundle_identifier}
                     output_path,
                     bundle_identifier,
                     version,
-                ],
+                ]
+                + (["--verbose"] if self.tools.logger.is_deep_debug else []),
                 check=True,
                 cwd=build_path,
             )

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import datetime
 import re
 import subprocess
 import time
 from pathlib import Path
-from typing import List
 
 from briefcase.commands import (
     BuildCommand,
@@ -17,6 +18,7 @@ from briefcase.commands import (
 from briefcase.config import BaseConfig, parsed_version
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.android_sdk import AndroidSDK
+from briefcase.integrations.subprocess import SubprocessArgT
 
 
 def safe_formal_name(name):
@@ -88,17 +90,14 @@ class GradleMixin:
         )
 
     def distribution_path(self, app):
-        packaging_format_extension = {
+        extension = {
             "aab": "aab",
             "apk": "apk",
-            "debug-apk": "apk",
-        }
-        return (
-            self.dist_path
-            / f"{app.formal_name}-{app.version}.{packaging_format_extension[app.packaging_format]}"
-        )
+            "debug-apk": "debug.apk",
+        }[app.packaging_format]
+        return self.dist_path / f"{app.formal_name}-{app.version}.{extension}"
 
-    def run_gradle(self, app, args):
+    def run_gradle(self, app, args: list[SubprocessArgT]):
         # Gradle may install the emulator via the dependency chain build-tools > tools >
         # emulator. (The `tools` package only shows up in sdkmanager if you pass
         # `--include_obsolete`.) However, the old sdkmanager built into Android Gradle
@@ -115,7 +114,13 @@ class GradleMixin:
             # Windows needs the full path to `gradlew`; macOS & Linux can find it
             # via `./gradlew`. For simplicity of implementation, we always provide
             # the full path.
-            [self.bundle_path(app) / gradlew] + args + ["--console", "plain"],
+            [
+                self.bundle_path(app) / gradlew,
+                "--console",
+                "plain",
+            ]
+            + (["--debug"] if self.tools.logger.is_deep_debug else [])
+            + args,
             env=self.tools.android_sdk.env,
             # Set working directory so gradle can use the app bundle path as its
             # project root, i.e., to avoid 'Task assembleDebug not found'.
@@ -250,7 +255,7 @@ class GradleRunCommand(GradleMixin, RunCommand):
         self,
         app: BaseConfig,
         test_mode: bool,
-        passthrough: List[str],
+        passthrough: list[str],
         device_or_avd=None,
         extra_emulator_args=None,
         shutdown_on_exit=False,
@@ -379,27 +384,18 @@ class GradlePackageCommand(GradleMixin, PackageCommand):
             prefix=app.app_name,
         )
         with self.input.wait_bar("Bundling..."):
+            build_type, build_artefact_path = {
+                "aab": ("bundleRelease", "bundle/release/app-release.aab"),
+                "apk": ("assembleRelease", "apk/release/app-release-unsigned.apk"),
+                "debug-apk": ("assembleDebug", "apk/debug/app-debug.apk"),
+            }[app.packaging_format]
+
             try:
-                self.run_gradle(
-                    app,
-                    [
-                        {
-                            "aab": "bundleRelease",
-                            "apk": "assembleRelease",
-                            "debug-apk": "assembleDebug",
-                        }[app.packaging_format]
-                    ],
-                )
+                self.run_gradle(app, [build_type])
             except subprocess.CalledProcessError as e:
                 raise BriefcaseCommandError("Error while building project.") from e
 
         # Move artefact to final location.
-        build_artefact_path = {
-            "aab": Path("bundle") / "release" / "app-release.aab",
-            "apk": Path("apk") / "release" / "app-release-unsigned.apk",
-            "debug-apk": Path("apk") / "debug" / "app-debug.apk",
-        }[app.packaging_format]
-
         self.tools.shutil.move(
             self.bundle_path(app) / "app" / "build" / "outputs" / build_artefact_path,
             self.distribution_path(app),

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -324,7 +324,7 @@ class iOSXcodeBuildCommand(iOSXcodePassiveMixin, BuildCommand):
                         self.tools.host_arch,
                         "-sdk",
                         "iphonesimulator",
-                        "-quiet",
+                        "-verbose" if self.tools.logger.is_deep_debug else "-quiet",
                     ],
                     check=True,
                 )

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -274,6 +274,10 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
                 # This can be used by some linuxdeploy plugins.
                 env["ARCH"] = self.tools.host_arch
 
+                # Enable debug logging for linuxdeploy GTK and Qt plugins
+                if self.logger.is_deep_debug:
+                    env["DEBUG"] = "1"
+
                 # Find all the .so files in app and app_packages,
                 # so they can be passed in to linuxdeploy to have their
                 # requirements added to the AppImage. Looks for any .so file
@@ -302,6 +306,7 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
                         ),
                         "--output",
                         "appimage",
+                        "-v0" if self.logger.is_deep_debug else "-v1",
                     ]
                     + additional_args,
                     env=env,

--- a/src/briefcase/platforms/macOS/xcode.py
+++ b/src/briefcase/platforms/macOS/xcode.py
@@ -64,7 +64,7 @@ class macOSXcodeBuildCommand(macOSXcodeMixin, BuildCommand):
                         "xcodebuild",
                         "-project",
                         self.project_path(app),
-                        "-quiet",
+                        "-verbose" if self.tools.logger.is_deep_debug else "-quiet",
                         "-configuration",
                         "Release",
                         "build",

--- a/src/briefcase/platforms/windows/visualstudio.py
+++ b/src/briefcase/platforms/windows/visualstudio.py
@@ -57,6 +57,11 @@ class WindowsVisualStudioBuildCommand(WindowsVisualStudioMixin, BuildCommand):
                         "-property:RestorePackagesConfig=true",
                         f"-target:{app.formal_name}",
                         "-property:Configuration=Release",
+                        (
+                            "-verbosity:detailed"
+                            if self.logger.is_deep_debug
+                            else "-verbosity:normal"
+                        ),
                     ],
                     check=True,
                     cwd=self.bundle_path(app),

--- a/tests/commands/base/test_parse_options.py
+++ b/tests/commands/base/test_parse_options.py
@@ -11,7 +11,7 @@ def test_parse_options(base_command):
         "required": "important",
     }
     assert base_command.input.enabled
-    assert base_command.logger.verbosity == 1
+    assert base_command.logger.verbosity == 0
 
 
 def test_missing_option(base_command, capsys):

--- a/tests/console/test_Log.py
+++ b/tests/console/test_Log.py
@@ -41,14 +41,15 @@ def command(mock_now, tmp_path) -> DevCommand:
 @pytest.mark.parametrize(
     "verbosity, enabled",
     [
+        (0, False),
         (1, False),
-        (2, False),
+        (2, True),
         (3, True),
         (4, True),
     ],
 )
 def test_is_deep_debug(verbosity, enabled):
-    """Deep debug is enabled at =>3 verbosity."""
+    """Deep debug is enabled at =>2 verbosity."""
     assert Log(verbosity=verbosity).is_deep_debug is enabled
 
 

--- a/tests/console/test_Log.py
+++ b/tests/console/test_Log.py
@@ -38,6 +38,20 @@ def command(mock_now, tmp_path) -> DevCommand:
     return command
 
 
+@pytest.mark.parametrize(
+    "verbosity, enabled",
+    [
+        (1, False),
+        (2, False),
+        (3, True),
+        (4, True),
+    ],
+)
+def test_is_deep_debug(verbosity, enabled):
+    """Deep debug is enabled at =>3 verbosity."""
+    assert Log(verbosity=verbosity).is_deep_debug is enabled
+
+
 def test_capture_stacktrace():
     """capture_stacktrace sets Log.stacktrace."""
     logger = Log()

--- a/tests/integrations/flatpak/test_Flatpak__build.py
+++ b/tests/integrations/flatpak/test_Flatpak__build.py
@@ -10,7 +10,7 @@ def test_build(flatpak, tool_debug_mode, tmp_path):
     """A Flatpak project can be built."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = 3
+        flatpak.tools.logger.verbosity = 2
 
     flatpak.build(
         bundle_identifier="com.example.my-app",

--- a/tests/integrations/flatpak/test_Flatpak__build.py
+++ b/tests/integrations/flatpak/test_Flatpak__build.py
@@ -5,8 +5,13 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError
 
 
-def test_build(flatpak, tmp_path):
+@pytest.mark.parametrize("tool_debug_mode", (True, False))
+def test_build(flatpak, tool_debug_mode, tmp_path):
     """A Flatpak project can be built."""
+    # Enable verbose tool logging
+    if tool_debug_mode:
+        flatpak.tools.logger.verbosity = 3
+
     flatpak.build(
         bundle_identifier="com.example.my-app",
         app_name="my-app",
@@ -24,7 +29,8 @@ def test_build(flatpak, tmp_path):
             "--user",
             "build",
             "manifest.yml",
-        ],
+        ]
+        + (["--verbose"] if tool_debug_mode else []),
         check=True,
         cwd=tmp_path,
     )

--- a/tests/integrations/flatpak/test_Flatpak__bundle.py
+++ b/tests/integrations/flatpak/test_Flatpak__bundle.py
@@ -10,7 +10,7 @@ def test_bundle(flatpak, tool_debug_mode, tmp_path):
     """A Flatpak project can be bundled."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = 3
+        flatpak.tools.logger.verbosity = 2
 
     flatpak.bundle(
         repo_url="https://example.com/flatpak",

--- a/tests/integrations/flatpak/test_Flatpak__bundle.py
+++ b/tests/integrations/flatpak/test_Flatpak__bundle.py
@@ -5,8 +5,12 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError
 
 
-def test_bundle(flatpak, tmp_path):
+@pytest.mark.parametrize("tool_debug_mode", (True, False))
+def test_bundle(flatpak, tool_debug_mode, tmp_path):
     """A Flatpak project can be bundled."""
+    # Enable verbose tool logging
+    if tool_debug_mode:
+        flatpak.tools.logger.verbosity = 3
 
     flatpak.bundle(
         repo_url="https://example.com/flatpak",
@@ -28,7 +32,8 @@ def test_bundle(flatpak, tmp_path):
             tmp_path / "output" / "MyApp.flatpak",
             "com.example.my-app",
             "1.2.3",
-        ],
+        ]
+        + (["--verbose"] if tool_debug_mode else []),
         check=True,
         cwd=tmp_path / "build",
     )

--- a/tests/integrations/flatpak/test_Flatpak__run.py
+++ b/tests/integrations/flatpak/test_Flatpak__run.py
@@ -9,7 +9,7 @@ def test_run(flatpak, tool_debug_mode):
     """A Flatpak project can be executed."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = 3
+        flatpak.tools.logger.verbosity = 2
 
     # Set up the log streamer to return a known stream
     log_popen = mock.MagicMock()
@@ -40,7 +40,7 @@ def test_run_with_args(flatpak, tool_debug_mode):
     """A Flatpak project can be executed with additional arguments."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = 3
+        flatpak.tools.logger.verbosity = 2
 
     # Set up the log streamer to return a known stream
     log_popen = mock.MagicMock()

--- a/tests/integrations/flatpak/test_Flatpak__run.py
+++ b/tests/integrations/flatpak/test_Flatpak__run.py
@@ -1,9 +1,16 @@
 import subprocess
 from unittest import mock
 
+import pytest
 
-def test_run(flatpak):
+
+@pytest.mark.parametrize("tool_debug_mode", (True, False))
+def test_run(flatpak, tool_debug_mode):
     """A Flatpak project can be executed."""
+    # Enable verbose tool logging
+    if tool_debug_mode:
+        flatpak.tools.logger.verbosity = 3
+
     # Set up the log streamer to return a known stream
     log_popen = mock.MagicMock()
     flatpak.tools.subprocess.Popen.return_value = log_popen
@@ -16,8 +23,9 @@ def test_run(flatpak):
         [
             "flatpak",
             "run",
-            "com.example.my-app",
-        ],
+        ]
+        + (["--verbose"] if tool_debug_mode else [])
+        + ["com.example.my-app"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         bufsize=1,
@@ -27,8 +35,13 @@ def test_run(flatpak):
     assert result == log_popen
 
 
-def test_run_with_args(flatpak):
+@pytest.mark.parametrize("tool_debug_mode", (True, False))
+def test_run_with_args(flatpak, tool_debug_mode):
     """A Flatpak project can be executed with additional arguments."""
+    # Enable verbose tool logging
+    if tool_debug_mode:
+        flatpak.tools.logger.verbosity = 3
+
     # Set up the log streamer to return a known stream
     log_popen = mock.MagicMock()
     flatpak.tools.subprocess.Popen.return_value = log_popen
@@ -44,10 +57,10 @@ def test_run_with_args(flatpak):
         [
             "flatpak",
             "run",
-            "com.example.my-app",
-            "foo",
-            "bar",
-        ],
+        ]
+        + (["--verbose"] if tool_debug_mode else [])
+        + ["com.example.my-app"]
+        + ["foo", "bar"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         bufsize=1,

--- a/tests/integrations/flatpak/test_Flatpak__verify_repo.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_repo.py
@@ -10,7 +10,7 @@ def test_verify_repo(flatpak, tool_debug_mode):
     """A Flatpak repo can be verified."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = 3
+        flatpak.tools.logger.verbosity = 2
 
     flatpak.verify_repo(
         repo_alias="test-alias",

--- a/tests/integrations/flatpak/test_Flatpak__verify_repo.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_repo.py
@@ -5,8 +5,12 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError
 
 
-def test_verify_repo(flatpak):
+@pytest.mark.parametrize("tool_debug_mode", (True, False))
+def test_verify_repo(flatpak, tool_debug_mode):
     """A Flatpak repo can be verified."""
+    # Enable verbose tool logging
+    if tool_debug_mode:
+        flatpak.tools.logger.verbosity = 3
 
     flatpak.verify_repo(
         repo_alias="test-alias",
@@ -22,7 +26,8 @@ def test_verify_repo(flatpak):
             "--if-not-exists",
             "test-alias",
             "https://example.com/flatpak",
-        ],
+        ]
+        + (["--verbose"] if tool_debug_mode else []),
         check=True,
     )
 

--- a/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
@@ -10,7 +10,7 @@ def test_verify_runtime(flatpak, tool_debug_mode):
     """A Flatpak runtime and SDK can be verified."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = 3
+        flatpak.tools.logger.verbosity = 2
 
     flatpak.verify_runtime(
         repo_alias="test-alias",

--- a/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
@@ -5,8 +5,12 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError
 
 
-def test_verify_runtime(flatpak):
+@pytest.mark.parametrize("tool_debug_mode", (True, False))
+def test_verify_runtime(flatpak, tool_debug_mode):
     """A Flatpak runtime and SDK can be verified."""
+    # Enable verbose tool logging
+    if tool_debug_mode:
+        flatpak.tools.logger.verbosity = 3
 
     flatpak.verify_runtime(
         repo_alias="test-alias",
@@ -25,7 +29,8 @@ def test_verify_runtime(flatpak):
             "test-alias",
             "org.beeware.flatpak.Platform/gothic/37.42",
             "org.beeware.flatpak.SDK/gothic/37.42",
-        ],
+        ]
+        + (["--verbose"] if tool_debug_mode else []),
         check=True,
         stream_output=False,
     )

--- a/tests/platforms/android/gradle/test_build.py
+++ b/tests/platforms/android/gradle/test_build.py
@@ -48,19 +48,28 @@ def test_unsupported_template_version(build_command, first_app_generated):
 
 
 @pytest.mark.parametrize(
-    "host_os, gradlew_name",
-    [("Windows", "gradlew.bat"), ("NonWindows", "gradlew")],
+    "host_os, gradlew_name, tool_debug_mode",
+    [
+        ("Windows", "gradlew.bat", True),
+        ("Windows", "gradlew.bat", False),
+        ("NonWindows", "gradlew", True),
+        ("NonWindows", "gradlew", False),
+    ],
 )
 def test_build_app(
     build_command,
     first_app_generated,
     host_os,
     gradlew_name,
+    tool_debug_mode,
     tmp_path,
 ):
     """The app can be built, invoking gradle."""
     # Mock out `host_os` so we can validate which name is used for gradlew.
     build_command.tools.host_os = host_os
+    # Enable verbose tool logging
+    if tool_debug_mode:
+        build_command.tools.logger.verbosity = 3
     # Create mock environment with `key`, which we expect to be preserved, and
     # `ANDROID_SDK_ROOT`, which we expect to be overwritten.
     build_command.tools.os.environ = {"ANDROID_SDK_ROOT": "somewhere", "key": "value"}
@@ -69,10 +78,11 @@ def test_build_app(
     build_command.tools.subprocess.run.assert_called_once_with(
         [
             build_command.bundle_path(first_app_generated) / gradlew_name,
-            "assembleDebug",
             "--console",
             "plain",
-        ],
+        ]
+        + (["--debug"] if tool_debug_mode else [])
+        + ["assembleDebug"],
         cwd=build_command.bundle_path(first_app_generated),
         env=build_command.tools.android_sdk.env,
         check=True,
@@ -104,19 +114,28 @@ def test_build_app(
 
 
 @pytest.mark.parametrize(
-    "host_os, gradlew_name",
-    [("Windows", "gradlew.bat"), ("NonWindows", "gradlew")],
+    "host_os, gradlew_name, debug_mode",
+    [
+        ("Windows", "gradlew.bat", True),
+        ("Windows", "gradlew.bat", False),
+        ("NonWindows", "gradlew", True),
+        ("NonWindows", "gradlew", False),
+    ],
 )
 def test_build_app_test_mode(
     build_command,
     first_app_generated,
     host_os,
     gradlew_name,
+    debug_mode,
     tmp_path,
 ):
     """The app can be built in test mode, invoking gradle and rewriting app metadata."""
     # Mock out `host_os` so we can validate which name is used for gradlew.
     build_command.tools.host_os = host_os
+    # Enable verbose tool logging
+    if debug_mode:
+        build_command.tools.logger.verbosity = 3
     # Create mock environment with `key`, which we expect to be preserved, and
     # `ANDROID_SDK_ROOT`, which we expect to be overwritten.
     build_command.tools.os.environ = {"ANDROID_SDK_ROOT": "somewhere", "key": "value"}
@@ -125,10 +144,11 @@ def test_build_app_test_mode(
     build_command.tools.subprocess.run.assert_called_once_with(
         [
             build_command.bundle_path(first_app_generated) / gradlew_name,
-            "assembleDebug",
             "--console",
             "plain",
-        ],
+        ]
+        + (["--debug"] if debug_mode else [])
+        + ["assembleDebug"],
         cwd=build_command.bundle_path(first_app_generated),
         env=build_command.tools.android_sdk.env,
         check=True,

--- a/tests/platforms/android/gradle/test_build.py
+++ b/tests/platforms/android/gradle/test_build.py
@@ -69,7 +69,7 @@ def test_build_app(
     build_command.tools.host_os = host_os
     # Enable verbose tool logging
     if tool_debug_mode:
-        build_command.tools.logger.verbosity = 3
+        build_command.tools.logger.verbosity = 2
     # Create mock environment with `key`, which we expect to be preserved, and
     # `ANDROID_SDK_ROOT`, which we expect to be overwritten.
     build_command.tools.os.environ = {"ANDROID_SDK_ROOT": "somewhere", "key": "value"}
@@ -135,7 +135,7 @@ def test_build_app_test_mode(
     build_command.tools.host_os = host_os
     # Enable verbose tool logging
     if debug_mode:
-        build_command.tools.logger.verbosity = 3
+        build_command.tools.logger.verbosity = 2
     # Create mock environment with `key`, which we expect to be preserved, and
     # `ANDROID_SDK_ROOT`, which we expect to be overwritten.
     build_command.tools.os.environ = {"ANDROID_SDK_ROOT": "somewhere", "key": "value"}

--- a/tests/platforms/android/gradle/test_package__aab.py
+++ b/tests/platforms/android/gradle/test_package__aab.py
@@ -66,7 +66,7 @@ def test_execute_gradle(
 
     # Enable verbose tool logging
     if tool_debug_mode:
-        package_command.tools.logger.verbosity = 3
+        package_command.tools.logger.verbosity = 2
 
     # Set up a side effect of invoking gradle to create a bundle
     def create_bundle(*args, **kwargs):

--- a/tests/platforms/android/gradle/test_package__apk.py
+++ b/tests/platforms/android/gradle/test_package__apk.py
@@ -43,14 +43,20 @@ def test_distribution_path(package_command, first_app_apk, tmp_path):
 
 
 @pytest.mark.parametrize(
-    "host_os,gradlew_name",
-    [("Windows", "gradlew.bat"), ("NonWindows", "gradlew")],
+    "host_os, gradlew_name, tool_debug_mode",
+    [
+        ("Windows", "gradlew.bat", True),
+        ("Windows", "gradlew.bat", False),
+        ("NonWindows", "gradlew", True),
+        ("NonWindows", "gradlew", False),
+    ],
 )
 def test_execute_gradle(
     package_command,
     first_app_apk,
     host_os,
     gradlew_name,
+    tool_debug_mode,
     tmp_path,
 ):
     """Validate that package_app() will launch `gradlew bundleRelease` with the
@@ -58,6 +64,10 @@ def test_execute_gradle(
     `gradlew` elsewhere."""
     # Mock out `host_os` so we can validate which name is used for gradlew.
     package_command.tools.host_os = host_os
+
+    # Enable verbose tool logging
+    if tool_debug_mode:
+        package_command.tools.logger.verbosity = 3
 
     # Set up a side effect of invoking gradle to create a bundle
     def create_bundle(*args, **kwargs):
@@ -89,10 +99,11 @@ def test_execute_gradle(
     package_command.tools.subprocess.run.assert_called_once_with(
         [
             package_command.bundle_path(first_app_apk) / gradlew_name,
-            "assembleRelease",
             "--console",
             "plain",
-        ],
+        ]
+        + (["--debug"] if tool_debug_mode else [])
+        + ["assembleRelease"],
         cwd=package_command.bundle_path(first_app_apk),
         env=package_command.tools.android_sdk.env,
         check=True,

--- a/tests/platforms/android/gradle/test_package__debug_apk.py
+++ b/tests/platforms/android/gradle/test_package__debug_apk.py
@@ -67,7 +67,7 @@ def test_execute_gradle(
 
     # Enable verbose tool logging
     if tool_debug_mode:
-        package_command.tools.logger.verbosity = 3
+        package_command.tools.logger.verbosity = 2
 
     # Set up a side effect of invoking gradle to create a bundle
     def create_bundle(*args, **kwargs):

--- a/tests/platforms/iOS/xcode/test_build.py
+++ b/tests/platforms/iOS/xcode/test_build.py
@@ -30,7 +30,7 @@ def test_build_app(build_command, first_app_generated, tool_debug_mode, tmp_path
 
     # Enable verbose tool logging
     if tool_debug_mode:
-        build_command.tools.logger.verbosity = 3
+        build_command.tools.logger.verbosity = 2
 
     build_command.build_app(first_app_generated)
 

--- a/tests/platforms/iOS/xcode/test_build.py
+++ b/tests/platforms/iOS/xcode/test_build.py
@@ -20,12 +20,17 @@ def build_command(tmp_path):
     )
 
 
-def test_build_app(build_command, first_app_generated, tmp_path):
+@pytest.mark.parametrize("tool_debug_mode", (True, False))
+def test_build_app(build_command, first_app_generated, tool_debug_mode, tmp_path):
     """An iOS App can be built."""
     build_command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
 
     # Mock the host's CPU architecture to ensure it's reflected in the Xcode call
     build_command.tools.host_arch = "weird"
+
+    # Enable verbose tool logging
+    if tool_debug_mode:
+        build_command.tools.logger.verbosity = 3
 
     build_command.build_app(first_app_generated)
 
@@ -49,7 +54,7 @@ def test_build_app(build_command, first_app_generated, tmp_path):
             "weird",
             "-sdk",
             "iphonesimulator",
-            "-quiet",
+            "-verbose" if tool_debug_mode else "-quiet",
         ],
         check=True,
     )

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -155,7 +155,7 @@ def test_build_appimage(build_command, first_app, debug_mode, tmp_path, sub_stre
     """A Linux app can be packaged as an AppImage."""
     # Enable verbose tool logging
     if debug_mode:
-        build_command.tools.logger.verbosity = 3
+        build_command.tools.logger.verbosity = 2
 
     build_command.verify_app_tools(first_app)
     build_command.build_app(first_app)

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -150,8 +150,12 @@ def test_verify_tools_download_failure(build_command):
     assert build_command.build_app.call_count == 0
 
 
-def test_build_appimage(build_command, first_app, tmp_path, sub_stream_kw):
+@pytest.mark.parametrize("debug_mode", (True, False))
+def test_build_appimage(build_command, first_app, debug_mode, tmp_path, sub_stream_kw):
     """A Linux app can be packaged as an AppImage."""
+    # Enable verbose tool logging
+    if debug_mode:
+        build_command.tools.logger.verbosity = 3
 
     build_command.verify_app_tools(first_app)
     build_command.build_app(first_app)
@@ -166,6 +170,15 @@ def test_build_appimage(build_command, first_app, tmp_path, sub_stream_kw):
         / "appimage"
         / "First App.AppDir"
     )
+    expected_env = {
+        "PATH": "/usr/local/bin:/usr/bin:/path/to/somewhere",
+        "LINUXDEPLOY_OUTPUT_VERSION": "0.0.1",
+        "DISABLE_COPYRIGHT_FILES_DEPLOYMENT": "1",
+        "APPIMAGE_EXTRACT_AND_RUN": "1",
+        "ARCH": "wonky",
+    }
+    if debug_mode:
+        expected_env["DEBUG"] = "1"
     build_command._subprocess.Popen.assert_called_with(
         [
             os.fsdecode(
@@ -177,6 +190,7 @@ def test_build_appimage(build_command, first_app, tmp_path, sub_stream_kw):
             os.fsdecode(app_dir / "com.example.first-app.desktop"),
             "--output",
             "appimage",
+            "-v0" if debug_mode else "-v1",
             "--deploy-deps-only",
             os.fsdecode(app_dir / "usr" / "app" / "support"),
             "--deploy-deps-only",
@@ -184,13 +198,7 @@ def test_build_appimage(build_command, first_app, tmp_path, sub_stream_kw):
             "--deploy-deps-only",
             os.fsdecode(app_dir / "usr" / "app_packages" / "secondlib"),
         ],
-        env={
-            "PATH": "/usr/local/bin:/usr/bin:/path/to/somewhere",
-            "LINUXDEPLOY_OUTPUT_VERSION": "0.0.1",
-            "DISABLE_COPYRIGHT_FILES_DEPLOYMENT": "1",
-            "APPIMAGE_EXTRACT_AND_RUN": "1",
-            "ARCH": "wonky",
-        },
+        env=expected_env,
         cwd=os.fsdecode(
             tmp_path / "base_path" / "build" / "first-app" / "linux" / "appimage"
         ),
@@ -262,6 +270,7 @@ def test_build_appimage_with_plugin(build_command, first_app, tmp_path, sub_stre
             os.fsdecode(app_dir / "com.example.first-app.desktop"),
             "--output",
             "appimage",
+            "-v1",
             "--deploy-deps-only",
             os.fsdecode(app_dir / "usr" / "app" / "support"),
             "--deploy-deps-only",
@@ -344,6 +353,7 @@ def test_build_failure(build_command, first_app, tmp_path, sub_stream_kw):
             os.fsdecode(app_dir / "com.example.first-app.desktop"),
             "--output",
             "appimage",
+            "-v1",
             "--deploy-deps-only",
             os.fsdecode(app_dir / "usr" / "app" / "support"),
             "--deploy-deps-only",
@@ -433,6 +443,7 @@ def test_build_appimage_in_docker(build_command, first_app, tmp_path, sub_stream
             "/app/First App.AppDir/com.example.first-app.desktop",
             "--output",
             "appimage",
+            "-v1",
             "--deploy-deps-only",
             "/app/First App.AppDir/usr/app/support",
             "--deploy-deps-only",
@@ -557,6 +568,7 @@ def test_build_appimage_with_plugins_in_docker(
             "/app/First App.AppDir/com.example.first-app.desktop",
             "--output",
             "appimage",
+            "-v1",
             "--deploy-deps-only",
             "/app/First App.AppDir/usr/app/support",
             "--deploy-deps-only",
@@ -662,6 +674,7 @@ def test_build_appimage_with_support_package_update(
             os.fsdecode(app_dir / "com.example.first-app.desktop"),
             "--output",
             "appimage",
+            "-v1",
             "--deploy-deps-only",
             os.fsdecode(app_dir / "usr" / "app" / "support"),
             "--deploy-deps-only",

--- a/tests/platforms/macOS/xcode/test_build.py
+++ b/tests/platforms/macOS/xcode/test_build.py
@@ -24,7 +24,7 @@ def test_build_app(build_command, first_app_generated, tool_debug_mode, tmp_path
     """An macOS App can be built."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        build_command.tools.logger.verbosity = 3
+        build_command.tools.logger.verbosity = 2
 
     build_command.tools.subprocess = MagicMock(spec_set=Subprocess)
     build_command.build_app(first_app_generated, test_mode=False)

--- a/tests/platforms/macOS/xcode/test_build.py
+++ b/tests/platforms/macOS/xcode/test_build.py
@@ -19,8 +19,13 @@ def build_command(tmp_path):
     )
 
 
-def test_build_app(build_command, first_app_generated, tmp_path):
+@pytest.mark.parametrize("tool_debug_mode", (True, False))
+def test_build_app(build_command, first_app_generated, tool_debug_mode, tmp_path):
     """An macOS App can be built."""
+    # Enable verbose tool logging
+    if tool_debug_mode:
+        build_command.tools.logger.verbosity = 3
+
     build_command.tools.subprocess = MagicMock(spec_set=Subprocess)
     build_command.build_app(first_app_generated, test_mode=False)
 
@@ -35,7 +40,7 @@ def test_build_app(build_command, first_app_generated, tmp_path):
             / "macos"
             / "xcode"
             / "First App.xcodeproj",
-            "-quiet",
+            "-verbose" if tool_debug_mode else "-quiet",
             "-configuration",
             "Release",
             "build",

--- a/tests/platforms/windows/visualstudio/test_build.py
+++ b/tests/platforms/windows/visualstudio/test_build.py
@@ -46,8 +46,12 @@ def test_verify(build_command, monkeypatch):
     assert isinstance(build_command.tools.visualstudio, VisualStudio)
 
 
-def test_build_app(build_command, first_app_config, tmp_path):
+@pytest.mark.parametrize("tool_debug_mode", (True, False))
+def test_build_app(build_command, first_app_config, tool_debug_mode, tmp_path):
     """The solution will be compiled when the project is built."""
+    # Enable verbose tool logging
+    if tool_debug_mode:
+        build_command.tools.logger.verbosity = 3
 
     build_command.build_app(first_app_config)
 
@@ -62,6 +66,7 @@ def test_build_app(build_command, first_app_config, tmp_path):
                     "-property:RestorePackagesConfig=true",
                     "-target:First App",
                     "-property:Configuration=Release",
+                    "-verbosity:detailed" if tool_debug_mode else "-verbosity:normal",
                 ],
                 check=True,
                 cwd=tmp_path

--- a/tests/platforms/windows/visualstudio/test_build.py
+++ b/tests/platforms/windows/visualstudio/test_build.py
@@ -51,7 +51,7 @@ def test_build_app(build_command, first_app_config, tool_debug_mode, tmp_path):
     """The solution will be compiled when the project is built."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        build_command.tools.logger.verbosity = 3
+        build_command.tools.logger.verbosity = 2
 
     build_command.build_app(first_app_config)
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -101,7 +101,7 @@ def test_new_command(logger, console):
     assert cmd.platform == "all"
     assert cmd.output_format is None
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {"template": None, "template_branch": None}
@@ -150,7 +150,7 @@ def test_dev_command(monkeypatch, logger, console, cmdline, expected_options):
     assert cmd.platform == "macOS"
     assert cmd.output_format is None
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {
@@ -185,7 +185,7 @@ def test_run_command(monkeypatch, logger, console, cmdline, expected_options):
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {
@@ -212,7 +212,7 @@ def test_upgrade_command(monkeypatch, logger, console):
     assert cmd.platform == "macOS"
     assert cmd.output_format is None
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {
@@ -232,7 +232,7 @@ def test_bare_command(monkeypatch, logger, console):
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -248,7 +248,7 @@ def test_linux_default(logger, console):
     assert cmd.platform == "linux"
     assert cmd.output_format == "system"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -264,7 +264,7 @@ def test_macOS_default(logger, console):
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -280,7 +280,7 @@ def test_windows_default(logger, console):
     assert cmd.platform == "windows"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -343,7 +343,7 @@ def test_command_explicit_platform(monkeypatch, logger, console):
     assert cmd.platform == "linux"
     assert cmd.output_format == "system"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -361,7 +361,7 @@ def test_command_explicit_platform_case_handling(monkeypatch, logger, console):
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -397,7 +397,7 @@ def test_command_explicit_format(monkeypatch, logger, console):
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -463,7 +463,7 @@ def test_command_disable_input(monkeypatch, logger, console):
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert not cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -480,7 +480,7 @@ def test_command_options(monkeypatch, capsys, logger, console):
 
     assert isinstance(cmd, macOSAppPublishCommand)
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 1
+    assert cmd.logger.verbosity == 0
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {"channel": "s3"}


### PR DESCRIPTION
## Changes
- Ensure the name of distributable debug APKs have a different file name than release APKs.
- Verbose tool logging is now enabled with `-vv`
- Gradle builds
  - Enable (very verbose) debug logging via `--debug`
- linuxdeploy builds
  - Set `DEBUG=1` for plugin debug logging
  - Pass `-v0` to linuxdeploy for debug logging
- iOS
  - `xcodebuild` now runs with `-verbose`
- Flatpak
  - Calls to `flatpak` and `flatpak-builder` use `--verbose`
- macOS Xcode
  - `xcodebuild` now runs with `-verbose`
- Visual Studio
  - Runs `MSBuild` with `-verbosity:detailed`

## Notes
- Linux System package builds
  - Evaluated verbose logging for package builds....but there wasn't much value there
- ADB commands
  - `ADB_TRACE=all` can increase logging...but it breaks output parsing so omitted
  - If there's potential value here, I can look more deeply at this
- RCEdit
  - Doesn't seem to support additional logging....not sure if value anyway
- WiX
  - Verbose logging doesn't seem to add any value...mostly very cryptic messages from `light.exe`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
