### PR TITLE
Simplify environmental definition of dev mode.

### DIFF
--- a/changes/1427.misc.rst
+++ b/changes/1427.misc.rst
@@ -1,0 +1,1 @@
+The mechanism of invoking dev mode with environment variables was simplified.

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -29,10 +29,7 @@ class DevCommand(RunAppMixin, BaseCommand):
         # Equivalent of passing "-u"
         "PYTHONUNBUFFERED": "1",
         # Equivalent of passing "-X dev"
-        "PYTHONMALLOC": "debug",
-        "PYTHONASYNCIODEBUG": "1",
-        "PYTHONFAULTHANDLER": "1",
-        "PYTHONWARNINGS": "default",
+        "PYTHONDEVMODE": "1",
         # Equivalent of passing "-X utf8"
         "PYTHONUTF8": "1",
     }

--- a/tests/commands/dev/conftest.py
+++ b/tests/commands/dev/conftest.py
@@ -11,8 +11,6 @@ from briefcase.integrations.subprocess import Subprocess
 @pytest.fixture
 def dev_command(tmp_path):
     command = DevCommand(logger=Log(), console=Console(), base_path=tmp_path)
-    command.DEV_ENVIRONMENT.clear()
-    command.DEV_ENVIRONMENT["PYTHONSTUBSETTING"] = "23"
     command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
     return command
 

--- a/tests/commands/dev/test_run_dev_app.py
+++ b/tests/commands/dev/test_run_dev_app.py
@@ -16,9 +16,6 @@ def test_dev_run(dev_command, first_app, tmp_path):
         passthrough=[],
     )
 
-    expected_env = {"a": 1, "b": 2, "c": 3}
-    expected_env.update(dev_command.DEV_ENVIRONMENT)
-
     dev_command.tools.subprocess.Popen.assert_called_once_with(
         [
             sys.executable,
@@ -30,7 +27,14 @@ def test_dev_run(dev_command, first_app, tmp_path):
                 'runpy.run_module("first", run_name="__main__", alter_sys=True)'
             ),
         ],
-        env=expected_env,
+        env={
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "PYTHONUNBUFFERED": "1",
+            "PYTHONDEVMODE": "1",
+            "PYTHONUTF8": "1",
+        },
         cwd=dev_command.tools.home_path,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -57,9 +61,6 @@ def test_dev_run_with_args(dev_command, first_app, tmp_path):
         passthrough=["foo", "bar", "--whiz"],
     )
 
-    expected_env = {"a": 1, "b": 2, "c": 3}
-    expected_env.update(dev_command.DEV_ENVIRONMENT)
-
     dev_command.tools.subprocess.Popen.assert_called_once_with(
         [
             sys.executable,
@@ -71,7 +72,14 @@ def test_dev_run_with_args(dev_command, first_app, tmp_path):
                 'runpy.run_module("first", run_name="__main__", alter_sys=True)'
             ),
         ],
-        env=expected_env,
+        env={
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "PYTHONUNBUFFERED": "1",
+            "PYTHONDEVMODE": "1",
+            "PYTHONUTF8": "1",
+        },
         cwd=dev_command.tools.home_path,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -98,9 +106,6 @@ def test_dev_test_mode(dev_command, first_app, tmp_path):
         passthrough=[],
     )
 
-    expected_env = {"a": 1, "b": 2, "c": 3}
-    expected_env.update(dev_command.DEV_ENVIRONMENT)
-
     dev_command.tools.subprocess.Popen.assert_called_once_with(
         [
             sys.executable,
@@ -112,7 +117,14 @@ def test_dev_test_mode(dev_command, first_app, tmp_path):
                 'runpy.run_module("tests.first", run_name="__main__", alter_sys=True)'
             ),
         ],
-        env=expected_env,
+        env={
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "PYTHONUNBUFFERED": "1",
+            "PYTHONDEVMODE": "1",
+            "PYTHONUTF8": "1",
+        },
         cwd=dev_command.tools.home_path,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -139,9 +151,6 @@ def test_dev_test_mode_with_args(dev_command, first_app, tmp_path):
         passthrough=["foo", "bar", "--whiz"],
     )
 
-    expected_env = {"a": 1, "b": 2, "c": 3}
-    expected_env.update(dev_command.DEV_ENVIRONMENT)
-
     dev_command.tools.subprocess.Popen.assert_called_once_with(
         [
             sys.executable,
@@ -153,7 +162,14 @@ def test_dev_test_mode_with_args(dev_command, first_app, tmp_path):
                 'runpy.run_module("tests.first", run_name="__main__", alter_sys=True)'
             ),
         ],
-        env=expected_env,
+        env={
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "PYTHONUNBUFFERED": "1",
+            "PYTHONDEVMODE": "1",
+            "PYTHONUTF8": "1",
+        },
         cwd=dev_command.tools.home_path,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
#1413 altered the invocation of dev mode to use environment variables, rather than command line arguments, so as to avoid conflicts on macOS with the interpretation of `open` command line arguments.

A [post-merge review](https://github.com/beeware/briefcase/pull/1413#discussion_r1300037920) identified a potential simplification; this implements that simplification.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
