### PR TITLE
Support testing against Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,12 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ "macos", "ubuntu", "windows" ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev" ]
         include:
         - experimental: false
         # Allow dev Python to fail without failing entire job
-        #- python-version: "3.13-dev"
-        #  experimental: true
+        - python-version: "3.13-dev"
+          experimental: true
     steps:
     - name: Checkout
       uses: actions/checkout@v4.1.1

--- a/changes/1495.misc.rst
+++ b/changes/1495.misc.rst
@@ -1,0 +1,1 @@
+Python 3.13 was added as a supported testing platform.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Utilities",
@@ -98,7 +99,7 @@ dev = [
     # Pre-commit 3.6.0 deprecated support for Python 3.8
     "pre-commit == 3.5.0 ; python_version < '3.9'",
     "pre-commit == 3.6.1 ; python_version >= '3.9'",
-    "pytest == 8.0.0",
+    "pytest == 8.0.1",
     "pytest-xdist == 3.5.0",
     "setuptools_scm == 8.0.4",
     "tox == 4.12.1",

--- a/tox.ini
+++ b/tox.ini
@@ -16,17 +16,18 @@ extend-ignore =
     E203,
 
 [tox]
-envlist = towncrier-check,docs-lint,pre-commit,py{38,39,310,311,312},coverage
+envlist = towncrier-check,docs-lint,pre-commit,py{38,39,310,311,312,313},coverage
 labels =
-    test = py{38,39,310,311,312},coverage
+    test = py{38,39,310,311,312,313},coverage
     test38 = py38,coverage38
     test39 = py39,coverage39
     test310 = py310,coverage310
     test311 = py311,coverage311
     test312 = py312,coverage312
-    test-fast = py{38,39,310,311,312}-fast
-    test-platform = py{38,39,310,311,312},coverage-platform
-    ci = towncrier-check,docs-lint,pre-commit,py{38,39,310,311,312},coverage-platform
+    test313 = py313,coverage313
+    test-fast = py{38,39,310,311,312,313}-fast
+    test-platform = py{38,39,310,311,312,313},coverage-platform
+    ci = towncrier-check,docs-lint,pre-commit,py{38,39,310,311,312,313},coverage-platform
 skip_missing_interpreters = True
 
 [testenv:pre-commit]
@@ -38,7 +39,7 @@ deps =
 commands_pre = python -m install_requirement pre-commit --extra dev --project-root "{tox_root}"
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
-[testenv:py{,38,39,310,311,312}{,-fast}]
+[testenv:py{,38,39,310,311,312,313}{,-fast}]
 package = wheel
 wheel_build_env = .pkg
 depends: pre-commit
@@ -51,18 +52,19 @@ commands =
     !fast : python -X warn_default_encoding -m coverage run -m pytest {posargs:-vv --color yes}
     fast : python -m pytest {posargs:-vv --color yes -n auto}
 
-[testenv:coverage{,38,39,310,311,312}{,-ci}{,-platform,-platform-linux,-platform-macos,-platform-windows,-project}{,-keep}{,-html}]
-depends = py{,38,39,310,311,312}
+[testenv:coverage{,38,39,310,311,312,313}{,-ci}{,-platform,-platform-linux,-platform-macos,-platform-windows,-project}{,-keep}{,-html}]
+depends = py{,38,39,310,311,312,313}
 skip_install = True
 # by default, coverage should run on oldest supported Python for testing platform coverage.
 # however, coverage for a particular Python version should match the version used for pytest.
 base_python =
-    coverage: py38,py39,py310,py311,py312
+    coverage: py38,py39,py310,py311,py312,py313
     coverage38: py38
     coverage39: py39
     coverage310: py310
     coverage311: py311
     coverage312: py312
+    coverage313: py313
 passenv = COVERAGE_FILE
 setenv =
     keep: COMBINE_FLAGS = --keep


### PR DESCRIPTION
## Changes
- Add support for CI to test Python 3.13
- Add support for `tox` to run using Python 3.13

## Issues
- [X] `coverage` needs support for Python 3.13 (added with v7.4.1)
- [x] Need a `pytest` release that includes https://github.com/pytest-dev/pytest/issues/11874

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct