### PR TITLE
Bump Android Command-line Tools from 6.0 to 9.0

### DIFF
--- a/changes/1397.feature.rst
+++ b/changes/1397.feature.rst
@@ -1,0 +1,1 @@
+The Android SDK's Command-Line Tools is now version 9.0. If an externally-managed Android SDK is being used, it must provide this version of Command-Line Tools. Use the SDK Manager in Android Studio to ensure it is installed.

--- a/docs/reference/platforms/android.rst
+++ b/docs/reference/platforms/android.rst
@@ -9,7 +9,9 @@ Gradle requires an install of the Android SDK and a Java 17 JDK.
 If you have an existing install of the Android SDK, it will be used by Briefcase
 if the ``ANDROID_HOME`` environment variable is set. If ``ANDROID_HOME`` is not
 present in the environment, Briefcase will honor the deprecated
-``ANDROID_SDK_ROOT`` environment variable.
+``ANDROID_SDK_ROOT`` environment variable. Additionally, an existing SDK install
+must have version 9.0 of Command-line Tools installed; this version can be
+installed in the SDK Manager in Android Studio.
 
 If you have an existing install of a Java 17 JDK, it will be used by Briefcase
 if the ``JAVA_HOME`` environment variable is set. On macOS, if ``JAVA_HOME`` is

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -413,7 +413,7 @@ Delete {cmdline_tools_zip_path} and run briefcase again.
                     if not self.tools.os.access(binpath, self.tools.os.X_OK):
                         binpath.chmod(0o755)
 
-        with self.tools.input.wait_bar("Removing Older Android SDK Packages..."):
+        with self.tools.input.wait_bar("Removing older Android SDK packages..."):
             self.cleanup_old_installs()
 
     def upgrade(self):

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -48,6 +48,7 @@ class AndroidSDK(ManagedTool):
     full_name = "Android SDK"
 
     # Latest version for Command-Line Tools download as of August 2023
+    # **Be sure the android.rst docs stay in sync with version updates here**
     SDK_MANAGER_DOWNLOAD_VER = "9477386"
     SDK_MANAGER_VER = "9.0"
 
@@ -275,7 +276,6 @@ class AndroidSDK(ManagedTool):
 """
                     )
             else:
-                sdk = None
                 tools.logger.warning(
                     f"""
 *************************************************************************
@@ -292,7 +292,7 @@ class AndroidSDK(ManagedTool):
     If {sdk_source_env} is an Android SDK, ensure it is the root directory
     of the Android SDK instance such that
 
-    ${sdk_source_env}/cmdline-tools/{cls.SDK_MANAGER_VER}/bin/sdkmanager
+    ${sdk_source_env}{os.sep}{sdk.sdkmanager_path.relative_to(sdk.root_path)}
 
     is a valid filepath.
 
