### PR TITLE
Fail CI if a default encoding is used

### DIFF
--- a/changes/1454.misc.rst
+++ b/changes/1454.misc.rst
@@ -1,0 +1,1 @@
+Explicit encodings are now enforced in CI.

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ install_requires =
     # cause API breakages). If the package uses calver, we don't pin the upper
     # version, as the upper version provides no basis for determining API
     # stability.
-    cookiecutter >= 2.2, < 3.0
+    cookiecutter >= 2.3.1, < 3.0
     dmgbuild >= 1.6, < 2.0; sys_platform == "darwin"
     GitPython >= 3.1, < 4.0
     platformdirs >= 2.6, < 4.0

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1225,7 +1225,7 @@ In future, you can specify this device by running:
         # Parse the existing config into key-value pairs
         avd_config = {}
         try:
-            with self.avd_config_filename(avd).open("r") as f:
+            with self.avd_config_filename(avd).open("r", encoding="utf-8") as f:
                 for line in f:
                     try:
                         key, value = line.rstrip().split("=", 1)
@@ -1252,7 +1252,7 @@ In future, you can specify this device by running:
         avd_config.update(updates)
 
         # Write the update configuration.
-        with self.avd_config_filename(avd).open("w") as f:
+        with self.avd_config_filename(avd).open("w", encoding="utf-8") as f:
             for key, value in avd_config.items():
                 f.write(f"{key}={value}\n")
 

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -708,7 +708,7 @@ with your app's licensing terms.
         with self.input.wait_bar("Installing changelog..."):
             changelog = self.base_path / "CHANGELOG"
             if changelog.is_file():
-                with changelog.open() as infile:
+                with changelog.open(encoding="utf-8") as infile:
                     outfile = gzip.GzipFile(
                         doc_folder / "changelog.gz", mode="wb", mtime=0
                     )
@@ -738,7 +738,7 @@ with details about the release.
         with self.input.wait_bar("Installing man page..."):
             manpage_source = self.bundle_path(app) / f"{app.app_name}.1"
             if manpage_source.is_file():
-                with manpage_source.open() as infile:
+                with manpage_source.open(encoding="utf-8") as infile:
                     outfile = gzip.GzipFile(
                         man_folder / f"{app.app_name}.1.gz", mode="wb", mtime=0
                     )

--- a/tests/commands/create/test_create_app.py
+++ b/tests/commands/create/test_create_app.py
@@ -37,7 +37,7 @@ def test_create_existing_app_overwrite(tracking_create_command, tmp_path):
     # Generate an app in the location.
     bundle_path = tmp_path / "base_path" / "build" / "first" / "tester" / "dummy"
     bundle_path.mkdir(parents=True)
-    with (bundle_path / "original").open("w") as f:
+    with (bundle_path / "original").open("w", encoding="utf-8") as f:
         f.write("original template!")
 
     tracking_create_command.create_app(tracking_create_command.apps["first"])
@@ -73,7 +73,7 @@ def test_create_existing_app_no_overwrite(tracking_create_command, tmp_path):
 
     bundle_path = tmp_path / "base_path" / "build" / "first" / "tester" / "dummy"
     bundle_path.mkdir(parents=True)
-    with (bundle_path / "original").open("w") as f:
+    with (bundle_path / "original").open("w", encoding="utf-8") as f:
         f.write("original template!")
     tracking_create_command.create_app(tracking_create_command.apps["first"])
 
