### PR TITLE
Capture logging for tools using stdlib logging

### DIFF
--- a/changes/1529.feature.rst
+++ b/changes/1529.feature.rst
@@ -1,0 +1,1 @@
+GitPython's debug logging is now included in deep debug output.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -13,7 +13,6 @@ from argparse import RawDescriptionHelpFormatter
 from pathlib import Path
 
 from cookiecutter import exceptions as cookiecutter_exceptions
-from cookiecutter.log import configure_logger as configure_cookiecutter_logger
 from cookiecutter.repository import is_repo_url
 from platformdirs import PlatformDirs
 
@@ -916,7 +915,7 @@ Did you run Briefcase in a project directory that contains {filename.name!r}?"""
             template=template, branch=branch
         )
 
-        configure_cookiecutter_logger("DEBUG" if self.logger.is_deep_debug else "INFO")
+        self.logger.configure_stdlib_logging("cookiecutter")
 
         try:
             # Unroll the template

--- a/src/briefcase/integrations/git.py
+++ b/src/briefcase/integrations/git.py
@@ -72,5 +72,7 @@ need to restart your terminal session.
 """
                 ) from e
 
+        tools.logger.configure_stdlib_logging("git")
+
         tools.git = git
         return git

--- a/tests/integrations/git/test_Git__verify.py
+++ b/tests/integrations/git/test_Git__verify.py
@@ -1,5 +1,8 @@
+import logging
+
 import pytest
 
+from briefcase.console import LogLevel, RichLoggingHandler
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.git import Git
 
@@ -23,3 +26,26 @@ def test_unsupported_os(mock_tools):
         match=f"{Git.name} is not supported on wonky",
     ):
         Git.verify(mock_tools)
+
+
+@pytest.mark.parametrize(
+    "logging_level, handler_expected",
+    [
+        (LogLevel.DEEP_DEBUG, True),
+        (LogLevel.DEBUG, False),
+        (LogLevel.VERBOSE, False),
+        (LogLevel.INFO, False),
+    ],
+)
+def test_git_stdlib_logging(mock_tools, logging_level, handler_expected):
+    """A logging handler is configured for GitPython when DEEP_DEBUG is enabled."""
+    mock_tools.logger.verbosity = logging_level
+
+    Git.verify(mock_tools)
+
+    assert handler_expected is any(
+        isinstance(h, RichLoggingHandler) for h in logging.getLogger("git").handlers
+    )
+
+    # reset handlers since they are persistent
+    logging.getLogger("git").handlers.clear()


### PR DESCRIPTION
## Changes
- This generalizes support for tools that log using the stdlib `logging` introduced in #1470
- Now, both logging for `cookiecutter` and `GitPython` are supported
- This also ensures that such logging is captured in the logfile and is dimmed in the console...which is nice

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct