### PR TITLE
Bump Flatpak runtime versions for new projects

### DIFF
--- a/changes/1545.feature.rst
+++ b/changes/1545.feature.rst
@@ -1,0 +1,1 @@
+The Flatpak runtimes for new projects were updated to their latest release versions.

--- a/changes/1545.feature.rst
+++ b/changes/1545.feature.rst
@@ -1,1 +1,1 @@
-The Flatpak runtimes for new projects were updated to their latest release versions.
+The Flatpak runtimes for new projects were updated. ``org.freedesktop.Platform`` will now default to 23.08; ``org.gnome.Platform`` will now default to 45; and ``org.kde.Platform`` will now default to 6.6.

--- a/src/briefcase/bootstraps/pursuedpybear.py
+++ b/src/briefcase/bootstraps/pursuedpybear.py
@@ -134,7 +134,7 @@ linuxdeploy_plugins = [
     def pyproject_table_linux_flatpak(self):
         return """
 flatpak_runtime = "org.freedesktop.Platform"
-flatpak_runtime_version = "22.08"
+flatpak_runtime_version = "23.08"
 flatpak_sdk = "org.freedesktop.Sdk"
 """
 

--- a/src/briefcase/bootstraps/pygame.py
+++ b/src/briefcase/bootstraps/pygame.py
@@ -134,7 +134,7 @@ linuxdeploy_plugins = [
     def pyproject_table_linux_flatpak(self):
         return """
 flatpak_runtime = "org.freedesktop.Platform"
-flatpak_runtime_version = "22.08"
+flatpak_runtime_version = "23.08"
 flatpak_sdk = "org.freedesktop.Sdk"
 """
 

--- a/src/briefcase/bootstraps/pyside6.py
+++ b/src/briefcase/bootstraps/pyside6.py
@@ -156,7 +156,7 @@ linuxdeploy_plugins = [
     def pyproject_table_linux_flatpak(self):
         return """
 flatpak_runtime = "org.kde.Platform"
-flatpak_runtime_version = "6.4"
+flatpak_runtime_version = "6.6"
 flatpak_sdk = "org.kde.Sdk"
 """
 

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -182,7 +182,7 @@ linuxdeploy_plugins = [
     def pyproject_table_linux_flatpak(self):
         return """
 flatpak_runtime = "org.gnome.Platform"
-flatpak_runtime_version = "44"
+flatpak_runtime_version = "45"
 flatpak_sdk = "org.gnome.Sdk"
 """
 

--- a/tests/commands/new/test_build_context.py
+++ b/tests/commands/new/test_build_context.py
@@ -220,7 +220,7 @@ linuxdeploy_plugins = [
 """,
         pyproject_table_linux_flatpak="""
 flatpak_runtime = "org.gnome.Platform"
-flatpak_runtime_version = "44"
+flatpak_runtime_version = "45"
 flatpak_sdk = "org.gnome.Sdk"
 """,
         pyproject_table_windows="""
@@ -420,7 +420,7 @@ linuxdeploy_plugins = [
 """,
         pyproject_table_linux_flatpak="""
 flatpak_runtime = "org.kde.Platform"
-flatpak_runtime_version = "6.4"
+flatpak_runtime_version = "6.6"
 flatpak_sdk = "org.kde.Sdk"
 """,
         pyproject_table_windows="""
@@ -589,7 +589,7 @@ linuxdeploy_plugins = [
 """,
         pyproject_table_linux_flatpak="""
 flatpak_runtime = "org.freedesktop.Platform"
-flatpak_runtime_version = "22.08"
+flatpak_runtime_version = "23.08"
 flatpak_sdk = "org.freedesktop.Sdk"
 """,
         pyproject_table_windows="""
@@ -758,7 +758,7 @@ linuxdeploy_plugins = [
 """,
         pyproject_table_linux_flatpak="""
 flatpak_runtime = "org.freedesktop.Platform"
-flatpak_runtime_version = "22.08"
+flatpak_runtime_version = "23.08"
 flatpak_sdk = "org.freedesktop.Sdk"
 """,
         pyproject_table_windows="""
@@ -1200,7 +1200,7 @@ linuxdeploy_plugins = [
 """,
         pyproject_table_linux_flatpak="""
 flatpak_runtime = "org.gnome.Platform"
-flatpak_runtime_version = "44"
+flatpak_runtime_version = "45"
 flatpak_sdk = "org.gnome.Sdk"
 """,
         pyproject_table_windows="""


### PR DESCRIPTION
## Changes
- Bump Flatpak runtime versions
  - `org.freedesktop.Platform`: `22.08` -> `23.08`
  - `org.kde.Platform`: `6.4` -> `6.6`
  - `org.gnome.Platform`: `44` -> `45`

## Notes
`org.gnome.Platform==45`, `org.kde.Platform==6.6`, and `org.freedesktop.Platform==23.08` do not have `libcrypt.so.1` and Flatpak builds are failing because Standalone Python is still looking for it.... I was under the [impression](https://github.com/beeware/briefcase/issues/1383) that Standalone Python was dropping its dependency on this ancient library....but maybe I misunderstood something....

`libcrypt.so` was dropped for Python 3.10, 3.9, and 3.8 with https://github.com/indygreg/python-build-standalone/commit/80cd87f3401ebe42618d98b23d62f6fc6f5d7f63 and released in [20240107](https://github.com/indygreg/python-build-standalone/releases/tag/20240107).

## Dependencies
- https://github.com/indygreg/python-build-standalone/issues/197
- https://github.com/beeware/briefcase-linux-flatpak-template/pull/32

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
