### PR TITLE
Modify flatpak-builder handling to allow for new-style version output

### DIFF
--- a/changes/1513.bugfix.rst
+++ b/changes/1513.bugfix.rst
@@ -1,0 +1,1 @@
+``flatpak-builder`` 1.3+ can now be correctly identified.

--- a/src/briefcase/integrations/flatpak.py
+++ b/src/briefcase/integrations/flatpak.py
@@ -85,7 +85,10 @@ You must install both flatpak and flatpak-builder.
                 ["flatpak-builder", "--version"]
             ).strip("\n")
 
-            parts = output.split(" ")
+            # flatpak-builder 1.3 changed the output of --version
+            # from "flatpak-builder 1.2.X" to "flatpak-build-1.3.X".
+            # Converge on the new-style format.
+            parts = output.replace(" ", "-").rsplit("-", 1)
             try:
                 if parts[0] == "flatpak-builder":
                     version = parts[1].split(".")

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -927,7 +927,7 @@ class LinuxSystemPackageCommand(LinuxSystemMixin, PackageCommand):
                             f"Package: {app.app_name}",
                             f"Version: {app.version}",
                             f"Architecture: {self.deb_abi(app)}",
-                            f"Maintainer: {app.author } <{app.author_email}>",
+                            f"Maintainer: {app.author} <{app.author_email}>",
                             f"Homepage: {app.url}",
                             f"Description: {app.description}",
                             f" {debian_multiline_description(app.long_description)}",

--- a/tests/integrations/flatpak/test_Flatpak__verify.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify.py
@@ -157,11 +157,20 @@ def test_flatpak_builder_old(mock_tools):
     )
 
 
-def test_installed(mock_tools):
+@pytest.mark.parametrize(
+    "flatpak_builder_version",
+    [
+        # Ubuntu 22.04; flatpak-builder < 1.3
+        "flatpak-builder 1.2.2",
+        # Fedora 38; flatpak-builder >= 1.3
+        "flatpak-builder-1.3.3",
+    ],
+)
+def test_installed(mock_tools, flatpak_builder_version, capsys):
     """If flatpak is installed, it can be verified."""
     mock_tools.subprocess.check_output.side_effect = [
         "Flatpak 1.12.7",
-        "flatpak-builder 1.2.2",
+        flatpak_builder_version,
     ]
 
     Flatpak.verify(mock_tools)
@@ -173,6 +182,14 @@ def test_installed(mock_tools):
         ],
         any_order=False,
     )
+
+    # We shouldn't get any warnings about unknown versions.
+    output = capsys.readouterr()
+    assert (
+        "** WARNING: Unable to determine the version of flatpak-builder"
+        not in output.out
+    )
+    assert output.err == ""
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1513 

Modifies the flatpak-builder version identification to allow for the v1.3 format output.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
