### PR TITLE
Use Windows Store Python 3.12 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         #  experimental: true
         # Run tests against the latest Windows Store Python
         - platform: "windows"
-          python-version: "winstore3.11"
+          python-version: "winstore3.12"
           experimental: false
     steps:
     - name: Checkout
@@ -70,7 +70,7 @@ jobs:
       if: startswith(matrix.python-version, 'winstore')
       uses: beeware/.github/.github/actions/install-win-store-python@main
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     - name: Get Packages
       uses: actions/download-artifact@v3.0.2

--- a/changes/1478.misc.rst
+++ b/changes/1478.misc.rst
@@ -1,0 +1,1 @@
+The test suite in CI now runs using Windows Store Python 3.12 instead of Python 3.11.


### PR DESCRIPTION
## Changes
- Run CI using Windows Store Python 3.12 instead of 3.11
- Dependent on https://github.com/beeware/.github/pull/54

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct