### PR TITLE
Wait for app to exit normally after log streaming

### DIFF
--- a/changes/1541.misc.rst
+++ b/changes/1541.misc.rst
@@ -1,0 +1,1 @@
+Once the exit condition is detected while log streaming, the app is now waited upon to exit normally instead of signaling it to exit immediately.

--- a/tests/commands/run/test__stream_app_logs.py
+++ b/tests/commands/run/test__stream_app_logs.py
@@ -9,7 +9,7 @@ from briefcase.exceptions import BriefcaseCommandError, BriefcaseTestSuiteFailur
 def test_run_app(run_command, first_app):
     """An app can have its logs streamed."""
     popen = mock.MagicMock()
-    popen.returncode = 0
+    popen.poll = mock.MagicMock(return_value=0)
     clean_filter = mock.MagicMock()
 
     # Invoke the stop func as part of streaming. This is to satisfy coverage.
@@ -47,7 +47,7 @@ def test_run_app(run_command, first_app):
 def test_run_app_custom_stop_func(run_command, first_app):
     """An app with a custom stop function can have its logs streamed."""
     popen = mock.MagicMock()
-    popen.returncode = 0
+    popen.poll = mock.MagicMock(return_value=0)
     clean_filter = mock.MagicMock()
     stop_func = mock.MagicMock()
     run_command.tools.subprocess.stream_output = mock.MagicMock()


### PR DESCRIPTION
## Changes
- Ensure the app has exited once it has indicated an exit condition in its output while log streaming
- Also, closes the log streaming `Popen` process after log streaming and uses `poll()` to determine the returncode

## Notes
- This doesn't affect app log streaming using `--test` because Briefcase doesn't care what happens to the app after the exit condition is found in its output.
- However, when an app includes the exit condition in its output while not under testing, then Briefcase uses the returncode of the app's `Popen` process to determine success.
- In general, it does seem better to wait for the app to exit on its own...since that should be what it's doing anyway
- Alternatively, we could change log streaming to _always_ use the returncode in the output exit condition to determine success....I think I'm mostly ambivalent on this...

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct