### PR TITLE
Formalize logging levels

### DIFF
--- a/changes/1501.feature.rst
+++ b/changes/1501.feature.rst
@@ -1,0 +1,1 @@
+The verbosity flag, ``-v``, was expanded to support three levels of logging verbosity.

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -105,10 +105,10 @@ def parse_cmdline(args):
 
     # argparse handles `--` specially, so make the passthrough args bypass the parser.
     def parse_known_args(args):
-        args, passthough = split_passthrough(args)
+        args, passthrough = split_passthrough(args)
         options, extra = parser.parse_known_args(args)
-        if passthough:
-            extra += ["--"] + passthough
+        if passthrough:
+            extra += ["--"] + passthrough
         return options, extra
 
     # Use parse_known_args to ensure any extra arguments can be ignored,

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -693,7 +693,7 @@ any compatibility problems, and then add the compatibility declaration.
             "--verbosity",
             action="count",
             default=0,
-            help="Enable verbose logging. -vv enables super verbose mode.",
+            help="Enable verbose logging. Use -vv and -vvv to increase logging verbosity.",
         )
         parser.add_argument("-V", "--version", action="version", version=__version__)
         parser.add_argument(

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -762,12 +762,10 @@ class CreateCommand(BaseCommand):
                 for path in self.bundle_path(app).glob(glob):
                     relative_path = path.relative_to(self.bundle_path(app))
                     if path.is_dir():
-                        if self.logger.verbosity >= 1:
-                            self.logger.info(f"Removing directory {relative_path}")
+                        self.logger.verbose(f"Removing directory {relative_path}")
                         self.tools.shutil.rmtree(path)
                     else:
-                        if self.logger.verbosity >= 1:
-                            self.logger.info(f"Removing {relative_path}")
+                        self.logger.verbose(f"Removing {relative_path}")
                         path.unlink()
 
     def create_app(self, app: AppConfig, test_mode: bool = False, **options):

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -126,8 +126,6 @@ class LogLevel(IntEnum):
 class Log:
     """Manage logging output driven by verbosity flags."""
 
-    # Printed at the beginning of all debug output
-    DEBUG_PREFACE = ">>> "
     # subdirectory of command.base_path to store log files
     LOG_DIR = "logs"
 
@@ -215,10 +213,10 @@ class Log:
                     style=style,
                 )
 
-    def debug(self, message="", *, prefix="", markup=False):
+    def debug(self, message="", *, preface="", prefix="", markup=False):
         """Log messages at debug level; included if verbosity >= 2."""
         self._log(
-            preface=self.DEBUG_PREFACE,
+            preface=preface,
             prefix=prefix,
             message=message,
             show=self.is_debug,
@@ -617,7 +615,7 @@ class Console:
         try:
             input_value = self.input(prompt, markup=markup)
             self.print.to_log(prompt)
-            self.print.to_log(f"{Log.DEBUG_PREFACE}User input: {input_value}")
+            self.print.to_log(f"User input: {input_value}")
             return input_value
         except EOFError:
             raise KeyboardInterrupt

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import operator
 import os
 import platform
@@ -6,6 +8,7 @@ import sys
 import traceback
 from contextlib import contextmanager
 from datetime import datetime
+from enum import IntEnum
 from pathlib import Path
 
 from rich.console import Console as RichConsole
@@ -113,19 +116,24 @@ class Printer:
         return cls.log.export_text()
 
 
+class LogLevel(IntEnum):
+    INFO = 0
+    VERBOSE = 1
+    DEBUG = 2
+    DEEP_DEBUG = 3
+
+
 class Log:
     """Manage logging output driven by verbosity flags."""
 
-    # Level of verbosity when debug output is shown in the console
-    DEBUG = 2
     # Printed at the beginning of all debug output
     DEBUG_PREFACE = ">>> "
     # subdirectory of command.base_path to store log files
     LOG_DIR = "logs"
 
-    def __init__(self, printer=Printer(), verbosity=0):
+    def __init__(self, printer=Printer(), verbosity: LogLevel = LogLevel.INFO):
         self.print = printer
-        # --verbosity flag: 0 for info, 1 for debug, 2 for super-verbose
+        # --verbosity flag: 0 for info, 1 for debug, 2 for deep debug
         self.verbosity = verbosity
         # --log flag to force logfile creation
         self.save_log = False
@@ -150,12 +158,12 @@ class Log:
         :param context: The name of the context to enter. This *must* be simple text,
             with no markup or other special characters.
         """
+        self.info()
+        self.info(f"Entering {context} context...")
+        old_context = self._context
+        self._context = f"{context}| "
+        self.info("-" * (72 - len(context)))
         try:
-            self.info()
-            self.info(f"Entering {context} context...")
-            old_context = self._context
-            self._context = f"{context}| "
-            self.info("-" * (72 - len(context)))
             yield
         finally:
             self.info("-" * (72 - len(context)))
@@ -208,15 +216,19 @@ class Log:
                 )
 
     def debug(self, message="", *, prefix="", markup=False):
-        """Log messages at debug level; included if verbosity>=2."""
+        """Log messages at debug level; included if verbosity >= 2."""
         self._log(
             preface=self.DEBUG_PREFACE,
             prefix=prefix,
             message=message,
-            show=self.verbosity >= self.DEBUG,
+            show=self.is_debug,
             markup=markup,
             style="dim",
         )
+
+    def verbose(self, message="", *, prefix="", markup=False):
+        """Log message at verbose level if debug enabled; included if verbosity >= 1."""
+        self._log(prefix=prefix, message=message, show=self.is_verbose, markup=markup)
 
     def info(self, message="", *, prefix="", markup=False):
         """Log message at info level; always included in output."""
@@ -231,12 +243,37 @@ class Log:
         self._log(prefix=prefix, message=message, markup=markup, style="bold red")
 
     @property
-    def is_deep_debug(self):
-        """Is extra verbosity enabled via -vv?
+    def verbosity(self) -> LogLevel:
+        return self._verbosity
 
-        Enables verbose output from third-party tools.
+    @verbosity.setter
+    def verbosity(self, value: int | LogLevel):
+        """Clamp verbosity between valid log levels."""
+        self._verbosity = LogLevel(max(min(LogLevel), min(value, max(LogLevel))))
+
+    @property
+    def is_verbose(self):
+        """Is verbose logging enabled via the -v flag?
+
+        This includes Briefcase logging that isn't relevant during normal operation.
         """
-        return self.verbosity >= 2
+        return self.verbosity >= LogLevel.VERBOSE
+
+    @property
+    def is_debug(self):
+        """Is debug logging enabled via the -vv flag?
+
+        This includes debug logging from third party tools.
+        """
+        return self.verbosity >= LogLevel.DEBUG
+
+    @property
+    def is_deep_debug(self):
+        """Is deep debug logging enabled via the -vvv flag?
+
+        This includes debug logging from third party tools.
+        """
+        return self.verbosity >= LogLevel.DEEP_DEBUG
 
     def capture_stacktrace(self, label="Main thread"):
         """Preserve Rich stacktrace from exception while in except block.

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -706,19 +706,21 @@ class Subprocess(Tool):
             self.tools.logger.warning(f"Forcibly killing {label}...")
             popen_process.kill()
 
+    def _log(self, msg: str = ""):
+        """Funnel for all subprocess details logging."""
+        self.tools.logger.debug(msg, preface=">>> " if msg else "")
+
     def _log_command(self, args: SubprocessArgsT):
         """Log the entire console command being executed."""
-        self.tools.logger.debug()
-        self.tools.logger.debug("Running Command:")
-        self.tools.logger.debug(
-            f"    {' '.join(shlex.quote(str(arg)) for arg in args)}"
-        )
+        self._log()
+        self._log("Running Command:")
+        self._log(f"    {' '.join(shlex.quote(str(arg)) for arg in args)}")
 
     def _log_cwd(self, cwd: str | Path | None):
-        """Log the working directory for the  command being executed."""
+        """Log the working directory for the command being executed."""
         effective_cwd = Path.cwd() if cwd is None else cwd
-        self.tools.logger.debug("Working Directory:")
-        self.tools.logger.debug(f"    {effective_cwd}")
+        self._log("Working Directory:")
+        self._log(f"    {effective_cwd}")
 
     def _log_environment(self, overrides: dict[str, str] | None):
         """Log the environment variables overrides prior to command execution.
@@ -727,22 +729,22 @@ class Subprocess(Tool):
             can be `None` if there are no explicit environment changes.
         """
         if overrides:
-            self.tools.logger.debug("Environment Overrides:")
+            self._log("Environment Overrides:")
             for env_var, value in overrides.items():
-                self.tools.logger.debug(f"    {env_var}={value}")
+                self._log(f"    {env_var}={value}")
 
     def _log_output(self, output: str, stderr: str | None = None):
         """Log the output of the executed command."""
         if output:
-            self.tools.logger.debug("Command Output:")
+            self._log("Command Output:")
             for line in ensure_str(output).splitlines():
-                self.tools.logger.debug(f"    {line}")
+                self._log(f"    {line}")
 
         if stderr:
-            self.tools.logger.debug("Command Error Output (stderr):")
+            self._log("Command Error Output (stderr):")
             for line in ensure_str(stderr).splitlines():
-                self.tools.logger.debug(f"    {line}")
+                self._log(f"    {line}")
 
     def _log_return_code(self, return_code: int | str):
         """Log the output value of the executed command."""
-        self.tools.logger.debug(f"Return code: {return_code}")
+        self._log(f"Return code: {return_code}")

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -364,8 +364,7 @@ or
             process_command.append("--options")
             process_command.append(options)
 
-        if self.logger.verbosity >= 1:
-            self.logger.info(f"Signing {Path(path).relative_to(self.base_path)}")
+        self.logger.verbose(f"Signing {Path(path).relative_to(self.base_path)}")
 
         try:
             self.tools.subprocess.run(
@@ -376,10 +375,9 @@ or
         except subprocess.CalledProcessError as e:
             errors = e.stderr
             if "code object is not signed at all" in errors:
-                if self.logger.verbosity >= 1:
-                    self.logger.info(
-                        f"... {Path(path).relative_to(self.base_path)} requires a deep sign; retrying"
-                    )
+                self.logger.verbose(
+                    f"... {Path(path).relative_to(self.base_path)} requires a deep sign; retrying"
+                )
                 try:
                     self.tools.subprocess.run(
                         process_command + ["--deep"],
@@ -402,10 +400,9 @@ or
                 ]
             ):
                 # We should not be signing this in the first place
-                if self.logger.verbosity >= 1:
-                    self.logger.info(
-                        f"... {Path(path).relative_to(self.base_path)} does not require a signature"
-                    )
+                self.logger.verbose(
+                    f"... {Path(path).relative_to(self.base_path)} does not require a signature"
+                )
                 return
             else:
                 raise BriefcaseCommandError(f"Unable to code sign {path}.")

--- a/src/briefcase/platforms/macOS/utils.py
+++ b/src/briefcase/platforms/macOS/utils.py
@@ -85,13 +85,11 @@ class AppPackagesMergeMixin:
             ) from e
         else:
             if output.startswith("Non-fat file: "):
-                if self.logger.verbosity >= 1:
-                    self.logger.info(f"{path} is already thin.")
+                self.logger.verbose(f"{path} is already thin.")
             elif output.startswith("Architectures in the fat file: "):
                 architectures = set(output.strip().split(":")[-1].strip().split(" "))
                 if arch in architectures:
-                    if self.logger.verbosity >= 1:
-                        self.logger.info(f"Thinning {path}")
+                    self.logger.verbose(f"Thinning {path}")
                     try:
                         thin_lib_path = path.parent / f"{path.name}.{arch}"
                         self.tools.subprocess.run(
@@ -129,8 +127,7 @@ class AppPackagesMergeMixin:
         :param target_path: The root location where the fat library will be written
         :param sources: A list of root locations providing single platform libraries.
         """
-        if self.logger.verbosity >= 1:
-            self.logger.info(f"Creating fat library {relative_path}")
+        self.logger.verbose(f"Creating fat library {relative_path}")
 
         try:
             # Ensure the directory where the library will be written exists.

--- a/tests/commands/base/test_cookiecutter_logging.py
+++ b/tests/commands/base/test_cookiecutter_logging.py
@@ -2,6 +2,8 @@ import logging
 
 import pytest
 
+from briefcase.console import LogLevel
+
 cookiecutter_logger = logging.getLogger("cookiecutter")
 
 
@@ -16,9 +18,9 @@ def base_command(base_command):
 @pytest.mark.parametrize(
     "verbosity, log_level",
     [
-        (0, logging.INFO),
-        (1, logging.INFO),
-        (2, logging.DEBUG),
+        (LogLevel.INFO, logging.INFO),
+        (LogLevel.DEBUG, logging.INFO),
+        (LogLevel.DEEP_DEBUG, logging.DEBUG),
     ],
 )
 def test_cookiecutter_logging_config(base_command, verbosity, log_level):

--- a/tests/commands/base/test_parse_options.py
+++ b/tests/commands/base/test_parse_options.py
@@ -1,5 +1,7 @@
 import pytest
 
+from briefcase.console import LogLevel
+
 
 def test_parse_options(base_command):
     """Command line options are parsed if provided."""
@@ -11,7 +13,25 @@ def test_parse_options(base_command):
         "required": "important",
     }
     assert base_command.input.enabled