@@ -301,6 +301,7 @@ class AndroidSDK(ManagedTool):
 *************************************************************************
 """
                 )
+                sdk = None
 
         # Verify Briefcase-managed Android SDK
         if sdk is None:
@@ -313,17 +314,18 @@ class AndroidSDK(ManagedTool):
 
                 sdk.delete_legacy_sdk_tools()
 
-                tools.logger.info(
-                    "Upgrading Android SDK..."
-                    if sdk.cmdline_tools_path.parent.exists()
-                    else "The Android SDK was not found; downloading and installing...",
-                    prefix=cls.name,
-                )
-                tools.logger.info(
-                    "To use an existing Android SDK instance, specify its root "
-                    "directory path in the ANDROID_HOME environment variable."
-                )
-                tools.logger.info()
+                if sdk.cmdline_tools_path.parent.exists():
+                    tools.logger.info("Upgrading Android SDK...", prefix=cls.name)
+                else:
+                    tools.logger.info(
+                        "The Android SDK was not found; downloading and installing...",
+                        prefix=cls.name,
+                    )
+                    tools.logger.info(
+                        "To use an existing Android SDK instance, specify its root "
+                        "directory path in the ANDROID_HOME environment variable."
+                    )
+                    tools.logger.info()
                 sdk.install()
 
         # Licences must be accepted to use the SDK

--- a/tests/integrations/android_sdk/AndroidSDK/test_properties.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_properties.py
@@ -5,6 +5,8 @@ import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
 
+from ..conftest import SDK_MGR_DL_VER, SDK_MGR_VER
+
 
 @pytest.mark.parametrize(
     "host_os, name",
@@ -20,7 +22,7 @@ def test_cmdline_tools_url(mock_tools, android_sdk, host_os, name):
     mock_tools.host_os = host_os
 
     assert android_sdk.cmdline_tools_url == (
-        f"https://dl.google.com/android/repository/commandlinetools-{name}-8092744_latest.zip"
+        f"https://dl.google.com/android/repository/commandlinetools-{name}-{SDK_MGR_DL_VER}_latest.zip"
     )
 
 
@@ -35,7 +37,7 @@ def test_sdkmanager_path(mock_tools, android_sdk, host_os, sdkmanager_name):
     mock_tools.host_os = host_os
 
     assert android_sdk.sdkmanager_path == (
-        android_sdk.root_path / "cmdline-tools" / "latest" / "bin" / sdkmanager_name
+        android_sdk.root_path / "cmdline-tools" / SDK_MGR_VER / "bin" / sdkmanager_name
     )
 
 
@@ -62,7 +64,7 @@ def test_avdmanager_path(mock_tools, android_sdk, host_os, avdmanager_name):
     mock_tools.host_os = host_os
 
     assert android_sdk.avdmanager_path == (
-        android_sdk.root_path / "cmdline-tools" / "latest" / "bin" / avdmanager_name
+        android_sdk.root_path / "cmdline-tools" / SDK_MGR_VER / "bin" / avdmanager_name
     )
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -16,6 +16,10 @@ from briefcase.integrations.base import ToolCache
 
 from ..conftest import SDK_MGR_DL_VER, SDK_MGR_VER
 
+SDKMANAGER_FILENAME = (
+    "sdkmanager.bat" if platform.system() == "Windows" else "sdkmanager"
+)
+
 
 @pytest.fixture
 def mock_tools(mock_tools) -> ToolCache:
@@ -24,6 +28,7 @@ def mock_tools(mock_tools) -> ToolCache:
     mock_tools.os.fsdecode = os.fsdecode
     mock_tools.os.access = os.access
     mock_tools.os.X_OK = os.X_OK
+    mock_tools.os.unlink = os.unlink
 
     # Identify the host platform
     mock_tools._test_download_tag = {
@@ -86,19 +91,11 @@ def test_succeeds_immediately_in_happy_path(mock_tools, tmp_path):
     # exists, verify() should succeed, create no subprocesses, make no requests, and
     # return an SDK wrapper.
 
-    # On Windows, this requires `sdkmanager.bat`; on non-Windows, it requires
-    # `sdkmanager`.
-
     # Create `sdkmanager` and the license file.
     android_sdk_root_path = tmp_path / "tools" / "android_sdk"
     tools_bin = android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
-    if platform.system() == "Windows":
-        sdk_manager = tools_bin / "sdkmanager.bat"
-        sdk_manager.touch()
-    else:
-        sdk_manager = tools_bin / "sdkmanager"
-        sdk_manager.touch(mode=0o755)
+    (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
     # Pre-accept the license
     accept_license(android_sdk_root_path)()
@@ -125,12 +122,7 @@ def test_user_provided_sdk(mock_tools, env_var, tmp_path, capsys):
     existing_android_sdk_root_path = tmp_path / "other_sdk"
     tools_bin = existing_android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
-    if platform.system() == "Windows":
-        sdk_manager = tools_bin / "sdkmanager.bat"
-        sdk_manager.touch()
-    else:
-        sdk_manager = tools_bin / "sdkmanager"
-        sdk_manager.touch(mode=0o755)
+    (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
     # Pre-accept the license
     accept_license(existing_android_sdk_root_path)()
@@ -169,12 +161,7 @@ def test_consistent_user_provided_sdk(mock_tools, tmp_path, capsys):
     existing_android_sdk_root_path = tmp_path / "other_sdk"
     tools_bin = existing_android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
-    if platform.system() == "Windows":
-        sdk_manager = tools_bin / "sdkmanager.bat"
-        sdk_manager.touch()
-    else:
-        sdk_manager = tools_bin / "sdkmanager"
-        sdk_manager.touch(mode=0o755)
+    (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
     # Pre-accept the license
     accept_license(existing_android_sdk_root_path)()
@@ -212,12 +199,7 @@ def test_inconsistent_user_provided_sdk(mock_tools, tmp_path, capsys):
     existing_android_sdk_root_path = tmp_path / "other_sdk"
     tools_bin = existing_android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
-    if platform.system() == "Windows":
-        sdk_manager = tools_bin / "sdkmanager.bat"
-        sdk_manager.touch()
-    else:
-        sdk_manager = tools_bin / "sdkmanager"
-        sdk_manager.touch(mode=0o755)
+    (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
     # Pre-accept the license
     accept_license(existing_android_sdk_root_path)()
@@ -247,18 +229,12 @@ def test_inconsistent_user_provided_sdk(mock_tools, tmp_path, capsys):
 @pytest.mark.parametrize("env_var", ["ANDROID_HOME", "ANDROID_SDK_ROOT"])
 def test_invalid_user_provided_sdk(mock_tools, env_var, tmp_path, capsys):
     """If the user's environment specifies an invalid Android SDK, it is ignored."""
