### PR TITLE
Add contributors to AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,141 @@ The PRIMARY AUTHORS are (and/or have been):
 And here is an inevitably incomplete list of MUCH-APPRECIATED CONTRIBUTORS --
 people who have submitted patches, reported bugs, added translations, helped
 answer newbie questions, and generally made Briefcase that much better:
+    Russell Martin
+    Dan Yeaw
+    Malcolm Smith
+    Sagi Shadur
+    Sam Schott
+    Asheesh Laroia
+    Katie McLaughlin
+    Ellie Graves
+    Andrew Leech
+    marcmolla
+    Colton Myers
+    Agyey Arya
+    Danny
+    nadi726
+    Eli
+    Kevin Brown-Silva
+    MarkusPiotrowski
+    Cody Wilson
+    Preston Mclean
+    Sanyam Khurana
+    Talley Lambert
+    proneon267
+    zili
+    Christopher Beacham
+    Philip James
+    Ahter Sönmez
+    Carlos de la Guardia
+    Elias Dorneles
+    Kyle O'Malley
+    Ronald Hayden
+    epba23
+    tomrutherford
+    Cimbali
+    Jimmy Girardet
+    Ray
+    samschott
+    Amy Mok
+    Marcelo Elizeche Landó
+    Melanie Arbor
+    Tomer Keren
+    Yaroslav Halchenko
+    isabelapnt
+    qlchan24
+    Brian Grohe
+    Emmanuel Leblond
+    Felice Ho
+    Kayla Brewer
+    Markus Piotrowski
+    Matthew Blau
+    Moshe Zadka
+    SamSchott
+    Tiago Montes
+    Tobias Kunze
+    Unknown
+    ekdnam
+    nondescryptid
+    AltoRetrato
+    Danil
+    Dwight Hubbard
+    Grzegorz Bokota
+    Hugo van Kemenade
+    Javier Llamas
+    Nadav Levi
+    PrestonMclean
+    Ricardo Newbery
+    Ry
+    Ryan Carl
+    Seth Russell
+    Ahter S
+    Casey
+    Cheukting
+    Cristián Maureira-Fredes
+    Dawid Bugajewski
+    Deb NIcholson
+    Eduardo Valle
+    Genevieve Buckley
+    Jeffrey Griffin
+    LAPTOP-0S0BLPIR\Rhydwyn
+    LinasNas
+    Min ho Kim
+    Ramiro Batista da Luz
+    Rudy Mutter
+    Yaakov
+    euhidaman
+    stephan-kashkarov
+    Adam Chainz
+    Alexander Nigl
+    Allan McElroy
+    Benno Rice
+    Bruno Rino
+    Cascode6
+    Curtis Autery
+    David Fokkema
+    David Lord
+    David Wales
+    Derek Keeler
+    Diane Chen
+    Elijah Ahianyo
+    Emma Gordon
+    Fable Turas
+    Holly Becker
+    Javier Llamas Ramirez
+    Jeff Triplett
+    JensDiemer
+    Jonas Schell
+    Lilly Ryan
+    Marlene Nadvornik
+    Matheus Vitório
+    MeIchthys
+    Mickaël Schoentgen
+    Miriam Sexton
+    Mohsin Mumtaz
+    Murilo Polese
+    NancySin
+    Nehar Arora
+    Nik Molnar
+    Olga Bulat
+    Patrick Coxall
+    Rachel Kelly
+    Rae Knowler
+    Ratan Kulshreshtha
+    Rick Weitzel
+    Saeed Esmaili
+    Seth Michael Larson
+    Tyler Dawson
+    Wes Turner
+    Zane Clark
+    agricoda
+    anna
+    attacus
+    bearnun
+    chillaranand
+    elliegraves
+    hnarasaki
+    jgirardet
+    mborawski
+    mofe23
+    probonopd


### PR DESCRIPTION
Should we add contributors to the `AUTHORS` file? Or should we just get rid of it?

Quick one-liner to update `AUTHORS` file:
```bash
sed -i '9,$d' AUTHORS && git shortlog --summary --numbered | grep -iEv 'dependabot|Brutus \(robot\)' | awk 'NR>1 {$1=""; print "   "$0}' >> AUTHORS
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
