### PR TITLE
Bump tox from 4.10.0 to 4.11.0

### DIFF
--- a/changes/1426.misc.rst
+++ b/changes/1426.misc.rst
@@ -1,0 +1,1 @@
+Updated tox from 4.10.0 to 4.11.0.

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ dev =
     pytest == 7.4.0
     pytest-xdist == 3.3.1
     setuptools_scm[toml] == 7.1.0
-    tox == 4.10.0
+    tox == 4.11.0
 docs =
     furo == 2023.8.19
     pyenchant == 3.2.2


### PR DESCRIPTION
## Changes
- `tox` is failing RTD builds for some reason; bump to 4.11.0

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