-
     # Create `sdkmanager` and the license file
     # for the *briefcase* managed version of the SDK.
     android_sdk_root_path = tmp_path / "tools" / "android_sdk"
     tools_bin = android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
-    if platform.system() == "Windows":
-        sdk_manager = tools_bin / "sdkmanager.bat"
-        sdk_manager.touch()
-    else:
-        sdk_manager = tools_bin / "sdkmanager"
-        sdk_manager.touch(mode=0o755)
+    (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
     # Pre-accept the license
     accept_license(android_sdk_root_path)()
@@ -282,28 +258,26 @@ def test_invalid_user_provided_sdk(mock_tools, env_var, tmp_path, capsys):
 
 
 @pytest.mark.parametrize("env_var", ["ANDROID_HOME", "ANDROID_SDK_ROOT"])
-def test_invalid_user_provided_sdk_wrong_cmdline_tools_ver(
-    mock_tools, env_var, tmp_path, capsys
+def test_user_provided_sdk_wrong_cmdline_tools_ver(
+    mock_tools,
+    env_var,
+    tmp_path,
+    capsys,
 ):
     """If the user's environment specifies an Android SDK without the expected cmdline
-    tools, it is ignored."""
+    tools and the cmdline-tools install fails, the Briefcase SDK is used."""
     # Create `sdkmanager` and the license file for the *user's* version of the SDK
     user_sdk_path = tmp_path / "other_sdk"
-    users_tools_bin = user_sdk_path / "cmdline-tools" / "latest" / "bin"
-    users_tools_bin.mkdir(parents=True, mode=0o755)
-    if platform.system() == "Windows":
-        (users_tools_bin / "sdkmanager.bat").touch()
-    else:
-        (users_tools_bin / "sdkmanager").touch(mode=0o755)
+    user_tools_bin = user_sdk_path / "cmdline-tools" / "6.0" / "bin"
+    user_tools_bin.mkdir(parents=True, mode=0o755)
+    (user_tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
-    # Create `sdkmanager` and the license file for the *briefcase* managed version of the SDK
+    # Create `sdkmanager` and the license file
+    # for the *briefcase* managed version of the SDK.
     android_sdk_root_path = tmp_path / "tools" / "android_sdk"
     tools_bin = android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
-    if platform.system() == "Windows":
-        (tools_bin / "sdkmanager.bat").touch()
-    else:
-        (tools_bin / "sdkmanager").touch(mode=0o755)
+    (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
     # Pre-accept the license
     accept_license(android_sdk_root_path)()
@@ -311,19 +285,85 @@ def test_invalid_user_provided_sdk_wrong_cmdline_tools_ver(
     # Set the environment to specify an ANDROID_SDK_ROOT that doesn't exist
     mock_tools.os.environ = {env_var: os.fsdecode(user_sdk_path)}
 
+    # Mock `cmdline-tools/latest` directory not existing
+    mock_tools.subprocess.run.side_effect = OSError
+
     # Expect verify() to succeed
     sdk = AndroidSDK.verify(mock_tools)
 
-    # No calls to download, run or unpack anything.
+    # No calls to download and nothing unpacked
     mock_tools.download.file.assert_not_called()
-    mock_tools.subprocess.run.assert_not_called()
     mock_tools.shutil.unpack_archive.assert_not_called()
+
+    # Required Command-line Tools installed
+    mock_tools.subprocess.run.assert_called_once_with(
+        [
+            tmp_path
+            / "other_sdk"
+            / "cmdline-tools"
+            / "latest"
+            / "bin"
+            / SDKMANAGER_FILENAME,
+            f"cmdline-tools;{SDK_MGR_VER}",
+        ],
+        check=True,
+        stream_output=False,
+    )
 
     # The returned SDK has the expected root path.
     assert sdk.root_path == android_sdk_root_path
 
-    # User is informed about invalid env var setting
-    assert "Incompatible Command-Line Tools Version" in capsys.readouterr().out
+    # User is informed about failed install and invalid SDK
+    output = capsys.readouterr().out
+    assert f"Failed to install cmdline-tools;{SDK_MGR_VER}" in output
+    assert "Incompatible Command-Line Tools Version" in output
+
+
+@pytest.mark.parametrize("env_var", ["ANDROID_HOME", "ANDROID_SDK_ROOT"])
+def test_user_provided_sdk_with_latest_cmdline_tools(
+    mock_tools,
+    env_var,
+    tmp_path,
+    capsys,
+):
+    """If the user's environment specifies an Android SDK without the expected cmdline
+    tools, the required cmdline-tools is installed in to it."""
+    # Create `sdkmanager` and the license file for the *user's* version of the SDK
+    user_sdk_path = tmp_path / "other_sdk"
+    user_tools_bin = user_sdk_path / "cmdline-tools" / "latest" / "bin"
+    user_tools_bin.mkdir(parents=True, mode=0o755)
+    (user_tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
+
+    # Pre-accept the license
+    accept_license(user_sdk_path)()
+
+    # Set the environment to specify an ANDROID_SDK_ROOT that doesn't exist
+    mock_tools.os.environ = {env_var: os.fsdecode(user_sdk_path)}
+
+    # Expect verify() to succeed
+    sdk = AndroidSDK.verify(mock_tools)
+
+    # No calls to download and nothing unpacked
+    mock_tools.download.file.assert_not_called()
+    mock_tools.shutil.unpack_archive.assert_not_called()
+
+    # Required Command-line Tools installed
+    mock_tools.subprocess.run.assert_called_once_with(
+        [
+            tmp_path
+            / "other_sdk"
+            / "cmdline-tools"
+            / "latest"
+            / "bin"
+            / SDKMANAGER_FILENAME,
+            f"cmdline-tools;{SDK_MGR_VER}",
+        ],
+        check=True,
+        stream_output=False,
+    )
+
+    # The returned SDK has the expected root path.
+    assert sdk.root_path == user_sdk_path
 
 
 def test_consistent_invalid_user_provided_sdk(mock_tools, tmp_path, capsys):
@@ -335,12 +375,7 @@ def test_consistent_invalid_user_provided_sdk(mock_tools, tmp_path, capsys):
     android_sdk_root_path = tmp_path / "tools" / "android_sdk"
     tools_bin = android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
-    if platform.system() == "Windows":
-        sdk_manager = tools_bin / "sdkmanager.bat"
-        sdk_manager.touch()
-    else:
-        sdk_manager = tools_bin / "sdkmanager"
-        sdk_manager.touch(mode=0o755)
+    (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
     # Pre-accept the license
     accept_license(android_sdk_root_path)()
@@ -375,12 +410,7 @@ def test_inconsistent_invalid_user_provided_sdk(mock_tools, tmp_path, capsys):
     android_sdk_root_path = tmp_path / "tools" / "android_sdk"
     tools_bin = android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
-    if platform.system() == "Windows":
-        sdk_manager = tools_bin / "sdkmanager.bat"
-        sdk_manager.touch()
-    else:
-        sdk_manager = tools_bin / "sdkmanager"
-        sdk_manager.touch(mode=0o755)
+    (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
     # Pre-accept the license
     accept_license(android_sdk_root_path)()
@@ -408,7 +438,7 @@ def test_inconsistent_invalid_user_provided_sdk(mock_tools, tmp_path, capsys):
     assert "ANDROID_HOME does not point to an Android SDK" in output
 
 
-def test_download_sdk(mock_tools, tmp_path):
+def test_download_sdk(mock_tools, tmp_path, capsys):
     """If an SDK is not available, one will be downloaded."""
     android_sdk_root_path = tmp_path / "tools" / "android_sdk"
     cmdline_tools_base_path = android_sdk_root_path / "cmdline-tools"
@@ -459,6 +489,72 @@ def test_download_sdk(mock_tools, tmp_path):
 
     # The returned SDK has the expected root path.
     assert sdk.root_path == android_sdk_root_path
+
+    assert "The Android SDK was not found" in capsys.readouterr().out
+
+
+def test_upgrade_existing_sdk(mock_tools, tmp_path, capsys):
+    """An existing SDK is upgraded if the required version of cmdline-tools isn't
+    installed."""
+    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    cmdline_tools_base_path = android_sdk_root_path / "cmdline-tools"
+
+    # Mock an existing cmdline-tools install
+    (cmdline_tools_base_path / "latest").mkdir(parents=True)
+    (cmdline_tools_base_path / "8092744").touch()
+
+    # The download will produce a cached file.
+    cache_file = MagicMock()
+    mock_tools.download.file.return_value = cache_file
+
+    # Calling unpack will create files
+    mock_tools.shutil.unpack_archive.side_effect = mock_unpack
+
+    # Set up a side effect for accepting the license
+    mock_tools.subprocess.run.side_effect = accept_license(android_sdk_root_path)
+
+    # Call `verify()`
+    sdk = AndroidSDK.verify(mock_tools)
+
+    # Validate that the SDK was downloaded and unpacked
+    url = (
+        "https://dl.google.com/android/repository/"
+        f"commandlinetools-{mock_tools._test_download_tag}-{SDK_MGR_DL_VER}_latest.zip"
+    )
+    mock_tools.download.file.assert_called_once_with(
+        url=url,
+        download_path=mock_tools.base_path,
+        role="Android SDK Command-Line Tools",
+    )
+
+    mock_tools.shutil.unpack_archive.assert_called_once_with(
+        cache_file, extract_dir=cmdline_tools_base_path
+    )
+
+    # The cached file will be deleted
+    cache_file.unlink.assert_called_once_with()
+
+    # The commandline tools path exists
+    assert sdk.cmdline_tools_path.is_dir()
+
+    if platform.system() != "Windows":
+        # On non-Windows, ensure the unpacked binary was made executable
+        assert os.access(
+            cmdline_tools_base_path / SDK_MGR_VER / "bin" / "sdkmanager",
+            os.X_OK,
+        )
+
+    # The license has been accepted
+    assert (android_sdk_root_path / "licenses" / "android-sdk-license").exists()
+
+    # The returned SDK has the expected root path.
+    assert sdk.root_path == android_sdk_root_path
+
+    # Ensure old cmdline-tools installs are cleaned up
+    assert not (cmdline_tools_base_path / "latest").exists()
+    assert not (cmdline_tools_base_path / "8092744").exists()
+
+    assert "Upgrading Android SDK..." in capsys.readouterr().out
 
 
 def test_download_sdk_legacy_install(mock_tools, tmp_path):

--- a/tests/integrations/android_sdk/conftest.py
+++ b/tests/integrations/android_sdk/conftest.py
@@ -9,6 +9,10 @@ from briefcase.integrations.download import Download
 from briefcase.integrations.java import JDK
 from briefcase.integrations.subprocess import Subprocess
 
+# current versions of Android SDK Manager
+SDK_MGR_VER = "9.0"
+SDK_MGR_DL_VER = "9477386"
+
 
 @pytest.fixture
 def mock_tools(mock_tools, tmp_path) -> ToolCache:

--- a/tests/platforms/android/gradle/test_open.py
+++ b/tests/platforms/android/gradle/test_open.py
@@ -7,6 +7,7 @@ import pytest
 
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
+from briefcase.integrations.android_sdk import AndroidSDK
 from briefcase.integrations.download import Download
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.android.gradle import GradleOpenCommand
@@ -21,7 +22,7 @@ def create_sdk_manager(tmp_path, extension=""):
         / "tools"
         / "android_sdk"
         / "cmdline-tools"
-        / "latest"
+        / AndroidSDK.SDK_MANAGER_VER
         / "bin"
         / f"sdkmanager{extension}",
         "Android SDK manager",

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -542,7 +542,7 @@ def test_log_file_extra(run_command, monkeypatch):
     run_command.tools.logger.save_log = True
     run_command.tools.logger.save_log_to_file(run_command)
 
-    sdk_manager = "/path/to/android_sdk/cmdline-tools/latest/bin/sdkmanager"
+    sdk_manager = f"/path/to/android_sdk/cmdline-tools/{AndroidSDK.SDK_MANAGER_VER}/bin/sdkmanager"
     if platform.system() == "Windows":
         sdk_manager += ".bat"
     run_command.tools.subprocess.check_output.assert_called_once_with(


### PR DESCRIPTION
## Changes
- The version of the Android Command-line Tools is bumped from 6.0 to 9.0
- Previously, Android's Command-line Tools were installed into `cmdline-tools/latest` by Briefcase.
- However, the SDK supports a versioned layout for installed packages. To take advantage of this, the Command-line Tools are now installed in to `cmdline-tools/9.0` in the Briefcase data directory.
- This also ensures that user SDKs are providing the same version of Command-line Tools as Briefcase installs.
- If an externally managed SDK doesn't have Command-line Tools version 9.0, it will be installed in to the SDK using the `latest` version of Command-line Tools.
  - If `latest` version isn't installed, the user is warned and the Briefcase-managed SDK is used.
  - This is especially necessary for CI because while GitHub has version 9.0 installed, it is installed as `latest`

## Notes
- Initial discussion: https://github.com/beeware/briefcase/pull/1360#discussion_r1278764413

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct