### PR TITLE
Bump black from 23.10.1 to 23.11.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: docformatter
         args: [--in-place, --black]
   - repo: https://github.com/psf/black
-    rev: 23.10.1
+    rev: 23.11.0
     hooks:
       - id: black
         language_version: python3

--- a/changes/1533.misc.rst
+++ b/changes/1533.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``black`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `black` from 23.10.1 to 23.11.0 and ran the update against the repo.