-    assert base_command.logger.verbosity == 0
+    assert base_command.logger.verbosity == LogLevel.INFO
+
+
+@pytest.mark.parametrize(
+    "verbosity, log_level",
+    [
+        ("", LogLevel.INFO),
+        ("-v", LogLevel.VERBOSE),
+        ("-vv", LogLevel.DEBUG),
+        ("-vvv", LogLevel.DEEP_DEBUG),
+        ("-vvvv", LogLevel.DEEP_DEBUG),
+        ("-vvvvv", LogLevel.DEEP_DEBUG),
+    ],
+)
+def test_verbosity(base_command, verbosity, log_level):
+    """The logging level is set correctly for the verbosity."""
+    base_command.parse_options(extra=filter(None, ("-r", "default", verbosity)))
+
+    assert base_command.logger.verbosity == log_level
 
 
 def test_missing_option(base_command, capsys):
@@ -27,7 +47,7 @@ def test_missing_option(base_command, capsys):
 
 
 def test_unknown_option(other_command, capsys):
-    """If an unknown command is provided, it rasises an error."""
+    """If an unknown command is provided, it raises an error."""
     with pytest.raises(SystemExit) as excinfo:
         other_command.parse_options(extra=("-y", "because"))
 

--- a/tests/commands/create/test_cleanup_app_content.py
+++ b/tests/commands/create/test_cleanup_app_content.py
@@ -1,5 +1,7 @@
 import pytest
 
+from briefcase.console import LogLevel
+
 from ...utils import create_file
 
 
@@ -23,7 +25,7 @@ def test_no_cleanup(create_command, myapp_unrolled, support_path, debug, capsys)
     """If there are no cleanup directives, bundle content isn't touched; but __pycache__
     is cleaned."""
     if debug:
-        create_command.logger.verbosity = 1
+        create_command.logger.verbosity = LogLevel.DEBUG
 
     # Cleanup app content
     create_command.cleanup_app_content(myapp_unrolled)
@@ -47,7 +49,7 @@ def test_no_cleanup(create_command, myapp_unrolled, support_path, debug, capsys)
 def test_dir_cleanup(create_command, myapp_unrolled, support_path, debug, capsys):
     """A directory can be cleaned up."""
     if debug:
-        create_command.logger.verbosity = 1
+        create_command.logger.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = ["path/to/support/dir1"]
 