@@ -99,7 +99,7 @@ def test_create_existing_app_no_overwrite_default(tracking_create_command, tmp_p
 
     bundle_path = tmp_path / "base_path" / "build" / "first" / "tester" / "dummy"
     bundle_path.mkdir(parents=True)
-    with (bundle_path / "original").open("w") as f:
+    with (bundle_path / "original").open("w", encoding="utf-8") as f:
         f.write("original template!")
 
     tracking_create_command.create_app(tracking_create_command.apps["first"])
@@ -126,7 +126,7 @@ def test_create_existing_app_input_disabled(tracking_create_command, tmp_path):
 
     bundle_path = tmp_path / "base_path" / "build" / "first" / "tester" / "dummy"
     bundle_path.mkdir(parents=True)
-    with (bundle_path / "original").open("w") as f:
+    with (bundle_path / "original").open("w", encoding="utf-8") as f:
         f.write("original template!")
 
     tracking_create_command.create_app(tracking_create_command.apps["first"])

--- a/tests/commands/create/test_install_app_code.py
+++ b/tests/commands/create/test_install_app_code.py
@@ -237,17 +237,17 @@ def test_no_existing_app_folder(
 
     # All the new sources exist, and contain the new content.
     assert (app_path / "demo.py").exists()
-    with (app_path / "demo.py").open() as f:
+    with (app_path / "demo.py").open(encoding="utf-8") as f:
         assert f.read() == "print('hello first')\n"
 
     assert (app_path / "second").exists()
     assert (app_path / "second" / "shallow.py").exists()
-    with (app_path / "second" / "shallow.py").open() as f:
+    with (app_path / "second" / "shallow.py").open(encoding="utf-8") as f:
         assert f.read() == "print('hello shallow second')\n"
 
     assert (app_path / "second" / "submodule").exists()
     assert (app_path / "second" / "submodule" / "deeper.py").exists()
-    with (app_path / "second" / "submodule" / "deeper.py").open() as f:
+    with (app_path / "second" / "submodule" / "deeper.py").open(encoding="utf-8") as f:
         assert f.read() == "print('hello deep second')\n"
 
     # The stale/broken modules have been removed.
@@ -340,17 +340,17 @@ def test_replace_sources(
 
     # All the new sources exist, and contain the new content.
     assert (app_path / "demo.py").exists()
-    with (app_path / "demo.py").open() as f:
+    with (app_path / "demo.py").open(encoding="utf-8") as f:
         assert f.read() == "print('hello first')\n"
 
     assert (app_path / "second").exists()
     assert (app_path / "second" / "shallow.py").exists()
-    with (app_path / "second" / "shallow.py").open() as f:
+    with (app_path / "second" / "shallow.py").open(encoding="utf-8") as f:
         assert f.read() == "print('hello shallow second')\n"
 
     assert (app_path / "second" / "submodule").exists()
     assert (app_path / "second" / "submodule" / "deeper.py").exists()
-    with (app_path / "second" / "submodule" / "deeper.py").open() as f:
+    with (app_path / "second" / "submodule" / "deeper.py").open(encoding="utf-8") as f:
         assert f.read() == "print('hello deep second')\n"
 
     # The stale/broken modules have been removed.

--- a/tests/commands/create/test_install_app_requirements.py
+++ b/tests/commands/create/test_install_app_requirements.py
@@ -31,10 +31,11 @@ def create_installation_artefacts(app_packages_path, packages):
 
     def _create_installation_artefacts(*args, **kwargs):
         for package in packages:
-            (app_packages_path / package).mkdir(parents=True)
-            with (app_packages_path / package / "__init__.py").open("w") as f:
+            package_path = app_packages_path / package
+            package_path.mkdir(parents=True)
+            with (package_path / "__init__.py").open("w", encoding="utf-8") as f:
                 f.write("")
-            with (app_packages_path / package / "__main__.py").open("w") as f:
+            with (package_path / "__main__.py").open("w", encoding="utf-8") as f:
                 f.write('print("I am {package}")')
 
     return _create_installation_artefacts
@@ -463,7 +464,7 @@ def test_app_requirements_no_requires(
 
     # requirements.txt doesn't exist either
     assert app_requirements_path.exists()
-    with app_requirements_path.open() as f:
+    with app_requirements_path.open(encoding="utf-8") as f:
         assert f.read() == ""
 
     # Original app definitions haven't changed
@@ -486,7 +487,7 @@ def test_app_requirements_empty_requires(
 
     # requirements.txt doesn't exist either
     assert app_requirements_path.exists()
-    with app_requirements_path.open() as f:
+    with app_requirements_path.open(encoding="utf-8") as f:
         assert f.read() == ""
 
     # Original app definitions haven't changed
@@ -509,7 +510,7 @@ def test_app_requirements_requires(
 
     # requirements.txt doesn't exist either
     assert app_requirements_path.exists()
-    with app_requirements_path.open() as f:
+    with app_requirements_path.open(encoding="utf-8") as f:
         assert f.read() == "first\nsecond==1.2.3\nthird>=3.2.1\n"
 
     # Original app definitions haven't changed
@@ -555,7 +556,7 @@ def _test_app_requirements_paths(
     myapp.requires = ["first", requirement, "third"]
 
     create_command.install_app_requirements(myapp, test_mode=False)
-    with app_requirements_path.open() as f:
+    with app_requirements_path.open(encoding="utf-8") as f:
         assert f.read() == (
             "\n".join(
                 [

--- a/tests/commands/create/test_install_image.py
+++ b/tests/commands/create/test_install_image.py
@@ -46,7 +46,7 @@ def test_no_requested_size(create_command, tmp_path, capsys):
     # Create the source image
     source_file = tmp_path / "base_path" / "input" / "original.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
-    with source_file.open("w") as f:
+    with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
 
     # Try to install the image
@@ -100,7 +100,7 @@ def test_requested_size(create_command, tmp_path, capsys):
     # Create the source image
     source_file = tmp_path / "base_path" / "input" / "original-3742.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
-    with source_file.open("w") as f:
+    with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
 
     # Try to install the image
@@ -154,7 +154,7 @@ def test_variant_with_no_requested_size(create_command, tmp_path, capsys):
     # Create the source image
     source_file = tmp_path / "base_path" / "input" / "original.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
-    with source_file.open("w") as f:
+    with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
 
     # Try to install the image
@@ -190,7 +190,7 @@ def test_variant_without_variant_source_and_no_requested_size(
     # Create the source image
     source_file = tmp_path / "base_path" / "input" / "original.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
-    with source_file.open("w") as f:
+    with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
 
     # Try to install the image
@@ -218,7 +218,7 @@ def test_unknown_variant_with_no_requested_size(create_command, tmp_path, capsys
     # Create the source image
     source_file = tmp_path / "base_path" / "input" / "original.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
-    with source_file.open("w") as f:
+    with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
 
     # Try to install the image
@@ -248,7 +248,7 @@ def test_variant_with_size(create_command, tmp_path, capsys):
     # Create the source image
     source_file = tmp_path / "base_path" / "input" / "original-3742.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
-    with source_file.open("w") as f:
+    with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
 
     # Try to install the image
@@ -284,7 +284,7 @@ def test_variant_with_size_without_variants(create_command, tmp_path, capsys):
     # Create the source image
     source_file = tmp_path / "base_path" / "input" / "original-3742.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
-    with source_file.open("w") as f:
+    with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
 
     # Try to install the image
@@ -313,7 +313,7 @@ def test_unknown_variant_with_size(create_command, tmp_path, capsys):
     # Create the source image
     source_file = tmp_path / "base_path" / "input" / "original-3742.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
-    with source_file.open("w") as f:
+    with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
 
     # Try to install the image
@@ -343,7 +343,7 @@ def test_unsized_variant(create_command, tmp_path, capsys):
     # Create the source image
     source_file = tmp_path / "base_path" / "input" / "original.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
-    with source_file.open("w") as f:
+    with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
 
     # Try to install the image

--- a/tests/commands/dev/conftest.py
+++ b/tests/commands/dev/conftest.py
@@ -19,7 +19,7 @@ def dev_command(tmp_path):
 def first_app_uninstalled(tmp_path):
     # Make sure the source code exists
     (tmp_path / "src" / "first").mkdir(parents=True, exist_ok=True)
-    with (tmp_path / "src" / "first" / "__init__.py").open("w") as f:
+    with (tmp_path / "src" / "first" / "__init__.py").open("w", encoding="UTF-8") as f:
         f.write('print("Hello world")')
 
     return AppConfig(
@@ -43,7 +43,7 @@ def first_app(tmp_path, first_app_uninstalled):
 def second_app(tmp_path):
     # Make sure the source code exists
     (tmp_path / "src" / "second").mkdir(parents=True, exist_ok=True)
-    with (tmp_path / "src" / "second" / "__init__.py").open("w") as f:
+    with (tmp_path / "src" / "second" / "__init__.py").open("w", encoding="UTF-8") as f:
         f.write('print("Hello world")')
 
     # Create the dist-info folder
@@ -62,7 +62,7 @@ def second_app(tmp_path):
 def third_app(tmp_path):
     # Make sure the source code exists
     (tmp_path / "src" / "third").mkdir(parents=True, exist_ok=True)
-    with (tmp_path / "src" / "third" / "__init__.py").open("w") as f:
+    with (tmp_path / "src" / "third" / "__init__.py").open("w", encoding="UTF-8") as f:
         f.write('print("Hello world")')
 
     # Create the dist-info folder

--- a/tests/integrations/android_sdk/ADB/test_run.py
+++ b/tests/integrations/android_sdk/ADB/test_run.py
@@ -67,7 +67,7 @@ def test_error_handling(mock_tools, adb, name, exception, tmp_path):
     """ADB.run() can parse errors returned by adb."""
     # Set up a mock command with a subprocess module that has with sample data loaded.
     adb_samples = Path(__file__).parent / "adb_errors"
-    with (adb_samples / (name + ".out")).open("r") as adb_output_file:
+    with (adb_samples / (name + ".out")).open("r", encoding="utf-8") as adb_output_file:
         with (adb_samples / (name + ".returncode")).open(
             encoding="utf-8"
         ) as returncode_file:

--- a/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
@@ -67,7 +67,7 @@ def test_create_emulator(
         tmp_path / "home" / ".android" / "avd" / "new-emulator.avd" / "config.ini"
     )
     avd_config_path.parent.mkdir(parents=True)
-    with avd_config_path.open("w") as f:
+    with avd_config_path.open("w", encoding="utf-8") as f:
         f.write("hw.device.name=pixel\n")
 
     # Create the emulator
@@ -106,7 +106,7 @@ def test_create_emulator(
     )
 
     # Emulator configuration file has been appended.
-    with avd_config_path.open() as f:
+    with avd_config_path.open(encoding="utf-8") as f:
         config = f.read().split("\n")
     assert "hw.keyboard=yes" in config
     assert "skin.name=slab_skin" in config
@@ -146,7 +146,7 @@ def test_create_emulator_with_defaults(
         tmp_path / "home" / ".android" / "avd" / "new-emulator.avd" / "config.ini"
     )
     avd_config_path.parent.mkdir(parents=True)
-    with avd_config_path.open("w") as f:
+    with avd_config_path.open("w", encoding="utf-8") as f:
         f.write("hw.device.name=pixel\n")
 
     # Create the emulator using defaults
@@ -180,7 +180,7 @@ def test_create_emulator_with_defaults(
     )
 
     # Emulator configuration file has been appended.
-    with avd_config_path.open() as f:
+    with avd_config_path.open(encoding="utf-8") as f:
         config = f.read().split("\n")
     assert "hw.keyboard=yes" in config
     assert "skin.name=pixel_3a" in config
@@ -240,7 +240,7 @@ def test_default_name(mock_tools, android_sdk, tmp_path):
         tmp_path / "home" / ".android" / "avd" / "beePhone.avd" / "config.ini"
     )
     avd_config_path.parent.mkdir(parents=True)
-    with avd_config_path.open("w") as f:
+    with avd_config_path.open("w", encoding="utf-8") as f:
         f.write("hw.device.name=pixel\n")
 
     # Create the emulator
@@ -271,7 +271,7 @@ def test_default_name_with_collisions(mock_tools, android_sdk, tmp_path):
         tmp_path / "home" / ".android" / "avd" / "beePhone3.avd" / "config.ini"
     )
     avd_config_path.parent.mkdir(parents=True)
-    with avd_config_path.open("w") as f:
+    with avd_config_path.open("w", encoding="utf-8") as f:
         f.write("hw.device.name=pixel\n")
 
     # Create the emulator

--- a/tests/integrations/android_sdk/AndroidSDK/test_avd_config.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_avd_config.py
@@ -8,7 +8,7 @@ def test_avd_config(mock_tools, android_sdk, tmp_path):
     # Write a default config. It contains:
     # * blank lines
     # * a key whose value explicitly contains an equals sign.
-    with config_file.open("w") as f:
+    with config_file.open("w", encoding="utf-8") as f:
         f.write(
             """
 avd.ini.encoding=UTF-8
@@ -46,7 +46,7 @@ def test_avd_config_with_space(mock_tools, android_sdk, tmp_path):
     # * blank lines
     # * a key whose value explicitly contains an equals sign.
     # * spaces either side of the key/value separator
-    with config_file.open("w") as f:
+    with config_file.open("w", encoding="utf-8") as f:
         f.write(
             """
 avd.ini.encoding = UTF-8

--- a/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
@@ -68,7 +68,7 @@ def test_create_emulator(
         tmp_path / "home" / ".android" / "avd" / "new-emulator.avd" / "config.ini"
     )
     avd_config_path.parent.mkdir(parents=True)
-    with avd_config_path.open("w") as f:
+    with avd_config_path.open("w", encoding="utf-8") as f:
         f.write("hw.device.name=pixel\n")
 
     # Mock the internal emulator creation method

--- a/tests/integrations/android_sdk/AndroidSDK/test_update_emulator_config.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_update_emulator_config.py
@@ -12,7 +12,7 @@ def test_device(tmp_path):
     # Write a default config. It contains:
     # * blank lines
     # * a key whose value explicitly contains an equals sign.
-    with config_file.open("w") as f:
+    with config_file.open("w", encoding="utf-8") as f:
         f.write(
             """
 avd.ini.encoding=UTF-8
@@ -41,7 +41,7 @@ def test_update_existing(android_sdk, test_device):
         },
     )
 
-    with test_device.open() as f:
+    with test_device.open(encoding="utf-8") as f:
         content = f.read()
 
     # Keys have been updated, order is preserved.
@@ -70,7 +70,7 @@ def test_new_content(android_sdk, test_device):
         },
     )
 
-    with test_device.open() as f:
+    with test_device.open(encoding="utf-8") as f:
         content = f.read()
 
     # New keys are appended to the end of the file

--- a/tests/integrations/download/test_Download__file.py
+++ b/tests/integrations/download/test_Download__file.py
@@ -128,7 +128,9 @@ def test_new_download_oneshot(mock_tools, file_perms, url, content_disposition):
     mock_tools.os.remove.assert_called_with(str(temp_filename))
 
     # File content is as expected
-    with (mock_tools.base_path / "downloads" / "something.zip").open() as f:
+    with (mock_tools.base_path / "downloads" / "something.zip").open(
+        encoding="utf-8"
+    ) as f:
         assert f.read() == "all content"
 
 
@@ -179,14 +181,14 @@ def test_new_download_chunked(mock_tools, file_perms):
 
     # The downloaded file exists, and content is as expected
     assert filename.exists()
-    with (mock_tools.base_path / "something.zip").open() as f:
+    with (mock_tools.base_path / "something.zip").open(encoding="utf-8") as f:
         assert f.read() == "chunk-1;chunk-2;chunk-3;"
 
 
 def test_already_downloaded(mock_tools):
     # Create an existing file
     existing_file = mock_tools.base_path / "something.zip"
-    with existing_file.open("w") as f:
+    with existing_file.open("w", encoding="utf-8") as f:
         f.write("existing content")
 
     response = mock.MagicMock()

--- a/tests/integrations/linuxdeploy/test_LinuxDeployBase__verify.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployBase__verify.py
@@ -142,7 +142,7 @@ def test_verify_does_not_exist_non_appimage(mock_tools, tmp_path):
     mock_tools.os.chmod.assert_called_with(tool_path, 0o755)
 
     # The tool content hasn't been altered
-    with tool_path.open("r") as f:
+    with tool_path.open("r", encoding="utf-8") as f:
         assert f.read() == "I am a complete tool"
 
     # The build command retains the path to the downloaded file.

--- a/tests/integrations/linuxdeploy/utils.py
+++ b/tests/integrations/linuxdeploy/utils.py
@@ -54,7 +54,7 @@ def side_effect_create_mock_tool(tool_path):
 
     def _side_effect(*args, **kwargs):
         tool_path.parent.mkdir(parents=True)
-        with tool_path.open("w") as f:
+        with tool_path.open("w", encoding="utf-8") as f:
             f.write("I am a complete tool")
         return "new-downloaded-file"
 

--- a/tests/integrations/visualstudio/test_VisualStudio__verify.py
+++ b/tests/integrations/visualstudio/test_VisualStudio__verify.py
@@ -21,7 +21,7 @@ def custom_msbuild_path(tmp_path):
     """Create a dummy MSBuild executable at a custom location."""
     msbuild_path = tmp_path / "custom" / "MSBuild.exe"
     msbuild_path.parent.mkdir(parents=True)
-    with msbuild_path.open("w") as f:
+    with msbuild_path.open("w", encoding="utf-8") as f:
         f.write("Dummy MSBuild")
 
     return msbuild_path
@@ -39,7 +39,7 @@ def vswhere_path(tmp_path):
     )
 
     vswhere_path.parent.mkdir(parents=True)
-    with vswhere_path.open("w") as f:
+    with vswhere_path.open("w", encoding="utf-8") as f:
         f.write("Dummy vswhere")
 
     return vswhere_path
@@ -52,7 +52,7 @@ def msbuild_path(tmp_path):
         tmp_path / "Visual Studio" / "MSBuild" / "Current" / "Bin" / "MSBuild.exe"
     )
     msbuild_path.parent.mkdir(parents=True)
-    with msbuild_path.open("w") as f:
+    with msbuild_path.open("w", encoding="utf-8") as f:
         f.write("Dummy MSBuild")
 
     return msbuild_path

--- a/tests/integrations/xcode/test_get_device_state.py
+++ b/tests/integrations/xcode/test_get_device_state.py
@@ -21,7 +21,7 @@ def mock_tools(mock_tools) -> ToolCache:
 def simctl_result(name):
     """Load a simctl result file from the sample directory, and return the content."""
     filename = Path(__file__).parent / "simctl" / f"{name}.json"
-    with filename.open() as f:
+    with filename.open(encoding="utf-8") as f:
         return f.read()
 
 

--- a/tests/integrations/xcode/test_get_identities.py
+++ b/tests/integrations/xcode/test_get_identities.py
@@ -10,7 +10,7 @@ from briefcase.integrations.xcode import get_identities
 def security_result(name):
     """Load a security result file from the sample directory, and return the content."""
     filename = Path(__file__).parent / "security" / f"{name}.out"
-    with filename.open() as f:
+    with filename.open(encoding="utf-8") as f:
         return f.read()
 
 

--- a/tests/platforms/android/gradle/test_build.py
+++ b/tests/platforms/android/gradle/test_build.py
@@ -103,7 +103,7 @@ def test_build_app(
         / "gradle"
         / "res"
         / "briefcase.xml"
-    ).open() as f:
+    ).open(encoding="utf-8") as f:
         assert (
             f.read()
             == "\n".join(
@@ -170,7 +170,7 @@ def test_build_app_test_mode(
         / "gradle"
         / "res"
         / "briefcase.xml"
-    ).open() as f:
+    ).open(encoding="utf-8") as f:
         assert (
             f.read()
             == "\n".join(

--- a/tests/platforms/linux/system/test_build.py
+++ b/tests/platforms/linux/system/test_build.py
@@ -51,7 +51,7 @@ def test_build_app(build_command, first_app, tmp_path):
     # The license file has been installed
     doc_path = bundle_path / "first-app-0.0.1" / "usr" / "share" / "doc" / "first-app"
     assert (doc_path / "copyright").exists()
-    with (doc_path / "copyright").open() as f:
+    with (doc_path / "copyright").open(encoding="utf-8") as f:
         assert f.read() == "First App License"
 
     # The Changelog has been compressed and installed
@@ -163,7 +163,7 @@ def test_missing_changelog(build_command, first_app, tmp_path):
     # The license file has been installed
     doc_path = bundle_path / "first-app-0.0.1" / "usr" / "share" / "doc" / "first-app"
     assert (doc_path / "copyright").exists()
-    with (doc_path / "copyright").open() as f:
+    with (doc_path / "copyright").open(encoding="utf-8") as f:
         assert f.read() == "First App License"
 
 
@@ -193,7 +193,7 @@ def test_missing_manpage(build_command, first_app, tmp_path):
     # The license file has been installed
     doc_path = bundle_path / "first-app-0.0.1" / "usr" / "share" / "doc" / "first-app"
     assert (doc_path / "copyright").exists()
-    with (doc_path / "copyright").open() as f:
+    with (doc_path / "copyright").open(encoding="utf-8") as f:
         assert f.read() == "First App License"
 
     # The Changelog has been compressed and installed

--- a/tests/platforms/macOS/app/conftest.py
+++ b/tests/platforms/macOS/app/conftest.py
@@ -94,9 +94,9 @@ entitlements_path="Entitlements.plist"
         f.write(b"\xCA\xFE\xBA\xBEBinary content here")
 
     # Make sure there are some files in the bundle that *don't* need to be signed...
-    with (lib_path / "first.other").open("w") as f:
+    with (lib_path / "first.other").open("w", encoding="utf-8") as f:
         f.write("other")
-    with (lib_path / "second.other").open("w") as f:
+    with (lib_path / "second.other").open("w", encoding="utf-8") as f:
         f.write("other")
 
     # A file that has a Mach-O header, but isn't executable

--- a/tests/platforms/macOS/app/test_package__notarize.py
+++ b/tests/platforms/macOS/app/test_package__notarize.py
@@ -31,7 +31,7 @@ def package_command(tmp_path):
 def first_app_dmg(tmp_path):
     dmg_path = tmp_path / "base_path" / "dist" / "First App.dmg"
     dmg_path.parent.mkdir(parents=True)
-    with dmg_path.open("w") as f:
+    with dmg_path.open("w", encoding="utf-8") as f:
         f.write("DMG content here")
 
     return dmg_path

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,7 +35,7 @@ def create_file(filepath, content, mode="w", chmod=None):
     :returns: The path to the file that was created.
     """
     filepath.parent.mkdir(parents=True, exist_ok=True)
-    with filepath.open(mode) as f:
+    with filepath.open(mode, encoding="utf-8") as f:
         f.write(content)
 
     if chmod:

--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,8 @@ passenv = LOCALAPPDATA
 setenv = COVERAGE_FILE = {env:COVERAGE_FILE:.coverage}
 extras = dev
 commands =
-    !fast : python -m coverage run -m pytest {posargs:-vv --color yes}
-    fast : python -m pytest {posargs:-vv --color yes -n auto}
+    !fast : python -X warn_default_encoding -m coverage run -m pytest {posargs:-vv --color yes}
+    fast : python -X warn_default_encoding -m pytest {posargs:-vv --color yes -n auto}
 
 [testenv:coverage{,38,39,310,311,312}{,-ci}{,-platform,-platform-linux,-platform-macos,-platform-windows,-project}{,-keep}{,-html}]
 depends = py{,38,39,310,311,312}


### PR DESCRIPTION
## Changes
- When CI runs, require an explicit encoding anywhere one is needed

## Notes
- Python 3.15 will finally default to UTF-8; however, even then, `PYTHONUTF8=0` or `-X utf8=0` can disable it
- This is dependent on https://github.com/cookiecutter/cookiecutter/pull/1937

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
