### PR TITLE
Set runtime icon for PyGame apps

### DIFF
--- a/changes/1532.bugfix.rst
+++ b/changes/1532.bugfix.rst
@@ -1,0 +1,1 @@
+The BeeWare icon of Brutus is now used as the runtime icon for new projects created with PyGame.

--- a/src/briefcase/bootstraps/pursuedpybear.py
+++ b/src/briefcase/bootstraps/pursuedpybear.py
@@ -25,14 +25,14 @@ class {{ cookiecutter.class_name }}(ppb.Scene):
 
 
 def main():
-    # Linux desktop environments use app's .desktop file to integrate the app
-    # to their application menus. The .desktop file of this app will include
-    # StartupWMClass key, set to app's formal name, which helps associate
+    # Linux desktop environments use an app's .desktop file to integrate the app
+    # in to their application menus. The .desktop file of this app will include
+    # the StartupWMClass key, set to app's formal name. This helps associate the
     # app's windows to its menu item.
     #
-    # For association to work any windows of the app must have WMCLASS
-    # property set to match the value set in app's desktop file. For PPB this
-    # is set using environment variable.
+    # For association to work, any windows of the app must have WMCLASS property
+    # set to match the value set in app's desktop file. For PPB, this is set
+    # using the SDL_VIDEO_X11_WMCLASS environment variable.
 
     # Find the name of the module that was used to start the app
     app_module = sys.modules["__main__"].__package__

--- a/src/briefcase/bootstraps/pygame.py
+++ b/src/briefcase/bootstraps/pygame.py
@@ -9,6 +9,7 @@ class PygameGuiBootstrap(BaseGuiBootstrap):
 import importlib.metadata
 import os
 import sys
+from pathlib import Path
 
 import pygame
 
@@ -18,14 +19,14 @@ WHITE = (255, 255, 255)
 
 
 def main():
-    # Linux desktop environments use app's .desktop file to integrate the app
-    # to their application menus. The .desktop file of this app will include
-    # StartupWMClass key, set to app's formal name, which helps associate
+    # Linux desktop environments use an app's .desktop file to integrate the app
+    # in to their application menus. The .desktop file of this app will include
+    # the StartupWMClass key, set to app's formal name. This helps associate the
     # app's windows to its menu item.
     #
-    # For association to work any windows of the app must have WMCLASS
-    # property set to match the value set in app's desktop file. For PPB this
-    # is set using environment variable.
+    # For association to work, any windows of the app must have WMCLASS property
+    # set to match the value set in app's desktop file. For PyGame, this is set
+    # using the SDL_VIDEO_X11_WMCLASS environment variable.
 
     # Find the name of the module that was used to start the app
     app_module = sys.modules["__main__"].__package__
@@ -33,6 +34,13 @@ def main():
     metadata = importlib.metadata.metadata(app_module)
 
     os.environ["SDL_VIDEO_X11_WMCLASS"] = metadata["Formal-Name"]
+
+    # Set the app's runtime icon
+    pygame.display.set_icon(
+        pygame.image.load(
+            Path(__file__).parent / "resources" / "{{ cookiecutter.app_name }}.png"
+        )
+    )
 
     pygame.init()
     pygame.display.set_caption(metadata["Formal-Name"])

--- a/src/briefcase/bootstraps/pyside6.py
+++ b/src/briefcase/bootstraps/pyside6.py
@@ -23,14 +23,14 @@ class {{ cookiecutter.class_name }}(QtWidgets.QMainWindow):
 
 
 def main():
-    # Linux desktop environments use app's .desktop file to integrate the app
-    # to their application menus. The .desktop file of this app will include
-    # StartupWMClass key, set to app's formal name, which helps associate
+    # Linux desktop environments use an app's .desktop file to integrate the app
+    # in to their application menus. The .desktop file of this app will include
+    # the StartupWMClass key, set to app's formal name. This helps associate the
     # app's windows to its menu item.
     #
-    # For association to work any windows of the app must have WMCLASS
-    # property set to match the value set in app's desktop file. For PySide6
-    # this is set with setApplicationName().
+    # For association to work, any windows of the app must have WMCLASS property
+    # set to match the value set in app's desktop file. For PySide6, this is set
+    # with setApplicationName().
 
     # Find the name of the module that was used to start the app
     app_module = sys.modules["__main__"].__package__

--- a/tests/commands/new/test_build_context.py
+++ b/tests/commands/new/test_build_context.py
@@ -304,14 +304,14 @@ class {{ cookiecutter.class_name }}(QtWidgets.QMainWindow):
 
 
 def main():
-    # Linux desktop environments use app's .desktop file to integrate the app
-    # to their application menus. The .desktop file of this app will include
-    # StartupWMClass key, set to app's formal name, which helps associate
+    # Linux desktop environments use an app's .desktop file to integrate the app
+    # in to their application menus. The .desktop file of this app will include
+    # the StartupWMClass key, set to app's formal name. This helps associate the
     # app's windows to its menu item.
     #
-    # For association to work any windows of the app must have WMCLASS
-    # property set to match the value set in app's desktop file. For PySide6
-    # this is set with setApplicationName().
+    # For association to work, any windows of the app must have WMCLASS property
+    # set to match the value set in app's desktop file. For PySide6, this is set
+    # with setApplicationName().
 
     # Find the name of the module that was used to start the app
     app_module = sys.modules["__main__"].__package__
@@ -496,14 +496,14 @@ class {{ cookiecutter.class_name }}(ppb.Scene):
 
 
 def main():
-    # Linux desktop environments use app's .desktop file to integrate the app
-    # to their application menus. The .desktop file of this app will include
-    # StartupWMClass key, set to app's formal name, which helps associate
+    # Linux desktop environments use an app's .desktop file to integrate the app
+    # in to their application menus. The .desktop file of this app will include
+    # the StartupWMClass key, set to app's formal name. This helps associate the
     # app's windows to its menu item.
     #
-    # For association to work any windows of the app must have WMCLASS
-    # property set to match the value set in app's desktop file. For PPB this
-    # is set using environment variable.
+    # For association to work, any windows of the app must have WMCLASS property
+    # set to match the value set in app's desktop file. For PPB, this is set
+    # using the SDL_VIDEO_X11_WMCLASS environment variable.
 
     # Find the name of the module that was used to start the app
     app_module = sys.modules["__main__"].__package__
@@ -647,6 +647,7 @@ def test_question_sequence_pygame(new_command):
 import importlib.metadata
 import os
 import sys
+from pathlib import Path
 
 import pygame
 
@@ -656,14 +657,14 @@ WHITE = (255, 255, 255)
 
 
 def main():
-    # Linux desktop environments use app's .desktop file to integrate the app
-    # to their application menus. The .desktop file of this app will include
-    # StartupWMClass key, set to app's formal name, which helps associate
+    # Linux desktop environments use an app's .desktop file to integrate the app
+    # in to their application menus. The .desktop file of this app will include
+    # the StartupWMClass key, set to app's formal name. This helps associate the
     # app's windows to its menu item.
     #
-    # For association to work any windows of the app must have WMCLASS
-    # property set to match the value set in app's desktop file. For PPB this
-    # is set using environment variable.
+    # For association to work, any windows of the app must have WMCLASS property
+    # set to match the value set in app's desktop file. For PyGame, this is set
+    # using the SDL_VIDEO_X11_WMCLASS environment variable.
 
     # Find the name of the module that was used to start the app
     app_module = sys.modules["__main__"].__package__
@@ -671,6 +672,13 @@ def main():
     metadata = importlib.metadata.metadata(app_module)
 
     os.environ["SDL_VIDEO_X11_WMCLASS"] = metadata["Formal-Name"]
+
+    # Set the app's runtime icon
+    pygame.display.set_icon(
+        pygame.image.load(
+            Path(__file__).parent / "resources" / "{{ cookiecutter.app_name }}.png"
+        )
+    )
 
     pygame.init()
     pygame.display.set_caption(metadata["Formal-Name"])


### PR DESCRIPTION
## Changes
- The default runtime icon for PyGame apps is now replaced with Brutus

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct