### PR TITLE
Require CI to succeed on Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,12 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ "macos", "ubuntu", "windows" ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12-dev" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         include:
         - experimental: false
         # Allow dev Python to fail without failing entire job
-        - python-version: "3.12-dev"
-          experimental: true
+        #- python-version: "3.13-dev"
+        #  experimental: true
         # Run tests against the latest Windows Store Python
         - platform: "windows"
           python-version: "winstore3.11"

--- a/changes/1476.misc.rst
+++ b/changes/1476.misc.rst
@@ -1,0 +1,1 @@
+With the release of Python 3.12.0, CI is now required to succeed for Python 3.12.


### PR DESCRIPTION
## Changes
- CI uses latest stable 3.12 release and tests are required to succeed now

## Notes
- Python 3.12 is [not available](https://apps.microsoft.com/store/search?publisher=Python%20Software%20Foundation) in Windows Store yet
- Running tests against Python 3.13 is [not an option](https://github.com/actions/python-versions/blob/main/versions-manifest.json) yet....and I'm not really sure when to expect it to be available...
- I'm not sure if there are bigger plans to incorporate m1 macOS testing yet...but feel free to supersede this PR

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
