### PR TITLE
Improve the filter for iOS build logs.

### DIFF
--- a/changes/1507.bugfix.rst
+++ b/changes/1507.bugfix.rst
@@ -1,0 +1,1 @@
+The filter for iOS build warnings was improved to catch messages from Xcode 15.0.1.

--- a/src/briefcase/platforms/macOS/filters.py
+++ b/src/briefcase/platforms/macOS/filters.py
@@ -112,7 +112,7 @@ class XcodeBuildFilter:
         XCODEBUILD_PREFIX + r"\[MT\] DVTAssertions: "
         r"Warning in /System/Volumes/Data/SWE/Apps/DT/BuildRoots/BuildRoot11/"
         r"ActiveBuildRoot/Library/Caches/com.apple.xbs/Sources/IDEFrameworks/"
-        r"IDEFrameworks-22267/IDEFoundation/Provisioning"
+        r"IDEFrameworks-\d+/IDEFoundation/Provisioning"
         r"/Capabilities Infrastructure/IDECapabilityQuerySelection.swift:\d+"
     )
 


### PR DESCRIPTION
The filter for iOS logs that was added in #1468 turns out to be version specific - with the release of Xcode 15.0.1, it no longer matches, because an ID number in the filter has been changed.

This PR modifies the regex to catch any framework number, which will hopefully match *any* Xcode release.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
