### PR TITLE
Use Pixel 7 Pro skin for new AVDs

### DIFF
--- a/changes/1554.feature.rst
+++ b/changes/1554.feature.rst
@@ -1,0 +1,1 @@
+New virtual devices for the Android emulator are created using the Pixel 7 Pro skin.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -168,7 +168,7 @@ class AndroidSDK(ManagedTool):
 
     @property
     def DEFAULT_DEVICE_SKIN(self) -> str:
-        return "pixel_3a"
+        return "pixel_7_pro"
 
     @property
     def DEFAULT_SYSTEM_IMAGE(self) -> str:

--- a/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
@@ -160,7 +160,7 @@ def test_create_emulator_with_defaults(
     )
 
     # The emulator skin was verified
-    android_sdk.verify_emulator_skin.assert_called_once_with("pixel_3a")
+    android_sdk.verify_emulator_skin.assert_called_once_with("pixel_7_pro")
 
     # avdmanager was invoked
     mock_tools.subprocess.check_output.assert_called_once_with(
@@ -185,7 +185,7 @@ def test_create_emulator_with_defaults(
     with avd_config_path.open(encoding="utf-8") as f:
         config = f.read().split("\n")
     assert "hw.keyboard=yes" in config
-    assert "skin.name=pixel_3a" in config
+    assert "skin.name=pixel_7_pro" in config
 
 
 def test_create_failure(mock_tools, android_sdk):
@@ -207,7 +207,7 @@ def test_create_failure(mock_tools, android_sdk):
     android_sdk.verify_system_image.assert_called_once_with(ANY)
 
     # The emulator skin was verified
-    android_sdk.verify_emulator_skin.assert_called_once_with("pixel_3a")
+    android_sdk.verify_emulator_skin.assert_called_once_with("pixel_7_pro")
 
     # avdmanager was invoked
     mock_tools.subprocess.check_output.assert_called_once_with(

--- a/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
@@ -85,7 +85,7 @@ def test_create_emulator(
     android_sdk._create_emulator.assert_called_once_with(
         avd="new-emulator",
         device_type="pixel",
-        skin="pixel_3a",
+        skin="pixel_7_pro",
         system_image=f"system-images;android-31;default;{emulator_abi}",
     )
 


### PR DESCRIPTION
## Changes
- I loved my Pixel 3....but those giant bezels make it look particularly dated at this point
- New AVDs now use the Pixel 7 Pro skin and look extra fresh

## Notes
- I'm not aware of special considerations for using a different skin....on my machine, this just works
- Switched to the Pixel 7 Pro skin since the hello world app looks a bit better than Pixel 8 Pro

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct