### PR TITLE
Add explanation on certificate identity retrieval for macOS and Windows

### DIFF
--- a/changes/1473.doc.rst
+++ b/changes/1473.doc.rst
@@ -1,0 +1,1 @@
+Add explanation on certificate identity retrieval for macOS and Windows

--- a/changes/1473.doc.rst
+++ b/changes/1473.doc.rst
@@ -1,1 +1,1 @@
-Add explanation on certificate identity retrieval for macOS and Windows
+Documentation on the process of retrieving certificate identities on macOS and Windows was improved.

--- a/docs/how-to/code-signing/macOS.rst
+++ b/docs/how-to/code-signing/macOS.rst
@@ -189,3 +189,7 @@ Next steps
 
 Now you can use the certificate to sign and notarize your application with the
 :doc:`briefcase package </reference/commands/package>` command.
+
+:doc:`briefcase package </reference/commands/package>` will ask you
+about the code-signing certificate you want to use and it will
+give you the command line for unattended installation.

--- a/docs/how-to/code-signing/macOS.rst
+++ b/docs/how-to/code-signing/macOS.rst
@@ -190,6 +190,7 @@ Next steps
 Now you can use the certificate to sign and notarize your application with the
 :doc:`briefcase package </reference/commands/package>` command.
 
-:doc:`briefcase package </reference/commands/package>` will ask you
-about the code-signing certificate you want to use and it will
-give you the command line for unattended installation.
+When you invoke :doc:`briefcase package </reference/commands/package>`, you will be
+prompted to select the code signing certificate you want to use from the certificates
+that are installed. Once you select a certificate, Briefcase will output the command
+line invocation to select that certificate for unattended installation.

--- a/docs/how-to/code-signing/windows.rst
+++ b/docs/how-to/code-signing/windows.rst
@@ -67,6 +67,11 @@ Refer to your Certificate Authority's documentation for specific instructions.
 Certificate's SHA-1 Thumbprint
 ------------------------------
 
+Unfortunately, on Windows, :doc:`briefcase package
+</reference/commands/package>` cannot retrieve the code-signing
+certificate's identity automatically so you will need to get it
+manually.
+
 The certificates installed on the machine are available in the Certificate
 Manager. Search for "User Certificates" in the Start Menu to access certificates
 for ``Current User`` or search for "Computer Certificates" for certificates for

--- a/docs/how-to/code-signing/windows.rst
+++ b/docs/how-to/code-signing/windows.rst
@@ -67,10 +67,9 @@ Refer to your Certificate Authority's documentation for specific instructions.
 Certificate's SHA-1 Thumbprint
 ------------------------------
 
-Unfortunately, on Windows, :doc:`briefcase package
-</reference/commands/package>` cannot retrieve the code-signing
-certificate's identity automatically so you will need to get it
-manually.
+On Windows, :doc:`briefcase package </reference/commands/package>` cannot retrieve the
+list of installed code signing certificates automatically. You need to retrieve the
+identity manually, and provide the certificates identity as a command line argument.
 
 The certificates installed on the machine are available in the Certificate
 Manager. Search for "User Certificates" in the Start Menu to access certificates


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Adds a section about certificate's identity on macOS. It took me a while to figure it out and the section was not as comprehensive as its Windows counterpart.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
