### PR TITLE
Remove copyright year from docs (fixes #1431)

### DIFF
--- a/changes/1431.misc.rst
+++ b/changes/1431.misc.rst
@@ -1,0 +1,1 @@
+The copyright year was removed from the documentation footer.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Briefcase"
-copyright = "2019, Russell Keith-Magee"
+copyright = "Russell Keith-Magee"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
## Changes
- The footer in the docs no longer include a copyright year
- IIUC, this was the desired outcome from #1431

Closes #1431

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
