### PR TITLE
Update the origin remote URL for a cached template before using it

### DIFF
--- a/changes/1158.bugfix.rst
+++ b/changes/1158.bugfix.rst
@@ -1,0 +1,1 @@
+When a custom Briefcase template from a git repository is used to create an app, Briefcase now ensures that git repository is always used.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -844,6 +844,10 @@ Did you run Briefcase in a project directory that contains {filename.name!r}?"""
                 repo = self.tools.git.Repo(cached_template)
                 # Raises ValueError if "origin" isn't a valid remote
                 remote = repo.remote(name="origin")
+                # Ensure the existing repo's origin URL points to the location
+                # being requested. A difference can occur, for instance, if a
+                # fork of the template is used.
+                remote.set_url(new_url=template, old_url=remote.url)
                 try:
                     # Attempt to update the repository
                     remote.fetch()


### PR DESCRIPTION
## Changes
- The URL for the `origin` remote for cached templates is always updated before fetching now
- Closes #1158

## Notes
- Tested without internet connectivity and `set-url` doesn't require a connection (as expected)
- I'm certainly not a git expert so definitely open to overlooked concerns with doing this
  - At least for my common case, i.e. using a fork of the template, this fixes my issue
- I haven't experimented with just letting cookiecutter take the remote address to the git repo directly....but I wonder if they have fixed the problems that necessitated all this git inspection and branch checking...

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
