### PR TITLE
Restore debug logging for `-v` flag

### DIFF
--- a/changes/1501.bugfix.rst
+++ b/changes/1501.bugfix.rst
@@ -1,0 +1,1 @@
+Debug logging was restored when the ``-v`` flag is used.

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -117,7 +117,7 @@ class Log:
     """Manage logging output driven by verbosity flags."""
 
     # Level of verbosity when debug output is shown in the console
-    DEBUG = 2
+    DEBUG = 1
     # Printed at the beginning of all debug output
     DEBUG_PREFACE = ">>> "
     # subdirectory of command.base_path to store log files
@@ -208,7 +208,7 @@ class Log:
                 )
 
     def debug(self, message="", *, prefix="", markup=False):
-        """Log messages at debug level; included if verbosity>=2."""
+        """Log messages at debug level; included if verbosity >= 1."""
         self._log(
             preface=self.DEBUG_PREFACE,
             prefix=prefix,


### PR DESCRIPTION
## Changes
- This is the immediate fix....unencumbered with subsequent changes I'm going to propose to mitigate this class of error going forward
- Closes #1501

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
