### PR TITLE
Add a warning about AppImage use.

### DIFF
--- a/changes/1500.removal.rst
+++ b/changes/1500.removal.rst
@@ -1,0 +1,1 @@
+The use of AppImage as an output format now generates a warning.

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -105,7 +105,7 @@ class LinuxAppImagePassiveMixin(LinuxMixin):
     Briefcase supports AppImage in a best-effort capacity. It has proven
     to be highly unreliable as a distribution platform. AppImages cannot
     use pre-compiled binary wheels, and has significant problems with
-    most commonly used GUI toolkits (include GTK and PySide).
+    most commonly used GUI toolkits (including GTK and PySide).
 
     Consider using system packages or Flatpak for Linux app
     distribution.

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -96,6 +96,24 @@ class LinuxAppImagePassiveMixin(LinuxMixin):
 """
             )
 
+        self.logger.warning(
+            """\
+*************************************************************************
+** WARNING: Use of AppImage is not recommended!                        **
+*************************************************************************
+
+    Briefcase supports AppImage in a best-effort capacity. It has proven
+    to be highly unreliable as a distribution platform. AppImages cannot
+    use pre-compiled binary wheels, and has significant problems with
+    most commonly used GUI toolkits (include GTK and PySide).
+
+    Consider using system packages or Flatpak for Linux app
+    distribution.
+
+*************************************************************************
+"""
+        )
+
 
 class LinuxAppImageMostlyPassiveMixin(LinuxAppImagePassiveMixin):
     # The Mostly Passive mixin verifies that Docker exists and can be run, but

--- a/tests/platforms/linux/appimage/test_create.py
+++ b/tests/platforms/linux/appimage/test_create.py
@@ -69,8 +69,12 @@ def test_finalize_docker(create_command, first_app_config, capsys):
 
     create_command.finalize_app_config(first_app_config)
 
+    stdout = capsys.readouterr().out
     # Warning message was not recorded
-    assert "WARNING: Building a Local AppImage!" not in capsys.readouterr().out
+    assert "WARNING: Building a Local AppImage!" not in stdout
+
+    # Generic appimage warning *was* recorded
+    assert "WARNING: Use of AppImage is not recommended!" in stdout
 
 
 def test_finalize_nodocker(create_command, first_app_config, capsys):
@@ -79,8 +83,12 @@ def test_finalize_nodocker(create_command, first_app_config, capsys):
 
     create_command.finalize_app_config(first_app_config)
 
-    # Warning message was not recorded
-    assert "WARNING: Building a Local AppImage!" in capsys.readouterr().out
+    stdout = capsys.readouterr().out
+    # Warning message was recorded
+    assert "WARNING: Building a Local AppImage!" in stdout
+
+    # Generic appimage warning *was* recorded
+    assert "WARNING: Use of AppImage is not recommended!" in stdout
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

Briefcase 0.3.16 moved AppImage to best-effort support; warn users that this is the case.

Fixes #1500 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