@@ -70,7 +72,7 @@ def test_dir_cleanup(create_command, myapp_unrolled, support_path, debug, capsys
 def test_file_cleanup(create_command, myapp_unrolled, support_path, debug, capsys):
     """A single file can be cleaned up."""
     if debug:
-        create_command.logger.verbosity = 1
+        create_command.logger.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = ["path/to/support/dir1/a_file1.txt"]
 
@@ -98,7 +100,7 @@ def test_all_files_in_dir_cleanup(
 ):
     """All files in a directory can be cleaned up."""
     if debug:
-        create_command.logger.verbosity = 1
+        create_command.logger.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = ["path/to/support/dir1/*"]
 
@@ -126,7 +128,7 @@ def test_all_files_in_dir_cleanup(
 def test_dir_glob_cleanup(create_command, myapp_unrolled, support_path, debug, capsys):
     """A glob of directories can be cleaned up."""
     if debug:
-        create_command.logger.verbosity = 1
+        create_command.logger.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = ["path/to/support/dir*"]
 
@@ -149,7 +151,7 @@ def test_dir_glob_cleanup(create_command, myapp_unrolled, support_path, debug, c
 def test_file_glob_cleanup(create_command, myapp_unrolled, support_path, debug, capsys):
     """A glob of files can be cleaned up."""
     if debug:
-        create_command.logger.verbosity = 1
+        create_command.logger.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = ["path/to/support/dir1/*.txt"]
 
@@ -175,7 +177,7 @@ def test_file_glob_cleanup(create_command, myapp_unrolled, support_path, debug, 
 def test_deep_glob_cleanup(create_command, myapp_unrolled, support_path, debug, capsys):
     """A glob that matches all directories will be added to the cleanup list."""
     if debug:
-        create_command.logger.verbosity = 1
+        create_command.logger.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = ["path/to/support/**/b_file.*"]
 
@@ -204,7 +206,7 @@ def test_template_glob_cleanup(
 ):
     """A glob of files specified in the template will be added to the cleanup list."""
     if debug:
-        create_command.logger.verbosity = 1
+        create_command.logger.verbosity = LogLevel.DEBUG
 
     # Define a cleanup_paths in the template *and* on the app
     create_command._briefcase_toml[myapp_unrolled] = {
@@ -243,7 +245,7 @@ def test_non_existent_cleanup(
 ):
     """Referencing a specific file that doesn't exist doesn't cause a problem."""
     if debug:
-        create_command.logger.verbosity = 1
+        create_command.logger.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = [
         # This file exists

--- a/tests/console/test_Log.py
+++ b/tests/console/test_Log.py
@@ -73,7 +73,7 @@ def test_info_logging(capsys):
 
     assert "info" in output
     assert "verbose" not in output
-    assert ">>> debug" not in output
+    assert "debug" not in output
 
 
 def test_verbose_logging(capsys):
@@ -88,7 +88,7 @@ def test_verbose_logging(capsys):
 
     assert "info" in output
     assert "verbose" in output
-    assert ">>> debug" not in output
+    assert "debug" not in output
 
 
 def test_debug_logging(capsys):
@@ -103,7 +103,7 @@ def test_debug_logging(capsys):
 
     assert "info" in output
     assert "verbose" in output
-    assert ">>> debug" in output
+    assert "debug" in output
 
 
 def test_capture_stacktrace():
@@ -189,7 +189,7 @@ def test_save_log_to_file_no_exception(mock_now, command, tmp_path):
         log_contents = log.read()
 
     assert log_contents.startswith("Date/Time:       2022-06-25 16:12:29")
-    assert ">>> this is debug output" in log_contents
+    assert "this is debug output" in log_contents
     assert "this is info output" in log_contents
     assert "this is [bold]info output with markup[/bold]" in log_contents
     assert "this is info output with escaped markup" in log_contents
@@ -403,7 +403,7 @@ def test_log_with_context(capsys):
             "Deep| ",
             "Deep| [prefix] prefixed deep context",
             "Deep| ",
-            "Deep| >>> this is deep debug",
+            "Deep| this is deep debug",
             "Deep| ",
             "Deep| Entering Really Deep context...",
             "Really Deep| -------------------------------------------------------------",
@@ -411,7 +411,7 @@ def test_log_with_context(capsys):
             "Really Deep| ",
             "Really Deep| [prefix2] prefixed really deep context",
             "Really Deep| ",
-            "Really Deep| >>> this is really deep debug",
+            "Really Deep| this is really deep debug",
             "Really Deep| -------------------------------------------------------------",
             "Deep| Leaving Really Deep context.",
             "Deep| ",

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.exceptions import (
     BriefcaseCommandError,
     IncompatibleToolError,
@@ -159,7 +160,7 @@ def test_succeeds_immediately_in_happy_path(mock_tools, tmp_path):
 def test_user_provided_sdk(mock_tools, env_var, tmp_path, capsys):
     """If the user environment specifies a valid Android SDK, it is used."""
     # Increase the log level.
-    mock_tools.logger.verbosity = 2
+    mock_tools.logger.verbosity = LogLevel.DEBUG
 
     # Create `sdkmanager` and the license file.
     existing_android_sdk_root_path = tmp_path / "other_sdk"
@@ -198,7 +199,7 @@ def test_consistent_user_provided_sdk(mock_tools, tmp_path, capsys):
     """If the user environment specifies a valid Android SDK in both ANDROID_HOME and
     ANDROID_SDK_ROOT, it is used."""
     # Increase the log level.
-    mock_tools.logger.verbosity = 2
+    mock_tools.logger.verbosity = LogLevel.DEBUG
 
     # Create `sdkmanager` and the license file.
     existing_android_sdk_root_path = tmp_path / "other_sdk"
@@ -236,7 +237,7 @@ def test_consistent_user_provided_sdk(mock_tools, tmp_path, capsys):
 def test_inconsistent_user_provided_sdk(mock_tools, tmp_path, capsys):
     """A warning is logged if ANDROID_HOME and ANDROID_SDK_ROOT are not the same."""
     # Increase the log level.
-    mock_tools.logger.verbosity = 2
+    mock_tools.logger.verbosity = LogLevel.DEBUG
 
     # Create `sdkmanager` and the license file.
     existing_android_sdk_root_path = tmp_path / "other_sdk"

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -189,9 +189,9 @@ def test_user_provided_sdk(mock_tools, env_var, tmp_path, capsys):
         assert "Using Android SDK from ANDROID_SDK_ROOT" in capsys.readouterr().out
     else:
         assert capsys.readouterr().out == (
-            "\n>>> [Android SDK] Evaluating ANDROID_HOME...\n"
-            f">>> ANDROID_HOME={tmp_path / 'other_sdk'}\n"
-            f">>> Using Android SDK at {tmp_path / 'other_sdk'}\n"
+            "\n[Android SDK] Evaluating ANDROID_HOME...\n"
+            f"ANDROID_HOME={tmp_path / 'other_sdk'}\n"
+            f"Using Android SDK at {tmp_path / 'other_sdk'}\n"
         )
 
 
@@ -228,9 +228,9 @@ def test_consistent_user_provided_sdk(mock_tools, tmp_path, capsys):
 
     # User is not warned about configuration
     assert capsys.readouterr().out == (
-        "\n>>> [Android SDK] Evaluating ANDROID_HOME...\n"
-        f">>> ANDROID_HOME={tmp_path / 'other_sdk'}\n"
-        f">>> Using Android SDK at {tmp_path / 'other_sdk'}\n"
+        "\n[Android SDK] Evaluating ANDROID_HOME...\n"
+        f"ANDROID_HOME={tmp_path / 'other_sdk'}\n"
+        f"Using Android SDK at {tmp_path / 'other_sdk'}\n"
     )
 
 

--- a/tests/integrations/docker/test_DockerAppContext__check_output.py
+++ b/tests/integrations/docker/test_DockerAppContext__check_output.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from briefcase.console import LogLevel
+
 
 def test_simple_call(mock_docker_app_context, tmp_path, sub_check_output_kw, capsys):
     """A simple call will be invoked."""
@@ -192,7 +194,7 @@ def test_simple_verbose_call(
     capsys,
 ):
     """If verbosity is turned out, there is output."""
-    mock_docker_app_context.tools.logger.verbosity = 2
+    mock_docker_app_context.tools.logger.verbosity = LogLevel.DEBUG
 
     assert mock_docker_app_context.check_output(["hello", "world"]) == "goodbye\n"
 

--- a/tests/integrations/docker/test_DockerAppContext__run.py
+++ b/tests/integrations/docker/test_DockerAppContext__run.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from briefcase.console import LogLevel
+
 
 def test_simple_call(mock_docker_app_context, tmp_path, sub_stream_kw, capsys):
     """A simple call will be invoked."""
@@ -310,7 +312,7 @@ def test_interactive_with_path_arg_and_env_and_mounts(
 )
 def test_simple_verbose_call(mock_docker_app_context, tmp_path, sub_stream_kw, capsys):
     """If verbosity is turned out, there is output."""
-    mock_docker_app_context.tools.logger.verbosity = 2
+    mock_docker_app_context.tools.logger.verbosity = LogLevel.DEBUG
 
     mock_docker_app_context.run(["hello", "world"])
 

--- a/tests/integrations/flatpak/test_Flatpak__build.py
+++ b/tests/integrations/flatpak/test_Flatpak__build.py
@@ -2,6 +2,7 @@ import subprocess
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 
 
@@ -10,7 +11,7 @@ def test_build(flatpak, tool_debug_mode, tmp_path):
     """A Flatpak project can be built."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = 2
+        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     flatpak.build(
         bundle_identifier="com.example.my-app",

--- a/tests/integrations/flatpak/test_Flatpak__bundle.py
+++ b/tests/integrations/flatpak/test_Flatpak__bundle.py
@@ -2,6 +2,7 @@ import subprocess
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 
 
@@ -10,7 +11,7 @@ def test_bundle(flatpak, tool_debug_mode, tmp_path):
     """A Flatpak project can be bundled."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = 2
+        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     flatpak.bundle(
         repo_url="https://example.com/flatpak",

--- a/tests/integrations/flatpak/test_Flatpak__run.py
+++ b/tests/integrations/flatpak/test_Flatpak__run.py
@@ -3,13 +3,15 @@ from unittest import mock
 
 import pytest
 
+from briefcase.console import LogLevel
+
 
 @pytest.mark.parametrize("tool_debug_mode", (True, False))
 def test_run(flatpak, tool_debug_mode):
     """A Flatpak project can be executed."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = 2
+        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     # Set up the log streamer to return a known stream
     log_popen = mock.MagicMock()
@@ -40,7 +42,7 @@ def test_run_with_args(flatpak, tool_debug_mode):
     """A Flatpak project can be executed with additional arguments."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = 2
+        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     # Set up the log streamer to return a known stream
     log_popen = mock.MagicMock()

--- a/tests/integrations/flatpak/test_Flatpak__verify_repo.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_repo.py
@@ -2,6 +2,7 @@ import subprocess
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 
 
@@ -10,7 +11,7 @@ def test_verify_repo(flatpak, tool_debug_mode):
     """A Flatpak repo can be verified."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = 2
+        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     flatpak.verify_repo(
         repo_alias="test-alias",

--- a/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
@@ -2,6 +2,7 @@ import subprocess
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 
 
@@ -10,7 +11,7 @@ def test_verify_runtime(flatpak, tool_debug_mode):
     """A Flatpak runtime and SDK can be verified."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = 2
+        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     flatpak.verify_runtime(
         repo_alias="test-alias",

--- a/tests/integrations/subprocess/test_Subprocess__Popen.py
+++ b/tests/integrations/subprocess/test_Subprocess__Popen.py
@@ -4,6 +4,8 @@ from unittest.mock import ANY
 
 import pytest
 
+from briefcase.console import LogLevel
+
 from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW
 
 
@@ -122,7 +124,7 @@ def test_call_windows_with_start_new_session_and_creationflags(
 
 def test_debug_call(mock_sub, capsys, sub_kw):
     """If verbosity is turned up, there is output."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
     mock_sub.Popen(["hello", "world"])
 
     mock_sub._subprocess.Popen.assert_called_with(["hello", "world"], **sub_kw)
@@ -138,7 +140,7 @@ def test_debug_call(mock_sub, capsys, sub_kw):
 
 def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_kw):
     """If verbosity is turned up, and injected env vars are included output."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     env = {"NewVar": "NewVarValue"}
     mock_sub.Popen(["hello", "world"], env=env, cwd=tmp_path / "cwd")

--- a/tests/integrations/subprocess/test_Subprocess__check_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__check_output.py
@@ -6,6 +6,8 @@ from unittest.mock import ANY
 
 import pytest
 
+from briefcase.console import LogLevel
+
 from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW
 
 
@@ -129,7 +131,7 @@ def test_call_windows_with_start_new_session_and_creationflags(
 
 def test_debug_call(mock_sub, capsys, sub_check_output_kw):
     """If verbosity is turned up, there is output."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     mock_sub.check_output(["hello", "world"])
 
@@ -155,7 +157,7 @@ def test_debug_call(mock_sub, capsys, sub_check_output_kw):
 
 def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_check_output_kw):
     """If verbosity is turned up, injected env vars are included in output."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     env = {"NewVar": "NewVarValue"}
     mock_sub.check_output(["hello", "world"], env=env, cwd=tmp_path / "cwd")
@@ -189,7 +191,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_check_output_kw):
 
 def test_debug_call_with_quiet(mock_sub, capsys, tmp_path, sub_check_output_kw):
     """If quiet mode is on, calls aren't logged, even if verbosity is turned up."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     env = {"NewVar": "NewVarValue"}
     mock_sub.check_output(
@@ -215,7 +217,7 @@ def test_debug_call_with_quiet(mock_sub, capsys, tmp_path, sub_check_output_kw):
 
 def test_debug_call_with_stderr(mock_sub, capsys, tmp_path, sub_check_output_kw):
     """If stderr is specified, it is not defaulted to stdout."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     mock_sub.check_output(
         ["hello", "world"],
@@ -248,7 +250,7 @@ def test_debug_call_with_stderr(mock_sub, capsys, tmp_path, sub_check_output_kw)
 
 def test_calledprocesserror_exception_logging(mock_sub, capsys):
     """If command errors, ensure command output is printed."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     called_process_error = CalledProcessError(
         returncode=-1,
@@ -281,7 +283,7 @@ def test_calledprocesserror_exception_logging(mock_sub, capsys):
 
 def test_calledprocesserror_exception_quiet(mock_sub, capsys):
     """If command errors in quiet mode, no command output is printed."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     called_process_error = CalledProcessError(
         returncode=-1,
@@ -300,7 +302,7 @@ def test_calledprocesserror_exception_quiet(mock_sub, capsys):
 
 def test_calledprocesserror_exception_logging_no_cmd_output(mock_sub, capsys):
     """If command errors, and there is no command output, errors are still printed."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     called_process_error = CalledProcessError(
         returncode=-1,

--- a/tests/integrations/subprocess/test_Subprocess__run__controlled_console.py
+++ b/tests/integrations/subprocess/test_Subprocess__run__controlled_console.py
@@ -5,6 +5,8 @@ from unittest.mock import ANY
 
 import pytest
 
+from briefcase.console import LogLevel
+
 
 def test_call(mock_sub, sub_stream_kw, sleep_zero, capsys):
     """A simple call will be invoked."""
@@ -48,7 +50,7 @@ def test_call_with_arg(mock_sub, sub_stream_kw, sleep_zero, capsys):
 
 def test_debug_call(mock_sub, sub_stream_kw, sleep_zero, capsys):
     """If verbosity is turned up, there is debug output."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     with mock_sub.tools.input.wait_bar():
         mock_sub.run(["hello", "world"])
@@ -71,7 +73,7 @@ def test_debug_call(mock_sub, sub_stream_kw, sleep_zero, capsys):
 
 def test_debug_call_with_env(mock_sub, sub_stream_kw, sleep_zero, capsys, tmp_path):
     """If verbosity is turned up, injected env vars are included in debug output."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     env = {"NewVar": "NewVarValue"}
     with mock_sub.tools.input.wait_bar():

--- a/tests/integrations/subprocess/test_Subprocess__run__stream_output__False.py
+++ b/tests/integrations/subprocess/test_Subprocess__run__stream_output__False.py
@@ -5,6 +5,8 @@ from unittest.mock import ANY
 
 import pytest
 
+from briefcase.console import LogLevel
+
 from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW
 
 
@@ -131,7 +133,7 @@ def test_call_windows_with_start_new_session_and_creationflags(
 
 def test_debug_call(mock_sub, capsys, sub_kw):
     """If verbosity is turned up, there is output."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     mock_sub.run(["hello", "world"], stream_output=False)
 
@@ -152,7 +154,7 @@ def test_debug_call(mock_sub, capsys, sub_kw):
 
 def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_kw):
     """If verbosity is turned up, injected env vars are included output."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     env = {"NewVar": "NewVarValue"}
     mock_sub.run(["hello", "world"], env=env, cwd=tmp_path / "cwd", stream_output=False)
@@ -180,7 +182,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_kw):
 
 
 def test_calledprocesserror_exception_logging(mock_sub, capsys):
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     mock_sub._subprocess.run.side_effect = CalledProcessError(
         returncode=-1,

--- a/tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py
+++ b/tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py
@@ -6,6 +6,8 @@ from unittest.mock import ANY
 
 import pytest
 
+from briefcase.console import LogLevel
+
 from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW
 
 
@@ -156,7 +158,7 @@ def test_call_windows_with_start_new_session_and_creationflags(
 
 def test_debug_call(mock_sub, capsys, sub_stream_kw, sleep_zero):
     """If verbosity is turned up, there is output."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     mock_sub.run(["hello", "world"])
 
@@ -180,7 +182,7 @@ def test_debug_call(mock_sub, capsys, sub_stream_kw, sleep_zero):
 
 def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_stream_kw, sleep_zero):
     """If verbosity is turned up, injected env vars are included output."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     env = {"NewVar": "NewVarValue"}
     mock_sub.run(["hello", "world"], env=env, cwd=tmp_path / "cwd")
@@ -211,7 +213,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_stream_kw, sleep_ze
 
 
 def test_calledprocesserror_exception_logging(mock_sub, sleep_zero, capsys):
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     with pytest.raises(CalledProcessError):
         mock_sub.run(["hello", "world"], check=True)

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.integrations import subprocess
 
 
@@ -31,7 +32,7 @@ def test_output(mock_sub, streaming_process, sleep_zero, capsys):
 
 def test_output_debug(mock_sub, streaming_process, sleep_zero, capsys):
     """Process output is printed; no debug output for only stream_output."""
-    mock_sub.tools.logger.verbosity = 2
+    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
 
     mock_sub.stream_output("testing", streaming_process)
 

--- a/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
@@ -237,10 +237,10 @@ def test_winsdk_nonlatest_install_from_reg(
     # Confirm invalid SDK was evaluated
     expected_output = (
         "\n"
-        ">>> [Windows SDK] Finding Suitable Installation...\n"
-        f">>> Evaluating Registry SDK version '85.0.9.0' at {tmp_path / 'invalid' / 'win_sdk'}\n"
-        f">>> Evaluating Registry SDK version '85.0.8.0' at {tmp_path / 'win_sdk'}\n"
-        f">>> Using Windows SDK v85.0.8.0 at {tmp_path / 'win_sdk'}\n"
+        "[Windows SDK] Finding Suitable Installation...\n"
+        f"Evaluating Registry SDK version '85.0.9.0' at {tmp_path / 'invalid' / 'win_sdk'}\n"
+        f"Evaluating Registry SDK version '85.0.8.0' at {tmp_path / 'win_sdk'}\n"
+        f"Using Windows SDK v85.0.8.0 at {tmp_path / 'win_sdk'}\n"
     )
     assert capsys.readouterr().out == expected_output
 
@@ -334,17 +334,17 @@ def test_winsdk_invalid_install_from_reg(
         WindowsSDK.verify(mock_tools)
 
     # Confirm invalid SDK was evaluated
-    expected_output = "\n>>> [Windows SDK] Finding Suitable Installation...\n"
+    expected_output = "\n[Windows SDK] Finding Suitable Installation...\n"
     for subdir, version in [t for t in reg_installs if FileNotFoundError not in t]:
         if subdir and version:
             sdk_path = tmp_path / subdir / "win_sdk"
             expected_output += (
-                f">>> Evaluating Registry SDK version '{version}.0' at {sdk_path}\n"
+                f"Evaluating Registry SDK version '{version}.0' at {sdk_path}\n"
             )
     for subdir, version in additional_installs:
         sdk_path = tmp_path / subdir / "win_sdk"
         expected_output += (
-            f">>> Evaluating Registry SDK Bin version '{version}.0' at {sdk_path}\n"
+            f"Evaluating Registry SDK Bin version '{version}.0' at {sdk_path}\n"
         )
     assert capsys.readouterr().out == expected_output
 
@@ -380,10 +380,10 @@ def test_winsdk_valid_install_from_default_dir(
     # Confirm invalid SDK was evaluated
     expected_output = (
         "\n"
-        ">>> [Windows SDK] Finding Suitable Installation...\n"
-        f">>> Evaluating Default Bin SDK version '86.0.7.0' at {tmp_path / 'invalid' / 'win_sdk'}\n"
-        f">>> Evaluating Default Bin SDK version '86.0.8.0' at {tmp_path / 'win_sdk'}\n"
-        f">>> Using Windows SDK v86.0.8.0 at {tmp_path / 'win_sdk'}\n"
+        "[Windows SDK] Finding Suitable Installation...\n"
+        f"Evaluating Default Bin SDK version '86.0.7.0' at {tmp_path / 'invalid' / 'win_sdk'}\n"
+        f"Evaluating Default Bin SDK version '86.0.8.0' at {tmp_path / 'win_sdk'}\n"
+        f"Using Windows SDK v86.0.8.0 at {tmp_path / 'win_sdk'}\n"
     )
     assert capsys.readouterr().out == expected_output
 
@@ -433,8 +433,8 @@ def test_winsdk_invalid_install_from_default_dir(
     # Confirm invalid SDK was evaluated
     expected_output = (
         "\n"
-        ">>> [Windows SDK] Finding Suitable Installation...\n"
-        f">>> Evaluating Default Bin SDK version '87.0.7.0' at {tmp_path / 'invalid_1' / 'win_sdk'}\n"
-        f">>> Evaluating Default Bin SDK version '87.0.8.0' at {tmp_path / 'invalid_2' / 'win_sdk'}\n"
+        "[Windows SDK] Finding Suitable Installation...\n"
+        f"Evaluating Default Bin SDK version '87.0.7.0' at {tmp_path / 'invalid_1' / 'win_sdk'}\n"
+        f"Evaluating Default Bin SDK version '87.0.8.0' at {tmp_path / 'invalid_2' / 'win_sdk'}\n"
     )
     assert capsys.readouterr().out == expected_output

--- a/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.integrations import windows_sdk
 from briefcase.integrations.windows_sdk import WindowsSDK
@@ -168,7 +169,7 @@ def test_winsdk_latest_install_from_reg(mock_tools, mock_winreg, tmp_path, monke
     mock_tools.os.environ.get.return_value = None
 
     # Turn on verbose logging
-    mock_tools.logger.verbosity = 2
+    mock_tools.logger.verbosity = LogLevel.DEBUG
 
     # Patch target SDK version
     monkeypatch.setattr(WindowsSDK, "SDK_VERSION", "83.0")
@@ -207,7 +208,7 @@ def test_winsdk_nonlatest_install_from_reg(
     mock_tools.os.environ.get.return_value = None
 
     # Turn on verbose logging
-    mock_tools.logger.verbosity = 2
+    mock_tools.logger.verbosity = LogLevel.DEBUG
 
     # Patch target SDK version
     monkeypatch.setattr(WindowsSDK, "SDK_VERSION", "85.0")
@@ -293,7 +294,7 @@ def test_winsdk_invalid_install_from_reg(
     WindowsSDK.DEFAULT_SDK_DIRS = []
 
     # Turn on verbose logging
-    mock_tools.logger.verbosity = 2
+    mock_tools.logger.verbosity = LogLevel.DEBUG
 
     # Patch target SDK version
     monkeypatch.setattr(WindowsSDK, "SDK_VERSION", "85.0")
@@ -360,7 +361,7 @@ def test_winsdk_valid_install_from_default_dir(
     mock_tools.os.environ.get.return_value = None
 
     # Turn on verbose logging
-    mock_tools.logger.verbosity = 2
+    mock_tools.logger.verbosity = LogLevel.DEBUG
 
     # Patch target SDK version
     monkeypatch.setattr(WindowsSDK, "SDK_VERSION", "86.0")
@@ -403,7 +404,7 @@ def test_winsdk_invalid_install_from_default_dir(
     mock_tools.os.environ.get.return_value = None
 
     # Turn on verbose logging
-    mock_tools.logger.verbosity = 2
+    mock_tools.logger.verbosity = LogLevel.DEBUG
 
     # Patch target SDK version
     monkeypatch.setattr(WindowsSDK, "SDK_VERSION", "87.0")

--- a/tests/platforms/android/gradle/test_build.py
+++ b/tests/platforms/android/gradle/test_build.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, PropertyMock
 import pytest
 import requests
 
-from briefcase.console import Console, Log
+from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.android_sdk import AndroidSDK
 from briefcase.integrations.subprocess import Subprocess
@@ -72,7 +72,7 @@ def test_build_app(
     build_command.tools.host_os = host_os
     # Enable verbose tool logging
     if tool_debug_mode:
-        build_command.tools.logger.verbosity = 2
+        build_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
     # Create mock environment with `key`, which we expect to be preserved, and
     # `ANDROID_SDK_ROOT`, which we expect to be overwritten.
     build_command.tools.os.environ = {"ANDROID_SDK_ROOT": "somewhere", "key": "value"}
@@ -139,7 +139,7 @@ def test_build_app_test_mode(
     build_command.tools.host_os = host_os
     # Enable verbose tool logging
     if debug_mode:
-        build_command.tools.logger.verbosity = 2
+        build_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
     # Create mock environment with `key`, which we expect to be preserved, and
     # `ANDROID_SDK_ROOT`, which we expect to be overwritten.
     build_command.tools.os.environ = {"ANDROID_SDK_ROOT": "somewhere", "key": "value"}

--- a/tests/platforms/android/gradle/test_package__aab.py
+++ b/tests/platforms/android/gradle/test_package__aab.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 
 from ....utils import create_file
@@ -66,7 +67,7 @@ def test_execute_gradle(
 
     # Enable verbose tool logging
     if tool_debug_mode:
-        package_command.tools.logger.verbosity = 2
+        package_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     # Set up a side effect of invoking gradle to create a bundle
     def create_bundle(*args, **kwargs):

--- a/tests/platforms/android/gradle/test_package__apk.py
+++ b/tests/platforms/android/gradle/test_package__apk.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 
 from ....utils import create_file
@@ -67,7 +68,7 @@ def test_execute_gradle(
 
     # Enable verbose tool logging
     if tool_debug_mode:
-        package_command.tools.logger.verbosity = 3
+        package_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     # Set up a side effect of invoking gradle to create a bundle
     def create_bundle(*args, **kwargs):

--- a/tests/platforms/android/gradle/test_package__debug_apk.py
+++ b/tests/platforms/android/gradle/test_package__debug_apk.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 
 from ....utils import create_file
@@ -67,7 +68,7 @@ def test_execute_gradle(
 
     # Enable verbose tool logging
     if tool_debug_mode:
-        package_command.tools.logger.verbosity = 2
+        package_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     # Set up a side effect of invoking gradle to create a bundle
     def create_bundle(*args, **kwargs):

--- a/tests/platforms/iOS/xcode/test_build.py
+++ b/tests/platforms/iOS/xcode/test_build.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.iOS.xcode import iOSXcodeBuildCommand
@@ -30,7 +30,7 @@ def test_build_app(build_command, first_app_generated, tool_debug_mode, tmp_path
 
     # Enable verbose tool logging
     if tool_debug_mode:
-        build_command.tools.logger.verbosity = 2
+        build_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     build_command.build_app(first_app_generated)
 

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 import tomli_w
 
-from briefcase.console import Console, Log
+from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import (
     BriefcaseCommandError,
     NetworkFailure,
@@ -155,7 +155,7 @@ def test_build_appimage(build_command, first_app, debug_mode, tmp_path, sub_stre
     """A Linux app can be packaged as an AppImage."""
     # Enable verbose tool logging
     if debug_mode:
-        build_command.tools.logger.verbosity = 2
+        build_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     build_command.verify_app_tools(first_app)
     build_command.build_app(first_app)

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 
 from briefcase.commands.base import BaseCommand
-from briefcase.console import Console, Log
+from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS import macOSSigningMixin
@@ -239,7 +239,7 @@ def test_selected_identity(dummy_command):
 def test_sign_file_adhoc_identity(dummy_command, tmp_path, debug, capsys):
     """If an ad-hoc identity is used, the runtime option isn't used."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Sign the file with an ad-hoc identity
     dummy_command.sign_file(tmp_path / "base_path" / "random.file", identity="-")
@@ -267,7 +267,7 @@ def test_sign_file_adhoc_identity(dummy_command, tmp_path, debug, capsys):
 def test_sign_file_entitlements(dummy_command, tmp_path, debug, capsys):
     """Entitlements can be included in a signing call."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Sign the file with an ad-hoc identity
     dummy_command.sign_file(
@@ -299,7 +299,7 @@ def test_sign_file_entitlements(dummy_command, tmp_path, debug, capsys):
 def test_sign_file_deep_sign(dummy_command, tmp_path, debug, capsys):
     """A file can be identified as needing a deep sign."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # First call raises the deep sign warning; second call succeeds
     dummy_command.tools.subprocess.run.side_effect = mock_codesign(
@@ -342,7 +342,7 @@ def test_sign_file_deep_sign(dummy_command, tmp_path, debug, capsys):
 def test_sign_file_deep_sign_failure(dummy_command, tmp_path, debug, capsys):
     """If deep signing fails, an error is raised."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # First invocation raises the deep sign error; second invocation raises some other error
     dummy_command.tools.subprocess.run.side_effect = mock_codesign(
@@ -385,7 +385,7 @@ def test_sign_file_unsupported_format(dummy_command, tmp_path, debug, capsys):
     """If codesign reports an unsupported format, the signing attempt is ignored with a
     warning."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # FIXME: I'm not sure how to manufacture this in practice.
     dummy_command.tools.subprocess.run.side_effect = mock_codesign(
@@ -424,7 +424,7 @@ def test_sign_file_unknown_bundle_format(dummy_command, tmp_path, debug, capsys)
     """If a folder happens to have a .framework extension, the signing attempt is
     ignored with a warning."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Raise an error caused by an unknown bundle format during codesign
     dummy_command.tools.subprocess.run.side_effect = mock_codesign(
@@ -462,7 +462,7 @@ def test_sign_file_unknown_bundle_format(dummy_command, tmp_path, debug, capsys)
 def test_sign_file_unknown_error(dummy_command, tmp_path, debug, capsys):
     """Any other codesigning error raises an error."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Raise an unknown error during codesign
     dummy_command.tools.subprocess.run.side_effect = mock_codesign("Unknown error")
@@ -494,7 +494,7 @@ def test_sign_file_unknown_error(dummy_command, tmp_path, debug, capsys):
 def test_sign_app(dummy_command, first_app_with_binaries, tmp_path, debug, capsys):
     """An app bundle can be signed."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Sign the app
     dummy_command.sign_app(
@@ -572,7 +572,7 @@ def test_sign_app(dummy_command, first_app_with_binaries, tmp_path, debug, capsy
 def test_sign_app_with_failure(dummy_command, first_app_with_binaries, debug, capsys):
     """If signing a single file in the app fails, the error is surfaced."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Sign the app. Signing first_dylib.dylib will fail.
     def _codesign(args, **kwargs):

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -235,11 +235,11 @@ def test_selected_identity(dummy_command):
     assert dummy_command.input.prompts == ["> "]
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_sign_file_adhoc_identity(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_sign_file_adhoc_identity(dummy_command, verbose, tmp_path, capsys):
     """If an ad-hoc identity is used, the runtime option isn't used."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Sign the file with an ad-hoc identity
     dummy_command.sign_file(tmp_path / "base_path" / "random.file", identity="-")
@@ -263,11 +263,11 @@ def test_sign_file_adhoc_identity(dummy_command, tmp_path, debug, capsys):
     assert len(output.strip("\n").split("\n")) == 1
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_sign_file_entitlements(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_sign_file_entitlements(dummy_command, verbose, tmp_path, capsys):
     """Entitlements can be included in a signing call."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Sign the file with an ad-hoc identity
     dummy_command.sign_file(
@@ -295,11 +295,11 @@ def test_sign_file_entitlements(dummy_command, tmp_path, debug, capsys):
     assert len(output.strip("\n").split("\n")) == 1
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_sign_file_deep_sign(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_sign_file_deep_sign(dummy_command, verbose, tmp_path, capsys):
     """A file can be identified as needing a deep sign."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # First call raises the deep sign warning; second call succeeds
     dummy_command.tools.subprocess.run.side_effect = mock_codesign(
@@ -330,19 +330,19 @@ def test_sign_file_deep_sign(dummy_command, tmp_path, debug, capsys):
     )
 
     output = capsys.readouterr().out
-    if debug:
+    if verbose:
         # The console includes a warning about the attempt to deep sign
         assert "... random.file requires a deep sign; retrying\n" in output
 
     # Output only happens if in debug mode
-    assert len(output.strip("\n").split("\n")) == (2 if debug else 1)
+    assert len(output.strip("\n").split("\n")) == (2 if verbose else 1)
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_sign_file_deep_sign_failure(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_sign_file_deep_sign_failure(dummy_command, verbose, tmp_path, capsys):
     """If deep signing fails, an error is raised."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # First invocation raises the deep sign error; second invocation raises some other error
     dummy_command.tools.subprocess.run.side_effect = mock_codesign(
@@ -372,20 +372,20 @@ def test_sign_file_deep_sign_failure(dummy_command, tmp_path, debug, capsys):
     )
 
     output = capsys.readouterr().out
-    if debug:
+    if verbose:
         # The console includes a warning about the attempt to deep sign
         assert "... random.file requires a deep sign; retrying\n" in output
 
     # Output only happens if in debug mode
-    assert len(output.strip("\n").split("\n")) == (2 if debug else 1)
+    assert len(output.strip("\n").split("\n")) == (2 if verbose else 1)
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_sign_file_unsupported_format(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_sign_file_unsupported_format(dummy_command, verbose, tmp_path, capsys):
     """If codesign reports an unsupported format, the signing attempt is ignored with a
     warning."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # FIXME: I'm not sure how to manufacture this in practice.
     dummy_command.tools.subprocess.run.side_effect = mock_codesign(
@@ -411,20 +411,20 @@ def test_sign_file_unsupported_format(dummy_command, tmp_path, debug, capsys):
     )
 
     output = capsys.readouterr().out
-    if debug:
+    if verbose:
         # The console includes a warning about not needing a signature.
         assert "... random.file does not require a signature\n" in output
 
     # Output only happens if in debug mode
-    assert len(output.strip("\n").split("\n")) == (2 if debug else 1)
+    assert len(output.strip("\n").split("\n")) == (2 if verbose else 1)
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_sign_file_unknown_bundle_format(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_sign_file_unknown_bundle_format(dummy_command, verbose, tmp_path, capsys):
     """If a folder happens to have a .framework extension, the signing attempt is
     ignored with a warning."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Raise an error caused by an unknown bundle format during codesign
     dummy_command.tools.subprocess.run.side_effect = mock_codesign(
@@ -450,19 +450,19 @@ def test_sign_file_unknown_bundle_format(dummy_command, tmp_path, debug, capsys)
     )
 
     output = capsys.readouterr().out
-    if debug:
+    if verbose:
         # The console includes a warning about not needing a signature.
         assert "... random.file does not require a signature\n" in output
 
     # Output only happens if in debug mode
-    assert len(output.strip("\n").split("\n")) == (2 if debug else 1)
+    assert len(output.strip("\n").split("\n")) == (2 if verbose else 1)
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_sign_file_unknown_error(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_sign_file_unknown_error(dummy_command, verbose, tmp_path, capsys):
     """Any other codesigning error raises an error."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Raise an unknown error during codesign
     dummy_command.tools.subprocess.run.side_effect = mock_codesign("Unknown error")
@@ -490,11 +490,11 @@ def test_sign_file_unknown_error(dummy_command, tmp_path, debug, capsys):
     assert len(output.strip("\n").split("\n")) == 1
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_sign_app(dummy_command, first_app_with_binaries, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_sign_app(dummy_command, first_app_with_binaries, verbose, tmp_path, capsys):
     """An app bundle can be signed."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Sign the app
     dummy_command.sign_app(
@@ -563,16 +563,16 @@ def test_sign_app(dummy_command, first_app_with_binaries, tmp_path, debug, capsy
         # coverage we need to. However, win32 doesn't handle executable permissions
         # the same as linux/unix, `unknown.binary` is identified as a signing target.
         # We ignore this discrepancy for testing purposes.
-        assert len(output.strip("\n").split("\n")) == (12 if debug else 1)
+        assert len(output.strip("\n").split("\n")) == (12 if verbose else 1)
     else:
-        assert len(output.strip("\n").split("\n")) == (11 if debug else 1)
+        assert len(output.strip("\n").split("\n")) == (11 if verbose else 1)
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_sign_app_with_failure(dummy_command, first_app_with_binaries, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_sign_app_with_failure(dummy_command, first_app_with_binaries, verbose, capsys):
     """If signing a single file in the app fails, the error is surfaced."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Sign the app. Signing first_dylib.dylib will fail.
     def _codesign(args, **kwargs):
@@ -603,6 +603,6 @@ def test_sign_app_with_failure(dummy_command, first_app_with_binaries, debug, ca
         # coverage we need to. However, win32 doesn't handle executable permissions
         # the same as linux/unix, `unknown.binary` is identified as a signing target.
         # We ignore this discrepancy for testing purposes.
-        assert len(output.strip("\n").split("\n")) == (7 if debug else 1)
+        assert len(output.strip("\n").split("\n")) == (7 if verbose else 1)
     else:
-        assert len(output.strip("\n").split("\n")) == (6 if debug else 1)
+        assert len(output.strip("\n").split("\n")) == (6 if verbose else 1)

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__ensure_thin_binary.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__ensure_thin_binary.py
@@ -2,6 +2,7 @@ import subprocess
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 
 from ...utils import create_file, file_content
@@ -11,7 +12,7 @@ from ...utils import create_file, file_content
 def test_thin_binary(dummy_command, tmp_path, debug, capsys):
     """A thin binary is left as-is."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Create a source binary.
     create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-original")
@@ -51,7 +52,7 @@ def test_thin_binary(dummy_command, tmp_path, debug, capsys):
 def test_fat_dylib(dummy_command, tmp_path, debug, capsys):
     """A fat binary library can be thinned."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Create a source binary.
     create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
@@ -107,7 +108,7 @@ def test_fat_dylib(dummy_command, tmp_path, debug, capsys):
 def test_fat_dylib_arch_mismatch(dummy_command, tmp_path, debug, capsys):
     """If a fat binary doesn't contain the target architecture, an error is raised."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Create a source binary.
     create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
@@ -145,7 +146,7 @@ def test_fat_dylib_unknown_info(dummy_command, tmp_path, debug, capsys):
     """If the lipo info call succeeds, but generates unknown output, an error is
     raised."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Create a source binary.
     create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
@@ -214,7 +215,7 @@ def test_lipo_info_fail(dummy_command, tmp_path):
 def test_lipo_thin_fail(dummy_command, tmp_path, debug, capsys):
     """If lipo fails thinning the binary, an error is raised."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Create a source binary.
     create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__ensure_thin_binary.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__ensure_thin_binary.py
@@ -8,11 +8,11 @@ from briefcase.exceptions import BriefcaseCommandError
 from ...utils import create_file, file_content
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_thin_binary(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_thin_binary(dummy_command, verbose, tmp_path, capsys):
     """A thin binary is left as-is."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
     create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-original")
@@ -45,14 +45,14 @@ def test_thin_binary(dummy_command, tmp_path, debug, capsys):
 
     # Output only happens if in debug mode
     output = capsys.readouterr().out.split("\n")
-    assert len(output) == (2 if debug else 1)
+    assert len(output) == (2 if verbose else 1)
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_fat_dylib(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_fat_dylib(dummy_command, verbose, tmp_path, capsys):
     """A fat binary library can be thinned."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
     create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
@@ -101,14 +101,14 @@ def test_fat_dylib(dummy_command, tmp_path, debug, capsys):
 
     # Output only happens if in debug mode
     output = capsys.readouterr().out.split("\n")
-    assert len(output) == (2 if debug else 1)
+    assert len(output) == (2 if verbose else 1)
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_fat_dylib_arch_mismatch(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_fat_dylib_arch_mismatch(dummy_command, verbose, tmp_path, capsys):
     """If a fat binary doesn't contain the target architecture, an error is raised."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
     create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
@@ -141,12 +141,12 @@ def test_fat_dylib_arch_mismatch(dummy_command, tmp_path, debug, capsys):
     dummy_command.tools.subprocess.run.assert_not_called()
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_fat_dylib_unknown_info(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_fat_dylib_unknown_info(dummy_command, verbose, tmp_path, capsys):
     """If the lipo info call succeeds, but generates unknown output, an error is
     raised."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
     create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
@@ -211,11 +211,11 @@ def test_lipo_info_fail(dummy_command, tmp_path):
     dummy_command.tools.subprocess.run.assert_not_called()
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_lipo_thin_fail(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_lipo_thin_fail(dummy_command, verbose, tmp_path, capsys):
     """If lipo fails thinning the binary, an error is raised."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
     create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
@@ -267,4 +267,4 @@ def test_lipo_thin_fail(dummy_command, tmp_path, debug, capsys):
 
     # Output only happens if in debug mode
     output = capsys.readouterr().out.split("\n")
-    assert len(output) == (2 if debug else 1)
+    assert len(output) == (2 if verbose else 1)

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__lipo_dylib.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__lipo_dylib.py
@@ -9,11 +9,11 @@ from briefcase.exceptions import BriefcaseCommandError
 from ...utils import create_file
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_lipo_dylib(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_lipo_dylib(dummy_command, verbose, tmp_path, capsys):
     """A binary library can be merged with lipo."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create 3 source binaries.
     create_file(tmp_path / "source-1" / "path" / "to" / "file.dylib", "dylib-1")
@@ -50,14 +50,14 @@ def test_lipo_dylib(dummy_command, tmp_path, debug, capsys):
 
     # Output only happens if in debug mode
     output = capsys.readouterr().out.split("\n")
-    assert len(output) == (2 if debug else 1)
+    assert len(output) == (2 if verbose else 1)
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_lipo_dylib_partial(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_lipo_dylib_partial(dummy_command, verbose, tmp_path, capsys):
     """If a source doesn't have the library, it isn't included in the merge."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create 2 source binaries. Source-2 doesn't have the binary.
     create_file(tmp_path / "source-1" / "path" / "to" / "file.dylib", "dylib-1")
@@ -91,14 +91,14 @@ def test_lipo_dylib_partial(dummy_command, tmp_path, debug, capsys):
 
     # Output only happens if in debug mode
     output = capsys.readouterr().out.split("\n")
-    assert len(output) == (2 if debug else 1)
+    assert len(output) == (2 if verbose else 1)
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_lipo_dylib_merge_error(dummy_command, tmp_path, debug, capsys):
+@pytest.mark.parametrize("verbose", [True, False])
+def test_lipo_dylib_merge_error(dummy_command, verbose, tmp_path, capsys):
     """If the merge process fails, an exception is raised."""
-    if debug:
-        dummy_command.logger.verbosity = LogLevel.DEBUG
+    if verbose:
+        dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create 3 source binaries.
     create_file(tmp_path / "source-1" / "path" / "to" / "file.dylib", "dylib-1")
@@ -144,4 +144,4 @@ def test_lipo_dylib_merge_error(dummy_command, tmp_path, debug, capsys):
 
     # Output only happens if in debug mode
     output = capsys.readouterr().out.split("\n")
-    assert len(output) == (2 if debug else 1)
+    assert len(output) == (2 if verbose else 1)

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__lipo_dylib.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__lipo_dylib.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 
 from ...utils import create_file
@@ -12,7 +13,7 @@ from ...utils import create_file
 def test_lipo_dylib(dummy_command, tmp_path, debug, capsys):
     """A binary library can be merged with lipo."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Create 3 source binaries.
     create_file(tmp_path / "source-1" / "path" / "to" / "file.dylib", "dylib-1")
@@ -56,7 +57,7 @@ def test_lipo_dylib(dummy_command, tmp_path, debug, capsys):
 def test_lipo_dylib_partial(dummy_command, tmp_path, debug, capsys):
     """If a source doesn't have the library, it isn't included in the merge."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Create 2 source binaries. Source-2 doesn't have the binary.
     create_file(tmp_path / "source-1" / "path" / "to" / "file.dylib", "dylib-1")
@@ -97,7 +98,7 @@ def test_lipo_dylib_partial(dummy_command, tmp_path, debug, capsys):
 def test_lipo_dylib_merge_error(dummy_command, tmp_path, debug, capsys):
     """If the merge process fails, an exception is raised."""
     if debug:
-        dummy_command.logger.verbosity = 1
+        dummy_command.logger.verbosity = LogLevel.DEBUG
 
     # Create 3 source binaries.
     create_file(tmp_path / "source-1" / "path" / "to" / "file.dylib", "dylib-1")

--- a/tests/platforms/macOS/xcode/test_build.py
+++ b/tests/platforms/macOS/xcode/test_build.py
@@ -3,7 +3,7 @@ from unittest.mock import ANY, MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS.xcode import macOSXcodeBuildCommand
@@ -24,7 +24,7 @@ def test_build_app(build_command, first_app_generated, tool_debug_mode, tmp_path
     """An macOS App can be built."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        build_command.tools.logger.verbosity = 2
+        build_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     build_command.tools.subprocess = MagicMock(spec_set=Subprocess)
     build_command.build_app(first_app_generated, test_mode=False)

--- a/tests/platforms/windows/visualstudio/test_build.py
+++ b/tests/platforms/windows/visualstudio/test_build.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 import briefcase.platforms.windows.visualstudio
-from briefcase.console import Console, Log
+from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.integrations.visualstudio import VisualStudio
@@ -51,7 +51,7 @@ def test_build_app(build_command, first_app_config, tool_debug_mode, tmp_path):
     """The solution will be compiled when the project is built."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        build_command.tools.logger.verbosity = 2
+        build_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
 
     build_command.build_app(first_app_config)
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -6,7 +6,7 @@ import pytest
 
 from briefcase import __version__, cmdline
 from briefcase.commands import DevCommand, NewCommand, UpgradeCommand
-from briefcase.console import Console, Log
+from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import (
     InvalidFormatError,
     NoCommandError,
@@ -101,7 +101,7 @@ def test_new_command(logger, console):
     assert cmd.platform == "all"
     assert cmd.output_format is None
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {"template": None, "template_branch": None}
@@ -150,7 +150,7 @@ def test_dev_command(monkeypatch, logger, console, cmdline, expected_options):
     assert cmd.platform == "macOS"
     assert cmd.output_format is None
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {
@@ -185,7 +185,7 @@ def test_run_command(monkeypatch, logger, console, cmdline, expected_options):
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {
@@ -212,7 +212,7 @@ def test_upgrade_command(monkeypatch, logger, console):
     assert cmd.platform == "macOS"
     assert cmd.output_format is None
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {
@@ -232,7 +232,7 @@ def test_bare_command(monkeypatch, logger, console):
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -248,7 +248,7 @@ def test_linux_default(logger, console):
     assert cmd.platform == "linux"
     assert cmd.output_format == "system"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -264,7 +264,7 @@ def test_macOS_default(logger, console):
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -280,7 +280,7 @@ def test_windows_default(logger, console):
     assert cmd.platform == "windows"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -343,7 +343,7 @@ def test_command_explicit_platform(monkeypatch, logger, console):
     assert cmd.platform == "linux"
     assert cmd.output_format == "system"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -361,7 +361,7 @@ def test_command_explicit_platform_case_handling(monkeypatch, logger, console):
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -397,7 +397,7 @@ def test_command_explicit_format(monkeypatch, logger, console):
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -463,7 +463,7 @@ def test_command_disable_input(monkeypatch, logger, console):
     assert cmd.platform == "macOS"
     assert cmd.output_format == "app"
     assert not cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {}
@@ -480,7 +480,7 @@ def test_command_options(monkeypatch, capsys, logger, console):
 
     assert isinstance(cmd, macOSAppPublishCommand)
     assert cmd.input.enabled
-    assert cmd.logger.verbosity == 0
+    assert cmd.logger.verbosity == LogLevel.INFO
     assert cmd.logger is logger
     assert cmd.input is console
     assert options == {"channel": "s3"}


### PR DESCRIPTION
## Changes
- Closes #1501
- Introduces a `verbose` logging level between `info` and `debug`
- Explicit references to the logging level are now abstracted by a `LogLevel` enum and properties `Log.is_verbose`, `Log.is_debug`, and `Log.is_deep_debug`
- Limited the `>>>` preface to subprocess details logging 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
