### PR TITLE
Link FAQ to specific issue trackers for mobile package requests

### DIFF
--- a/changes/1433.misc.rst
+++ b/changes/1433.misc.rst
@@ -1,0 +1,1 @@
+Link FAQ to specific issue trackers for mobile package requests

--- a/docs/background/faq.rst
+++ b/docs/background/faq.rst
@@ -35,7 +35,6 @@ with Briefcase by testing for the existence of the ``Briefcase-Version`` tag::
 
     in_briefcase = 'Briefcase-Version' in metadata
 
-
 Can I use third-party Python packages in my app?
 ------------------------------------------------
 
@@ -54,10 +53,9 @@ are hosted on the `Chaquopy package index <https://chaquo.com/pypi-7.0/>`__; iOS
 binary wheels are available on the `BeeWare repository on anaconda.org
 <https://anaconda.org/beeware/repo>`__.
 
-The Android and iOS repositories do not have binary wheels for *every* package
-that is on PyPI. If you experience problems when building or running an app on a
-mobile platform that appear to be related to a missing dependency, check the
-build logs for your app. If you see:
+However, the Android and iOS repositories do not have binary wheels for *every* package
+that needs them. If you see any of the following messages when building an app for a
+mobile platform, then the package (or this version of it) probably isn't supported yet:
 
 * On Android: the error `"Chaquopy cannot compile native code"
   <https://chaquo.com/chaquopy/doc/current/faq.html#chaquopy-cannot-compile-native-code>`__
@@ -65,7 +63,7 @@ build logs for your app. If you see:
 * A reference to downloading a ``.tar.gz`` version of the package
 * A reference to ``Building wheels for collected packages: <package>``
 
-The binary dependency isn't supported on mobile. Binary mobile packages are
-currently maintained by the BeeWare team; if you have a particular third-party
-package that you'd like us to support, `open a ticket
-<https://github.com/beeware/briefcase>`__ providing details.
+Binary mobile packages are currently maintained by the BeeWare team. If you have a
+particular package that you'd like us to support, please visit the issue tracker for
+`Android <https://github.com/chaquo/chaquopy/issues>`__ or `iOS
+<https://github.com/freakboy3742/chaquopy/issues>`__.


### PR DESCRIPTION
Rather than cluttering the Briefcase issue tracker with mobile package requests, we should direct people to [chaquo/chaquopy](https://github.com/chaquo/chaquopy/issues) and [freakboy3742/chaquopy](https://github.com/freakboy3742/chaquopy/issues).

Sometimes such a request actually indicates a problem with a packaging tool (Briefcase, Chaquopy or pip). Or sometimes the user's problem can be solved in some other way, such as by reducing the version of a requirement.

In all other cases, I post a [stock response](https://github.com/chaquo/chaquopy/issues/869#issuecomment-1542771592), and add a thumbs up button to the original post to encourage people to use that instead of spamming "+1" comments.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
