### PR TITLE
Remove finally block exit coverage exclusion

### DIFF
--- a/changes/1429.misc.rst
+++ b/changes/1429.misc.rst
@@ -1,0 +1,1 @@
+The coverage exclusion for a finally block exit was removed after the issue was fixed upstream.

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -575,8 +575,7 @@ password:
         finally:
             # Clean up house; we don't need the archive anymore.
             if archive_filename != filename:
-                # coverage exclusion required for https://github.com/python/cpython/issues/105658
-                self.tools.os.unlink(archive_filename)  # no-cover-if-is-py312
+                self.tools.os.unlink(archive_filename)
 
         try:
             self.logger.info()


### PR DESCRIPTION
## Changes
- Fixes #1429

## Notes
- Tested on a fresh build of Python 3.12 with https://github.com/python/cpython/commit/3eae45f94da5b9cdc5aa14844d48871ab85bd537
- Waiting on Python 3.12.0 release

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
