### PR TITLE
Ensure that dynamic lib merge targets are unique.

### DIFF
--- a/changes/1481.misc.rst
+++ b/changes/1481.misc.rst
@@ -1,0 +1,1 @@
+macOS dynamic libraries are now inspected to ensure that they are single platform before merging, and they are only merged once.

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -95,7 +95,22 @@ class macOSInstallMixin(AppPackagesMergeMixin):
                     },
                 )
         else:
-            self.logger.info("All packages are pure python or universal.")
+            self.logger.info("All packages are pure Python, or universal.")
+
+        # If given the option of a single architecture binary or a universal2 binary,
+        # pip will install the single platform binary. However, a common situation on
+        # macOS is for there to be an x86_64 binary and a universal2 binary. This means
+        # you only get a universal2 binary in the "other" install pass. This then causes
+        # problems with merging, because the "other" binary contains a copy of the
+        # architecture that the "host" platform provides.
+        #
+        # To avoid this - ensure that the libraries in the app packages for the "other"
+        # arch are all thin.
+        #
+        # This doesn't matter if it happens the other way around - if the "host" arch
+        # installs a universal binary, then the "other" arch won't be asked to install
+        # a binary at all.
+        self.thin_app_packages(other_app_packages_path, arch=other_arch)
 
         # Merge the binaries
         self.merge_app_packages(

--- a/src/briefcase/platforms/macOS/utils.py
+++ b/src/briefcase/platforms/macOS/utils.py
@@ -127,7 +127,7 @@ class AppPackagesMergeMixin:
         # different, but they'll be purged later anyway. Don't warn for anything in a
         # .dist-info folder either; these are going to be different because of platform
         # difference, but core package metadata should be consistent.
-        dylibs = []
+        dylibs = set()
         digests = {}
         for source_app_packages in sources:
             with self.input.wait_bar(f"Merging {source_app_packages.name}..."):
@@ -139,7 +139,7 @@ class AppPackagesMergeMixin:
                     else:
                         if source_path.suffix in {".so", ".dylib"}:
                             # Dynamic libraries need to be merged; do this in a second pass.
-                            dylibs.append(relative_path)
+                            dylibs.add(relative_path)
                         elif target_path.exists():
                             # The file already exists. Check for differences; if there are any
                             # differences outside `dist-info` or `__pycache__` folders, warn

--- a/tests/platforms/linux/system/test_package__pkg.py
+++ b/tests/platforms/linux/system/test_package__pkg.py
@@ -31,8 +31,15 @@ def package_command(first_app, tmp_path):
     # Mock the app context
     command.tools.app_tools[first_app].app_context = mock.MagicMock()
 
-    # Mock shutil move and rmtree
-    command.tools.shutil.move = mock.MagicMock()
+    # Mock shutil
+    command.tools.shutil = mock.MagicMock()
+
+    # Make the mock copy still copy
+    command.tools.shutil.copy = mock.MagicMock(side_effect=shutil.copy)
+
+    # Make the mock make_archive still package tarballs
+    command.tools.shutil.make_archive = mock.MagicMock(side_effect=shutil.make_archive)
+
     # Make the mock rmtree still remove content
     command.tools.shutil.rmtree = mock.MagicMock(side_effect=shutil.rmtree)
 

--- a/tests/platforms/linux/system/test_package__rpm.py
+++ b/tests/platforms/linux/system/test_package__rpm.py
@@ -31,8 +31,12 @@ def package_command(first_app, tmp_path):
     # Mock the app context
     command.tools.app_tools[first_app].app_context = mock.MagicMock()
 
-    # Mock shutil move and rmtree
-    command.tools.shutil.move = mock.MagicMock()
+    # Mock shutil
+    command.tools.shutil = mock.MagicMock()
+
+    # Make the mock make_archive still package tarballs
+    command.tools.shutil.make_archive = mock.MagicMock(side_effect=shutil.make_archive)
+
     # Make the mock rmtree still remove content
     command.tools.shutil.rmtree = mock.MagicMock(side_effect=shutil.rmtree)
 

--- a/tests/platforms/macOS/app/test_create.py
+++ b/tests/platforms/macOS/app/test_create.py
@@ -55,6 +55,10 @@ def test_install_app_packages(
             ("third", "3.4.5"),
         ]
     )
+
+    # Mock the thin command so we can confirm it was invoked.
+    create_command.thin_app_packages = mock.Mock()
+
     # Mock the merge command so we can confirm it was invoked.
     create_command.merge_app_packages = mock.Mock()
 
@@ -123,6 +127,12 @@ def test_install_app_packages(
     # versions is validated as a result of the underlying install/merge methods.
     assert (bundle_path / f"app_packages.{other_arch}").is_dir()
 
+    # An attempt was made thin the "other" arch packages.
+    create_command.thin_app_packages.assert_called_once_with(
+        bundle_path / f"app_packages.{other_arch}",
+        arch=other_arch,
+    )
+
     # An attempt was made to merge packages.
     create_command.merge_app_packages.assert_called_once_with(
         target_app_packages=bundle_path
@@ -162,6 +172,9 @@ def test_install_app_packages_no_binary(
 
     # Mock the result of finding no binary packages.
     create_command.find_binary_packages = mock.Mock(return_value=[])
+
+    # Mock the thin command so we can confirm it was invoked.
+    create_command.thin_app_packages = mock.Mock()
 
     # Mock the merge command so we can confirm it was invoked.
     create_command.merge_app_packages = mock.Mock()
@@ -205,7 +218,11 @@ def test_install_app_packages_no_binary(
     # result of the underlying install/merge methods.
     assert (bundle_path / f"app_packages.{other_arch}").is_dir()
 
-    # We still need to merge the app packages; this is effectively just a copy.
+    # We still need to thin and merge the app packages; this is effectively just a copy.
+    create_command.thin_app_packages.assert_called_once_with(
+        bundle_path / f"app_packages.{other_arch}",
+        arch=other_arch,
+    )
     create_command.merge_app_packages.assert_called_once_with(
         target_app_packages=bundle_path
         / "First App.app"
@@ -237,6 +254,9 @@ def test_install_app_packages_failure(create_command, first_app_templated, tmp_p
             ("third", "3.4.5"),
         ]
     )
+
+    # Mock the thin command so we can confirm it was invoked.
+    create_command.thin_app_packages = mock.Mock()
 
     # Mock the merge command so we can confirm it was invoked.
     create_command.merge_app_packages = mock.Mock()
@@ -323,7 +343,8 @@ def test_install_app_packages_failure(create_command, first_app_templated, tmp_p
     # result of the underlying install/merge methods.
     assert (bundle_path / "app_packages.x86_64").is_dir()
 
-    # We didn't attempt to merge, because we didn't complete installing.
+    # We didn't attempt to thin or  merge, because we didn't complete installing.
+    create_command.thin_app_packages.assert_not_called()
     create_command.merge_app_packages.assert_not_called()
 
 

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__ensure_thin_dylib.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__ensure_thin_dylib.py
@@ -1,0 +1,269 @@
+import subprocess
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError
+
+from ...utils import create_file, file_content
+
+
+@pytest.mark.parametrize("debug", [True, False])
+def test_thin_dylib(dummy_command, tmp_path, debug, capsys):
+    """A thin binary library is left as-is."""
+    if debug:
+        dummy_command.logger.verbosity = 1
+
+    # Create a source binary.
+    create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-original")
+
+    # Mock the result of the "lipo info" call.
+    dummy_command.tools.subprocess.check_output.return_value = (
+        "Non-fat file: path/to/file.dylib is architecture: gothic\n"
+    )
+
+    # Thin the library; this is effectively a no-op
+    dummy_command.ensure_thin_dylib(
+        tmp_path / "path" / "to" / "file.dylib",
+        arch="gothic",
+    )
+
+    # Lipo -info was invoked
+    dummy_command.tools.subprocess.check_output.assert_called_once_with(
+        [
+            "lipo",
+            "-info",
+            tmp_path / "path" / "to" / "file.dylib",
+        ],
+    )
+
+    # Lipo -thin was *not* invoked
+    dummy_command.tools.subprocess.run.assert_not_called()
+
+    # The original file is unmodified.
+    assert file_content(tmp_path / "path" / "to" / "file.dylib") == "dylib-original"
+
+    # Output only happens if in debug mode
+    output = capsys.readouterr().out.split("\n")
+    assert len(output) == (2 if debug else 1)
+
+
+@pytest.mark.parametrize("debug", [True, False])
+def test_fat_dylib(dummy_command, tmp_path, debug, capsys):
+    """A fat binary library can be thinned."""
+    if debug:
+        dummy_command.logger.verbosity = 1
+
+    # Create a source binary.
+    create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
+
+    # Mock the result of the "lipo info" call.
+    dummy_command.tools.subprocess.check_output.return_value = (
+        "Architectures in the fat file: path/to/file.dylib are: modern gothic\n"
+    )
+
+    # Mock the result of successfully thinning a library
+    def thin_dylib(*args, **kwargs):
+        create_file(args[0][args[0].index("-output") + 1], "dylib-thin")
+
+    dummy_command.tools.subprocess.run.side_effect = thin_dylib
+
+    # Thin the library to the "gothic" architecture
+    dummy_command.ensure_thin_dylib(
+        tmp_path / "path" / "to" / "file.dylib",
+        arch="gothic",
+    )
+
+    # Lipo -info was invoked
+    dummy_command.tools.subprocess.check_output.assert_called_once_with(
+        [
+            "lipo",
+            "-info",
+            tmp_path / "path" / "to" / "file.dylib",
+        ],
+    )
+
+    # Lipo -thin was invoked
+    dummy_command.tools.subprocess.run.assert_called_once_with(
+        [
+            "lipo",
+            "-thin",
+            "gothic",
+            "-output",
+            tmp_path / "path" / "to" / "file.dylib.gothic",
+            tmp_path / "path" / "to" / "file.dylib",
+        ],
+        check=True,
+    )
+
+    # The original file now has the thinned content.
+    assert file_content(tmp_path / "path" / "to" / "file.dylib") == "dylib-thin"
+
+    # Output only happens if in debug mode
+    output = capsys.readouterr().out.split("\n")
+    assert len(output) == (2 if debug else 1)
+
+
+@pytest.mark.parametrize("debug", [True, False])
+def test_fat_dylib_arch_mismatch(dummy_command, tmp_path, debug, capsys):
+    """If a fat binary doesn't contain the target architecture, an error is raised."""
+    if debug:
+        dummy_command.logger.verbosity = 1
+
+    # Create a source binary.
+    create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
+
+    # Mock the result of the "lipo info" call.
+    dummy_command.tools.subprocess.check_output.return_value = (
+        "Architectures in the fat file: path/to/file.dylib are: modern artdeco\n"
+    )
+
+    # Thin the library to the "gothic" architecture. This will raise an exception
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r"file\.dylib does not contain a gothic slice",
+    ):
+        dummy_command.ensure_thin_dylib(
+            tmp_path / "path" / "to" / "file.dylib",
+            arch="gothic",
+        )
+
+    # Lipo -info was invoked
+    dummy_command.tools.subprocess.check_output.assert_called_once_with(
+        [
+            "lipo",
+            "-info",
+            tmp_path / "path" / "to" / "file.dylib",
+        ],
+    )
+
+    # Lipo -thin was *not* invoked
+    dummy_command.tools.subprocess.run.assert_not_called()
+
+
+@pytest.mark.parametrize("debug", [True, False])
+def test_fat_dylib_unknown_info(dummy_command, tmp_path, debug, capsys):
+    """If the lipo info call succeeds, but generates unknown output, an error is
+    raised."""
+    if debug:
+        dummy_command.logger.verbosity = 1
+
+    # Create a source binary.
+    create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
+
+    # Mock the result of the "lipo info" call.
+    dummy_command.tools.subprocess.check_output.return_value = (
+        "This is unexpected output...\n"
+    )
+
+    # Thin the library to the "gothic" architecture. This will raise an exception
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r"Unable to determine architectures in .*file\.dylib",
+    ):
+        dummy_command.ensure_thin_dylib(
+            tmp_path / "path" / "to" / "file.dylib",
+            arch="gothic",
+        )
+
+    # Lipo -info was invoked
+    dummy_command.tools.subprocess.check_output.assert_called_once_with(
+        [
+            "lipo",
+            "-info",
+            tmp_path / "path" / "to" / "file.dylib",
+        ],
+    )
+
+    # Lipo -thin was *not* invoked
+    dummy_command.tools.subprocess.run.assert_not_called()
+
+
+def test_lipo_info_fail(dummy_command, tmp_path):
+    """If lipo can't inspect a binary, an error is raised."""
+    # Create a source binary.
+    create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
+
+    # Mock the result of the "lipo info" call.
+    dummy_command.tools.subprocess.check_output.side_effect = (
+        subprocess.CalledProcessError(cmd="lipo -info", returncode=-1)
+    )
+
+    # Thin the library to the "gothic" architecture. This will raise an exception
+    with pytest.raises(
+        BriefcaseCommandError, match=r"Unable to inspect architectures in .*file\.dylib"
+    ):
+        dummy_command.ensure_thin_dylib(
+            tmp_path / "path" / "to" / "file.dylib",
+            arch="gothic",
+        )
+
+    # Lipo -info was invoked
+    dummy_command.tools.subprocess.check_output.assert_called_once_with(
+        [
+            "lipo",
+            "-info",
+            tmp_path / "path" / "to" / "file.dylib",
+        ],
+    )
+
+    # Lipo -thin was not invoked
+    dummy_command.tools.subprocess.run.assert_not_called()
+
+
+@pytest.mark.parametrize("debug", [True, False])
+def test_lipo_thin_fail(dummy_command, tmp_path, debug, capsys):
+    """If lipo fails thinning the binary, an error is raised."""
+    if debug:
+        dummy_command.logger.verbosity = 1
+
+    # Create a source binary.
+    create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
+
+    # Mock the result of the "lipo -info" call.
+    dummy_command.tools.subprocess.check_output.return_value = (
+        "Architectures in the fat file: path/to/file.dylib are: modern gothic\n"
+    )
+
+    # Mock the result of the failed "lipo -thin" call.
+    dummy_command.tools.subprocess.run.side_effect = subprocess.CalledProcessError(
+        cmd="lipo -thin", returncode=-1
+    )
+
+    # Thin the library to the "gothic" architecture. This will raise an exception
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r"Unable to create thin library from .*file.dylib",
+    ):
+        dummy_command.ensure_thin_dylib(
+            tmp_path / "path" / "to" / "file.dylib",
+            arch="gothic",
+        )
+
+    # Lipo -info was invoked
+    dummy_command.tools.subprocess.check_output.assert_called_once_with(
+        [
+            "lipo",
+            "-info",
+            tmp_path / "path" / "to" / "file.dylib",
+        ],
+    )
+
+    # Lipo -thin was invoked
+    dummy_command.tools.subprocess.run.assert_called_once_with(
+        [
+            "lipo",
+            "-thin",
+            "gothic",
+            "-output",
+            tmp_path / "path" / "to" / "file.dylib.gothic",
+            tmp_path / "path" / "to" / "file.dylib",
+        ],
+        check=True,
+    )
+
+    # The original file is unmodified.
+    assert file_content(tmp_path / "path" / "to" / "file.dylib") == "dylib-fat"
+
+    # Output only happens if in debug mode
+    output = capsys.readouterr().out.split("\n")
+    assert len(output) == (2 if debug else 1)

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__thin_app_packages.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__thin_app_packages.py
@@ -1,0 +1,107 @@
+import subprocess
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError
+
+from ...utils import create_file, create_installed_package, file_content
+
+
+def test_thin_app_packages(dummy_command, tmp_path):
+    "An app packages folder can be thinned"
+    app_packages = tmp_path / "app_pacakges.gothic"
+
+    # Install a package into the app_packages folder that contains source and binaries.
+    create_installed_package(
+        app_packages,
+        "pkg",
+        "2.3.4",
+        tag="macOS_11_0_gothic",
+        extra_content=[
+            ("pkg/other.py", "# other python"),
+            ("pkg/sub1/module1.dylib", "dylib-fat"),
+            ("pkg/sub1/module2.so", "dylib-fat"),
+            ("pkg/sub2/module3.dylib", "dylib-fat"),
+        ],
+    )
+
+    # All dylibs have 2 architectures
+    dummy_command.tools.subprocess.check_output.return_value = (
+        "Architectures in the fat file: path/to/file.dylib are: modern gothic\n"
+    )
+
+    # Mock the effect of calling lipo -thin
+    def thin_dylib(*args, **kwargs):
+        create_file(args[0][args[0].index("-output") + 1], "dylib-thin")
+
+    dummy_command.tools.subprocess.run.side_effect = thin_dylib
+
+    # Thin the app_packages folder to gothic dylibs
+    dummy_command.thin_app_packages(app_packages, arch="gothic")
+
+    # All libraries have been thinned
+    assert file_content(app_packages / "pkg" / "sub1" / "module1.dylib") == "dylib-thin"
+    assert file_content(app_packages / "pkg" / "sub1" / "module2.so") == "dylib-thin"
+    assert file_content(app_packages / "pkg" / "sub2" / "module3.dylib") == "dylib-thin"
+
+
+def test_thin_app_packages_problem(dummy_command, tmp_path):
+    "If one of the libraries can't be thinned, an error is raised"
+    app_packages = tmp_path / "app_pacakges.gothic"
+
+    # Install a package into the app_packages folder that contains source and binaries.
+    create_installed_package(
+        app_packages,
+        "pkg",
+        "2.3.4",
+        tag="macOS_11_0_gothic",
+        extra_content=[
+            ("pkg/other.py", "# other python"),
+            ("pkg/sub1/module1.dylib", "dylib-fat"),
+            ("pkg/sub1/module2.so", "dylib-fat"),
+            ("pkg/sub2/module3.dylib", "dylib-fat"),
+        ],
+    )
+
+    # All dylibs have 2 architectures
+    dummy_command.tools.subprocess.check_output.return_value = (
+        "Architectures in the fat file: path/to/file.dylib are: modern gothic\n"
+    )
+
+    # Mock the effect of calling lipo -thin. Calling on a .so file raises an error.
+    def thin_dylib(*args, **kwargs):
+        if str(args[0][-1]).endswith(".so"):
+            raise subprocess.CalledProcessError(cmd="lipo -thin", returncode=-1)
+        create_file(args[0][args[0].index("-output") + 1], "dylib-thin")
+
+    dummy_command.tools.subprocess.run.side_effect = thin_dylib
+
+    # Thin the app_packages folder to gothic dylibs. This raises an error:
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r"Unable to create thin library from .*module2\.so",
+    ):
+        dummy_command.thin_app_packages(app_packages, arch="gothic")
+
+
+def test_thin_no_dylibs(dummy_command, tmp_path):
+    "If there are no dylibs, thinning is a no-op."
+    app_packages = tmp_path / "app_pacakges.gothic"
+
+    # Install a package into the app_packages folder that only contains source.
+    create_installed_package(
+        app_packages,
+        "pkg",
+        "2.3.4",
+        tag="macOS_11_0_gothic",
+        extra_content=[
+            ("pkg/other.py", "# other python"),
+        ],
+    )
+
+    # Thin the app packages folder
+    dummy_command.thin_app_packages(app_packages, arch="gothic")
+
+    # lipo was not called.
+    dummy_command.tools.subprocess.check_output.assert_not_called()
+    dummy_command.tools.subprocess.run.assert_not_called()


### PR DESCRIPTION
The candidate list for dylibs to be merged will not be unique; every dylib will be found twice. This may also be the cause of the CI failure.

Also ensures that the merge step only operates on single-platform wheels.

Fixes #1481 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
