### PR TITLE
Ensure `setuptools` and `wheel` installed for `install_requirement.py`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools build wheel
         # Utility script installs tox as defined in pyproject.toml
-        python -m install_requirement --extra dev tox
+        python -m install_requirement tox --extra dev
 
     - name: Test
       id: test
@@ -128,7 +128,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools build wheel
         # Utility script installs tox as defined in pyproject.toml
-        python -m install_requirement --extra dev tox
+        python -m install_requirement tox --extra dev
 
     - name: Retrieve Coverage Data
       uses: actions/download-artifact@v3.0.2

--- a/changes/1526.misc.rst
+++ b/changes/1526.misc.rst
@@ -1,0 +1,1 @@
+The ``setuptools`` and ``build`` packages are always installed prior to running ``install_requirement.py`` now.

--- a/install_requirement.py
+++ b/install_requirement.py
@@ -35,6 +35,10 @@
 #
 # Therefore, this script will evaluate the requirements defined in the project's
 # metadata and install the ones matching those being requested to be installed.
+#
+# Dependencies
+# ------------
+# The ``build``, ``setuptools``, and ``wheel`` packages must be installed to run.
 
 from __future__ import annotations
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,11 @@ skip_missing_interpreters = True
 
 [testenv:pre-commit]
 skip_install = True
-deps = build
-commands_pre = python -m install_requirement --extra dev --project-root "{tox_root}" pre-commit
+deps =
+    build
+    setuptools
+    wheel
+commands_pre = python -m install_requirement pre-commit --extra dev --project-root "{tox_root}"
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
 [testenv:py{,38,39,310,311,312}{,-fast}]
@@ -64,7 +67,7 @@ deps =
     wheel
 commands_pre =
     python --version
-    python -m install_requirement --extra dev --project-root "{tox_root}" coverage coverage-conditional-plugin
+    python -m install_requirement coverage coverage-conditional-plugin --extra dev --project-root "{tox_root}"
 commands =
     -python -m coverage combine {env:COMBINE_FLAGS}
     html: python -m coverage html --skip-covered --skip-empty


### PR DESCRIPTION
I think this is fallout from `setuptools` no longer being installed by default in 3.12+.

Run `tox -e pre-commit` with Python 3.12 to replicate locally.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct