### PR TITLE
Remove default encoding checks for `py-fast` tox env

### DIFF
--- a/changes/1474.misc.rst
+++ b/changes/1474.misc.rst
@@ -1,0 +1,1 @@
+The error for using a default character encoding was disabled for ``tox -e py-fast``.

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ setenv = COVERAGE_FILE = {env:COVERAGE_FILE:.coverage}
 extras = dev
 commands =
     !fast : python -X warn_default_encoding -m coverage run -m pytest {posargs:-vv --color yes}
-    fast : python -X warn_default_encoding -m pytest {posargs:-vv --color yes -n auto}
+    fast : python -m pytest {posargs:-vv --color yes -n auto}
 
 [testenv:coverage{,38,39,310,311,312}{,-ci}{,-platform,-platform-linux,-platform-macos,-platform-windows,-project}{,-keep}{,-html}]
 depends = py{,38,39,310,311,312}


### PR DESCRIPTION
I don't understand why....but `tox -e py-fast` fails for a default encoding from `setuptools_scm`...but `tox -e py` does not...

```
❯ tox -e py-fast
.pkg: _optional_hooks> python /home/russell/github/beeware/briefcase/venv-3.11-briefcase/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: get_requires_for_build_wheel> python /home/russell/github/beeware/briefcase/venv-3.11-briefcase/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: get_requires_for_build_editable> python /home/russell/github/beeware/briefcase/venv-3.11-briefcase/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: build_editable> python /home/russell/github/beeware/briefcase/venv-3.11-briefcase/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta
py-fast: install_package> python -I -m pip install --force-reinstall --no-deps /home/russell/github/beeware/briefcase/.tox/.tmp/package/2/briefcase-0.3.16.dev246+g8daf920c-0.editable-py3-none-any.whl
py-fast: commands[0]> python -X warn_default_encoding -m pytest -vv --color yes -n auto
ImportError while loading conftest '/home/russell/github/beeware/briefcase/tests/conftest.py'.
tests/conftest.py:8: in <module>
    from briefcase.config import AppConfig
src/briefcase/__init__.py:12: in <module>
    __version__ = get_version("../..", relative_to=__file__)  # pragma: no cover
.tox/py-fast/lib/python3.11/site-packages/setuptools_scm/_get_version_impl.py:151: in get_version
    maybe_version = _get_version(config, force_write_version_files=True)
.tox/py-fast/lib/python3.11/site-packages/setuptools_scm/_get_version_impl.py:89: in _get_version
    parsed_version = parse_version(config)
.tox/py-fast/lib/python3.11/site-packages/setuptools_scm/_get_version_impl.py:52: in parse_version
    or parse_scm_version(config)
.tox/py-fast/lib/python3.11/site-packages/setuptools_scm/_get_version_impl.py:37: in parse_scm_version
    return _entrypoints.version_from_entrypoint(config, entrypoint, root)
.tox/py-fast/lib/python3.11/site-packages/setuptools_scm/_entrypoints.py:55: in version_from_entrypoint
    maybe_version: version.ScmVersion | None = fn(root, config=config)
.tox/py-fast/lib/python3.11/site-packages/setuptools_scm/git.py:207: in parse
    _require_command("git")
.tox/py-fast/lib/python3.11/site-packages/setuptools_scm/_run_cmd.py:200: in require_command
    if not has_command(name, warn=False):
.tox/py-fast/lib/python3.11/site-packages/setuptools_scm/_run_cmd.py:177: in has_command
    p = run([name, *args], cwd=".", timeout=5)
.tox/py-fast/lib/python3.11/site-packages/setuptools_scm/_run_cmd.py:138: in run
    res = subprocess.run(
../../../.pyenv/versions/3.11.4/lib/python3.11/subprocess.py:548: in run
    with Popen(*popenargs, **kwargs) as process:
../../../.pyenv/versions/3.11.4/lib/python3.11/subprocess.py:877: in __init__
    self.encoding = encoding = _text_encoding()
../../../.pyenv/versions/3.11.4/lib/python3.11/subprocess.py:372: in _text_encoding
    warnings.warn("'encoding' argument not specified.",
E   EncodingWarning: 'encoding' argument not specified.
py-fast: exit 4 (0.30 seconds) /home/russell/github/beeware/briefcase> python -X warn_default_encoding -m pytest -vv --color yes -n auto pid=1754412
.pkg: _exit> python /home/russell/github/beeware/briefcase/venv-3.11-briefcase/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta
  py-fast: FAIL code 4 (3.03=setup[2.74]+cmd[0.30] seconds)
  evaluation failed :( (3.16 seconds)
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct