### PR TITLE
Bump JDK to 17.0.9+9

### DIFF
--- a/changes/1498.feature.rst
+++ b/changes/1498.feature.rst
@@ -1,0 +1,1 @@
+The Java JDK was upgraded to 17.0.9+9.

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -19,8 +19,8 @@ class JDK(ManagedTool):
 
     # Latest OpenJDK as of September 2023: https://adoptium.net/temurin/releases/
     JDK_MAJOR_VER = "17"
-    JDK_RELEASE = "17.0.8.1"
-    JDK_BUILD = "1"
+    JDK_RELEASE = "17.0.9"
+    JDK_BUILD = "9"
     JDK_INSTALL_DIR_NAME = f"java{JDK_MAJOR_VER}"
 
     def __init__(self, tools: ToolCache, java_home: Path):

--- a/tests/integrations/java/conftest.py
+++ b/tests/integrations/java/conftest.py
@@ -6,8 +6,8 @@ from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.subprocess import Subprocess
 
-JDK_RELEASE = "17.0.8.1"
-JDK_BUILD = "1"
+JDK_RELEASE = "17.0.9"
+JDK_BUILD = "9"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Changes
- Bump JDK to 17.0.9+9 (from 17.0.7+7 in v0.3.15)

## Notes
- hmmm....the 17.0.9+9 [release](https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.9%2B9) has slowly been gaining the missing assets since it was originally published...
- Windows x64 is still missing...
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
