### PR TITLE
Bump codespell from v2.2.5 to v2.2.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.2.6
     hooks:
     - id: codespell
       additional_dependencies:

--- a/changes/1487.misc.rst
+++ b/changes/1487.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``codespell`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `codespell` from v2.2.5 to v2.2.6 and ran the update against the repo.