### PR TITLE
Move command-line args out of dev-mode Python invocation

### DIFF
--- a/changes/1413.bugfix.rst
+++ b/changes/1413.bugfix.rst
@@ -1,0 +1,1 @@
+The command line arguments used to configure the Python environment for ``briefcase dev`` no longer leak into the runtime environment on macOS.

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -18,6 +18,25 @@ class DevCommand(RunAppMixin, BaseCommand):
     output_format = None
     description = "Run a Briefcase project in the dev environment."
 
+    # On macOS CoreFoundation/NSApplication will do its own independent parsing of argc/argv.
+    # This means that whatever we pass to the Python interpreter on start-up will also be
+    # visible to NSApplication which will interpret things like `-u` (used to make I/O
+    # unbuffered in CPython) as `-u [URL]` (a request to open a document by URL). This is,
+    # rather patently, Not Good.
+    # To avoid this causing unwanted hilarity, we use environment variables to configure the
+    # Python interpreter rather than command-line options.
+    DEV_ENVIRONMENT = {
+        # Equivalent of passing "-u"
+        "PYTHONUNBUFFERED": "1",
+        # Equivalent of passing "-X dev"
+        "PYTHONMALLOC": "debug",
+        "PYTHONASYNCIODEBUG": "1",
+        "PYTHONFAULTHANDLER": "1",
+        "PYTHONWARNINGS": "default",
+        # Equivalent of passing "-X utf8"
+        "PYTHONUTF8": "1",
+    }
+
     @property
     def platform(self):
         """The dev command always reports as the local platform."""
@@ -104,14 +123,13 @@ class DevCommand(RunAppMixin, BaseCommand):
         :param passthrough: A list of arguments to pass to the app
         """
         main_module = app.main_module(test_mode)
+
+        # Add in the environment settings to get Python in the state we want.
+        env.update(self.DEV_ENVIRONMENT)
+
         app_popen = self.tools.subprocess.Popen(
             [
                 sys.executable,
-                "-u",
-                "-X",
-                "dev",
-                "-X",
-                "utf8",
                 "-c",
                 (
                     "import runpy, sys;"

--- a/tests/commands/dev/conftest.py
+++ b/tests/commands/dev/conftest.py
@@ -11,6 +11,8 @@ from briefcase.integrations.subprocess import Subprocess
 @pytest.fixture
 def dev_command(tmp_path):
     command = DevCommand(logger=Log(), console=Console(), base_path=tmp_path)
+    command.DEV_ENVIRONMENT.clear()
+    command.DEV_ENVIRONMENT["PYTHONSTUBSETTING"] = "23"
     command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
     return command
 

--- a/tests/commands/dev/test_run_dev_app.py
+++ b/tests/commands/dev/test_run_dev_app.py
@@ -15,14 +15,13 @@ def test_dev_run(dev_command, first_app, tmp_path):
         test_mode=False,
         passthrough=[],
     )
+
+    expected_env = {"a": 1, "b": 2, "c": 3}
+    expected_env.update(dev_command.DEV_ENVIRONMENT)
+
     dev_command.tools.subprocess.Popen.assert_called_once_with(
         [
             sys.executable,
-            "-u",
-            "-X",
-            "dev",
-            "-X",
-            "utf8",
             "-c",
             (
                 "import runpy, sys;"
@@ -31,7 +30,7 @@ def test_dev_run(dev_command, first_app, tmp_path):
                 'runpy.run_module("first", run_name="__main__", alter_sys=True)'
             ),
         ],
-        env={"a": 1, "b": 2, "c": 3},
+        env=expected_env,
         cwd=dev_command.tools.home_path,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -57,14 +56,13 @@ def test_dev_run_with_args(dev_command, first_app, tmp_path):
         test_mode=False,
         passthrough=["foo", "bar", "--whiz"],
     )
+
+    expected_env = {"a": 1, "b": 2, "c": 3}
+    expected_env.update(dev_command.DEV_ENVIRONMENT)
+
     dev_command.tools.subprocess.Popen.assert_called_once_with(
         [
             sys.executable,
-            "-u",
-            "-X",
-            "dev",
-            "-X",
-            "utf8",
             "-c",
             (
                 "import runpy, sys;"
@@ -73,7 +71,7 @@ def test_dev_run_with_args(dev_command, first_app, tmp_path):
                 'runpy.run_module("first", run_name="__main__", alter_sys=True)'
             ),
         ],
-        env={"a": 1, "b": 2, "c": 3},
+        env=expected_env,
         cwd=dev_command.tools.home_path,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -99,14 +97,13 @@ def test_dev_test_mode(dev_command, first_app, tmp_path):
         test_mode=True,
         passthrough=[],
     )
+
+    expected_env = {"a": 1, "b": 2, "c": 3}
+    expected_env.update(dev_command.DEV_ENVIRONMENT)
+
     dev_command.tools.subprocess.Popen.assert_called_once_with(
         [
             sys.executable,
-            "-u",
-            "-X",
-            "dev",
-            "-X",
-            "utf8",
             "-c",
             (
                 "import runpy, sys;"
@@ -115,7 +112,7 @@ def test_dev_test_mode(dev_command, first_app, tmp_path):
                 'runpy.run_module("tests.first", run_name="__main__", alter_sys=True)'
             ),
         ],
-        env={"a": 1, "b": 2, "c": 3},
+        env=expected_env,
         cwd=dev_command.tools.home_path,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -141,14 +138,13 @@ def test_dev_test_mode_with_args(dev_command, first_app, tmp_path):
         test_mode=True,
         passthrough=["foo", "bar", "--whiz"],
     )
+
+    expected_env = {"a": 1, "b": 2, "c": 3}
+    expected_env.update(dev_command.DEV_ENVIRONMENT)
+
     dev_command.tools.subprocess.Popen.assert_called_once_with(
         [
             sys.executable,
-            "-u",
-            "-X",
-            "dev",
-            "-X",
-            "utf8",
             "-c",
             (
                 "import runpy, sys;"
@@ -157,7 +153,7 @@ def test_dev_test_mode_with_args(dev_command, first_app, tmp_path):
                 'runpy.run_module("tests.first", run_name="__main__", alter_sys=True)'
             ),
         ],
-        env={"a": 1, "b": 2, "c": 3},
+        env=expected_env,
         cwd=dev_command.tools.home_path,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
For some reason NSApplication/CoreFoundation gets very confused if we pass certain command-line arguments to the outer Python interpreter when running in dev mode.

This patch removes all command-line arguments from the invocation, using environment variables to achieve the equivalent outcomes. The remaining argument, the actual code to start the application, appears to not cause problems.