### PR TITLE
Consolidate Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
-
 version: 2
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -8,6 +8,10 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -16,3 +20,7 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+      groups:
+        pip:
+          patterns:
+            - "*"

--- a/changes/1458.misc.rst
+++ b/changes/1458.misc.rst
@@ -1,0 +1,1 @@
+The individual Dependabot PRs are now grouped in to consolidated PRs for GitHub Actions and PyPI packages.


### PR DESCRIPTION
## Changes
- Consolidates Dependabot PRs in to two categories:
  - GitHub Actions
  - PyPI packages

## Notes
- Saw this in another [repo](https://github.com/PhasecoreX/docker-user-image/pull/23#event-10390328989) and figured you might benefit from it
- There are quite a few [options](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) to configure it if you want to control the grouping a bit more
  - For instance, only group updates for minor and patch updates to packages (although, `setup.cfg` basically prevents all major version updates soo...)
- Unfortunately, I don't see a way to effectively tell Dependabot "separate out the update for XXX package in to an individual PR"
  - Instead, I think its necessary to explicitly exclude that package from the group and re-run dependabot

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
