### PR TITLE
Building on Python 3.12 requires `setuptools >=67`

### DIFF
--- a/changes/1527.misc.rst
+++ b/changes/1527.misc.rst
@@ -1,0 +1,1 @@
+The build version requirement for ``setuptools`` was bumped from 60 to 67.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=60", "setuptools_scm[toml]>=7.0"]
+requires = ["setuptools>=67", "setuptools_scm[toml]>=7.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]


### PR DESCRIPTION
This is as much an FYI as anything, I suppose.

I was messing around with package building and noticed `setuptools_scm >=8` recommends (err...requires...) `setuptools >=64`. Out of curiosity, I tried to build Briefcase with `setuptools ==60` using Python 3.12 but it bombs out in `setuptools` on some import of nonexistent code. I bumped `setuptools` until the build would work and landed at `>=67`.

For any of our purposes, this doesn't really matter since the latest version of `setuptools` will always be used. However, if someone tried to package Briefcase themselves, the current `setuptools` version constraint isn't really truthful.

Furthermore, if you were following greg's recent [chain](https://discuss.python.org/t/user-experience-with-porting-off-setup-py) about moving to `pyproject.toml`, he [pointed out](https://discuss.python.org/t/user-experience-with-porting-off-setup-py/37502/87) that pinning build requirements can create downstream problems. So, while Briefcase is unlikely to be a dependency for anything....it doesn't generally seem reliable to use pinning here 😕 

At any rate...this'll make the `setuptools` build version constraint a little more truthful.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct