### PR TITLE
Filter out DVTCoreDeviceEnabledState warnings from Xcode builds.

### DIFF
--- a/changes/1477.misc.rst
+++ b/changes/1477.misc.rst
@@ -1,0 +1,1 @@
+The DVTCoreDeviceEnabledState warning produced by Xcode 14 on x86_64 is now suppressed.

--- a/src/briefcase/platforms/macOS/filters.py
+++ b/src/briefcase/platforms/macOS/filters.py
@@ -43,6 +43,16 @@ class XcodeBuildFilter:
         r"\d{4}-\d{2}-\d{2} +\d+:\d{2}:\d{2}\.\d{3} xcodebuild\[\d+:\d+\] +"
     )
 
+    # Xcode 14 generates the following warning on x86_64 hardware
+    # 2023-10-04 08:05:21.757 xcodebuild[46899:11335453] DVTCoreDeviceEnabledState:
+    #   DVTCoreDeviceEnabledState_Disabled set via user default
+    #   (DVTEnableCoreDevice=disabled)
+    DEVICE_ENABLED_STATE_RE = re.compile(
+        XCODEBUILD_PREFIX
+        + r"DVTCoreDeviceEnabledState: DVTCoreDeviceEnabledState_Disabled "
+        r"set via user default \(DVTEnableCoreDevice=disabled\)"
+    )
+
     # Xcode 14 generates the following warning when there is a passcode protected device
     # attached to your computer, even if you're not doing anything to target that device:
     # ---------------------------------------------------------------------
@@ -125,6 +135,9 @@ class XcodeBuildFilter:
             self.locked_device = True
         elif self.LOCKED_DEVICE_ADDITIONAL_RE.match(line):
             # Ignore the additional 1-line warning about failing to start the service.
+            pass
+        elif self.DEVICE_ENABLED_STATE_RE.match(line):
+            # Ignore the DVTCoreDeviceEnabledState warning
             pass
         elif self.DVT_ASSERTIONS_RE.match(line):
             # Ignore the 4 lines after the DVTAssertions message

--- a/tests/platforms/macOS/test_XcodeBuildFilter.py
+++ b/tests/platforms/macOS/test_XcodeBuildFilter.py
@@ -71,6 +71,18 @@ from briefcase.platforms.macOS.filters import XcodeBuildFilter
                 "Did gyre and gimble in the wabe;",
             ],
         ),
+        # XCode 14: x86_64 "device enabled state" warning.
+        (
+            [
+                "'Twas brillig, and the slithy toves",
+                "2023-10-04 08:05:21.757 xcodebuild[46899:11335453] DVTCoreDeviceEnabledState: DVTCoreDeviceEnabledState_Disabled set via user default (DVTEnableCoreDevice=disabled)",
+                "Did gyre and gimble in the wabe;",
+            ],
+            [
+                "'Twas brillig, and the slithy toves",
+                "Did gyre and gimble in the wabe;",
+            ],
+        ),
         # Xcode 15: DVTAssertions warning about createItemModels
         (
             [


### PR DESCRIPTION
Another filter to remove a warning produced by Xcode.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
