### PR TITLE
Copy permissions when merging macOS app packages

### DIFF
--- a/changes/1510.bugfix.rst
+++ b/changes/1510.bugfix.rst
@@ -1,0 +1,1 @@
+When merging dependencies on macOS, file permissions are now preserved.

--- a/src/briefcase/platforms/macOS/utils.py
+++ b/src/briefcase/platforms/macOS/utils.py
@@ -243,11 +243,9 @@ class AppPackagesMergeMixin:
                                     f"between sources; ignoring {source_app_packages.suffix[1:]} version."
                                 )
                         else:
-                            # The file doesn't exist yet; copy it as is, and store the
-                            # digest for later comparison
-                            self.tools.shutil.copyfile(source_path, target_path)
-                            # Ensure permissions as well.
-                            self.tools.shutil.copymode(source_path, target_path)
+                            # The file doesn't exist yet; copy it as is (including
+                            # permissions), and store the digest for later comparison
+                            self.tools.shutil.copy(source_path, target_path)
                             digests[relative_path] = sha256_file_digest(source_path)
 
         # Call lipo on each dylib that was found to create the fat version.

--- a/src/briefcase/platforms/macOS/utils.py
+++ b/src/briefcase/platforms/macOS/utils.py
@@ -246,6 +246,8 @@ class AppPackagesMergeMixin:
                             # The file doesn't exist yet; copy it as is, and store the
                             # digest for later comparison
                             self.tools.shutil.copyfile(source_path, target_path)
+                            # Ensure permissions as well.
+                            self.tools.shutil.copymode(source_path, target_path)
                             digests[relative_path] = sha256_file_digest(source_path)
 
         # Call lipo on each dylib that was found to create the fat version.

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__merge_app_packages.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__merge_app_packages.py
@@ -154,7 +154,7 @@ def test_merge(dummy_command, pre_existing, tmp_path):
     }
 
     # Check that the embedded binary has executable permissions
-    assert os.access(merged_path / "second" / "some-binary", 0o755)
+    assert os.access(merged_path / "second" / "some-binary", os.X_OK)
 
 
 def test_merge_problem(dummy_command, tmp_path):

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__merge_app_packages.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__merge_app_packages.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -26,11 +27,13 @@ def test_merge(dummy_command, pre_existing, tmp_path):
         extra_content=[
             ("second/other.py", "# other python"),
             ("second/different.py", "# different python"),
+            ("second/some-binary", "# A file with executable permissions", 0o755),
             ("second/sub1/module1.dylib", "dylib-gothic"),
             ("second/sub1/module2.so", "dylib-gothic"),
             ("second/sub1/module3.dylib", "dylib-gothic"),
         ],
     )
+
     # Create 2 packages in the "modern" architecture app package sources
     # The first package is pure, so it won't exist in the second app_packages.
     # The "second" package:
@@ -110,6 +113,7 @@ def test_merge(dummy_command, pre_existing, tmp_path):
         (Path("second/__init__.py"), ""),
         (Path("second/app.py"), "# This is the app"),
         (Path("second/different.py"), "# different python"),
+        (Path("second/some-binary"), "# A file with executable permissions"),
         (Path("second/other.py"), "# other python"),
         (Path("second/sub1"), None),
         (Path("second/sub1/module1.dylib"), "dylib-merged"),
@@ -148,6 +152,9 @@ def test_merge(dummy_command, pre_existing, tmp_path):
             ),
         ),
     }
+
+    # Check that the embedded binary has executable permissions
+    assert os.access(merged_path / "second" / "some-binary", 0o755)
 
 
 def test_merge_problem(dummy_command, tmp_path):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -235,16 +235,22 @@ def create_installed_package(
     :param package: The name of the package in the wheel. Defaults to ``dummy``
     :param version: The version number of the package. Defaults to ``1.2.3``
     :param tag: The installation tag for the package. Defaults to a pure python wheel.
-    :param extra_content: Optional. A list of tuples of ``(path, content)`` that will be
-        added to the wheel.
+    :param extra_content: Optional. A list of tuples of ``(path, content)`` or
+        ``(path, content, chmod)`` that will be added to the wheel. If ``chmod`` is
+        not specified, default filesystem permissions will be used.
     """
-    for filename, content in installed_package_content(
+    for entry in installed_package_content(
         package=package,
         version=version,
         tag=tag,
         extra_content=extra_content,
     ):
-        create_file(path / filename, content=content)
+        try:
+            filename, content, chmod = entry
+        except ValueError:
+            filename, content = entry
+            chmod = None
+        create_file(path / filename, content=content, chmod=chmod)
 
 
 def create_wheel(
@@ -260,8 +266,9 @@ def create_wheel(
     :param package: The name of the package in the wheel. Defaults to ``dummy``
     :param version: The version number of the package. Defaults to ``1.2.3``
     :param tag: The installation tag for the package. Defaults to a pure python wheel.
-    :param extra_content: Optional. A list of tuples of ``(path, content)`` that
-        will be added to the wheel.
+    :param extra_content: Optional. A list of tuples of ``(path, content)`` or
+        ``(path, content, chmod)`` that will be added to the wheel. If ``chmod`` is
+        not specified, default filesystem permissions will be used.
     """
     wheel_filename = path / f"{package}-{version}-{tag}.whl"
 


### PR DESCRIPTION
Fixes #1510

When merging app packages, file permissions (and in particular, the executable bit) are now preserved.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
