### PR TITLE
Simplified Path declarations

### DIFF
--- a/changes/1556.misc.txt
+++ b/changes/1556.misc.txt
@@ -1,0 +1,1 @@
+Path declarations across the project have been simplified, with unneeded slash operators removed.

--- a/src/briefcase/bootstraps/pygame.py
+++ b/src/briefcase/bootstraps/pygame.py
@@ -37,7 +37,7 @@ def main():
 
     # Set the app's runtime icon
     pygame.display.set_icon(
-        pygame.image.load(Path(__file__).parent / "resources" / "{{ cookiecutter.app_name }}.png")
+        pygame.image.load(Path(__file__).parent / "resources/{{ cookiecutter.app_name }}.png")
     )
 
     pygame.init()

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -129,7 +129,7 @@ class AndroidSDK(ManagedTool):
         return self.dot_android_path / "avd"
 
     def avd_config_filename(self, avd: str) -> Path:
-        return self.avd_path / f"{avd}.avd" / "config.ini"
+        return self.avd_path / f"{avd}.avd/config.ini"
 
     @property
     def env(self) -> dict[str, str]:
@@ -580,7 +580,7 @@ its output for errors.
 
         Raises an error if licenses are not.
         """
-        license_path = self.root_path / "licenses" / "android-sdk-license"
+        license_path = self.root_path / "licenses/android-sdk-license"
         if license_path.exists():
             return
 

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -214,7 +214,7 @@ See https://docs.docker.com/go/buildx/ to install the buildx plugin.
 
     def _write_test_path(self) -> Path:
         """Host system filepath to perform write test from a container."""
-        return Path.cwd() / "build" / "container_write_test"
+        return Path.cwd() / "build/container_write_test"
 
     def _is_user_mapping_enabled(self, image_tag: str | None = None) -> bool:
         """Determine whether Docker is mapping users between the container and the host.

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -78,7 +78,7 @@ class JDK(ManagedTool):
         """
         output = tools.subprocess.check_output(
             [
-                os.fsdecode(Path(java_path) / "bin" / "javac"),
+                os.fsdecode(Path(java_path) / "bin/javac"),
                 "-version",
             ],
         )
@@ -239,7 +239,7 @@ class JDK(ManagedTool):
             # The macOS download has a weird layout (inherited from the official Oracle
             # release). The actual JAVA_HOME is deeper inside the directory structure.
             if tools.host_os == "Darwin":
-                java_home = java_home / "Contents" / "Home"
+                java_home = java_home / "Contents/Home"
 
             java = JDK(tools=tools, java_home=java_home)
 

--- a/src/briefcase/integrations/wix.py
+++ b/src/briefcase/integrations/wix.py
@@ -42,21 +42,21 @@ class WiX(ManagedTool):
         if self.bin_install:
             return self.wix_home / "heat.exe"
         else:
-            return self.wix_home / "bin" / "heat.exe"
+            return self.wix_home / "bin/heat.exe"
 
     @property
     def light_exe(self) -> Path:
         if self.bin_install:
             return self.wix_home / "light.exe"
         else:
-            return self.wix_home / "bin" / "light.exe"
+            return self.wix_home / "bin/light.exe"
 
     @property
     def candle_exe(self) -> Path:
         if self.bin_install:
             return self.wix_home / "candle.exe"
         else:
-            return self.wix_home / "bin" / "candle.exe"
+            return self.wix_home / "bin/candle.exe"
 
     @classmethod
     def verify_install(cls, tools: ToolCache, install: bool = True, **kwargs) -> WiX:

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -405,7 +405,7 @@ class GradlePackageCommand(GradleMixin, PackageCommand):
 
         # Move artefact to final location.
         self.tools.shutil.move(
-            self.bundle_path(app) / "app" / "build" / "outputs" / build_artefact_path,
+            self.bundle_path(app) / "app/build/outputs" / build_artefact_path,
             self.distribution_path(app),
         )
 

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -281,7 +281,7 @@ class iOSXcodeCreateCommand(iOSXcodePassiveMixin, CreateCommand):
             pip_kwargs={
                 "env": {
                     "PYTHONPATH": str(
-                        self.support_path(app) / "platform-site" / "iphoneos.arm64"
+                        self.support_path(app) / "platform-site/iphoneos.arm64"
                     ),
                 }
             },

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -69,7 +69,7 @@ class LinuxSystemPassiveMixin(LinuxMixin):
         return self.bundle_path(app) / f"{app.app_name}-{app.version}"
 
     def binary_path(self, app):
-        return self.project_path(app) / "usr" / "bin" / app.app_name
+        return self.project_path(app) / "usr/bin" / app.app_name
 
     def rpm_tag(self, app):
         if app.target_vendor == "fedora":

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -178,9 +178,7 @@ class macOSRunMixin:
         # as the process will generate lots of system-level messages.
         # We can't filter on *just* the senderImagePath, because other
         # apps will generate log messages that would be caught by the filter.
-        sender = os.fsdecode(
-            self.binary_path(app) / "Contents" / "MacOS" / app.formal_name
-        )
+        sender = os.fsdecode(self.binary_path(app) / "Contents/MacOS" / app.formal_name)
         log_popen = self.tools.subprocess.Popen(
             [
                 "log",
@@ -414,8 +412,8 @@ or
         :param identity: The signing identity to use
         """
         bundle_path = self.binary_path(app)
-        resources_path = bundle_path / "Contents" / "Resources"
-        frameworks_path = bundle_path / "Contents" / "Frameworks"
+        resources_path = bundle_path / "Contents/Resources"
+        frameworks_path = bundle_path / "Contents/Frameworks"
 
         sign_targets = []
 

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -64,7 +64,7 @@ class macOSAppCreateCommand(macOSAppMixin, macOSInstallMixin, CreateCommand):
                 # The stub binary is universal by default. If we're building a non-universal app,
                 # we can strip the binary to remove the unused slice.
                 self.ensure_thin_binary(
-                    self.binary_path(app) / "Contents" / "MacOS" / app.formal_name,
+                    self.binary_path(app) / "Contents/MacOS" / app.formal_name,
                     arch=self.tools.host_arch,
                 )
 

--- a/src/briefcase/platforms/macOS/xcode.py
+++ b/src/briefcase/platforms/macOS/xcode.py
@@ -39,7 +39,7 @@ class macOSXcodeMixin(macOSMixin):
         return self.bundle_path(app) / f"{app.formal_name}.xcodeproj"
 
     def binary_path(self, app):
-        return self.bundle_path(app) / "build" / "Release" / f"{app.formal_name}.app"
+        return self.bundle_path(app) / "build/Release" / f"{app.formal_name}.app"
 
 
 class macOSXcodeCreateCommand(macOSXcodeMixin, macOSInstallMixin, CreateCommand):

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -37,10 +37,10 @@ class StaticWebMixin:
         return self.bundle_path(app) / "www"
 
     def binary_path(self, app):
-        return self.bundle_path(app) / "www" / "index.html"
+        return self.bundle_path(app) / "www/index.html"
 
     def wheel_path(self, app):
-        return self.project_path(app) / "static" / "wheels"
+        return self.project_path(app) / "static/wheels"
 
     def distribution_path(self, app):
         return self.dist_path / f"{app.formal_name}-{app.version}.web.zip"
@@ -211,9 +211,7 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
         self.logger.info("Compile static web content from wheels")
         with self.input.wait_bar("Compiling static web content from wheels..."):
             # Trim previously compiled content out of briefcase.css
-            briefcase_css_path = (
-                self.project_path(app) / "static" / "css" / "briefcase.css"
-            )
+            briefcase_css_path = self.project_path(app) / "static/css/briefcase.css"
             self._trim_file(
                 briefcase_css_path,
                 sentinel=" ******************* Wheel contributed styles **********************/",

--- a/src/briefcase/platforms/windows/visualstudio.py
+++ b/src/briefcase/platforms/windows/visualstudio.py
@@ -15,7 +15,7 @@ from briefcase.platforms.windows import (
 
 class WindowsVisualStudioMixin(WindowsMixin):
     output_format = "VisualStudio"
-    packaging_root = Path("x64") / "Release"
+    packaging_root = Path("x64/Release")
 
     def project_path(self, app):
         return self.bundle_path(app) / f"{app.formal_name}.sln"

--- a/tests/commands/base/test_app_module_path.py
+++ b/tests/commands/base/test_app_module_path.py
@@ -8,10 +8,7 @@ def test_single_source(base_command, my_app):
     dist-info location."""
     my_app.sources = ["src/my_app"]
 
-    assert (
-        base_command.app_module_path(my_app)
-        == base_command.base_path / "src" / "my_app"
-    )
+    assert base_command.app_module_path(my_app) == base_command.base_path / "src/my_app"
 
 
 def test_no_prefix(base_command, my_app):
@@ -29,7 +26,7 @@ def test_long_prefix(base_command, my_app):
 
     assert (
         base_command.app_module_path(my_app)
-        == base_command.base_path / "path" / "to" / "src" / "my_app"
+        == base_command.base_path / "path/to/src/my_app"
     )
 
 
@@ -38,10 +35,7 @@ def test_matching_source(base_command, my_app):
     info location."""
     my_app.sources = ["src/other", "src/my_app", "src/extra"]
 
-    assert (
-        base_command.app_module_path(my_app)
-        == base_command.base_path / "src" / "my_app"
-    )
+    assert base_command.app_module_path(my_app) == base_command.base_path / "src/my_app"
 
 
 def test_multiple_match(base_command, my_app):

--- a/tests/commands/base/test_properties.py
+++ b/tests/commands/base/test_properties.py
@@ -8,9 +8,7 @@ def test_briefcase_required_python_version(base_command):
 def test_bundle_path(base_command, my_app, tmp_path):
     bundle_path = base_command.bundle_path(my_app)
 
-    assert (
-        bundle_path == tmp_path / "base_path" / "build" / "my-app" / "tester" / "dummy"
-    )
+    assert bundle_path == tmp_path / "base_path/build/my-app/tester/dummy"
 
 
 def test_create_command(base_command):

--- a/tests/commands/build/conftest.py
+++ b/tests/commands/build/conftest.py
@@ -114,7 +114,7 @@ def second_app(second_app_config, tmp_path):
         "second.bundle",
     )
     create_file(
-        tmp_path / "base_path" / "build" / "second" / "tester" / "dummy" / "second.bin",
+        tmp_path / "base_path/build/second/tester/dummy/second.bin",
         "second.bin",
     )
 

--- a/tests/commands/create/conftest.py
+++ b/tests/commands/create/conftest.py
@@ -203,15 +203,15 @@ def bundle_path(myapp, tmp_path):
     # Return the bundle path for the app; however, as a side effect,
     # ensure that the app, and app_packages target directories
     # exist, and the briefcase index file has been created.
-    bundle_path = tmp_path / "base_path" / "build" / myapp.app_name / "tester" / "dummy"
-    (bundle_path / "path" / "to" / "app").mkdir(parents=True, exist_ok=True)
+    bundle_path = tmp_path / "base_path/build" / myapp.app_name / "tester/dummy"
+    (bundle_path / "path/to/app").mkdir(parents=True, exist_ok=True)
 
     return bundle_path
 
 
 @pytest.fixture
 def app_packages_path_index(bundle_path):
-    (bundle_path / "path" / "to" / "app_packages").mkdir(parents=True, exist_ok=True)
+    (bundle_path / "path/to/app_packages").mkdir(parents=True, exist_ok=True)
     with (bundle_path / "briefcase.toml").open("wb") as f:
         index = {
             "paths": {
@@ -265,19 +265,19 @@ def no_support_path_index(bundle_path):
 
 @pytest.fixture
 def support_path(bundle_path):
-    return bundle_path / "path" / "to" / "support"
+    return bundle_path / "path/to/support"
 
 
 @pytest.fixture
 def app_requirements_path(bundle_path):
-    return bundle_path / "path" / "to" / "requirements.txt"
+    return bundle_path / "path/to/requirements.txt"
 
 
 @pytest.fixture
 def app_packages_path(bundle_path):
-    return bundle_path / "path" / "to" / "app_packages"
+    return bundle_path / "path/to/app_packages"
 
 
 @pytest.fixture
 def app_path(bundle_path):
-    return bundle_path / "path" / "to" / "app"
+    return bundle_path / "path/to/app"

--- a/tests/commands/create/test_call.py
+++ b/tests/commands/create/test_call.py
@@ -54,12 +54,8 @@ def test_create(tracking_create_command, tmp_path):
     ]
 
     # New app content has been created
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "new"
-    ).exists()
-    assert (
-        tmp_path / "base_path" / "build" / "second" / "tester" / "dummy" / "new"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/new").exists()
+    assert (tmp_path / "base_path/build/second/tester/dummy/new").exists()
 
 
 def test_create_single(tracking_create_command, tmp_path):
@@ -86,9 +82,5 @@ def test_create_single(tracking_create_command, tmp_path):
     ]
 
     # New app content has been created
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "new"
-    ).exists()
-    assert not (
-        tmp_path / "base_path" / "build" / "second" / "tester" / "dummy" / "new"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/new").exists()
+    assert not (tmp_path / "base_path/build/second/tester/dummy/new").exists()

--- a/tests/commands/create/test_cleanup_app_content.py
+++ b/tests/commands/create/test_cleanup_app_content.py
@@ -8,14 +8,14 @@ from ...utils import create_file
 @pytest.fixture
 def myapp_unrolled(myapp, support_path, app_packages_path_index):
     # Create some files that can be cleaned up
-    create_file(support_path / "dir1" / "a_file1.txt", "pork")
-    create_file(support_path / "dir1" / "a_file2.doc", "ham")
-    create_file(support_path / "dir1" / "b_file.txt", "eggs")
-    create_file(support_path / "dir1" / "__pycache__" / "first.pyc", "pyc 1")
-    create_file(support_path / "dir1" / "__pycache__" / "second.pyc", "pyc 2")
-    create_file(support_path / "dir2" / "b_file.txt", "spam")
-    create_file(support_path / "other" / "deep" / "b_file.doc", "wigs")
-    create_file(support_path / "other" / "deep" / "other.doc", "wigs")
+    create_file(support_path / "dir1/a_file1.txt", "pork")
+    create_file(support_path / "dir1/a_file2.doc", "ham")
+    create_file(support_path / "dir1/b_file.txt", "eggs")
+    create_file(support_path / "dir1/__pycache__/first.pyc", "pyc 1")
+    create_file(support_path / "dir1/__pycache__/second.pyc", "pyc 2")
+    create_file(support_path / "dir2/b_file.txt", "spam")
+    create_file(support_path / "other/deep/b_file.doc", "wigs")
+    create_file(support_path / "other/deep/other.doc", "wigs")
 
     return myapp
 
@@ -31,12 +31,12 @@ def test_no_cleanup(create_command, myapp_unrolled, support_path, debug, capsys)
     create_command.cleanup_app_content(myapp_unrolled)
 
     # Confirm the files are still there, except for the pycache
-    assert (support_path / "dir1" / "a_file1.txt").exists()
-    assert (support_path / "dir1" / "a_file2.doc").exists()
-    assert (support_path / "dir1" / "b_file.txt").exists()
-    assert not (support_path / "dir1" / "__pycache__").exists()
-    assert (support_path / "dir2" / "b_file.txt").exists()
-    assert (support_path / "other" / "deep" / "b_file.doc").exists()
+    assert (support_path / "dir1/a_file1.txt").exists()
+    assert (support_path / "dir1/a_file2.doc").exists()
+    assert (support_path / "dir1/b_file.txt").exists()
+    assert not (support_path / "dir1/__pycache__").exists()
+    assert (support_path / "dir2/b_file.txt").exists()
+    assert (support_path / "other/deep/b_file.doc").exists()
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -58,8 +58,8 @@ def test_dir_cleanup(create_command, myapp_unrolled, support_path, debug, capsys
 
     # Confirm that dir1 has been removed
     assert not (support_path / "dir1").exists()
-    assert (support_path / "dir2" / "b_file.txt").exists()
-    assert (support_path / "other" / "deep" / "b_file.doc").exists()
+    assert (support_path / "dir2/b_file.txt").exists()
+    assert (support_path / "other/deep/b_file.doc").exists()
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -80,12 +80,12 @@ def test_file_cleanup(create_command, myapp_unrolled, support_path, debug, capsy
     create_command.cleanup_app_content(myapp_unrolled)
 
     # Confirm the named file (plus __pycache__) has been removed
-    assert not (support_path / "dir1" / "a_file1.txt").exists()
-    assert (support_path / "dir1" / "a_file2.doc").exists()
-    assert (support_path / "dir1" / "b_file.txt").exists()
-    assert (support_path / "dir2" / "b_file.txt").exists()
-    assert not (support_path / "dir1" / "__pycache__").exists()
-    assert (support_path / "other" / "deep" / "b_file.doc").exists()
+    assert not (support_path / "dir1/a_file1.txt").exists()
+    assert (support_path / "dir1/a_file2.doc").exists()
+    assert (support_path / "dir1/b_file.txt").exists()
+    assert (support_path / "dir2/b_file.txt").exists()
+    assert not (support_path / "dir1/__pycache__").exists()
+    assert (support_path / "other/deep/b_file.doc").exists()
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -109,13 +109,13 @@ def test_all_files_in_dir_cleanup(
 
     # Confirm the named files (and __pycache__) have been removed,
     # but the dir still exists
-    assert not (support_path / "dir1" / "a_file1.txt").exists()
-    assert not (support_path / "dir1" / "a_file2.doc").exists()
-    assert not (support_path / "dir1" / "b_file.txt").exists()
-    assert not (support_path / "dir1" / "__pycache__").exists()
+    assert not (support_path / "dir1/a_file1.txt").exists()
+    assert not (support_path / "dir1/a_file2.doc").exists()
+    assert not (support_path / "dir1/b_file.txt").exists()
+    assert not (support_path / "dir1/__pycache__").exists()
     assert (support_path / "dir1").exists()
-    assert (support_path / "dir2" / "b_file.txt").exists()
-    assert (support_path / "other" / "deep" / "b_file.doc").exists()
+    assert (support_path / "dir2/b_file.txt").exists()
+    assert (support_path / "other/deep/b_file.doc").exists()
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -138,7 +138,7 @@ def test_dir_glob_cleanup(create_command, myapp_unrolled, support_path, debug, c
     # Confirm the matching directories have been removed
     assert not (support_path / "dir1").exists()
     assert not (support_path / "dir2").exists()
-    assert (support_path / "other" / "deep" / "b_file.doc").exists()
+    assert (support_path / "other/deep/b_file.doc").exists()
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -159,12 +159,12 @@ def test_file_glob_cleanup(create_command, myapp_unrolled, support_path, debug, 
     create_command.cleanup_app_content(myapp_unrolled)
 
     # Confirm the matching files (plus __pycache__) have been removed
-    assert not (support_path / "dir1" / "a_file1.txt").exists()
-    assert (support_path / "dir1" / "a_file2.doc").exists()
-    assert not (support_path / "dir1" / "b_file.txt").exists()
-    assert not (support_path / "dir1" / "__pycache__").exists()
-    assert (support_path / "dir2" / "b_file.txt").exists()
-    assert (support_path / "other" / "deep" / "b_file.doc").exists()
+    assert not (support_path / "dir1/a_file1.txt").exists()
+    assert (support_path / "dir1/a_file2.doc").exists()
+    assert not (support_path / "dir1/b_file.txt").exists()
+    assert not (support_path / "dir1/__pycache__").exists()
+    assert (support_path / "dir2/b_file.txt").exists()
+    assert (support_path / "other/deep/b_file.doc").exists()
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -185,13 +185,13 @@ def test_deep_glob_cleanup(create_command, myapp_unrolled, support_path, debug, 
     create_command.cleanup_app_content(myapp_unrolled)
 
     # Confirm the matching files (plus __pycache__) have been removed
-    assert (support_path / "dir1" / "a_file1.txt").exists()
-    assert (support_path / "dir1" / "a_file2.doc").exists()
-    assert not (support_path / "dir1" / "b_file.txt").exists()
-    assert not (support_path / "dir1" / "__pycache__").exists()
-    assert not (support_path / "dir2" / "b_file.txt").exists()
-    assert not (support_path / "other" / "deep" / "b_file.doc").exists()
-    assert (support_path / "other" / "deep" / "other.doc").exists()
+    assert (support_path / "dir1/a_file1.txt").exists()
+    assert (support_path / "dir1/a_file2.doc").exists()
+    assert not (support_path / "dir1/b_file.txt").exists()
+    assert not (support_path / "dir1/__pycache__").exists()
+    assert not (support_path / "dir2/b_file.txt").exists()
+    assert not (support_path / "other/deep/b_file.doc").exists()
+    assert (support_path / "other/deep/other.doc").exists()
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -221,12 +221,12 @@ def test_template_glob_cleanup(
 
     # Confirm the files from the app config and template config have been
     # removed, as well as __pycache__
-    assert not (support_path / "dir1" / "a_file1.txt").exists()
-    assert not (support_path / "dir1" / "a_file2.doc").exists()
-    assert (support_path / "dir1" / "b_file.txt").exists()
-    assert not (support_path / "dir1" / "__pycache__").exists()
-    assert (support_path / "dir2" / "b_file.txt").exists()
-    assert not (support_path / "other" / "deep" / "b_file.doc").exists()
+    assert not (support_path / "dir1/a_file1.txt").exists()
+    assert not (support_path / "dir1/a_file2.doc").exists()
+    assert (support_path / "dir1/b_file.txt").exists()
+    assert not (support_path / "dir1/__pycache__").exists()
+    assert (support_path / "dir2/b_file.txt").exists()
+    assert not (support_path / "other/deep/b_file.doc").exists()
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -261,12 +261,12 @@ def test_non_existent_cleanup(
 
     # Confirm the single existing file named has been removed,
     # as well as __pycache__
-    assert not (support_path / "dir1" / "a_file1.txt").exists()
-    assert (support_path / "dir1" / "a_file2.doc").exists()
-    assert (support_path / "dir1" / "b_file.txt").exists()
-    assert not (support_path / "dir1" / "__pycache__").exists()
-    assert (support_path / "dir2" / "b_file.txt").exists()
-    assert (support_path / "other" / "deep" / "b_file.doc").exists()
+    assert not (support_path / "dir1/a_file1.txt").exists()
+    assert (support_path / "dir1/a_file2.doc").exists()
+    assert (support_path / "dir1/b_file.txt").exists()
+    assert not (support_path / "dir1/__pycache__").exists()
+    assert (support_path / "dir2/b_file.txt").exists()
+    assert (support_path / "other/deep/b_file.doc").exists()
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.

--- a/tests/commands/create/test_cleanup_app_support_package.py
+++ b/tests/commands/create/test_cleanup_app_support_package.py
@@ -35,7 +35,7 @@ def test_cleanup_support_package(
     """If a support package already exists, it can be cleaned up."""
 
     # Mock an existing support file
-    create_file(support_path / "old" / "trash.txt", "Old support file")
+    create_file(support_path / "old/trash.txt", "Old support file")
 
     # Mock shutil so we can confirm that rmtree is called,
     # but we still want the side effect of calling it

--- a/tests/commands/create/test_create_app.py
+++ b/tests/commands/create/test_create_app.py
@@ -24,9 +24,7 @@ def test_create_app(tracking_create_command, tmp_path):
     ]
 
     # New app content has been created
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "new"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/new").exists()
 
 
 def test_create_existing_app_overwrite(tracking_create_command, tmp_path):
@@ -35,7 +33,7 @@ def test_create_existing_app_overwrite(tracking_create_command, tmp_path):
     tracking_create_command.input.values = ["y"]
 
     # Generate an app in the location.
-    bundle_path = tmp_path / "base_path" / "build" / "first" / "tester" / "dummy"
+    bundle_path = tmp_path / "base_path/build/first/tester/dummy"
     bundle_path.mkdir(parents=True)
     with (bundle_path / "original").open("w", encoding="utf-8") as f:
         f.write("original template!")
@@ -71,7 +69,7 @@ def test_create_existing_app_no_overwrite(tracking_create_command, tmp_path):
     # Answer no when asked
     tracking_create_command.input.values = ["n"]
 
-    bundle_path = tmp_path / "base_path" / "build" / "first" / "tester" / "dummy"
+    bundle_path = tmp_path / "base_path/build/first/tester/dummy"
     bundle_path.mkdir(parents=True)
     with (bundle_path / "original").open("w", encoding="utf-8") as f:
         f.write("original template!")
@@ -97,7 +95,7 @@ def test_create_existing_app_no_overwrite_default(tracking_create_command, tmp_p
     # Answer '' (i.e., just press return) when asked
     tracking_create_command.input.values = [""]
 
-    bundle_path = tmp_path / "base_path" / "build" / "first" / "tester" / "dummy"
+    bundle_path = tmp_path / "base_path/build/first/tester/dummy"
     bundle_path.mkdir(parents=True)
     with (bundle_path / "original").open("w", encoding="utf-8") as f:
         f.write("original template!")
@@ -124,7 +122,7 @@ def test_create_existing_app_input_disabled(tracking_create_command, tmp_path):
     # Answer '' (i.e., just press return) when asked
     tracking_create_command.input.enabled = False
 
-    bundle_path = tmp_path / "base_path" / "build" / "first" / "tester" / "dummy"
+    bundle_path = tmp_path / "base_path/build/first/tester/dummy"
     bundle_path.mkdir(parents=True)
     with (bundle_path / "original").open("w", encoding="utf-8") as f:
         f.write("original template!")

--- a/tests/commands/create/test_generate_app_template.py
+++ b/tests/commands/create/test_generate_app_template.py
@@ -97,7 +97,7 @@ def test_default_template(
         "https://github.com/beeware/briefcase-Tester-Dummy-template.git",
         no_input=True,
         checkout=expected_branch,
-        output_dir=os.fsdecode(tmp_path / "base_path" / "build" / "my-app" / "tester"),
+        output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
         extra_context=full_context,
     )
 
@@ -141,18 +141,14 @@ def test_default_template_dev(
             "https://github.com/beeware/briefcase-Tester-Dummy-template.git",
             no_input=True,
             checkout="v37.42.7",
-            output_dir=os.fsdecode(
-                tmp_path / "base_path" / "build" / "my-app" / "tester"
-            ),
+            output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
             extra_context=full_context,
         ),
         mock.call(
             "https://github.com/beeware/briefcase-Tester-Dummy-template.git",
             no_input=True,
             checkout="main",
-            output_dir=os.fsdecode(
-                tmp_path / "base_path" / "build" / "my-app" / "tester"
-            ),
+            output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
             extra_context=full_context,
         ),
     ]
@@ -192,9 +188,7 @@ def test_default_template_dev_explicit_branch(
             "https://github.com/beeware/briefcase-Tester-Dummy-template.git",
             no_input=True,
             checkout=branch,
-            output_dir=os.fsdecode(
-                tmp_path / "base_path" / "build" / "my-app" / "tester"
-            ),
+            output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
             extra_context=full_context,
         ),
     ]
@@ -241,9 +235,7 @@ def test_default_template_dev_explicit_invalid_branch(
             "https://github.com/beeware/briefcase-Tester-Dummy-template.git",
             no_input=True,
             checkout=branch,
-            output_dir=os.fsdecode(
-                tmp_path / "base_path" / "build" / "my-app" / "tester"
-            ),
+            output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
             extra_context=full_context,
         ),
     ]
@@ -271,7 +263,7 @@ def test_explicit_branch(monkeypatch, create_command, myapp, full_context, tmp_p
         "https://github.com/beeware/briefcase-Tester-Dummy-template.git",
         no_input=True,
         checkout=branch,
-        output_dir=os.fsdecode(tmp_path / "base_path" / "build" / "my-app" / "tester"),
+        output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
         extra_context=full_context,
     )
 
@@ -297,7 +289,7 @@ def test_platform_exists(monkeypatch, create_command, myapp, full_context, tmp_p
         "https://github.com/beeware/briefcase-Tester-Dummy-template.git",
         no_input=True,
         checkout="v37.42.7",
-        output_dir=os.fsdecode(tmp_path / "base_path" / "build" / "my-app" / "tester"),
+        output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
         extra_context=full_context,
     )
 
@@ -324,7 +316,7 @@ def test_explicit_repo_template(
         "https://example.com/magic/special-template.git",
         no_input=True,
         checkout="v37.42.7",
-        output_dir=os.fsdecode(tmp_path / "base_path" / "build" / "my-app" / "tester"),
+        output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
         extra_context=full_context,
     )
 
@@ -358,7 +350,7 @@ def test_explicit_repo_template_and_branch(
         "https://example.com/magic/special-template.git",
         no_input=True,
         checkout=branch,
-        output_dir=os.fsdecode(tmp_path / "base_path" / "build" / "my-app" / "tester"),
+        output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
         extra_context=full_context,
     )
 
@@ -381,7 +373,7 @@ def test_explicit_local_template(
         "/path/to/special-template",
         no_input=True,
         checkout="v37.42.7",
-        output_dir=os.fsdecode(tmp_path / "base_path" / "build" / "my-app" / "tester"),
+        output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
         extra_context=full_context,
     )
 
@@ -414,7 +406,7 @@ def test_explicit_local_template_and_branch(
         "/path/to/special-template",
         no_input=True,
         checkout=branch,
-        output_dir=os.fsdecode(tmp_path / "base_path" / "build" / "my-app" / "tester"),
+        output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
         extra_context=full_context,
     )
 
@@ -454,7 +446,7 @@ def test_offline_repo_template(
         "https://github.com/beeware/briefcase-Tester-Dummy-template.git",
         no_input=True,
         checkout="v37.42.7",
-        output_dir=os.fsdecode(tmp_path / "base_path" / "build" / "my-app" / "tester"),
+        output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
         extra_context=full_context,
     )
 
@@ -487,7 +479,7 @@ def test_invalid_repo_template(
         "https://example.com/somewhere/not-a-repo.git",
         no_input=True,
         checkout="v37.42.7",
-        output_dir=os.fsdecode(tmp_path / "base_path" / "build" / "my-app" / "tester"),
+        output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
         extra_context=full_context,
     )
 
@@ -522,7 +514,7 @@ def test_missing_branch_template(
         "https://example.com/somewhere/missing-branch.git",
         no_input=True,
         checkout="v37.42.7",
-        output_dir=os.fsdecode(tmp_path / "base_path" / "build" / "my-app" / "tester"),
+        output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
         extra_context=full_context,
     )
 
@@ -555,10 +547,10 @@ def test_cached_template(monkeypatch, create_command, myapp, full_context, tmp_p
 
     # Cookiecutter was invoked with the path to the *cached* template name
     create_command.tools.cookiecutter.assert_called_once_with(
-        os.fsdecode(Path.home() / ".cookiecutters" / "briefcase-Tester-Dummy-template"),
+        os.fsdecode(Path.home() / ".cookiecutters/briefcase-Tester-Dummy-template"),
         no_input=True,
         checkout="v37.42.7",
-        output_dir=os.fsdecode(tmp_path / "base_path" / "build" / "my-app" / "tester"),
+        output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
         extra_context=full_context,
     )
 
@@ -605,10 +597,10 @@ def test_cached_template_offline(
 
     # Cookiecutter was invoked with the path to the *cached* template name
     create_command.tools.cookiecutter.assert_called_once_with(
-        os.fsdecode(Path.home() / ".cookiecutters" / "briefcase-Tester-Dummy-template"),
+        os.fsdecode(Path.home() / ".cookiecutters/briefcase-Tester-Dummy-template"),
         no_input=True,
         checkout="v37.42.7",
-        output_dir=os.fsdecode(tmp_path / "base_path" / "build" / "my-app" / "tester"),
+        output_dir=os.fsdecode(tmp_path / "base_path/build/my-app/tester"),
         extra_context=full_context,
     )
 

--- a/tests/commands/create/test_install_app_code.py
+++ b/tests/commands/create/test_install_app_code.py
@@ -125,15 +125,15 @@ def test_source_dir(
     #     submodule /
     #       deeper.py
     create_file(
-        tmp_path / "base_path" / "src" / "first" / "demo.py",
+        tmp_path / "base_path/src/first/demo.py",
         "print('hello first')\n",
     )
     create_file(
-        tmp_path / "base_path" / "src" / "second" / "shallow.py",
+        tmp_path / "base_path/src/second/shallow.py",
         "print('hello shallow second')\n",
     )
     create_file(
-        tmp_path / "base_path" / "src" / "second" / "submodule" / "deeper.py",
+        tmp_path / "base_path/src/second/submodule/deeper.py",
         "print('hello deep second')\n",
     )
 
@@ -144,13 +144,13 @@ def test_source_dir(
 
     # All the sources exist.
     assert (app_path / "first").exists()
-    assert (app_path / "first" / "demo.py").exists()
+    assert (app_path / "first/demo.py").exists()
 
     assert (app_path / "second").exists()
-    assert (app_path / "second" / "shallow.py").exists()
+    assert (app_path / "second/shallow.py").exists()
 
-    assert (app_path / "second" / "submodule").exists()
-    assert (app_path / "second" / "submodule" / "deeper.py").exists()
+    assert (app_path / "second/submodule").exists()
+    assert (app_path / "second/submodule/deeper.py").exists()
 
     # Metadata has been created
     assert_dist_info(app_path)
@@ -173,11 +173,11 @@ def test_source_file(
     #   demo.py
     # other.py
     create_file(
-        tmp_path / "base_path" / "src" / "demo.py",
+        tmp_path / "base_path/src/demo.py",
         "print('hello first')\n",
     )
     create_file(
-        tmp_path / "base_path" / "other.py",
+        tmp_path / "base_path/other.py",
         "print('hello second')\n",
     )
 
@@ -215,15 +215,15 @@ def test_no_existing_app_folder(
     #     submodule /
     #       deeper.py
     create_file(
-        tmp_path / "base_path" / "src" / "first" / "demo.py",
+        tmp_path / "base_path/src/first/demo.py",
         "print('hello first')\n",
     )
     create_file(
-        tmp_path / "base_path" / "src" / "second" / "shallow.py",
+        tmp_path / "base_path/src/second/shallow.py",
         "print('hello shallow second')\n",
     )
     create_file(
-        tmp_path / "base_path" / "src" / "second" / "submodule" / "deeper.py",
+        tmp_path / "base_path/src/second/submodule/deeper.py",
         "print('hello deep second')\n",
     )
 
@@ -241,19 +241,19 @@ def test_no_existing_app_folder(
         assert f.read() == "print('hello first')\n"
 
     assert (app_path / "second").exists()
-    assert (app_path / "second" / "shallow.py").exists()
-    with (app_path / "second" / "shallow.py").open(encoding="utf-8") as f:
+    assert (app_path / "second/shallow.py").exists()
+    with (app_path / "second/shallow.py").open(encoding="utf-8") as f:
         assert f.read() == "print('hello shallow second')\n"
 
-    assert (app_path / "second" / "submodule").exists()
-    assert (app_path / "second" / "submodule" / "deeper.py").exists()
-    with (app_path / "second" / "submodule" / "deeper.py").open(encoding="utf-8") as f:
+    assert (app_path / "second/submodule").exists()
+    assert (app_path / "second/submodule/deeper.py").exists()
+    with (app_path / "second/submodule/deeper.py").open(encoding="utf-8") as f:
         assert f.read() == "print('hello deep second')\n"
 
     # The stale/broken modules have been removed.
     assert not (app_path / "stale.py").exists()
-    assert not (app_path / "second" / "stale.py").exists()
-    assert not (app_path / "second" / "broken").exists()
+    assert not (app_path / "second/stale.py").exists()
+    assert not (app_path / "second/broken").exists()
 
     # Metadata has been updated.
     assert not (app_path / "my_app-1.2.2.dist-info").exists()
@@ -281,15 +281,15 @@ def test_replace_sources(
     #     submodule /
     #       deeper.py
     create_file(
-        tmp_path / "base_path" / "src" / "first" / "demo.py",
+        tmp_path / "base_path/src/first/demo.py",
         "print('hello first')\n",
     )
     create_file(
-        tmp_path / "base_path" / "src" / "second" / "shallow.py",
+        tmp_path / "base_path/src/second/shallow.py",
         "print('hello shallow second')\n",
     )
     create_file(
-        tmp_path / "base_path" / "src" / "second" / "submodule" / "deeper.py",
+        tmp_path / "base_path/src/second/submodule/deeper.py",
         "print('hello deep second')\n",
     )
 
@@ -306,27 +306,27 @@ def test_replace_sources(
     #       other.py
     #   my_app-1.2.2.dist-info /
     create_file(
-        app_path / "src" / "demo.py",
+        app_path / "src/demo.py",
         "print('old hello first')\n",
     )
     create_file(
-        app_path / "src" / "stale.py",
+        app_path / "src/stale.py",
         "print('stale hello first')\n",
     )
     create_file(
-        app_path / "src" / "second" / "shallow.py",
+        app_path / "src/second/shallow.py",
         "print('old hello shallow second')\n",
     )
     create_file(
-        app_path / "src" / "second" / "stale.py",
+        app_path / "src/second/stale.py",
         "print('hello second stale')\n",
     )
     create_file(
-        app_path / "src" / "second" / "submodule" / "deeper.py",
+        app_path / "src/second/submodule/deeper.py",
         "print('hello deep second')\n",
     )
     create_file(
-        app_path / "src" / "second" / "broken" / "other.py",
+        app_path / "src/second/broken/other.py",
         "print('hello second deep broken')\n",
     )
 
@@ -344,19 +344,19 @@ def test_replace_sources(
         assert f.read() == "print('hello first')\n"
 
     assert (app_path / "second").exists()
-    assert (app_path / "second" / "shallow.py").exists()
-    with (app_path / "second" / "shallow.py").open(encoding="utf-8") as f:
+    assert (app_path / "second/shallow.py").exists()
+    with (app_path / "second/shallow.py").open(encoding="utf-8") as f:
         assert f.read() == "print('hello shallow second')\n"
 
-    assert (app_path / "second" / "submodule").exists()
-    assert (app_path / "second" / "submodule" / "deeper.py").exists()
-    with (app_path / "second" / "submodule" / "deeper.py").open(encoding="utf-8") as f:
+    assert (app_path / "second/submodule").exists()
+    assert (app_path / "second/submodule/deeper.py").exists()
+    with (app_path / "second/submodule/deeper.py").open(encoding="utf-8") as f:
         assert f.read() == "print('hello deep second')\n"
 
     # The stale/broken modules have been removed.
     assert not (app_path / "stale.py").exists()
-    assert not (app_path / "second" / "stale.py").exists()
-    assert not (app_path / "second" / "broken").exists()
+    assert not (app_path / "second/stale.py").exists()
+    assert not (app_path / "second/broken").exists()
 
     # Metadata has been updated.
     assert not (app_path / "my_app-1.2.2.dist-info").exists()
@@ -446,27 +446,27 @@ def test_test_sources(
     #   special /
     #     test_weird.py
     create_file(
-        tmp_path / "base_path" / "src" / "first" / "demo.py",
+        tmp_path / "base_path/src/first/demo.py",
         "print('hello first')\n",
     )
     create_file(
-        tmp_path / "base_path" / "src" / "second" / "shallow.py",
+        tmp_path / "base_path/src/second/shallow.py",
         "print('hello shallow second')\n",
     )
     create_file(
-        tmp_path / "base_path" / "tests" / "first.py",
+        tmp_path / "base_path/tests/first.py",
         "print('hello first test suite')\n",
     )
     create_file(
-        tmp_path / "base_path" / "tests" / "deep" / "test_case.py",
+        tmp_path / "base_path/tests/deep/test_case.py",
         "print('hello test case')\n",
     )
     create_file(
-        tmp_path / "base_path" / "othertests" / "test_more.py",
+        tmp_path / "base_path/othertests/test_more.py",
         "print('hello more tests')\n",
     )
     create_file(
-        tmp_path / "base_path" / "othertests" / "special" / "test_weird.py",
+        tmp_path / "base_path/othertests/special/test_weird.py",
         "print('hello weird tests')\n",
     )
 
@@ -478,10 +478,10 @@ def test_test_sources(
 
     # App sources exist.
     assert (app_path / "first").exists()
-    assert (app_path / "first" / "demo.py").exists()
+    assert (app_path / "first/demo.py").exists()
 
     assert (app_path / "second").exists()
-    assert (app_path / "second" / "shallow.py").exists()
+    assert (app_path / "second/shallow.py").exists()
 
     # Test sources do not exist
     assert not (app_path / "tests").exists()
@@ -518,27 +518,27 @@ def test_test_sources_test_mode(
     #   special /
     #     test_weird.py
     create_file(
-        tmp_path / "base_path" / "src" / "first" / "demo.py",
+        tmp_path / "base_path/src/first/demo.py",
         "print('hello first')\n",
     )
     create_file(
-        tmp_path / "base_path" / "src" / "second" / "shallow.py",
+        tmp_path / "base_path/src/second/shallow.py",
         "print('hello shallow second')\n",
     )
     create_file(
-        tmp_path / "base_path" / "tests" / "first.py",
+        tmp_path / "base_path/tests/first.py",
         "print('hello first test suite')\n",
     )
     create_file(
-        tmp_path / "base_path" / "tests" / "deep" / "test_case.py",
+        tmp_path / "base_path/tests/deep/test_case.py",
         "print('hello test case')\n",
     )
     create_file(
-        tmp_path / "base_path" / "othertests" / "test_more.py",
+        tmp_path / "base_path/othertests/test_more.py",
         "print('hello more tests')\n",
     )
     create_file(
-        tmp_path / "base_path" / "othertests" / "special" / "test_weird.py",
+        tmp_path / "base_path/othertests/special/test_weird.py",
         "print('hello weird tests')\n",
     )
 
@@ -550,17 +550,17 @@ def test_test_sources_test_mode(
 
     # App sources exist.
     assert (app_path / "first").exists()
-    assert (app_path / "first" / "demo.py").exists()
+    assert (app_path / "first/demo.py").exists()
 
     assert (app_path / "second").exists()
-    assert (app_path / "second" / "shallow.py").exists()
+    assert (app_path / "second/shallow.py").exists()
 
     # Test sources exist
-    assert (app_path / "tests" / "first.py").exists()
-    assert (app_path / "tests" / "deep" / "test_case.py").exists()
+    assert (app_path / "tests/first.py").exists()
+    assert (app_path / "tests/deep/test_case.py").exists()
 
-    assert (app_path / "othertests" / "test_more.py").exists()
-    assert (app_path / "othertests" / "special" / "test_weird.py").exists()
+    assert (app_path / "othertests/test_more.py").exists()
+    assert (app_path / "othertests/special/test_weird.py").exists()
 
     # Metadata has been created
     assert_dist_info(app_path)
@@ -589,27 +589,27 @@ def test_only_test_sources_test_mode(
     #   special /
     #     test_weird.py
     create_file(
-        tmp_path / "base_path" / "src" / "first" / "demo.py",
+        tmp_path / "base_path/src/first/demo.py",
         "print('hello first')\n",
     )
     create_file(
-        tmp_path / "base_path" / "src" / "second" / "shallow.py",
+        tmp_path / "base_path/src/second/shallow.py",
         "print('hello shallow second')\n",
     )
     create_file(
-        tmp_path / "base_path" / "tests" / "first.py",
+        tmp_path / "base_path/tests/first.py",
         "print('hello first test suite')\n",
     )
     create_file(
-        tmp_path / "base_path" / "tests" / "deep" / "test_case.py",
+        tmp_path / "base_path/tests/deep/test_case.py",
         "print('hello test case')\n",
     )
     create_file(
-        tmp_path / "base_path" / "othertests" / "test_more.py",
+        tmp_path / "base_path/othertests/test_more.py",
         "print('hello more tests')\n",
     )
     create_file(
-        tmp_path / "base_path" / "othertests" / "special" / "test_weird.py",
+        tmp_path / "base_path/othertests/special/test_weird.py",
         "print('hello weird tests')\n",
     )
 
@@ -624,11 +624,11 @@ def test_only_test_sources_test_mode(
     assert not (app_path / "second").exists()
 
     # Test sources exist
-    assert (app_path / "tests" / "first.py").exists()
-    assert (app_path / "tests" / "deep" / "test_case.py").exists()
+    assert (app_path / "tests/first.py").exists()
+    assert (app_path / "tests/deep/test_case.py").exists()
 
-    assert (app_path / "othertests" / "test_more.py").exists()
-    assert (app_path / "othertests" / "special" / "test_weird.py").exists()
+    assert (app_path / "othertests/test_more.py").exists()
+    assert (app_path / "othertests/special/test_weird.py").exists()
 
     # Metadata has been created
     assert_dist_info(app_path)

--- a/tests/commands/create/test_install_app_requirements.py
+++ b/tests/commands/create/test_install_app_requirements.py
@@ -331,11 +331,11 @@ def test_app_packages_install_requirements(
 
     # The new app packages have installation artefacts created
     assert (app_packages_path / "first").exists()
-    assert (app_packages_path / "first" / "__main__.py").exists()
+    assert (app_packages_path / "first/__main__.py").exists()
     assert (app_packages_path / "second").exists()
-    assert (app_packages_path / "second" / "__main__.py").exists()
+    assert (app_packages_path / "second/__main__.py").exists()
     assert (app_packages_path / "third").exists()
-    assert (app_packages_path / "third" / "__main__.py").exists()
+    assert (app_packages_path / "third/__main__.py").exists()
 
     # Original app definitions haven't changed
     assert myapp.requires == ["first", "second", "third"]
@@ -390,11 +390,11 @@ def test_app_packages_replace_existing_requirements(
 
     # The new app packages have installation artefacts created
     assert (app_packages_path / "first").exists()
-    assert (app_packages_path / "first" / "__main__.py").exists()
+    assert (app_packages_path / "first/__main__.py").exists()
     assert (app_packages_path / "second").exists()
-    assert (app_packages_path / "second" / "__main__.py").exists()
+    assert (app_packages_path / "second/__main__.py").exists()
     assert (app_packages_path / "third").exists()
-    assert (app_packages_path / "third" / "__main__.py").exists()
+    assert (app_packages_path / "third/__main__.py").exists()
 
     # The old app packages no longer exist.
     assert not (app_packages_path / "old").exists()

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -54,14 +54,14 @@ def test_install_app_support_package(
 
     # Confirm the right file was unpacked
     create_command.tools.shutil.unpack_archive.assert_called_with(
-        tmp_path / "data" / "support" / "Python-3.X-tester-support.b37.tar.gz",
+        tmp_path / "data/support/Python-3.X-tester-support.b37.tar.gz",
         extract_dir=support_path,
         **({"filter": "data"} if sys.version_info >= (3, 12) else {}),
     )
 
     # Confirm that the full path to the support file
     # has been unpacked.
-    assert (support_path / "internal" / "file.txt").exists()
+    assert (support_path / "internal/file.txt").exists()
 
 
 def test_install_pinned_app_support_package(
@@ -100,14 +100,14 @@ def test_install_pinned_app_support_package(
 
     # Confirm the right file was unpacked
     create_command.tools.shutil.unpack_archive.assert_called_with(
-        tmp_path / "data" / "support" / "Python-3.X-Tester-support.b42.tar.gz",
+        tmp_path / "data/support/Python-3.X-Tester-support.b42.tar.gz",
         extract_dir=support_path,
         **({"filter": "data"} if sys.version_info >= (3, 12) else {}),
     )
 
     # Confirm that the full path to the support file
     # has been unpacked.
-    assert (support_path / "internal" / "file.txt").exists()
+    assert (support_path / "internal/file.txt").exists()
 
 
 def test_install_custom_app_support_package_file(
@@ -119,11 +119,11 @@ def test_install_custom_app_support_package_file(
 ):
     """A custom support package can be specified as a local file."""
     # Provide an app-specific override of the package URL
-    myapp.support_package = os.fsdecode(tmp_path / "custom" / "support.zip")
+    myapp.support_package = os.fsdecode(tmp_path / "custom/support.zip")
 
     # Write a temporary support zip file
     support_file = create_zip_file(
-        tmp_path / "custom" / "support.zip",
+        tmp_path / "custom/support.zip",
         [("internal/file.txt", "hello world")],
     )
 
@@ -150,7 +150,7 @@ def test_install_custom_app_support_package_file(
 
     # Confirm that the full path to the support file
     # has been unpacked.
-    assert (support_path / "internal" / "file.txt").exists()
+    assert (support_path / "internal/file.txt").exists()
 
 
 def test_install_custom_app_support_package_file_with_revision(
@@ -164,12 +164,12 @@ def test_install_custom_app_support_package_file_with_revision(
     """If a custom support package file also specifies a revision, the revision is
     ignored with a warning."""
     # Provide an app-specific override of the package URL
-    myapp.support_package = os.fsdecode(tmp_path / "custom" / "support.zip")
+    myapp.support_package = os.fsdecode(tmp_path / "custom/support.zip")
     myapp.support_revision = "42"
 
     # Write a temporary support zip file
     support_file = create_zip_file(
-        tmp_path / "custom" / "support.zip",
+        tmp_path / "custom/support.zip",
         [("internal/file.txt", "hello world")],
     )
 
@@ -196,7 +196,7 @@ def test_install_custom_app_support_package_file_with_revision(
 
     # Confirm that the full path to the support file
     # has been unpacked.
-    assert (support_path / "internal" / "file.txt").exists()
+    assert (support_path / "internal/file.txt").exists()
 
     # A warning about the support revision was generated.
     assert "support revision will be ignored." in capsys.readouterr().out
@@ -309,7 +309,7 @@ def test_install_custom_app_support_package_url(
 
     # Confirm that the full path to the support file
     # has been unpacked.
-    assert (support_path / "internal" / "file.txt").exists()
+    assert (support_path / "internal/file.txt").exists()
 
 
 def test_install_custom_app_support_package_url_with_revision(
@@ -365,7 +365,7 @@ def test_install_custom_app_support_package_url_with_revision(
 
     # Confirm that the full path to the support file
     # has been unpacked.
-    assert (support_path / "internal" / "file.txt").exists()
+    assert (support_path / "internal/file.txt").exists()
 
     # A warning about the support revision was generated.
     assert "support revision will be ignored." in capsys.readouterr().out
@@ -418,7 +418,7 @@ def test_install_custom_app_support_package_url_with_args(
 
     # Confirm that the full path to the support file
     # has been unpacked.
-    assert (support_path / "internal" / "file.txt").exists()
+    assert (support_path / "internal/file.txt").exists()
 
 
 def test_offline_install(

--- a/tests/commands/create/test_install_image.py
+++ b/tests/commands/create/test_install_image.py
@@ -44,7 +44,7 @@ def test_no_requested_size(create_command, tmp_path, capsys):
     create_command.tools.shutil = mock.MagicMock(spec_set=shutil)
 
     # Create the source image
-    source_file = tmp_path / "base_path" / "input" / "original.png"
+    source_file = tmp_path / "base_path/input/original.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
     with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
@@ -65,7 +65,7 @@ def test_no_requested_size(create_command, tmp_path, capsys):
 
     # The file was copied into position
     create_command.tools.shutil.copy.assert_called_with(
-        create_command.base_path / "input" / "original.png",
+        create_command.base_path / "input/original.png",
         out_path,
     )
 
@@ -98,7 +98,7 @@ def test_requested_size(create_command, tmp_path, capsys):
     create_command.tools.shutil = mock.MagicMock(spec_set=shutil)
 
     # Create the source image
-    source_file = tmp_path / "base_path" / "input" / "original-3742.png"
+    source_file = tmp_path / "base_path/input/original-3742.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
     with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
@@ -119,7 +119,7 @@ def test_requested_size(create_command, tmp_path, capsys):
 
     # The file was copied into position
     create_command.tools.shutil.copy.assert_called_with(
-        create_command.base_path / "input" / "original-3742.png",
+        create_command.base_path / "input/original-3742.png",
         out_path,
     )
 
@@ -152,7 +152,7 @@ def test_variant_with_no_requested_size(create_command, tmp_path, capsys):
     create_command.tools.shutil = mock.MagicMock(spec_set=shutil)
 
     # Create the source image
-    source_file = tmp_path / "base_path" / "input" / "original.png"
+    source_file = tmp_path / "base_path/input/original.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
     with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
@@ -175,7 +175,7 @@ def test_variant_with_no_requested_size(create_command, tmp_path, capsys):
 
     # The file was copied into position
     create_command.tools.shutil.copy.assert_called_with(
-        create_command.base_path / "input" / "original.png",
+        create_command.base_path / "input/original.png",
         out_path,
     )
 
@@ -188,7 +188,7 @@ def test_variant_without_variant_source_and_no_requested_size(
     create_command.tools.shutil = mock.MagicMock(spec_set=shutil)
 
     # Create the source image
-    source_file = tmp_path / "base_path" / "input" / "original.png"
+    source_file = tmp_path / "base_path/input/original.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
     with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
@@ -216,7 +216,7 @@ def test_unknown_variant_with_no_requested_size(create_command, tmp_path, capsys
     create_command.tools.shutil = mock.MagicMock(spec_set=shutil)
 
     # Create the source image
-    source_file = tmp_path / "base_path" / "input" / "original.png"
+    source_file = tmp_path / "base_path/input/original.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
     with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
@@ -246,7 +246,7 @@ def test_variant_with_size(create_command, tmp_path, capsys):
     create_command.tools.shutil = mock.MagicMock(spec_set=shutil)
 
     # Create the source image
-    source_file = tmp_path / "base_path" / "input" / "original-3742.png"
+    source_file = tmp_path / "base_path/input/original-3742.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
     with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
@@ -271,7 +271,7 @@ def test_variant_with_size(create_command, tmp_path, capsys):
 
     # The file was copied into position
     create_command.tools.shutil.copy.assert_called_with(
-        create_command.base_path / "input" / "original-3742.png",
+        create_command.base_path / "input/original-3742.png",
         out_path,
     )
 
@@ -282,7 +282,7 @@ def test_variant_with_size_without_variants(create_command, tmp_path, capsys):
     create_command.tools.shutil = mock.MagicMock(spec_set=shutil)
 
     # Create the source image
-    source_file = tmp_path / "base_path" / "input" / "original-3742.png"
+    source_file = tmp_path / "base_path/input/original-3742.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
     with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
@@ -311,7 +311,7 @@ def test_unknown_variant_with_size(create_command, tmp_path, capsys):
     create_command.tools.shutil = mock.MagicMock(spec_set=shutil)
 
     # Create the source image
-    source_file = tmp_path / "base_path" / "input" / "original-3742.png"
+    source_file = tmp_path / "base_path/input/original-3742.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
     with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
@@ -341,7 +341,7 @@ def test_unsized_variant(create_command, tmp_path, capsys):
     create_command.tools.shutil = mock.MagicMock(spec_set=shutil)
 
     # Create the source image
-    source_file = tmp_path / "base_path" / "input" / "original.png"
+    source_file = tmp_path / "base_path/input/original.png"
     source_file.parent.mkdir(parents=True, exist_ok=True)
     with source_file.open("w", encoding="utf-8") as f:
         f.write("image")
@@ -366,6 +366,6 @@ def test_unsized_variant(create_command, tmp_path, capsys):
 
     # The file was copied into position
     create_command.tools.shutil.copy.assert_called_with(
-        create_command.base_path / "input" / "original.png",
+        create_command.base_path / "input/original.png",
         out_path,
     )

--- a/tests/commands/create/test_properties.py
+++ b/tests/commands/create/test_properties.py
@@ -30,13 +30,13 @@ def test_app_path(create_command, myapp):
         }
         tomli_w.dump(index, f)
 
-    assert create_command.app_path(myapp) == bundle_path / "path" / "to" / "app"
+    assert create_command.app_path(myapp) == bundle_path / "path/to/app"
 
     # Requesting a second time should hit the cache,
     # so the briefcase file won't be needed.
     # Delete it to make sure the cache is used.
     (bundle_path / "briefcase.toml").unlink()
-    assert create_command.app_path(myapp) == bundle_path / "path" / "to" / "app"
+    assert create_command.app_path(myapp) == bundle_path / "path/to/app"
 
 
 def test_app_packages_path(create_command, myapp):
@@ -53,8 +53,7 @@ def test_app_packages_path(create_command, myapp):
         tomli_w.dump(index, f)
 
     assert (
-        create_command.app_packages_path(myapp)
-        == bundle_path / "path" / "to" / "app_packages"
+        create_command.app_packages_path(myapp) == bundle_path / "path/to/app_packages"
     )
 
     # Requesting a second time should hit the cache,
@@ -62,8 +61,7 @@ def test_app_packages_path(create_command, myapp):
     # Delete it to make sure the cache is used.
     (bundle_path / "briefcase.toml").unlink()
     assert (
-        create_command.app_packages_path(myapp)
-        == bundle_path / "path" / "to" / "app_packages"
+        create_command.app_packages_path(myapp) == bundle_path / "path/to/app_packages"
     )
 
 
@@ -80,13 +78,13 @@ def test_support_path(create_command, myapp):
         }
         tomli_w.dump(index, f)
 
-    assert create_command.support_path(myapp) == bundle_path / "path" / "to" / "support"
+    assert create_command.support_path(myapp) == bundle_path / "path/to/support"
 
     # Requesting a second time should hit the cache,
     # so the briefcase file won't be needed.
     # Delete it to make sure the cache is used.
     (bundle_path / "briefcase.toml").unlink()
-    assert create_command.support_path(myapp) == bundle_path / "path" / "to" / "support"
+    assert create_command.support_path(myapp) == bundle_path / "path/to/support"
 
 
 def test_support_revision(create_command, myapp):

--- a/tests/commands/dev/conftest.py
+++ b/tests/commands/dev/conftest.py
@@ -18,8 +18,8 @@ def dev_command(tmp_path):
 @pytest.fixture
 def first_app_uninstalled(tmp_path):
     # Make sure the source code exists
-    (tmp_path / "src" / "first").mkdir(parents=True, exist_ok=True)
-    with (tmp_path / "src" / "first" / "__init__.py").open("w", encoding="UTF-8") as f:
+    (tmp_path / "src/first").mkdir(parents=True, exist_ok=True)
+    with (tmp_path / "src/first/__init__.py").open("w", encoding="UTF-8") as f:
         f.write('print("Hello world")')
 
     return AppConfig(
@@ -35,19 +35,19 @@ def first_app_uninstalled(tmp_path):
 def first_app(tmp_path, first_app_uninstalled):
     # The same fixture as first_app_uninstalled,
     # but ensures that the .dist-info folder for the app exists
-    (tmp_path / "src" / "first.dist-info").mkdir(exist_ok=True)
+    (tmp_path / "src/first.dist-info").mkdir(exist_ok=True)
     return first_app_uninstalled
 
 
 @pytest.fixture
 def second_app(tmp_path):
     # Make sure the source code exists
-    (tmp_path / "src" / "second").mkdir(parents=True, exist_ok=True)
-    with (tmp_path / "src" / "second" / "__init__.py").open("w", encoding="UTF-8") as f:
+    (tmp_path / "src/second").mkdir(parents=True, exist_ok=True)
+    with (tmp_path / "src/second/__init__.py").open("w", encoding="UTF-8") as f:
         f.write('print("Hello world")')
 
     # Create the dist-info folder
-    (tmp_path / "src" / "second.dist-info").mkdir(exist_ok=True)
+    (tmp_path / "src/second.dist-info").mkdir(exist_ok=True)
 
     return AppConfig(
         app_name="second",
@@ -61,12 +61,12 @@ def second_app(tmp_path):
 @pytest.fixture
 def third_app(tmp_path):
     # Make sure the source code exists
-    (tmp_path / "src" / "third").mkdir(parents=True, exist_ok=True)
-    with (tmp_path / "src" / "third" / "__init__.py").open("w", encoding="UTF-8") as f:
+    (tmp_path / "src/third").mkdir(parents=True, exist_ok=True)
+    with (tmp_path / "src/third/__init__.py").open("w", encoding="UTF-8") as f:
         f.write('print("Hello world")')
 
     # Create the dist-info folder
-    (tmp_path / "src" / "third.dist-info").mkdir(exist_ok=True)
+    (tmp_path / "src/third.dist-info").mkdir(exist_ok=True)
 
     return AppConfig(
         app_name="third",

--- a/tests/commands/new/test_build_context.py
+++ b/tests/commands/new/test_build_context.py
@@ -678,7 +678,7 @@ def main():
 
     # Set the app's runtime icon
     pygame.display.set_icon(
-        pygame.image.load(Path(__file__).parent / "resources" / "{{ cookiecutter.app_name }}.png")
+        pygame.image.load(Path(__file__).parent / "resources/{{ cookiecutter.app_name }}.png")
     )
 
     pygame.init()

--- a/tests/commands/package/conftest.py
+++ b/tests/commands/package/conftest.py
@@ -140,7 +140,7 @@ def first_app_unbuilt(first_app_config, tmp_path):
     # The same fixture as first_app_config,
     # but ensures that the bundle for the app exists
     create_file(
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "first.dummy",
+        tmp_path / "base_path/build/first/tester/dummy/first.dummy",
         "first.dummy",
     )
 
@@ -152,7 +152,7 @@ def first_app(first_app_unbuilt, tmp_path):
     # The same fixture as first_app_uncompiled,
     # but ensures that the binary for the app exists
     create_file(
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "first.bin",
+        tmp_path / "base_path/build/first/tester/dummy/first.bin",
         "first.bin",
     )
 
@@ -193,7 +193,7 @@ def second_app(second_app_uncompiled, tmp_path):
     # The same fixture as second_app_uncompiled,
     # but ensures that the binary for the app exists
     create_file(
-        tmp_path / "base_path" / "build" / "second" / "tester" / "dummy" / "second.bin",
+        tmp_path / "base_path/build/second/tester/dummy/second.bin",
         "second.bin",
     )
 

--- a/tests/commands/package/test_call.py
+++ b/tests/commands/package/test_call.py
@@ -41,7 +41,7 @@ def test_no_args_package_one_app(package_command, first_app, tmp_path):
     assert first_app.packaging_format == "pkg"
 
     # The dist folder has been created.
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
 
 def test_package_one_explicit_app(package_command, first_app, second_app, tmp_path):
@@ -86,7 +86,7 @@ def test_package_one_explicit_app(package_command, first_app, second_app, tmp_pa
     assert not hasattr(second_app, "packaging_format")
 
     # The dist folder has been created.
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
 
 def test_no_args_package_two_app(package_command, first_app, second_app, tmp_path):
@@ -147,7 +147,7 @@ def test_no_args_package_two_app(package_command, first_app, second_app, tmp_pat
     assert second_app.packaging_format == "pkg"
 
     # The dist folder has been created.
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
 
 def test_identity_arg_package_one_app(package_command, first_app, tmp_path):
@@ -191,7 +191,7 @@ def test_identity_arg_package_one_app(package_command, first_app, tmp_path):
     assert first_app.packaging_format == "pkg"
 
     # The dist folder has been created.
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
 
 def test_adhoc_sign_package_one_app(package_command, first_app, tmp_path):
@@ -235,7 +235,7 @@ def test_adhoc_sign_package_one_app(package_command, first_app, tmp_path):
     assert first_app.packaging_format == "pkg"
 
     # The dist folder has been created.
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
 
 def test_adhoc_sign_args_package_two_app(
@@ -301,7 +301,7 @@ def test_adhoc_sign_args_package_two_app(
     assert second_app.packaging_format == "pkg"
 
     # The dist folder has been created.
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
 
 def test_identity_sign_args_package_two_app(
@@ -365,7 +365,7 @@ def test_identity_sign_args_package_two_app(
     assert second_app.packaging_format == "pkg"
 
     # The dist folder has been created.
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
 
 def test_package_alternate_format(package_command, first_app, tmp_path):
@@ -408,7 +408,7 @@ def test_package_alternate_format(package_command, first_app, tmp_path):
     assert first_app.packaging_format == "box"
 
     # The dist folder has been created.
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
 
 def test_create_before_package(package_command, first_app_config, tmp_path):
@@ -471,7 +471,7 @@ def test_create_before_package(package_command, first_app_config, tmp_path):
     assert first_app_config.packaging_format == "pkg"
 
     # The dist folder has been created.
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
 
 def test_update_package_one_app(package_command, first_app, tmp_path):
@@ -537,7 +537,7 @@ def test_update_package_one_app(package_command, first_app, tmp_path):
     assert first_app.packaging_format == "pkg"
 
     # The dist folder has been created.
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
 
 def test_update_package_two_app(package_command, first_app, second_app, tmp_path):
@@ -651,7 +651,7 @@ def test_update_package_two_app(package_command, first_app, second_app, tmp_path
     assert second_app.packaging_format == "pkg"
 
     # The dist folder has been created.
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
 
 def test_build_before_package(package_command, first_app_unbuilt, tmp_path):
@@ -704,7 +704,7 @@ def test_build_before_package(package_command, first_app_unbuilt, tmp_path):
     assert first_app_unbuilt.packaging_format == "pkg"
 
     # The dist folder has been created.
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
 
 def test_already_packaged(package_command, first_app, tmp_path):
@@ -715,7 +715,7 @@ def test_already_packaged(package_command, first_app, tmp_path):
     }
 
     # Mock a historical package artefact.
-    artefact_path = tmp_path / "base_path" / "dist" / "first-0.0.1.pkg"
+    artefact_path = tmp_path / "base_path/dist/first-0.0.1.pkg"
     create_file(artefact_path, "Packaged app")
 
     # Configure no command line options
@@ -751,7 +751,7 @@ def test_already_packaged(package_command, first_app, tmp_path):
     assert first_app.packaging_format == "pkg"
 
     # The dist folder still exists
-    assert tmp_path / "base_path" / "dist"
+    assert tmp_path / "base_path/dist"
 
     # But the artefact has been deleted.
     # NOTE: This is a testing quirk - because we're mocking the

--- a/tests/commands/publish/conftest.py
+++ b/tests/commands/publish/conftest.py
@@ -131,7 +131,7 @@ def first_app(first_app_unbuilt, tmp_path):
     # The same fixture as first_app_config,
     # but ensures that the binary for the app exists
     create_file(
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "first.bin",
+        tmp_path / "base_path/build/first/tester/dummy/first.bin",
         "first.bin",
     )
 
@@ -164,7 +164,7 @@ def second_app(second_app_config, tmp_path):
         "second.bundle",
     )
     create_file(
-        tmp_path / "base_path" / "build" / "second" / "tester" / "dummy" / "second.bin",
+        tmp_path / "base_path/build/second/tester/dummy/second.bin",
         "second.bin",
     )
 

--- a/tests/commands/run/conftest.py
+++ b/tests/commands/run/conftest.py
@@ -135,7 +135,7 @@ def first_app(first_app_unbuild, tmp_path):
     # The same fixture as first_app_unbuild,
     # but ensures that the binary for the app exists
     create_file(
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "first.bin",
+        tmp_path / "base_path/build/first/tester/dummy/first.bin",
         "first.bin",
     )
 
@@ -176,7 +176,7 @@ def second_app(second_app_uncompiled, tmp_path):
     # The same fixture as second_app_uncompiled,
     # but ensures that the binary for the app exists
     create_file(
-        tmp_path / "base_path" / "build" / "second" / "tester" / "dummy" / "second.bin",
+        tmp_path / "base_path/build/second/tester/dummy/second.bin",
         "second.bin",
     )
 

--- a/tests/commands/update/conftest.py
+++ b/tests/commands/update/conftest.py
@@ -71,7 +71,7 @@ class DummyUpdateCommand(UpdateCommand):
 
     def install_app_support_package(self, app):
         self.actions.append(("support", app.app_name))
-        create_file(self.bundle_path(app) / "support" / "content.txt", "app support")
+        create_file(self.bundle_path(app) / "support/content.txt", "app support")
 
     def cleanup_app_content(self, app):
         self.actions.append(("cleanup", app.app_name))

--- a/tests/commands/update/test_update_app.py
+++ b/tests/commands/update/test_update_app.py
@@ -17,20 +17,12 @@ def test_update_app(update_command, first_app, tmp_path):
     ]
 
     # App content and resources have been updated
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "code.py"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/code.py").exists()
     # requirements and resources haven't been updated
-    assert not (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "requirements"
-    ).exists()
-    assert not (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "resources"
-    ).exists()
+    assert not (tmp_path / "base_path/build/first/tester/dummy/requirements").exists()
+    assert not (tmp_path / "base_path/build/first/tester/dummy/resources").exists()
     # ... and the app still exists
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "first.bundle"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/first.bundle").exists()
 
 
 def test_update_non_existing_app(update_command, tmp_path):
@@ -48,12 +40,8 @@ def test_update_non_existing_app(update_command, tmp_path):
     assert update_command.actions == []
 
     # App content has been not updated
-    assert not (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "requirements"
-    ).exists()
-    assert not (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "code.py"
-    ).exists()
+    assert not (tmp_path / "base_path/build/first/tester/dummy/requirements").exists()
+    assert not (tmp_path / "base_path/build/first/tester/dummy/code.py").exists()
 
 
 def test_update_app_with_requirements(update_command, first_app, tmp_path):
@@ -76,20 +64,12 @@ def test_update_app_with_requirements(update_command, first_app, tmp_path):
     ]
 
     # App content has been updated
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "requirements"
-    ).exists()
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "code.py"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/requirements").exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/code.py").exists()
     # Extras haven't been updated
-    assert not (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "resources"
-    ).exists()
+    assert not (tmp_path / "base_path/build/first/tester/dummy/resources").exists()
     # ... and the app still exists
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "first.bundle"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/first.bundle").exists()
 
 
 def test_update_app_with_resources(update_command, first_app, tmp_path):
@@ -112,20 +92,12 @@ def test_update_app_with_resources(update_command, first_app, tmp_path):
     ]
 
     # App content and resources have been updated
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "code.py"
-    ).exists()
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "resources"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/code.py").exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/resources").exists()
     # requirements haven't been updated
-    assert not (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "requirements"
-    ).exists()
+    assert not (tmp_path / "base_path/build/first/tester/dummy/requirements").exists()
     # ... and the app still exists
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "first.bundle"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/first.bundle").exists()
 
 
 def test_update_app_with_support_package(update_command, first_app, tmp_path):
@@ -149,23 +121,13 @@ def test_update_app_with_support_package(update_command, first_app, tmp_path):
     ]
 
     # App content and support have been updated
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "code.py"
-    ).exists()
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "support"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/code.py").exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/support").exists()
     # requirements and resources haven't been updated
-    assert not (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "resources"
-    ).exists()
-    assert not (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "requirements"
-    ).exists()
+    assert not (tmp_path / "base_path/build/first/tester/dummy/resources").exists()
+    assert not (tmp_path / "base_path/build/first/tester/dummy/requirements").exists()
     # ... and the app still exists
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "first.bundle"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/first.bundle").exists()
 
 
 def test_update_app_test_mode(update_command, first_app, tmp_path):
@@ -188,20 +150,12 @@ def test_update_app_test_mode(update_command, first_app, tmp_path):
     ]
 
     # App code has been updated
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "code.py"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/code.py").exists()
     # App requirements and resources have not been updated
-    assert not (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "requirements"
-    ).exists()
-    assert not (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "resources"
-    ).exists()
+    assert not (tmp_path / "base_path/build/first/tester/dummy/requirements").exists()
+    assert not (tmp_path / "base_path/build/first/tester/dummy/resources").exists()
     # ... and the app still exists
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "first.bundle"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/first.bundle").exists()
 
 
 def test_update_app_test_mode_requirements(update_command, first_app, tmp_path):
@@ -225,20 +179,12 @@ def test_update_app_test_mode_requirements(update_command, first_app, tmp_path):
     ]
 
     # App content and requirements have been updated
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "code.py"
-    ).exists()
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "requirements"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/code.py").exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/requirements").exists()
     # App resources have not been updated
-    assert not (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "resources"
-    ).exists()
+    assert not (tmp_path / "base_path/build/first/tester/dummy/resources").exists()
     # ... and the app still exists
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "first.bundle"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/first.bundle").exists()
 
 
 def test_update_app_test_mode_resources(update_command, first_app, tmp_path):
@@ -262,17 +208,9 @@ def test_update_app_test_mode_resources(update_command, first_app, tmp_path):
     ]
 
     # App content and resources have been updated
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "code.py"
-    ).exists()
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "resources"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/code.py").exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/resources").exists()
     # App requirements have not been updated
-    assert not (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "requirements"
-    ).exists()
+    assert not (tmp_path / "base_path/build/first/tester/dummy/requirements").exists()
     # ... and the app still exists
-    assert (
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "first.bundle"
-    ).exists()
+    assert (tmp_path / "base_path/build/first/tester/dummy/first.bundle").exists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,7 @@ def first_app(first_app_unbuilt, tmp_path):
     # The same fixture as first_app_config,
     # but ensures that the binary for the app exists
     create_file(
-        tmp_path / "base_path" / "build" / "first" / "tester" / "dummy" / "first.bin",
+        tmp_path / "base_path/build/first/tester/dummy/first.bin",
         "first.bin",
     )
 

--- a/tests/console/test_Log.py
+++ b/tests/console/test_Log.py
@@ -191,7 +191,7 @@ def test_save_log_to_file_no_exception(mock_now, command, tmp_path):
     )
     logger.save_log_to_file(command=command)
 
-    log_filepath = tmp_path / "logs" / "briefcase.2022_06_25-16_12_29.dev.log"
+    log_filepath = tmp_path / "logs/briefcase.2022_06_25-16_12_29.dev.log"
 
     assert log_filepath.exists()
     with open(log_filepath, encoding="utf-8") as log:
@@ -228,7 +228,7 @@ def test_save_log_to_file_with_exception(mock_now, command, tmp_path):
         logger.capture_stacktrace()
     logger.save_log_to_file(command=command)
 
-    log_filepath = tmp_path / "logs" / "briefcase.2022_06_25-16_12_29.dev.log"
+    log_filepath = tmp_path / "logs/briefcase.2022_06_25-16_12_29.dev.log"
 
     assert log_filepath.exists()
     with open(log_filepath, encoding="utf-8") as log:
@@ -252,7 +252,7 @@ def test_save_log_to_file_with_multiple_exceptions(mock_now, command, tmp_path):
 
     logger.save_log_to_file(command=command)
 
-    log_filepath = tmp_path / "logs" / "briefcase.2022_06_25-16_12_29.dev.log"
+    log_filepath = tmp_path / "logs/briefcase.2022_06_25-16_12_29.dev.log"
 
     assert log_filepath.exists()
     with open(log_filepath, encoding="utf-8") as log:
@@ -283,7 +283,7 @@ def test_save_log_to_file_extra(mock_now, command, tmp_path):
     for extra in [extra1, extra2, extra3]:
         logger.add_log_file_extra(extra)
     logger.save_log_to_file(command=command)
-    log_filepath = tmp_path / "logs" / "briefcase.2022_06_25-16_12_29.dev.log"
+    log_filepath = tmp_path / "logs/briefcase.2022_06_25-16_12_29.dev.log"
     with open(log_filepath, encoding="utf-8") as log:
         log_contents = log.read()
 
@@ -308,7 +308,7 @@ def test_save_log_to_file_extra_interrupted(mock_now, command, tmp_path):
     with pytest.raises(KeyboardInterrupt):
         logger.save_log_to_file(command=command)
     extra2.assert_not_called()
-    log_filepath = tmp_path / "logs" / "briefcase.2022_06_25-16_12_29.dev.log"
+    log_filepath = tmp_path / "logs/briefcase.2022_06_25-16_12_29.dev.log"
     assert log_filepath.stat().st_size == 0
 
 
@@ -371,7 +371,7 @@ def test_save_log_to_file_fail_to_write_file(
     logger.print("a line of output")
     logger.save_log_to_file(command=command)
 
-    log_filepath = tmp_path / "logs" / "briefcase.2022_06_25-16_12_29.dev.log"
+    log_filepath = tmp_path / "logs/briefcase.2022_06_25-16_12_29.dev.log"
     assert capsys.readouterr().out == "\n".join(
         [
             "a line of output",

--- a/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
@@ -64,9 +64,7 @@ def test_create_emulator(
     android_sdk.verify_emulator_skin = MagicMock()
 
     # Mock the initial output of an AVD config file.
-    avd_config_path = (
-        tmp_path / "home" / ".android" / "avd" / "new-emulator.avd" / "config.ini"
-    )
+    avd_config_path = tmp_path / "home/.android/avd/new-emulator.avd/config.ini"
     avd_config_path.parent.mkdir(parents=True)
     with avd_config_path.open("w", encoding="utf-8") as f:
         f.write("hw.device.name=pixel\n")
@@ -144,9 +142,7 @@ def test_create_emulator_with_defaults(
     android_sdk.verify_emulator_skin = MagicMock()
 
     # Mock the initial output of an AVD config file.
-    avd_config_path = (
-        tmp_path / "home" / ".android" / "avd" / "new-emulator.avd" / "config.ini"
-    )
+    avd_config_path = tmp_path / "home/.android/avd/new-emulator.avd/config.ini"
     avd_config_path.parent.mkdir(parents=True)
     with avd_config_path.open("w", encoding="utf-8") as f:
         f.write("hw.device.name=pixel\n")
@@ -238,9 +234,7 @@ def test_default_name(mock_tools, android_sdk, tmp_path):
     mock_tools.input.return_value = ""
 
     # Mock the initial output of an AVD config file.
-    avd_config_path = (
-        tmp_path / "home" / ".android" / "avd" / "beePhone.avd" / "config.ini"
-    )
+    avd_config_path = tmp_path / "home/.android/avd/beePhone.avd/config.ini"
     avd_config_path.parent.mkdir(parents=True)
     with avd_config_path.open("w", encoding="utf-8") as f:
         f.write("hw.device.name=pixel\n")
@@ -269,9 +263,7 @@ def test_default_name_with_collisions(mock_tools, android_sdk, tmp_path):
     mock_tools.input.return_value = ""
 
     # Mock the initial output of an AVD config file.
-    avd_config_path = (
-        tmp_path / "home" / ".android" / "avd" / "beePhone3.avd" / "config.ini"
-    )
+    avd_config_path = tmp_path / "home/.android/avd/beePhone3.avd/config.ini"
     avd_config_path.parent.mkdir(parents=True)
     with avd_config_path.open("w", encoding="utf-8") as f:
         f.write("hw.device.name=pixel\n")

--- a/tests/integrations/android_sdk/AndroidSDK/test_avd_config.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_avd_config.py
@@ -1,8 +1,6 @@
 def test_avd_config(mock_tools, android_sdk, tmp_path):
     """An AVD configuration can be read."""
-    config_file = (
-        tmp_path / "home" / ".android" / "avd" / "testDevice.avd" / "config.ini"
-    )
+    config_file = tmp_path / "home/.android/avd/testDevice.avd/config.ini"
     config_file.parent.mkdir(parents=True)
 
     # Write a default config. It contains:
@@ -37,9 +35,7 @@ disk.cachePartition.size=37MB
 
 def test_avd_config_with_space(mock_tools, android_sdk, tmp_path):
     """An AVD configuration that contains spaces can be read."""
-    config_file = (
-        tmp_path / "home" / ".android" / "avd" / "testDevice.avd" / "config.ini"
-    )
+    config_file = tmp_path / "home/.android/avd/testDevice.avd/config.ini"
     config_file.parent.mkdir(parents=True)
 
     # Write a default config. It contains:

--- a/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
@@ -65,9 +65,7 @@ def test_create_emulator(
     ]
 
     # Mock the initial output of an AVD config file.
-    avd_config_path = (
-        tmp_path / "home" / ".android" / "avd" / "new-emulator.avd" / "config.ini"
-    )
+    avd_config_path = tmp_path / "home/.android/avd/new-emulator.avd/config.ini"
     avd_config_path.parent.mkdir(parents=True)
     with avd_config_path.open("w", encoding="utf-8") as f:
         f.write("hw.device.name=pixel\n")

--- a/tests/integrations/android_sdk/AndroidSDK/test_properties.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_properties.py
@@ -85,7 +85,7 @@ def test_emulator_path(mock_tools, android_sdk, host_os, emulator_name):
 
 
 def test_avd_path(mock_tools, android_sdk, tmp_path):
-    assert android_sdk.avd_path == tmp_path / "home" / ".android" / "avd"
+    assert android_sdk.avd_path == tmp_path / "home/.android/avd"
 
 
 def test_simple_env(mock_tools, android_sdk, tmp_path):

--- a/tests/integrations/android_sdk/AndroidSDK/test_update_emulator_config.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_update_emulator_config.py
@@ -4,9 +4,7 @@ import pytest
 @pytest.fixture
 def test_device(tmp_path):
     """Create an AVD configuration file."""
-    config_file = (
-        tmp_path / "home" / ".android" / "avd" / "testDevice.avd" / "config.ini"
-    )
+    config_file = tmp_path / "home/.android/avd/testDevice.avd/config.ini"
     config_file.parent.mkdir(parents=True)
 
     # Write a default config. It contains:

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -48,11 +48,11 @@ def mock_tools(mock_tools) -> ToolCache:
 def mock_unpack(filename, extract_dir):
     # Create a file that would have been created by unpacking the archive
     # This includes the duplicated "cmdline-tools" folder name
-    (extract_dir / "cmdline-tools" / "bin").mkdir(parents=True)
-    (extract_dir / "cmdline-tools" / "bin" / "sdkmanager").touch(mode=0o644)
-    (extract_dir / "cmdline-tools" / "bin" / "avdmanager").touch(mode=0o644)
+    (extract_dir / "cmdline-tools/bin").mkdir(parents=True)
+    (extract_dir / "cmdline-tools/bin/sdkmanager").touch(mode=0o644)
+    (extract_dir / "cmdline-tools/bin/avdmanager").touch(mode=0o644)
     # Include an extra tool that is already executable.
-    (extract_dir / "cmdline-tools" / "bin" / "other").touch(mode=0o755)
+    (extract_dir / "cmdline-tools/bin/other").touch(mode=0o755)
 
 
 def accept_license(android_sdk_root_path):
@@ -114,8 +114,8 @@ def test_supported_os_arch(mock_tools, host_os, host_arch, tmp_path):
     mock_tools.host_arch = host_arch
 
     # Create `sdkmanager` and the license file.
-    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
-    tools_bin = android_sdk_root_path / "cmdline-tools" / "9.0" / "bin"
+    android_sdk_root_path = tmp_path / "tools/android_sdk"
+    tools_bin = android_sdk_root_path / "cmdline-tools/9.0/bin"
     tools_bin.mkdir(parents=True, mode=0o755)
     if host_os == "Windows":
         sdk_manager = tools_bin / "sdkmanager.bat"
@@ -137,7 +137,7 @@ def test_succeeds_immediately_in_happy_path(mock_tools, tmp_path):
     # return an SDK wrapper.
 
     # Create `sdkmanager` and the license file.
-    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    android_sdk_root_path = tmp_path / "tools/android_sdk"
     tools_bin = android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
     (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
@@ -276,7 +276,7 @@ def test_invalid_user_provided_sdk(mock_tools, env_var, tmp_path, capsys):
     """If the user's environment specifies an invalid Android SDK, it is ignored."""
     # Create `sdkmanager` and the license file
     # for the *briefcase* managed version of the SDK.
-    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    android_sdk_root_path = tmp_path / "tools/android_sdk"
     tools_bin = android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
     (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
@@ -313,13 +313,13 @@ def test_user_provided_sdk_wrong_cmdline_tools_ver(
     tools and the cmdline-tools install fails, the Briefcase SDK is used."""
     # Create `sdkmanager` and the license file for the *user's* version of the SDK
     user_sdk_path = tmp_path / "other_sdk"
-    user_tools_bin = user_sdk_path / "cmdline-tools" / "6.0" / "bin"
+    user_tools_bin = user_sdk_path / "cmdline-tools/6.0/bin"
     user_tools_bin.mkdir(parents=True, mode=0o755)
     (user_tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
     # Create `sdkmanager` and the license file
     # for the *briefcase* managed version of the SDK.
-    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    android_sdk_root_path = tmp_path / "tools/android_sdk"
     tools_bin = android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
     (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
@@ -375,7 +375,7 @@ def test_user_provided_sdk_with_latest_cmdline_tools(
     tools, the required cmdline-tools is installed in to it."""
     # Create `sdkmanager` and the license file for the *user's* version of the SDK
     user_sdk_path = tmp_path / "other_sdk"
-    user_tools_bin = user_sdk_path / "cmdline-tools" / "latest" / "bin"
+    user_tools_bin = user_sdk_path / "cmdline-tools/latest/bin"
     user_tools_bin.mkdir(parents=True, mode=0o755)
     (user_tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
@@ -417,7 +417,7 @@ def test_consistent_invalid_user_provided_sdk(mock_tools, tmp_path, capsys):
 
     # Create `sdkmanager` and the license file
     # for the *briefcase* managed version of the SDK.
-    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    android_sdk_root_path = tmp_path / "tools/android_sdk"
     tools_bin = android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
     (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
@@ -452,7 +452,7 @@ def test_inconsistent_invalid_user_provided_sdk(mock_tools, tmp_path, capsys):
 
     # Create `sdkmanager` and the license file
     # for the *briefcase* managed version of the SDK.
-    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    android_sdk_root_path = tmp_path / "tools/android_sdk"
     tools_bin = android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
     (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
@@ -485,7 +485,7 @@ def test_inconsistent_invalid_user_provided_sdk(mock_tools, tmp_path, capsys):
 
 def test_download_sdk(mock_tools, tmp_path, capsys):
     """If an SDK is not available, one will be downloaded."""
-    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    android_sdk_root_path = tmp_path / "tools/android_sdk"
     cmdline_tools_base_path = android_sdk_root_path / "cmdline-tools"
 
     # The download will produce a cached file.
@@ -525,12 +525,12 @@ def test_download_sdk(mock_tools, tmp_path, capsys):
     if platform.system() != "Windows":
         # On non-Windows, ensure the unpacked binary was made executable
         assert os.access(
-            cmdline_tools_base_path / SDK_MGR_VER / "bin" / "sdkmanager",
+            cmdline_tools_base_path / SDK_MGR_VER / "bin/sdkmanager",
             os.X_OK,
         )
 
     # The license has been accepted
-    assert (android_sdk_root_path / "licenses" / "android-sdk-license").exists()
+    assert (android_sdk_root_path / "licenses/android-sdk-license").exists()
 
     # The returned SDK has the expected root path.
     assert sdk.root_path == android_sdk_root_path
@@ -541,7 +541,7 @@ def test_download_sdk(mock_tools, tmp_path, capsys):
 def test_upgrade_existing_sdk(mock_tools, tmp_path, capsys):
     """An existing SDK is upgraded if the required version of cmdline-tools isn't
     installed."""
-    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    android_sdk_root_path = tmp_path / "tools/android_sdk"
     cmdline_tools_base_path = android_sdk_root_path / "cmdline-tools"
 
     # Mock an existing cmdline-tools install
@@ -585,12 +585,12 @@ def test_upgrade_existing_sdk(mock_tools, tmp_path, capsys):
     if platform.system() != "Windows":
         # On non-Windows, ensure the unpacked binary was made executable
         assert os.access(
-            cmdline_tools_base_path / SDK_MGR_VER / "bin" / "sdkmanager",
+            cmdline_tools_base_path / SDK_MGR_VER / "bin/sdkmanager",
             os.X_OK,
         )
 
     # The license has been accepted
-    assert (android_sdk_root_path / "licenses" / "android-sdk-license").exists()
+    assert (android_sdk_root_path / "licenses/android-sdk-license").exists()
 
     # The returned SDK has the expected root path.
     assert sdk.root_path == android_sdk_root_path
@@ -604,14 +604,14 @@ def test_upgrade_existing_sdk(mock_tools, tmp_path, capsys):
 
 def test_download_sdk_legacy_install(mock_tools, tmp_path):
     """If the legacy SDK tools are present, they will be deleted."""
-    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    android_sdk_root_path = tmp_path / "tools/android_sdk"
     cmdline_tools_base_path = android_sdk_root_path / "cmdline-tools"
 
     # Create files that mock the existence of the *old* SDK tools.
     sdk_tools_base_path = android_sdk_root_path / "tools"
     (sdk_tools_base_path / "bin").mkdir(parents=True)
-    (sdk_tools_base_path / "bin" / "sdkmanager").touch(mode=0o755)
-    (sdk_tools_base_path / "bin" / "avdmanager").touch(mode=0o755)
+    (sdk_tools_base_path / "bin/sdkmanager").touch(mode=0o755)
+    (sdk_tools_base_path / "bin/avdmanager").touch(mode=0o755)
 
     # Create some of the tools that have locations that overlap
     # between legacy and new.
@@ -656,7 +656,7 @@ def test_download_sdk_legacy_install(mock_tools, tmp_path):
     if platform.system() != "Windows":
         # On non-Windows, ensure the unpacked binary was made executable
         assert os.access(
-            cmdline_tools_base_path / SDK_MGR_VER / "bin" / "sdkmanager", os.X_OK
+            cmdline_tools_base_path / SDK_MGR_VER / "bin/sdkmanager", os.X_OK
         )
 
     # The legacy SDK tools have been removed
@@ -664,7 +664,7 @@ def test_download_sdk_legacy_install(mock_tools, tmp_path):
     assert not emulator_path.exists()
 
     # The license has been accepted
-    assert (android_sdk_root_path / "licenses" / "android-sdk-license").exists()
+    assert (android_sdk_root_path / "licenses/android-sdk-license").exists()
 
     # The returned SDK has the expected root path.
     assert sdk.root_path == android_sdk_root_path
@@ -683,12 +683,12 @@ def test_no_install(mock_tools, tmp_path):
 def test_download_sdk_if_sdkmanager_not_executable(mock_tools, tmp_path):
     """An SDK will be downloaded and unpacked if `tools/bin/sdkmanager` exists but does
     not have its permissions set properly."""
-    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    android_sdk_root_path = tmp_path / "tools/android_sdk"
     cmdline_tools_base_path = android_sdk_root_path / "cmdline-tools"
 
     # Create pre-existing non-executable `sdkmanager`.
     (cmdline_tools_base_path / SDK_MGR_VER / "bin").mkdir(parents=True)
-    (cmdline_tools_base_path / SDK_MGR_VER / "bin" / "sdkmanager").touch(mode=0o644)
+    (cmdline_tools_base_path / SDK_MGR_VER / "bin/sdkmanager").touch(mode=0o644)
     (cmdline_tools_base_path / SDK_MGR_DL_VER).touch()
 
     # The download will produce a cached file
@@ -724,7 +724,7 @@ def test_download_sdk_if_sdkmanager_not_executable(mock_tools, tmp_path):
     cache_file.unlink.assert_called_once_with()
 
     # The license has been accepted
-    assert (android_sdk_root_path / "licenses" / "android-sdk-license").exists()
+    assert (android_sdk_root_path / "licenses/android-sdk-license").exists()
 
     # The returned SDK has the expected root path.
     assert sdk.root_path == android_sdk_root_path
@@ -753,7 +753,7 @@ def test_raises_networkfailure_on_connectionerror(mock_tools):
 
 def test_detects_bad_zipfile(mock_tools, tmp_path):
     """If the ZIP file is corrupted, an error is raised."""
-    android_sdk_root_path = tmp_path / "tools" / "android_sdk"
+    android_sdk_root_path = tmp_path / "tools/android_sdk"
 
     cache_file = MagicMock()
     mock_tools.download.file.return_value = cache_file

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_avd.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_avd.py
@@ -68,7 +68,7 @@ def test_valid_system_image(android_sdk):
             "disk.cachePartition.size": "42M",
             # Add an OS-dependent image.sysdir.1 value, with a trailing slash.
             "image.sysdir.1": os.fsdecode(
-                Path("system-images") / "android-31" / "default" / "arm64-v8a"
+                Path("system-images/android-31/default/arm64-v8a")
             )
             + "/",
         }

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
@@ -10,7 +10,7 @@ from briefcase.exceptions import BriefcaseCommandError, NetworkFailure
 def test_existing_skin(mock_tools, android_sdk):
     """If the skin already exists, don't attempt to download it again."""
     # Mock the existence of a system image
-    (android_sdk.root_path / "skins" / "pixel_X").mkdir(parents=True)
+    (android_sdk.root_path / "skins/pixel_X").mkdir(parents=True)
 
     # Verify the system image that we already have
     android_sdk.verify_emulator_skin("pixel_X")
@@ -40,7 +40,7 @@ def test_new_skin(mock_tools, android_sdk):
     # Skin is unpacked.
     mock_tools.shutil.unpack_archive.assert_called_once_with(
         skin_tgz_path,
-        extract_dir=android_sdk.root_path / "skins" / "pixel_X",
+        extract_dir=android_sdk.root_path / "skins/pixel_X",
         **({"filter": "data"} if sys.version_info >= (3, 12) else {}),
     )
 
@@ -103,7 +103,7 @@ def test_unpack_failure(mock_tools, android_sdk, tmp_path):
     # An attempt to unpack the skin was made.
     mock_tools.shutil.unpack_archive.assert_called_once_with(
         skin_tgz_path,
-        extract_dir=android_sdk.root_path / "skins" / "pixel_X",
+        extract_dir=android_sdk.root_path / "skins/pixel_X",
         **({"filter": "data"} if sys.version_info >= (3, 12) else {}),
     )
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_license.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_license.py
@@ -12,7 +12,7 @@ def test_verify_license_passes_quickly_if_license_present(mock_tools, android_sd
     If `android-sdk-license` exists in the right place, we expect verify_license() to
     run no subprocesses.
     """
-    license_path = android_sdk.root_path / "licenses" / "android-sdk-license"
+    license_path = android_sdk.root_path / "licenses/android-sdk-license"
     license_path.parent.mkdir(parents=True)
     license_path.touch()
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
@@ -83,9 +83,9 @@ def test_existing_system_image(mock_tools, android_sdk):
     mock_tools.host_arch = "AMD64" if platform.system() == "Windows" else "x86_64"
 
     # Mock the existence of a system image
-    (
-        android_sdk.root_path / "system-images" / "android-31" / "default" / "x86_64"
-    ).mkdir(parents=True)
+    (android_sdk.root_path / "system-images/android-31/default/x86_64").mkdir(
+        parents=True
+    )
 
     # Verify the system image that we already have
     android_sdk.verify_system_image("system-images;android-31;default;x86_64")

--- a/tests/integrations/docker/conftest.py
+++ b/tests/integrations/docker/conftest.py
@@ -57,7 +57,7 @@ def mock_docker_app_context(tmp_path, my_app, mock_tools) -> DockerAppContext:
     mock_docker_app_context = DockerAppContext(mock_tools, my_app)
     mock_docker_app_context.prepare(
         image_tag="briefcase/com.example.myapp:py3.X",
-        dockerfile_path=tmp_path / "bundle" / "Dockerfile",
+        dockerfile_path=tmp_path / "bundle/Dockerfile",
         app_base_path=tmp_path / "base",
         host_bundle_path=tmp_path / "bundle",
         host_data_path=tmp_path / "briefcase",
@@ -76,7 +76,7 @@ def user_mapping_run_calls(tmp_path, monkeypatch) -> list:
     monkeypatch.setattr(
         briefcase.integrations.docker.Docker,
         "_write_test_path",
-        MagicMock(return_value=tmp_path / "build" / "mock_write_test"),
+        MagicMock(return_value=tmp_path / "build/mock_write_test"),
     )
     return [
         call(

--- a/tests/integrations/docker/test_DockerAppContext__check_output.py
+++ b/tests/integrations/docker/test_DockerAppContext__check_output.py
@@ -72,7 +72,7 @@ def test_cwd(mock_docker_app_context, tmp_path, sub_check_output_kw, capsys):
     assert (
         mock_docker_app_context.check_output(
             ["hello", "world"],
-            cwd=tmp_path / "bundle" / "foobar",
+            cwd=tmp_path / "bundle/foobar",
         )
         == "goodbye\n"
     )

--- a/tests/integrations/docker/test_DockerAppContext__prepare.py
+++ b/tests/integrations/docker/test_DockerAppContext__prepare.py
@@ -12,7 +12,7 @@ def test_prepare(mock_tools, my_app, tmp_path, sub_stream_kw):
     mock_docker_app_context = DockerAppContext(mock_tools, my_app)
     mock_docker_app_context.prepare(
         image_tag="briefcase/com.example.myapp:py3.X",
-        dockerfile_path=tmp_path / "bundle" / "Dockerfile",
+        dockerfile_path=tmp_path / "bundle/Dockerfile",
         app_base_path=tmp_path / "base",
         host_bundle_path=tmp_path / "bundle",
         host_data_path=tmp_path / "briefcase",
@@ -28,14 +28,14 @@ def test_prepare(mock_tools, my_app, tmp_path, sub_stream_kw):
             "--tag",
             "briefcase/com.example.myapp:py3.X",
             "--file",
-            os.fsdecode(tmp_path / "bundle" / "Dockerfile"),
+            os.fsdecode(tmp_path / "bundle/Dockerfile"),
             "--build-arg",
             "SYSTEM_REQUIRES=things==1.2 stuff>=3.4",
             "--build-arg",
             "HOST_UID=37",
             "--build-arg",
             "HOST_GID=42",
-            os.fsdecode(tmp_path / "base" / "path" / "to" / "src"),
+            os.fsdecode(tmp_path / "base/path/to/src"),
         ],
         **sub_stream_kw,
     )
@@ -57,7 +57,7 @@ def test_prepare_failure(mock_docker_app_context, tmp_path, sub_stream_kw):
     with pytest.raises(BriefcaseCommandError):
         mock_docker_app_context.prepare(
             image_tag="briefcase/com.example.myapp:py3.X",
-            dockerfile_path=tmp_path / "bundle" / "Dockerfile",
+            dockerfile_path=tmp_path / "bundle/Dockerfile",
             app_base_path=tmp_path / "base",
             host_bundle_path=tmp_path / "bundle",
             host_data_path=tmp_path / "briefcase",
@@ -73,14 +73,14 @@ def test_prepare_failure(mock_docker_app_context, tmp_path, sub_stream_kw):
             "--tag",
             "briefcase/com.example.myapp:py3.X",
             "--file",
-            os.fsdecode(tmp_path / "bundle" / "Dockerfile"),
+            os.fsdecode(tmp_path / "bundle/Dockerfile"),
             "--build-arg",
             "SYSTEM_REQUIRES=things==1.2 stuff>=3.4",
             "--build-arg",
             "HOST_UID=37",
             "--build-arg",
             "HOST_GID=42",
-            os.fsdecode(tmp_path / "base" / "path" / "to" / "src"),
+            os.fsdecode(tmp_path / "base/path/to/src"),
         ],
         **sub_stream_kw,
     )

--- a/tests/integrations/docker/test_DockerAppContext__run.py
+++ b/tests/integrations/docker/test_DockerAppContext__run.py
@@ -116,7 +116,7 @@ def test_cwd(mock_docker_app_context, tmp_path, sub_stream_kw, capsys):
 
     mock_docker_app_context.run(
         ["hello", "world"],
-        cwd=tmp_path / "bundle" / "foobar",
+        cwd=tmp_path / "bundle/foobar",
     )
 
     mock_docker_app_context.tools.subprocess._subprocess.Popen.assert_called_once_with(

--- a/tests/integrations/docker/test_Docker__verify.py
+++ b/tests/integrations/docker/test_Docker__verify.py
@@ -323,7 +323,7 @@ def test_docker_image_hint(mock_tools):
 
 def test_user_mapping_write_file_path(mock_tools):
     """The write test file path is as expected."""
-    expected_path = Path.cwd() / "build" / "container_write_test"
+    expected_path = Path.cwd() / "build/container_write_test"
     assert Docker(mock_tools)._write_test_path() == expected_path
 
 

--- a/tests/integrations/download/test_Download__file.py
+++ b/tests/integrations/download/test_Download__file.py
@@ -111,7 +111,7 @@ def test_new_download_oneshot(mock_tools, file_perms, url, content_disposition):
     response.iter_content.assert_not_called()
 
     # The filename is derived from the URL or header
-    assert filename == mock_tools.base_path / "downloads" / "something.zip"
+    assert filename == mock_tools.base_path / "downloads/something.zip"
 
     # Temporary file was created in download dir and was renamed
     temp_filename = Path(mock_tools.shutil.move.call_args_list[0].args[0])
@@ -128,9 +128,7 @@ def test_new_download_oneshot(mock_tools, file_perms, url, content_disposition):
     mock_tools.os.remove.assert_called_with(str(temp_filename))
 
     # File content is as expected
-    with (mock_tools.base_path / "downloads" / "something.zip").open(
-        encoding="utf-8"
-    ) as f:
+    with (mock_tools.base_path / "downloads/something.zip").open(encoding="utf-8") as f:
         assert f.read() == "all content"
 
 

--- a/tests/integrations/flatpak/test_Flatpak__bundle.py
+++ b/tests/integrations/flatpak/test_Flatpak__bundle.py
@@ -19,7 +19,7 @@ def test_bundle(flatpak, tool_debug_mode, tmp_path):
         app_name="my-app",
         version="1.2.3",
         build_path=tmp_path / "build",
-        output_path=tmp_path / "output" / "MyApp.flatpak",
+        output_path=tmp_path / "output/MyApp.flatpak",
     )
 
     # The expected call was made
@@ -30,7 +30,7 @@ def test_bundle(flatpak, tool_debug_mode, tmp_path):
             "--runtime-repo",
             "https://example.com/flatpak",
             "repo",
-            tmp_path / "output" / "MyApp.flatpak",
+            tmp_path / "output/MyApp.flatpak",
             "com.example.my-app",
             "1.2.3",
         ]
@@ -56,5 +56,5 @@ def test_bundle_fail(flatpak, tmp_path):
             app_name="my-app",
             version="1.2.3",
             build_path=tmp_path / "build",
-            output_path=tmp_path / "output" / "MyApp.flatpak",
+            output_path=tmp_path / "output/MyApp.flatpak",
         )

--- a/tests/integrations/java/test_JDK__upgrade.py
+++ b/tests/integrations/java/test_JDK__upgrade.py
@@ -40,7 +40,7 @@ def test_non_managed_install(mock_tools, tmp_path, capsys):
 def test_non_existing_install(mock_tools, tmp_path):
     """If there's no existing managed JDK install, upgrading is an error."""
     # Create an SDK wrapper around a non-existing managed install
-    jdk = JDK(mock_tools, java_home=tmp_path / "tools" / "java")
+    jdk = JDK(mock_tools, java_home=tmp_path / "tools/java")
 
     with pytest.raises(MissingToolError):
         jdk.upgrade()
@@ -52,7 +52,7 @@ def test_non_existing_install(mock_tools, tmp_path):
 def test_existing_install(mock_tools, tmp_path):
     """If there's an existing managed JDK install, it is deleted and re-downloaded."""
     # Create a mock of a previously installed Java version.
-    java_home = tmp_path / "tools" / "java"
+    java_home = tmp_path / "tools/java"
     (java_home / "bin").mkdir(parents=True)
 
     # We actually need to delete the original java install
@@ -101,7 +101,7 @@ def test_macOS_existing_install(mock_tools, tmp_path):
     mock_tools.host_os = "Darwin"
 
     # Create a mock of a previously installed Java version.
-    java_home = tmp_path / "tools" / "java" / "Contents" / "Home"
+    java_home = tmp_path / "tools/java/Contents/Home"
     (java_home / "bin").mkdir(parents=True)
 
     # We actually need to delete the original java install
@@ -125,7 +125,7 @@ def test_macOS_existing_install(mock_tools, tmp_path):
     jdk.upgrade()
 
     # The old version has been deleted
-    mock_tools.shutil.rmtree.assert_called_with(tmp_path / "tools" / "java")
+    mock_tools.shutil.rmtree.assert_called_with(tmp_path / "tools/java")
 
     # A download was initiated
     mock_tools.download.file.assert_called_with(
@@ -147,7 +147,7 @@ def test_macOS_existing_install(mock_tools, tmp_path):
 def test_download_fail(mock_tools, tmp_path):
     """If there's an existing managed JDK install, it is deleted and re-downloaded."""
     # Create a mock of a previously installed Java version.
-    java_home = tmp_path / "tools" / "java"
+    java_home = tmp_path / "tools/java"
     (java_home / "bin").mkdir(parents=True)
 
     # We actually need to delete the original java install
@@ -184,7 +184,7 @@ def test_download_fail(mock_tools, tmp_path):
 def test_unpack_fail(mock_tools, tmp_path):
     """If there's an existing managed JDK install, it is deleted and re-downloaded."""
     # Create a mock of a previously installed Java version.
-    java_home = tmp_path / "tools" / "java"
+    java_home = tmp_path / "tools/java"
     (java_home / "bin").mkdir(parents=True)
 
     # We actually need to delete the original java install

--- a/tests/integrations/java/test_JDK__verify.py
+++ b/tests/integrations/java/test_JDK__verify.py
@@ -92,13 +92,13 @@ def test_macos_tool_failure(mock_tools, tmp_path, capsys):
     )
 
     # Create a directory to make it look like the Briefcase Java already exists.
-    (tmp_path / "tools" / "java17" / "Contents" / "Home" / "bin").mkdir(parents=True)
+    (tmp_path / "tools/java17/Contents/Home/bin").mkdir(parents=True)
 
     # Create a JDK wrapper by verification
     jdk = JDK.verify(mock_tools)
 
     # The JDK should have the briefcase JAVA_HOME
-    assert jdk.java_home == tmp_path / "tools" / "java17" / "Contents" / "Home"
+    assert jdk.java_home == tmp_path / "tools/java17/Contents/Home"
 
     assert mock_tools.subprocess.check_output.mock_calls == [CALL_JAVA_HOME]
 
@@ -121,13 +121,13 @@ def test_macos_wrong_jdk_version(mock_tools, tmp_path, capsys):
     ]
 
     # Create a directory to make it look like the Briefcase Java already exists.
-    (tmp_path / "tools" / "java17" / "Contents" / "Home" / "bin").mkdir(parents=True)
+    (tmp_path / "tools/java17/Contents/Home/bin").mkdir(parents=True)
 
     # Create a JDK wrapper by verification
     jdk = JDK.verify(mock_tools)
 
     # The JDK should have the briefcase JAVA_HOME
-    assert jdk.java_home == tmp_path / "tools" / "java17" / "Contents" / "Home"
+    assert jdk.java_home == tmp_path / "tools/java17/Contents/Home"
 
     assert mock_tools.subprocess.check_output.mock_calls == [
         CALL_JAVA_HOME,
@@ -153,13 +153,13 @@ def test_macos_invalid_jdk_path(mock_tools, tmp_path, capsys):
     ]
 
     # Create a directory to make it look like the Briefcase Java already exists.
-    (tmp_path / "tools" / "java17" / "Contents" / "Home" / "bin").mkdir(parents=True)
+    (tmp_path / "tools/java17/Contents/Home/bin").mkdir(parents=True)
 
     # Create a JDK wrapper by verification
     jdk = JDK.verify(mock_tools)
 
     # The JDK should have the briefcase JAVA_HOME
-    assert jdk.java_home == tmp_path / "tools" / "java17" / "Contents" / "Home"
+    assert jdk.java_home == tmp_path / "tools/java17/Contents/Home"
 
     assert mock_tools.subprocess.check_output.mock_calls == [
         CALL_JAVA_HOME,

--- a/tests/integrations/linuxdeploy/test_LinuxDeployBase__patch_elf_binary.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployBase__patch_elf_binary.py
@@ -11,7 +11,7 @@ from tests.integrations.linuxdeploy.utils import create_mock_appimage
 
 def test_patch_linuxdeploy_elf_header_unpatched(linuxdeploy, tmp_path):
     """If the linuxdeploy tool/plugin is not patched, patch it."""
-    appimage_path = tmp_path / "tools" / "linuxdeploy-i386.AppImage"
+    appimage_path = tmp_path / "tools/linuxdeploy-i386.AppImage"
 
     # Mock an unpatched linuxdeploy AppImage
     pre_patch_header = create_mock_appimage(
@@ -32,7 +32,7 @@ def test_patch_linuxdeploy_elf_header_unpatched(linuxdeploy, tmp_path):
 
 def test_patch_linuxdeploy_elf_header_already_patched(linuxdeploy, tmp_path):
     """If linuxdeploy is already patched, don't patch it."""
-    appimage_path = tmp_path / "tools" / "linuxdeploy-i386.AppImage"
+    appimage_path = tmp_path / "tools/linuxdeploy-i386.AppImage"
 
     # Mock a patched linuxdeploy AppImage
     pre_patch_header = create_mock_appimage(
@@ -53,7 +53,7 @@ def test_patch_linuxdeploy_elf_header_already_patched(linuxdeploy, tmp_path):
 
 def test_patch_linuxdeploy_elf_header_bad_appimage(linuxdeploy, tmp_path):
     """If linuxdeploy does not have a valid header, raise an error."""
-    appimage_path = tmp_path / "tools" / "linuxdeploy-i386.AppImage"
+    appimage_path = tmp_path / "tools/linuxdeploy-i386.AppImage"
 
     # Mock a bad linuxdeploy AppImage
     create_mock_appimage(appimage_path=appimage_path, mock_appimage_kind="corrupt")
@@ -65,7 +65,7 @@ def test_patch_linuxdeploy_elf_header_bad_appimage(linuxdeploy, tmp_path):
 
 def test_patch_linuxdeploy_elf_header_empty_appimage(linuxdeploy, tmp_path):
     """If file is empty, raise an error."""
-    appimage_path = tmp_path / "tools" / "linuxdeploy-i386.AppImage"
+    appimage_path = tmp_path / "tools/linuxdeploy-i386.AppImage"
 
     # Mock a bad linuxdeploy AppImage
     create_mock_appimage(appimage_path=appimage_path, mock_appimage_kind="empty")

--- a/tests/integrations/linuxdeploy/test_LinuxDeployBase__upgrade.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployBase__upgrade.py
@@ -6,7 +6,7 @@ from tests.integrations.linuxdeploy.utils import side_effect_create_mock_appimag
 
 def test_upgrade_exists(linuxdeploy, mock_tools, tmp_path):
     """If linuxdeploy already exists, upgrading deletes first."""
-    appimage_path = tmp_path / "tools" / "linuxdeploy-i386.AppImage"
+    appimage_path = tmp_path / "tools/linuxdeploy-i386.AppImage"
 
     # Mock the existence of an install
     appimage_path.touch()
@@ -45,7 +45,7 @@ def test_upgrade_does_not_exist(linuxdeploy, mock_tools):
 def test_upgrade_linuxdeploy_download_failure(linuxdeploy, mock_tools, tmp_path):
     """If linuxdeploy doesn't exist, but a download failure occurs, an error is
     raised."""
-    appimage_path = tmp_path / "tools" / "linuxdeploy-i386.AppImage"
+    appimage_path = tmp_path / "tools/linuxdeploy-i386.AppImage"
 
     # Mock the existence of an install
     appimage_path.touch()

--- a/tests/integrations/linuxdeploy/test_LinuxDeployBase__verify.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployBase__verify.py
@@ -56,9 +56,7 @@ def test_unsupported_os(mock_tools, host_os):
 
 def test_verify_exists(mock_tools, tmp_path):
     """If the tool/plugin already exists, verification doesn't download."""
-    appimage_path = (
-        tmp_path / "tools" / "somewhere" / "linuxdeploy-dummy-wonky.AppImage"
-    )
+    appimage_path = tmp_path / "tools/somewhere/linuxdeploy-dummy-wonky.AppImage"
 
     # Mock the existence of an install
     appimage_path.parent.mkdir(parents=True)
@@ -89,9 +87,7 @@ def test_verify_does_not_exist_dont_install(mock_tools):
 
 def test_verify_does_not_exist(mock_tools, tmp_path):
     """If the tool/plugin doesn't exist, it is downloaded."""
-    appimage_path = (
-        tmp_path / "tools" / "somewhere" / "linuxdeploy-dummy-wonky.AppImage"
-    )
+    appimage_path = tmp_path / "tools/somewhere/linuxdeploy-dummy-wonky.AppImage"
 
     # Mock a successful download
     mock_tools.download.file.side_effect = side_effect_create_mock_appimage(
@@ -111,7 +107,7 @@ def test_verify_does_not_exist(mock_tools, tmp_path):
     # A download is invoked
     mock_tools.download.file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy-wonky.AppImage",
-        download_path=tmp_path / "tools" / "somewhere",
+        download_path=tmp_path / "tools/somewhere",
         role="Dummy plugin",
     )
     # The downloaded file will be made executable
@@ -124,7 +120,7 @@ def test_verify_does_not_exist(mock_tools, tmp_path):
 def test_verify_does_not_exist_non_appimage(mock_tools, tmp_path):
     """If a non-Appimage tool/plugin doesn't exist, it is downloaded, but not elf-
     patched."""
-    tool_path = tmp_path / "tools" / "somewhere" / "linuxdeploy-dummy.sh"
+    tool_path = tmp_path / "tools/somewhere/linuxdeploy-dummy.sh"
 
     # Mock a successful download
     mock_tools.download.file.side_effect = side_effect_create_mock_tool(tool_path)
@@ -135,7 +131,7 @@ def test_verify_does_not_exist_non_appimage(mock_tools, tmp_path):
     # A download is invoked
     mock_tools.download.file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy.sh",
-        download_path=tmp_path / "tools" / "somewhere",
+        download_path=tmp_path / "tools/somewhere",
         role="Dummy plugin",
     )
     # The downloaded file will be made executable
@@ -160,6 +156,6 @@ def test_verify_linuxdeploy_download_failure(mock_tools, tmp_path):
     # A download was invoked
     mock_tools.download.file.assert_called_with(
         url="https://example.com/path/to/linuxdeploy-dummy-wonky.AppImage",
-        download_path=tmp_path / "tools" / "somewhere",
+        download_path=tmp_path / "tools/somewhere",
         role="Dummy plugin",
     )

--- a/tests/integrations/linuxdeploy/test_LinuxDeployGtkPlugin__properties.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployGtkPlugin__properties.py
@@ -12,7 +12,7 @@ def test_file_path(linuxdeploy_gtk_plugin, mock_tools):
     """Default Linuxdeploy plugins reside in the linuxdeploy plugins path."""
     assert (
         linuxdeploy_gtk_plugin.file_path
-        == mock_tools.base_path / "linuxdeploy_plugins" / "gtk"
+        == mock_tools.base_path / "linuxdeploy_plugins/gtk"
     )
 
 

--- a/tests/integrations/linuxdeploy/test_LinuxDeployLocalFilePlugin__properties.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployLocalFilePlugin__properties.py
@@ -7,7 +7,7 @@ from briefcase.integrations.linuxdeploy import LinuxDeployLocalFilePlugin
 def linuxdeploy_local_file_plugin(mock_tools, tmp_path):
     return LinuxDeployLocalFilePlugin(
         mock_tools,
-        plugin_path=tmp_path / "path" / "to" / "linuxdeploy-plugin-custom.sh",
+        plugin_path=tmp_path / "path/to/linuxdeploy-plugin-custom.sh",
         bundle_path=tmp_path / "bundle",
     )
 

--- a/tests/integrations/linuxdeploy/test_LinuxDeployLocalFilePlugin__verify.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployLocalFilePlugin__verify.py
@@ -20,7 +20,7 @@ def test_unsupported_os(mock_tools, host_os):
 
 def test_verify(mock_tools, tmp_path):
     """Local file plugins are installed by copying."""
-    plugin_path = tmp_path / "path" / "to" / "linuxdeploy-plugin-custom.sh"
+    plugin_path = tmp_path / "path/to/linuxdeploy-plugin-custom.sh"
     create_mock_appimage(plugin_path)
 
     LinuxDeployLocalFilePlugin.verify(
@@ -30,12 +30,12 @@ def test_verify(mock_tools, tmp_path):
     )
 
     # The plugin is copied into place
-    assert (tmp_path / "bundle" / "linuxdeploy-plugin-custom.sh").exists()
+    assert (tmp_path / "bundle/linuxdeploy-plugin-custom.sh").exists()
 
 
 def test_bad_path(mock_tools, tmp_path):
     """If the plugin file path is invalid, an error is raised."""
-    plugin_path = tmp_path / "path" / "to" / "linuxdeploy-plugin-custom.sh"
+    plugin_path = tmp_path / "path/to/linuxdeploy-plugin-custom.sh"
 
     with pytest.raises(
         BriefcaseCommandError,
@@ -51,7 +51,7 @@ def test_bad_path(mock_tools, tmp_path):
 def test_non_plugin(mock_tools, tmp_path):
     """If the plugin file path exists, but the filename doesn't match the pattern of a
     linuxdeploy plugin, an error is raised."""
-    plugin_path = tmp_path / "path" / "to" / "not-a-plugin.exe"
+    plugin_path = tmp_path / "path/to/not-a-plugin.exe"
     create_mock_appimage(plugin_path)
 
     with pytest.raises(

--- a/tests/integrations/linuxdeploy/test_LinuxDeployQtPlugin__properties.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployQtPlugin__properties.py
@@ -12,7 +12,7 @@ def test_file_path(mock_tools, linuxdeploy_qt_plugin):
     """Default Linuxdeploy plugins reside in the linuxdeploy plugins path."""
     assert (
         linuxdeploy_qt_plugin.file_path
-        == mock_tools.base_path / "linuxdeploy_plugins" / "qt"
+        == mock_tools.base_path / "linuxdeploy_plugins/qt"
     )
 
 

--- a/tests/integrations/linuxdeploy/test_LinuxDeploy__is_elf_file.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeploy__is_elf_file.py
@@ -3,14 +3,14 @@ from tests.integrations.linuxdeploy.utils import create_mock_appimage
 
 def test_is_elf_header_positive_detection(linuxdeploy, tmp_path):
     """File with an ELF Header is identified as an ELF file."""
-    create_mock_appimage(appimage_path=tmp_path / "tools" / "linuxdeploy-i386.AppImage")
+    create_mock_appimage(appimage_path=tmp_path / "tools/linuxdeploy-i386.AppImage")
     assert linuxdeploy.is_elf_file() is True
 
 
 def test_is_elf_header_negative_detection(linuxdeploy, tmp_path):
     """File without an ELF Header is not identified as an ELF file."""
     create_mock_appimage(
-        appimage_path=tmp_path / "tools" / "linuxdeploy-i386.AppImage",
+        appimage_path=tmp_path / "tools/linuxdeploy-i386.AppImage",
         mock_appimage_kind="corrupt",
     )
     assert linuxdeploy.is_elf_file() is False
@@ -19,7 +19,7 @@ def test_is_elf_header_negative_detection(linuxdeploy, tmp_path):
 def test_is_elf_header_empty_file(linuxdeploy, tmp_path):
     """Empty file is not identified as an ELF file without any errors."""
     create_mock_appimage(
-        appimage_path=tmp_path / "tools" / "linuxdeploy-i386.AppImage",
+        appimage_path=tmp_path / "tools/linuxdeploy-i386.AppImage",
         mock_appimage_kind="empty",
     )
     assert linuxdeploy.is_elf_file() is False

--- a/tests/integrations/linuxdeploy/test_LinuxDeploy__verify_plugins.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeploy__verify_plugins.py
@@ -33,7 +33,7 @@ def test_gtk_plugin(linuxdeploy, mock_tools, tmp_path):
 
     # Mock a successful download
     mock_tools.download.file.side_effect = side_effect_create_mock_tool(
-        tmp_path / "tools" / "linuxdeploy_plugins" / "gtk" / "linuxdeploy-plugin-gtk.sh"
+        tmp_path / "tools/linuxdeploy_plugins/gtk/linuxdeploy-plugin-gtk.sh"
     )
 
     plugins = linuxdeploy.verify_plugins(["gtk"], bundle_path=tmp_path / "bundle")
@@ -43,7 +43,7 @@ def test_gtk_plugin(linuxdeploy, mock_tools, tmp_path):
 
     mock_tools.download.file.assert_called_with(
         url="https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh",
-        download_path=tmp_path / "tools" / "linuxdeploy_plugins" / "gtk",
+        download_path=tmp_path / "tools/linuxdeploy_plugins/gtk",
         role="linuxdeploy GTK plugin",
     )
 
@@ -70,7 +70,7 @@ def test_qt_plugin(linuxdeploy, mock_tools, tmp_path):
             "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/"
             "releases/download/continuous/linuxdeploy-plugin-qt-i386.AppImage"
         ),
-        download_path=tmp_path / "tools" / "linuxdeploy_plugins" / "qt",
+        download_path=tmp_path / "tools/linuxdeploy_plugins/qt",
         role="linuxdeploy Qt plugin",
     )
 
@@ -115,7 +115,7 @@ def test_custom_local_file_plugin(linuxdeploy, mock_tools, tmp_path):
     """A Custom local file plugin can be verified."""
 
     # Create a local file
-    plugin_path = tmp_path / "path" / "to" / "linuxdeploy-plugin-sometool-i386.AppImage"
+    plugin_path = tmp_path / "path/to/linuxdeploy-plugin-sometool-i386.AppImage"
     create_mock_appimage(plugin_path)
 
     plugins = linuxdeploy.verify_plugins(
@@ -129,7 +129,7 @@ def test_custom_local_file_plugin(linuxdeploy, mock_tools, tmp_path):
     # No download happened
     mock_tools.download.file.assert_not_called()
     # But a copy happened
-    assert (tmp_path / "bundle" / "linuxdeploy-plugin-sometool-i386.AppImage").exists()
+    assert (tmp_path / "bundle/linuxdeploy-plugin-sometool-i386.AppImage").exists()
 
 
 @pytest.mark.parametrize(
@@ -229,9 +229,7 @@ def test_complex_plugin_config(linuxdeploy, mock_tools, tmp_path):
     mock_tools.download.file.side_effect = mock_downloads
 
     # Local file tool is a local file.
-    local_plugin_path = (
-        tmp_path / "path" / "to" / "linuxdeploy-plugin-sometool-i386.AppImage"
-    )
+    local_plugin_path = tmp_path / "path/to/linuxdeploy-plugin-sometool-i386.AppImage"
     create_mock_appimage(local_plugin_path)
 
     # Verify all the plugins
@@ -258,7 +256,7 @@ def test_complex_plugin_config(linuxdeploy, mock_tools, tmp_path):
     # Local file plugin is as expected
     assert isinstance(plugins["sometool"], LinuxDeployLocalFilePlugin)
     assert plugins["sometool"].env == {"QUALITY": "really nice"}
-    assert (tmp_path / "bundle" / "linuxdeploy-plugin-sometool-i386.AppImage").exists()
+    assert (tmp_path / "bundle/linuxdeploy-plugin-sometool-i386.AppImage").exists()
 
     # URL plugin is as expected
     assert isinstance(plugins["network"], LinuxDeployURLPlugin)

--- a/tests/integrations/rcedit/test_RCEdit__upgrade.py
+++ b/tests/integrations/rcedit/test_RCEdit__upgrade.py
@@ -5,7 +5,7 @@ from briefcase.exceptions import MissingToolError, NetworkFailure
 
 def test_upgrade_exists(mock_tools, rcedit, tmp_path):
     """If rcedit already exists, upgrading deletes first."""
-    rcedit_path = tmp_path / "tools" / "rcedit-x64.exe"
+    rcedit_path = tmp_path / "tools/rcedit-x64.exe"
 
     # Mock the existence of an install
     rcedit_path.touch()
@@ -45,7 +45,7 @@ def test_upgrade_does_not_exist(mock_tools, rcedit, tmp_path):
 def test_upgrade_rcedit_download_failure(mock_tools, rcedit, tmp_path):
     """If rcedit doesn't exist, but a download failure occurs, an error is raised."""
     # Mock the existence of an install
-    rcedit_path = tmp_path / "tools" / "rcedit-x64.exe"
+    rcedit_path = tmp_path / "tools/rcedit-x64.exe"
     rcedit_path.touch()
 
     mock_tools.download.file.side_effect = NetworkFailure("mock")

--- a/tests/integrations/rcedit/test_RCEdit__verify.py
+++ b/tests/integrations/rcedit/test_RCEdit__verify.py
@@ -28,7 +28,7 @@ def test_unsupported_os(mock_tools, host_os):
 
 def test_verify_exists(mock_tools, tmp_path):
     """If RCEdit already exists, verification doesn't download."""
-    rcedit_path = tmp_path / "tools" / "rcedit-x64.exe"
+    rcedit_path = tmp_path / "tools/rcedit-x64.exe"
 
     # Mock the existence of an install
     rcedit_path.touch()
@@ -61,7 +61,7 @@ def test_verify_does_not_exist_dont_install(mock_tools, tmp_path):
 
 def test_verify_does_not_exist(mock_tools, tmp_path):
     """If RCEdit doesn't exist, it is downloaded."""
-    rcedit_path = tmp_path / "tools" / "rcedit-x64.exe"
+    rcedit_path = tmp_path / "tools/rcedit-x64.exe"
 
     # Mock a successful download
     def side_effect_create_mock_appimage(*args, **kwargs):

--- a/tests/integrations/visualstudio/test_VisualStudio__properties.py
+++ b/tests/integrations/visualstudio/test_VisualStudio__properties.py
@@ -8,7 +8,7 @@ from briefcase.integrations.visualstudio import VisualStudio
 
 @pytest.fixture
 def visualstudio(mock_tools, tmp_path) -> VisualStudio:
-    msbuild_path = tmp_path / "Visual Studio" / "MSBuild.exe"
+    msbuild_path = tmp_path / "Visual Studio/MSBuild.exe"
     return VisualStudio(mock_tools, msbuild_path=msbuild_path)
 
 
@@ -19,12 +19,12 @@ def test_managed_install(visualstudio, tmp_path):
 
 def test_msbuild_path(visualstudio, tmp_path):
     """The MSBuild path is the one used for construction."""
-    assert visualstudio.msbuild_path == tmp_path / "Visual Studio" / "MSBuild.exe"
+    assert visualstudio.msbuild_path == tmp_path / "Visual Studio/MSBuild.exe"
 
 
 def test_install_metadata(tmp_path):
     """Install metadata can be provided and retrieved."""
-    msbuild_path = tmp_path / "Visual Studio" / "MSBuild.exe"
+    msbuild_path = tmp_path / "Visual Studio/MSBuild.exe"
     install_metadata = {
         "instanceId": "deadbeef",
         "installDate": "2022-07-14T10:42:37Z",

--- a/tests/integrations/visualstudio/test_VisualStudio__verify.py
+++ b/tests/integrations/visualstudio/test_VisualStudio__verify.py
@@ -19,7 +19,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 @pytest.fixture
 def custom_msbuild_path(tmp_path):
     """Create a dummy MSBuild executable at a custom location."""
-    msbuild_path = tmp_path / "custom" / "MSBuild.exe"
+    msbuild_path = tmp_path / "custom/MSBuild.exe"
     msbuild_path.parent.mkdir(parents=True)
     with msbuild_path.open("w", encoding="utf-8") as f:
         f.write("Dummy MSBuild")
@@ -48,9 +48,7 @@ def vswhere_path(tmp_path):
 @pytest.fixture
 def msbuild_path(tmp_path):
     """Create a dummy MSBuild executable."""
-    msbuild_path = (
-        tmp_path / "Visual Studio" / "MSBuild" / "Current" / "Bin" / "MSBuild.exe"
-    )
+    msbuild_path = tmp_path / "Visual Studio/MSBuild/Current/Bin/MSBuild.exe"
     msbuild_path.parent.mkdir(parents=True)
     with msbuild_path.open("w", encoding="utf-8") as f:
         f.write("Dummy MSBuild")
@@ -155,7 +153,7 @@ def test_msbuild_envvar_doesnt_exist(mock_tools, tmp_path):
     """If MSBUILD is set in the environment, but it points to a non-existent file, an
     error is raised."""
     # Point at an MSBuild that does not exist
-    mock_tools.os.environ["MSBUILD"] = tmp_path / "custom" / "MSBuild.exe"
+    mock_tools.os.environ["MSBUILD"] = tmp_path / "custom/MSBuild.exe"
 
     # MSBuild is not on the path
     mock_tools.subprocess.check_output.side_effect = FileNotFoundError

--- a/tests/integrations/windows_sdk/test_WindowsSDK__properties.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK__properties.py
@@ -23,6 +23,6 @@ def test_paths(windows_sdk, tmp_path, sdk_arch):
     """Windows SDK paths are appropriate for arch and version."""
     windows_sdk.arch = sdk_arch
 
-    expected_bin_path = tmp_path / "bin" / "10.0.19000.0" / sdk_arch
+    expected_bin_path = tmp_path / "bin/10.0.19000.0" / sdk_arch
     assert windows_sdk.bin_path == expected_bin_path
     assert windows_sdk.signtool_exe == expected_bin_path / "signtool.exe"

--- a/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
@@ -109,7 +109,7 @@ def test_winsdk_arch(
     win_sdk = WindowsSDK.verify(mock_tools)
 
     # The returned paths are as expected (and are the full paths)
-    signtool_path = tmp_path / "win_sdk" / "bin" / "1.1.1.0" / sdk_arch / "signtool.exe"
+    signtool_path = tmp_path / "win_sdk/bin/1.1.1.0" / sdk_arch / "signtool.exe"
     assert win_sdk.signtool_exe == signtool_path
 
 
@@ -133,7 +133,7 @@ def test_winsdk_valid_env_vars(mock_tools, mock_winreg, tmp_path, monkeypatch):
     win_sdk = WindowsSDK.verify(mock_tools)
 
     # The returned paths are as expected (and are the full paths)
-    signtool_path = tmp_path / "win_sdk" / "bin" / "1.1.1.0" / "x64" / "signtool.exe"
+    signtool_path = tmp_path / "win_sdk/bin/1.1.1.0/x64/signtool.exe"
     assert win_sdk.signtool_exe == signtool_path
 
 
@@ -191,7 +191,7 @@ def test_winsdk_latest_install_from_reg(mock_tools, mock_winreg, tmp_path, monke
     mock_tools.os.environ.get.assert_called_once_with("WindowsSDKDir")
 
     # The returned paths are as expected (and are the full paths)
-    signtool_path = tmp_path / "win_sdk" / "bin" / "83.0.1.0" / "x64" / "signtool.exe"
+    signtool_path = tmp_path / "win_sdk/bin/83.0.1.0/x64/signtool.exe"
     assert win_sdk.signtool_exe == signtool_path
 
 
@@ -245,7 +245,7 @@ def test_winsdk_nonlatest_install_from_reg(
     assert capsys.readouterr().out == expected_output
 
     # The returned paths are as expected (and are the full paths)
-    signtool_path = tmp_path / "win_sdk" / "bin" / "85.0.8.0" / "x64" / "signtool.exe"
+    signtool_path = tmp_path / "win_sdk/bin/85.0.8.0/x64/signtool.exe"
     assert win_sdk.signtool_exe == signtool_path
 
 
@@ -388,7 +388,7 @@ def test_winsdk_valid_install_from_default_dir(
     assert capsys.readouterr().out == expected_output
 
     # The returned paths are as expected (and are the full paths)
-    signtool_path = tmp_path / "win_sdk" / "bin" / "86.0.8.0" / "x64" / "signtool.exe"
+    signtool_path = tmp_path / "win_sdk/bin/86.0.8.0/x64/signtool.exe"
     assert win_sdk.signtool_exe == signtool_path
 
 

--- a/tests/integrations/wix/test_WiX__upgrade.py
+++ b/tests/integrations/wix/test_WiX__upgrade.py
@@ -29,7 +29,7 @@ def test_non_managed_install(mock_tools, tmp_path, capsys):
 def test_non_existing_wix_install(mock_tools, tmp_path):
     """If there's no existing managed WiX install, upgrading is an error."""
     # Create an SDK wrapper around a non-existing managed install
-    wix = WiX(mock_tools, wix_home=tmp_path / "tools" / "wix")
+    wix = WiX(mock_tools, wix_home=tmp_path / "tools/wix")
 
     with pytest.raises(MissingToolError):
         wix.upgrade()
@@ -41,16 +41,16 @@ def test_non_existing_wix_install(mock_tools, tmp_path):
 def test_existing_wix_install(mock_tools, tmp_path):
     """If there's an existing managed WiX install, it is deleted and redownloaded."""
     # Create a mock of a previously installed WiX version.
-    wix_path = tmp_path / "tools" / "wix"
+    wix_path = tmp_path / "tools/wix"
     wix_path.mkdir(parents=True)
     (wix_path / "heat.exe").touch()
     (wix_path / "light.exe").touch()
     (wix_path / "candle.exe").touch()
 
     # Mock the download
-    wix_path = tmp_path / "tools" / "wix"
+    wix_path = tmp_path / "tools/wix"
 
-    wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
+    wix_zip_path = os.fsdecode(tmp_path / "tools/wix.zip")
     wix_zip = MagicMock()
     wix_zip.__fspath__.return_value = wix_zip_path
 
@@ -84,7 +84,7 @@ def test_existing_wix_install(mock_tools, tmp_path):
 def test_download_fail(mock_tools, tmp_path):
     """If the download doesn't complete, the upgrade fails."""
     # Create a mock of a previously installed WiX version.
-    wix_path = tmp_path / "tools" / "wix"
+    wix_path = tmp_path / "tools/wix"
     wix_path.mkdir(parents=True)
     (wix_path / "heat.exe").touch()
     (wix_path / "light.exe").touch()
@@ -114,14 +114,14 @@ def test_download_fail(mock_tools, tmp_path):
 def test_unpack_fail(mock_tools, tmp_path):
     """If the download archive is corrupted, the validator fails."""
     # Create a mock of a previously installed WiX version.
-    wix_path = tmp_path / "tools" / "wix"
+    wix_path = tmp_path / "tools/wix"
     wix_path.mkdir(parents=True)
     (wix_path / "heat.exe").touch()
     (wix_path / "light.exe").touch()
     (wix_path / "candle.exe").touch()
 
     # Mock the download
-    wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
+    wix_zip_path = os.fsdecode(tmp_path / "tools/wix.zip")
     wix_zip = MagicMock()
     wix_zip.__fspath__.return_value = wix_zip_path
 

--- a/tests/integrations/wix/test_WiX__verify.py
+++ b/tests/integrations/wix/test_WiX__verify.py
@@ -42,9 +42,9 @@ def test_valid_wix_envvar(mock_tools, tmp_path):
 
     # Mock the interesting parts of a WiX install
     (wix_path / "bin").mkdir(parents=True)
-    (wix_path / "bin" / "heat.exe").touch()
-    (wix_path / "bin" / "light.exe").touch()
-    (wix_path / "bin" / "candle.exe").touch()
+    (wix_path / "bin/heat.exe").touch()
+    (wix_path / "bin/light.exe").touch()
+    (wix_path / "bin/candle.exe").touch()
 
     # Verify the install
     wix = WiX.verify(mock_tools)
@@ -53,9 +53,9 @@ def test_valid_wix_envvar(mock_tools, tmp_path):
     mock_tools.os.environ.get.assert_called_with("WIX")
 
     # The returned paths are as expected (and are the full paths)
-    assert wix.heat_exe == tmp_path / "wix" / "bin" / "heat.exe"
-    assert wix.light_exe == tmp_path / "wix" / "bin" / "light.exe"
-    assert wix.candle_exe == tmp_path / "wix" / "bin" / "candle.exe"
+    assert wix.heat_exe == tmp_path / "wix/bin/heat.exe"
+    assert wix.light_exe == tmp_path / "wix/bin/light.exe"
+    assert wix.candle_exe == tmp_path / "wix/bin/candle.exe"
 
 
 def test_invalid_wix_envvar(mock_tools, tmp_path):
@@ -75,7 +75,7 @@ def test_existing_wix_install(mock_tools, tmp_path):
     mock_tools.os.environ.get.return_value = None
 
     # Create a mock of a previously installed WiX version.
-    wix_path = tmp_path / "tools" / "wix"
+    wix_path = tmp_path / "tools/wix"
     wix_path.mkdir(parents=True)
     (wix_path / "heat.exe").touch()
     (wix_path / "light.exe").touch()
@@ -90,9 +90,9 @@ def test_existing_wix_install(mock_tools, tmp_path):
     assert mock_tools.download.file.call_count == 0
 
     # The returned paths are as expected
-    assert wix.heat_exe == tmp_path / "tools" / "wix" / "heat.exe"
-    assert wix.light_exe == tmp_path / "tools" / "wix" / "light.exe"
-    assert wix.candle_exe == tmp_path / "tools" / "wix" / "candle.exe"
+    assert wix.heat_exe == tmp_path / "tools/wix/heat.exe"
+    assert wix.light_exe == tmp_path / "tools/wix/light.exe"
+    assert wix.candle_exe == tmp_path / "tools/wix/candle.exe"
 
 
 def test_download_wix(mock_tools, tmp_path):
@@ -101,9 +101,9 @@ def test_download_wix(mock_tools, tmp_path):
     mock_tools.os.environ.get.return_value = None
 
     # Mock the download
-    wix_path = tmp_path / "tools" / "wix"
+    wix_path = tmp_path / "tools/wix"
 
-    wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
+    wix_zip_path = os.fsdecode(tmp_path / "tools/wix.zip")
     wix_zip = MagicMock()
     wix_zip.__fspath__.return_value = wix_zip_path
 
@@ -131,9 +131,9 @@ def test_download_wix(mock_tools, tmp_path):
     wix_zip.unlink.assert_called_with()
 
     # The returned paths are as expected
-    assert wix.heat_exe == tmp_path / "tools" / "wix" / "heat.exe"
-    assert wix.light_exe == tmp_path / "tools" / "wix" / "light.exe"
-    assert wix.candle_exe == tmp_path / "tools" / "wix" / "candle.exe"
+    assert wix.heat_exe == tmp_path / "tools/wix/heat.exe"
+    assert wix.light_exe == tmp_path / "tools/wix/light.exe"
+    assert wix.candle_exe == tmp_path / "tools/wix/candle.exe"
 
 
 def test_dont_install(mock_tools, tmp_path):
@@ -185,9 +185,9 @@ def test_unpack_fail(mock_tools, tmp_path):
     mock_tools.os.environ.get.return_value = None
 
     # Mock the download
-    wix_path = tmp_path / "tools" / "wix"
+    wix_path = tmp_path / "tools/wix"
 
-    wix_zip_path = os.fsdecode(tmp_path / "tools" / "wix.zip")
+    wix_zip_path = os.fsdecode(tmp_path / "tools/wix.zip")
     wix_zip = MagicMock()
     wix_zip.__fspath__.return_value = wix_zip_path
 

--- a/tests/integrations/xcode/test_ensure_xcode_is_installed.py
+++ b/tests/integrations/xcode/test_ensure_xcode_is_installed.py
@@ -10,7 +10,7 @@ from briefcase.integrations.xcode import Xcode
 
 @pytest.fixture
 def default_xcode_install_path(tmp_path):
-    return tmp_path / "Applications" / "Xcode.app"
+    return tmp_path / "Applications/Xcode.app"
 
 
 @pytest.fixture
@@ -41,7 +41,7 @@ def test_not_installed(tmp_path, mock_tools):
 def test_custom_install_location(default_xcode_install_path, tmp_path, mock_tools):
     """If Xcode is in a non-default location, that's fine."""
     # Create a custom Xcode location
-    custom_xcode_location = tmp_path / "custom" / "Xcode.app"
+    custom_xcode_location = tmp_path / "custom/Xcode.app"
     custom_xcode_location.mkdir(parents=True, exist_ok=True)
 
     mock_tools.subprocess.check_output.side_effect = [
@@ -140,7 +140,7 @@ def test_custom_install_with_command_line_tools(
     """If the cmdline tools are installed, and Xcode is in a non-default location, raise
     an error."""
     # Create a custom Xcode location
-    custom_xcode_location = tmp_path / "custom" / "Xcode.app"
+    custom_xcode_location = tmp_path / "custom/Xcode.app"
     custom_xcode_location.mkdir(parents=True, exist_ok=True)
 
     mock_tools.subprocess.check_output.side_effect = [

--- a/tests/platforms/android/gradle/conftest.py
+++ b/tests/platforms/android/gradle/conftest.py
@@ -32,7 +32,7 @@ def package_command(tmp_path, first_app_config, monkeypatch):
     )
 
     # Make sure the dist folder exists
-    (tmp_path / "base_path" / "dist").mkdir(parents=True)
+    (tmp_path / "base_path/dist").mkdir(parents=True)
     return command
 
 

--- a/tests/platforms/android/gradle/test_open.py
+++ b/tests/platforms/android/gradle/test_open.py
@@ -101,7 +101,7 @@ def test_open_macOS(open_command, first_app_config, tmp_path):
     open_command.tools.subprocess.Popen.assert_called_once_with(
         [
             "open",
-            tmp_path / "base_path" / "build" / "first-app" / "android" / "gradle",
+            tmp_path / "base_path/build/first-app/android/gradle",
         ]
     )
 
@@ -113,7 +113,7 @@ def test_open_linux(open_command, first_app_config, tmp_path):
     open_command.project_path(first_app_config).mkdir(parents=True)
 
     # Create a stub java binary
-    create_file(tmp_path / "briefcase" / "tools" / "java17" / "bin" / "java", "java")
+    create_file(tmp_path / "briefcase/tools/java17/bin/java", "java")
 
     # Create a stub sdkmanager
     create_sdk_manager(tmp_path)
@@ -123,7 +123,7 @@ def test_open_linux(open_command, first_app_config, tmp_path):
     open_command.tools.subprocess.Popen.assert_called_once_with(
         [
             "xdg-open",
-            tmp_path / "base_path" / "build" / "first-app" / "android" / "gradle",
+            tmp_path / "base_path/build/first-app/android/gradle",
         ]
     )
 
@@ -135,7 +135,7 @@ def test_open_windows(open_command, first_app_config, tmp_path):
     open_command.project_path(first_app_config).mkdir(parents=True)
 
     # Create a stub java binary
-    create_file(tmp_path / "briefcase" / "tools" / "java17" / "bin" / "java", "java")
+    create_file(tmp_path / "briefcase/tools/java17/bin/java", "java")
 
     # Create a stub sdkmanager
     create_sdk_manager(tmp_path, extension=".bat")
@@ -143,5 +143,5 @@ def test_open_windows(open_command, first_app_config, tmp_path):
     open_command(first_app_config)
 
     open_command.tools.os.startfile.assert_called_once_with(
-        tmp_path / "base_path" / "build" / "first-app" / "android" / "gradle"
+        tmp_path / "base_path/build/first-app/android/gradle"
     )

--- a/tests/platforms/android/gradle/test_package__aab.py
+++ b/tests/platforms/android/gradle/test_package__aab.py
@@ -38,7 +38,7 @@ def test_unsupported_template_version(package_command, first_app_generated):
 def test_distribution_path(package_command, first_app_aab, tmp_path):
     assert (
         package_command.distribution_path(first_app_aab)
-        == tmp_path / "base_path" / "dist" / "First App-0.0.1.aab"
+        == tmp_path / "base_path/dist/First App-0.0.1.aab"
     )
 
 
@@ -111,7 +111,7 @@ def test_execute_gradle(
     )
 
     # The release asset has been moved into the dist folder
-    assert (tmp_path / "base_path" / "dist" / "First App-0.0.1.aab").exists()
+    assert (tmp_path / "base_path/dist/First App-0.0.1.aab").exists()
 
 
 def test_print_gradle_errors(package_command, first_app_aab):

--- a/tests/platforms/android/gradle/test_package__apk.py
+++ b/tests/platforms/android/gradle/test_package__apk.py
@@ -39,7 +39,7 @@ def test_distribution_path(package_command, first_app_apk, tmp_path):
     print(package_command.packaging_formats)
     assert (
         package_command.distribution_path(first_app_apk)
-        == tmp_path / "base_path" / "dist" / "First App-0.0.1.apk"
+        == tmp_path / "base_path/dist/First App-0.0.1.apk"
     )
 
 
@@ -112,7 +112,7 @@ def test_execute_gradle(
     )
 
     # The release asset has been moved into the dist folder
-    assert (tmp_path / "base_path" / "dist" / "First App-0.0.1.apk").exists()
+    assert (tmp_path / "base_path/dist/First App-0.0.1.apk").exists()
 
 
 def test_print_gradle_errors(package_command, first_app_apk):

--- a/tests/platforms/android/gradle/test_package__debug_apk.py
+++ b/tests/platforms/android/gradle/test_package__debug_apk.py
@@ -39,7 +39,7 @@ def test_distribution_path(package_command, first_app_apk, tmp_path):
     print(package_command.packaging_formats)
     assert (
         package_command.distribution_path(first_app_apk)
-        == tmp_path / "base_path" / "dist" / "First App-0.0.1.debug.apk"
+        == tmp_path / "base_path/dist/First App-0.0.1.debug.apk"
     )
 
 
@@ -112,7 +112,7 @@ def test_execute_gradle(
     )
 
     # The release asset has been moved into the dist folder
-    assert (tmp_path / "base_path" / "dist" / "First App-0.0.1.debug.apk").exists()
+    assert (tmp_path / "base_path/dist/First App-0.0.1.debug.apk").exists()
 
 
 def test_print_gradle_errors(package_command, first_app_apk):

--- a/tests/platforms/iOS/xcode/conftest.py
+++ b/tests/platforms/iOS/xcode/conftest.py
@@ -23,7 +23,7 @@ info_plist_path="Info.plist"
     )
 
     create_plist_file(
-        tmp_path / "base_path" / "build" / "first-app" / "ios" / "xcode" / "Info.plist",
+        tmp_path / "base_path/build/first-app/ios/xcode/Info.plist",
         {
             "MainModule": "first_app",
         },

--- a/tests/platforms/iOS/xcode/test_build.py
+++ b/tests/platforms/iOS/xcode/test_build.py
@@ -61,9 +61,7 @@ def test_build_app(build_command, first_app_generated, tool_debug_mode, tmp_path
     )
 
     # The app metadata references the app module
-    with (
-        tmp_path / "base_path" / "build" / "first-app" / "ios" / "xcode" / "Info.plist"
-    ).open("rb") as f:
+    with (tmp_path / "base_path/build/first-app/ios/xcode/Info.plist").open("rb") as f:
         plist = plistlib.load(f)
         assert plist["MainModule"] == "first_app"
 
@@ -104,9 +102,7 @@ def test_build_app_test_mode(build_command, first_app_generated, tmp_path):
     )
 
     # The app metadata has been rewritten to reference the test module
-    with (
-        tmp_path / "base_path" / "build" / "first-app" / "ios" / "xcode" / "Info.plist"
-    ).open("rb") as f:
+    with (tmp_path / "base_path/build/first-app/ios/xcode/Info.plist").open("rb") as f:
         plist = plistlib.load(f)
         assert plist["MainModule"] == "tests.first_app"
 

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -45,7 +45,7 @@ def test_extra_pip_args(create_command, first_app_generated, tmp_path):
 
     create_command.install_app_requirements(first_app_generated, test_mode=False)
 
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "ios" / "xcode"
+    bundle_path = tmp_path / "base_path/build/first-app/ios/xcode"
     assert create_command.tools[first_app_generated].app_context.run.mock_calls == [
         call(
             [

--- a/tests/platforms/iOS/xcode/test_update.py
+++ b/tests/platforms/iOS/xcode/test_update.py
@@ -32,7 +32,7 @@ def test_extra_pip_args(update_command, first_app_generated, tmp_path):
 
     update_command.install_app_requirements(first_app_generated, test_mode=False)
 
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "ios" / "xcode"
+    bundle_path = tmp_path / "base_path/build/first-app/ios/xcode"
     assert update_command.tools[first_app_generated].app_context.run.mock_calls == [
         call(
             [

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -33,15 +33,15 @@ def first_app(first_app_config, tmp_path):
         / "appimage"
         / "First App.AppDir"
     )
-    (app_dir / "usr" / "app" / "support").mkdir(parents=True, exist_ok=True)
-    (app_dir / "usr" / "app_packages" / "firstlib").mkdir(parents=True, exist_ok=True)
-    (app_dir / "usr" / "app_packages" / "secondlib").mkdir(parents=True, exist_ok=True)
+    (app_dir / "usr/app/support").mkdir(parents=True, exist_ok=True)
+    (app_dir / "usr/app_packages/firstlib").mkdir(parents=True, exist_ok=True)
+    (app_dir / "usr/app_packages/secondlib").mkdir(parents=True, exist_ok=True)
 
     # Create some .so files
-    (app_dir / "usr" / "app" / "support" / "support.so").touch()
-    (app_dir / "usr" / "app_packages" / "firstlib" / "first.so").touch()
-    (app_dir / "usr" / "app_packages" / "secondlib" / "second_a.so").touch()
-    (app_dir / "usr" / "app_packages" / "secondlib" / "second_b.so").touch()
+    (app_dir / "usr/app/support/support.so").touch()
+    (app_dir / "usr/app_packages/firstlib/first.so").touch()
+    (app_dir / "usr/app_packages/secondlib/second_a.so").touch()
+    (app_dir / "usr/app_packages/secondlib/second_b.so").touch()
 
     return first_app_config
 
@@ -181,9 +181,7 @@ def test_build_appimage(build_command, first_app, debug_mode, tmp_path, sub_stre
         expected_env["DEBUG"] = "1"
     build_command._subprocess.Popen.assert_called_with(
         [
-            os.fsdecode(
-                tmp_path / "briefcase" / "tools" / "linuxdeploy-x86_64.AppImage"
-            ),
+            os.fsdecode(tmp_path / "briefcase/tools/linuxdeploy-x86_64.AppImage"),
             "--appdir",
             os.fsdecode(app_dir),
             "--desktop-file",
@@ -192,16 +190,14 @@ def test_build_appimage(build_command, first_app, debug_mode, tmp_path, sub_stre
             "appimage",
             "-v0" if debug_mode else "-v1",
             "--deploy-deps-only",
-            os.fsdecode(app_dir / "usr" / "app" / "support"),
+            os.fsdecode(app_dir / "usr/app/support"),
             "--deploy-deps-only",
-            os.fsdecode(app_dir / "usr" / "app_packages" / "firstlib"),
+            os.fsdecode(app_dir / "usr/app_packages/firstlib"),
             "--deploy-deps-only",
-            os.fsdecode(app_dir / "usr" / "app_packages" / "secondlib"),
+            os.fsdecode(app_dir / "usr/app_packages/secondlib"),
         ],
         env=expected_env,
-        cwd=os.fsdecode(
-            tmp_path / "base_path" / "build" / "first-app" / "linux" / "appimage"
-        ),
+        cwd=os.fsdecode(tmp_path / "base_path/build/first-app/linux/appimage"),
         **sub_stream_kw,
     )
     # Binary is marked executable
@@ -235,7 +231,7 @@ def test_build_appimage_with_plugin(build_command, first_app, tmp_path, sub_stre
     gtk_plugin_path.parent.mkdir(parents=True)
     gtk_plugin_path.touch()
 
-    local_file_plugin_path = tmp_path / "local" / "linuxdeploy-plugin-something.sh"
+    local_file_plugin_path = tmp_path / "local/linuxdeploy-plugin-something.sh"
     local_file_plugin_path.parent.mkdir(parents=True)
     local_file_plugin_path.touch()
 
@@ -261,9 +257,7 @@ def test_build_appimage_with_plugin(build_command, first_app, tmp_path, sub_stre
     )
     build_command._subprocess.Popen.assert_called_with(
         [
-            os.fsdecode(
-                tmp_path / "briefcase" / "tools" / "linuxdeploy-x86_64.AppImage"
-            ),
+            os.fsdecode(tmp_path / "briefcase/tools/linuxdeploy-x86_64.AppImage"),
             "--appdir",
             os.fsdecode(app_dir),
             "--desktop-file",
@@ -272,11 +266,11 @@ def test_build_appimage_with_plugin(build_command, first_app, tmp_path, sub_stre
             "appimage",
             "-v1",
             "--deploy-deps-only",
-            os.fsdecode(app_dir / "usr" / "app" / "support"),
+            os.fsdecode(app_dir / "usr/app/support"),
             "--deploy-deps-only",
-            os.fsdecode(app_dir / "usr" / "app_packages" / "firstlib"),
+            os.fsdecode(app_dir / "usr/app_packages/firstlib"),
             "--deploy-deps-only",
-            os.fsdecode(app_dir / "usr" / "app_packages" / "secondlib"),
+            os.fsdecode(app_dir / "usr/app_packages/secondlib"),
             "--plugin",
             "gtk",
             "--plugin",
@@ -290,9 +284,7 @@ def test_build_appimage_with_plugin(build_command, first_app, tmp_path, sub_stre
             "APPIMAGE_EXTRACT_AND_RUN": "1",
             "ARCH": "x86_64",
         },
-        cwd=os.fsdecode(
-            tmp_path / "base_path" / "build" / "first-app" / "linux" / "appimage"
-        ),
+        cwd=os.fsdecode(tmp_path / "base_path/build/first-app/linux/appimage"),
         **sub_stream_kw,
     )
     # Local plugin marked executable
@@ -344,9 +336,7 @@ def test_build_failure(build_command, first_app, tmp_path, sub_stream_kw):
     )
     build_command._subprocess.Popen.assert_called_with(
         [
-            os.fsdecode(
-                tmp_path / "briefcase" / "tools" / "linuxdeploy-x86_64.AppImage"
-            ),
+            os.fsdecode(tmp_path / "briefcase/tools/linuxdeploy-x86_64.AppImage"),
             "--appdir",
             os.fsdecode(app_dir),
             "--desktop-file",
@@ -355,11 +345,11 @@ def test_build_failure(build_command, first_app, tmp_path, sub_stream_kw):
             "appimage",
             "-v1",
             "--deploy-deps-only",
-            os.fsdecode(app_dir / "usr" / "app" / "support"),
+            os.fsdecode(app_dir / "usr/app/support"),
             "--deploy-deps-only",
-            os.fsdecode(app_dir / "usr" / "app_packages" / "firstlib"),
+            os.fsdecode(app_dir / "usr/app_packages/firstlib"),
             "--deploy-deps-only",
-            os.fsdecode(app_dir / "usr" / "app_packages" / "secondlib"),
+            os.fsdecode(app_dir / "usr/app_packages/secondlib"),
         ],
         env={
             "PATH": "/usr/local/bin:/usr/bin:/path/to/somewhere",
@@ -368,9 +358,7 @@ def test_build_failure(build_command, first_app, tmp_path, sub_stream_kw):
             "APPIMAGE_EXTRACT_AND_RUN": "1",
             "ARCH": "x86_64",
         },
-        cwd=os.fsdecode(
-            tmp_path / "base_path" / "build" / "first-app" / "linux" / "appimage"
-        ),
+        cwd=os.fsdecode(tmp_path / "base_path/build/first-app/linux/appimage"),
         **sub_stream_kw,
     )
 
@@ -489,7 +477,7 @@ def test_build_appimage_with_plugins_in_docker(
     gtk_plugin_path.parent.mkdir(parents=True)
     gtk_plugin_path.touch()
 
-    local_file_plugin_path = tmp_path / "local" / "linuxdeploy-plugin-something.sh"
+    local_file_plugin_path = tmp_path / "local/linuxdeploy-plugin-something.sh"
     local_file_plugin_path.parent.mkdir(parents=True)
     local_file_plugin_path.touch()
 
@@ -632,7 +620,7 @@ def test_build_appimage_with_support_package_update(
 
     # Fake the existence of some source files.
     create_file(
-        tmp_path / "base_path" / "src" / "first_app" / "app.py",
+        tmp_path / "base_path/src/first_app/app.py",
         "print('an app')",
     )
 
@@ -665,9 +653,7 @@ def test_build_appimage_with_support_package_update(
     )
     build_command._subprocess.Popen.assert_called_with(
         [
-            os.fsdecode(
-                tmp_path / "briefcase" / "tools" / "linuxdeploy-x86_64.AppImage"
-            ),
+            os.fsdecode(tmp_path / "briefcase/tools/linuxdeploy-x86_64.AppImage"),
             "--appdir",
             os.fsdecode(app_dir),
             "--desktop-file",
@@ -676,11 +662,11 @@ def test_build_appimage_with_support_package_update(
             "appimage",
             "-v1",
             "--deploy-deps-only",
-            os.fsdecode(app_dir / "usr" / "app" / "support"),
+            os.fsdecode(app_dir / "usr/app/support"),
             "--deploy-deps-only",
-            os.fsdecode(app_dir / "usr" / "app_packages" / "firstlib"),
+            os.fsdecode(app_dir / "usr/app_packages/firstlib"),
             "--deploy-deps-only",
-            os.fsdecode(app_dir / "usr" / "app_packages" / "secondlib"),
+            os.fsdecode(app_dir / "usr/app_packages/secondlib"),
         ],
         env={
             "PATH": "/usr/local/bin:/usr/bin:/path/to/somewhere",
@@ -689,9 +675,7 @@ def test_build_appimage_with_support_package_update(
             "APPIMAGE_EXTRACT_AND_RUN": "1",
             "ARCH": "x86_64",
         },
-        cwd=os.fsdecode(
-            tmp_path / "base_path" / "build" / "first-app" / "linux" / "appimage"
-        ),
+        cwd=os.fsdecode(tmp_path / "base_path/build/first-app/linux/appimage"),
         **sub_stream_kw,
     )
     # Binary is marked executable

--- a/tests/platforms/linux/appimage/test_mixin.py
+++ b/tests/platforms/linux/appimage/test_mixin.py
@@ -49,9 +49,7 @@ def test_project_path(create_command, first_app_config, tmp_path):
     project_path = create_command.project_path(first_app_config)
     bundle_path = create_command.bundle_path(first_app_config)
 
-    expected_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "linux" / "appimage"
-    )
+    expected_path = tmp_path / "base_path/build/first-app/linux/appimage"
     assert expected_path == project_path == bundle_path
 
 
@@ -61,8 +59,7 @@ def test_distribution_path(create_command, first_app_config, tmp_path):
     distribution_path = create_command.distribution_path(first_app_config)
 
     assert (
-        distribution_path
-        == tmp_path / "base_path" / "dist" / "First_App-0.0.1-x86_64.AppImage"
+        distribution_path == tmp_path / "base_path/dist/First_App-0.0.1-x86_64.AppImage"
     )
 
 

--- a/tests/platforms/linux/appimage/test_package.py
+++ b/tests/platforms/linux/appimage/test_package.py
@@ -18,7 +18,7 @@ def package_command(tmp_path, first_app_config):
     command.tools.host_arch = "x86_64"
 
     # Ensure the dist folder exists
-    (tmp_path / "base_path" / "dist").mkdir(parents=True)
+    (tmp_path / "base_path/dist").mkdir(parents=True)
 
     return command
 
@@ -42,6 +42,4 @@ def test_package_app(package_command, first_app_config, tmp_path):
     package_command.package_app(first_app_config)
 
     # The binary has been copied to the dist folder
-    assert (
-        tmp_path / "base_path" / "dist" / "First_App-0.0.1-x86_64.AppImage"
-    ).exists()
+    assert (tmp_path / "base_path/dist/First_App-0.0.1-x86_64.AppImage").exists()

--- a/tests/platforms/linux/flatpak/test_build.py
+++ b/tests/platforms/linux/flatpak/test_build.py
@@ -49,7 +49,7 @@ def test_build(build_command, first_app_config, tmp_path):
     build_command.tools.flatpak.build.assert_called_once_with(
         bundle_identifier="com.example.first-app",
         app_name="first-app",
-        path=tmp_path / "base_path" / "build" / "first-app" / "linux" / "flatpak",
+        path=tmp_path / "base_path/build/first-app/linux/flatpak",
     )
 
 

--- a/tests/platforms/linux/flatpak/test_mixin.py
+++ b/tests/platforms/linux/flatpak/test_mixin.py
@@ -41,7 +41,7 @@ def test_project_path(create_command, first_app_config, tmp_path):
     project_path = create_command.project_path(first_app_config)
     bundle_path = create_command.bundle_path(first_app_config)
 
-    expected_path = tmp_path / "base_path" / "build" / "first-app" / "linux" / "flatpak"
+    expected_path = tmp_path / "base_path/build/first-app/linux/flatpak"
     assert expected_path == project_path == bundle_path
 
 
@@ -51,7 +51,7 @@ def test_distribution_path(create_command, first_app_config, tmp_path):
     create_command.tools.host_arch = "gothic"
     distribution_path = create_command.distribution_path(first_app_config)
 
-    expected_path = tmp_path / "base_path" / "dist" / "First_App-0.0.1-gothic.flatpak"
+    expected_path = tmp_path / "base_path/dist/First_App-0.0.1-gothic.flatpak"
     assert distribution_path == expected_path
 
 

--- a/tests/platforms/linux/flatpak/test_open.py
+++ b/tests/platforms/linux/flatpak/test_open.py
@@ -47,6 +47,6 @@ def test_open(open_command, first_app_config, tmp_path):
     open_command.tools.subprocess.Popen.assert_called_once_with(
         [
             "xdg-open",
-            tmp_path / "base_path" / "build" / "first-app" / "linux" / "flatpak",
+            tmp_path / "base_path/build/first-app/linux/flatpak",
         ]
     )

--- a/tests/platforms/linux/flatpak/test_package.py
+++ b/tests/platforms/linux/flatpak/test_package.py
@@ -34,6 +34,6 @@ def test_package(package_command, first_app_config, tmp_path):
         bundle_identifier="com.example.first-app",
         app_name="first-app",
         version="0.0.1",
-        build_path=tmp_path / "base_path" / "build" / "first-app" / "linux" / "flatpak",
-        output_path=tmp_path / "base_path" / "dist" / "First_App-0.0.1-gothic.flatpak",
+        build_path=tmp_path / "base_path/build/first-app/linux/flatpak",
+        output_path=tmp_path / "base_path/dist/First_App-0.0.1-gothic.flatpak",
     )

--- a/tests/platforms/linux/system/conftest.py
+++ b/tests/platforms/linux/system/conftest.py
@@ -25,38 +25,36 @@ def first_app(first_app_config, tmp_path):
     first_app_config.target_vendor_base = "basevendor"
 
     # Some project-level files.
-    create_file(tmp_path / "base_path" / "LICENSE", "First App License")
-    create_file(tmp_path / "base_path" / "CHANGELOG", "First App Changelog")
+    create_file(tmp_path / "base_path/LICENSE", "First App License")
+    create_file(tmp_path / "base_path/CHANGELOG", "First App Changelog")
 
     # Make it look like the template has been generated
-    bundle_dir = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_dir = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     create_file(bundle_dir / "first-app.1", "First App manpage")
 
-    lib_dir = bundle_dir / "first-app-0.0.1" / "usr" / "lib" / "first-app"
+    lib_dir = bundle_dir / "first-app-0.0.1/usr/lib/first-app"
     (lib_dir / "app").mkdir(parents=True, exist_ok=True)
-    (lib_dir / "app_packages" / "firstlib").mkdir(parents=True, exist_ok=True)
-    (lib_dir / "app_packages" / "secondlib").mkdir(parents=True, exist_ok=True)
+    (lib_dir / "app_packages/firstlib").mkdir(parents=True, exist_ok=True)
+    (lib_dir / "app_packages/secondlib").mkdir(parents=True, exist_ok=True)
 
     # Create some .so files
     # An SO file with different group and world permissions
-    (lib_dir / "app" / "support.so").touch()
-    (lib_dir / "app" / "support.so").chmod(0o775)
+    (lib_dir / "app/support.so").touch()
+    (lib_dir / "app/support.so").chmod(0o775)
 
     # An SO file with same group and world permissions
-    (lib_dir / "app" / "support_same_perms.so").touch()
-    (lib_dir / "app" / "support_same_perms.so").chmod(0o744)
+    (lib_dir / "app/support_same_perms.so").touch()
+    (lib_dir / "app/support_same_perms.so").chmod(0o744)
 
     # A SO file with both .so and .so.1.0 forms
-    (lib_dir / "app_packages" / "firstlib" / "first.so").touch()
-    (lib_dir / "app_packages" / "firstlib" / "first.so.1.0").touch()
+    (lib_dir / "app_packages/firstlib/first.so").touch()
+    (lib_dir / "app_packages/firstlib/first.so.1.0").touch()
 
     # An SO file with 664 permissions
-    (lib_dir / "app_packages" / "secondlib" / "second_a.so").touch()
-    (lib_dir / "app_packages" / "secondlib" / "second_a.so").chmod(0o664)
+    (lib_dir / "app_packages/secondlib/second_a.so").touch()
+    (lib_dir / "app_packages/secondlib/second_a.so").chmod(0o664)
 
-    (lib_dir / "app_packages" / "secondlib" / "second_b.so").touch()
+    (lib_dir / "app_packages/secondlib/second_b.so").touch()
 
     return first_app_config

--- a/tests/platforms/linux/system/test_build.py
+++ b/tests/platforms/linux/system/test_build.py
@@ -39,9 +39,7 @@ def test_build_app(build_command, first_app, tmp_path):
     build_command.build_app(first_app)
 
     # The bootstrap binary was compiled
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
     build_command.tools[first_app].app_context.run.assert_called_with(
         ["make", "-C", "bootstrap", "install"],
         check=True,
@@ -49,7 +47,7 @@ def test_build_app(build_command, first_app, tmp_path):
     )
 
     # The license file has been installed
-    doc_path = bundle_path / "first-app-0.0.1" / "usr" / "share" / "doc" / "first-app"
+    doc_path = bundle_path / "first-app-0.0.1/usr/share/doc/first-app"
     assert (doc_path / "copyright").exists()
     with (doc_path / "copyright").open(encoding="utf-8") as f:
         assert f.read() == "First App License"
@@ -60,28 +58,27 @@ def test_build_app(build_command, first_app, tmp_path):
         assert f.read().decode() == "First App Changelog"
 
     # The manpage has been installed
-    man_path = bundle_path / "first-app-0.0.1" / "usr" / "share" / "man" / "man1"
+    man_path = bundle_path / "first-app-0.0.1/usr/share/man/man1"
     assert (man_path / "first-app.1.gz").exists()
     with gzip.open(man_path / "first-app.1.gz") as f:
         assert f.read().decode() == "First App manpage"
 
     # Problematic permissions have been updated
-    lib_dir = bundle_path / "first-app-0.0.1" / "usr" / "lib" / "first-app"
+    lib_dir = bundle_path / "first-app-0.0.1/usr/lib/first-app"
     # 775 -> 775
-    assert os.stat(lib_dir / "app" / "support.so").st_mode & 0o777 == 0o755
+    assert os.stat(lib_dir / "app/support.so").st_mode & 0o777 == 0o755
     # 664 -> 644
     assert (
-        os.stat(lib_dir / "app_packages" / "secondlib" / "second_a.so").st_mode & 0o777
-        == 0o644
+        os.stat(lib_dir / "app_packages/secondlib/second_a.so").st_mode & 0o777 == 0o644
     )
     # no perms change
-    assert os.stat(lib_dir / "app" / "support_same_perms.so").st_mode & 0o777 == 0o744
+    assert os.stat(lib_dir / "app/support_same_perms.so").st_mode & 0o777 == 0o744
 
     # Strip has been invoked on the binary
     build_command.tools.subprocess.check_output.assert_called_once_with(
         [
             "strip",
-            bundle_path / "first-app-0.0.1" / "usr" / "bin" / "first-app",
+            bundle_path / "first-app-0.0.1/usr/bin/first-app",
         ]
     )
 
@@ -103,9 +100,7 @@ def test_build_bootstrap_failed(build_command, first_app, tmp_path):
         build_command.build_app(first_app)
 
     # An attempt to do the compile occurred.
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
     build_command.tools[first_app].app_context.run.assert_called_with(
         ["make", "-C", "bootstrap", "install"],
         check=True,
@@ -115,12 +110,10 @@ def test_build_bootstrap_failed(build_command, first_app, tmp_path):
 
 def test_missing_license(build_command, first_app, tmp_path):
     """If the license source file is missing, an error is raised."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Delete the license source
-    (tmp_path / "base_path" / "LICENSE").unlink()
+    (tmp_path / "base_path/LICENSE").unlink()
 
     # Build the app; it will fail
     with pytest.raises(
@@ -139,12 +132,10 @@ def test_missing_license(build_command, first_app, tmp_path):
 
 def test_missing_changelog(build_command, first_app, tmp_path):
     """If the changelog source file is missing, an error is raised."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Delete the changelog source
-    (tmp_path / "base_path" / "CHANGELOG").unlink()
+    (tmp_path / "base_path/CHANGELOG").unlink()
 
     # Build the app; it will fail
     with pytest.raises(
@@ -161,7 +152,7 @@ def test_missing_changelog(build_command, first_app, tmp_path):
     )
 
     # The license file has been installed
-    doc_path = bundle_path / "first-app-0.0.1" / "usr" / "share" / "doc" / "first-app"
+    doc_path = bundle_path / "first-app-0.0.1/usr/share/doc/first-app"
     assert (doc_path / "copyright").exists()
     with (doc_path / "copyright").open(encoding="utf-8") as f:
         assert f.read() == "First App License"
@@ -169,9 +160,7 @@ def test_missing_changelog(build_command, first_app, tmp_path):
 
 def test_missing_manpage(build_command, first_app, tmp_path):
     """If the manpage source file is missing, an error is raised."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Delete the manpage source
     (bundle_path / "first-app.1").unlink()
@@ -191,7 +180,7 @@ def test_missing_manpage(build_command, first_app, tmp_path):
     )
 
     # The license file has been installed
-    doc_path = bundle_path / "first-app-0.0.1" / "usr" / "share" / "doc" / "first-app"
+    doc_path = bundle_path / "first-app-0.0.1/usr/share/doc/first-app"
     assert (doc_path / "copyright").exists()
     with (doc_path / "copyright").open(encoding="utf-8") as f:
         assert f.read() == "First App License"

--- a/tests/platforms/linux/system/test_mixin__properties.py
+++ b/tests/platforms/linux/system/test_mixin__properties.py
@@ -27,7 +27,7 @@ def test_build_path(
 
     assert (
         create_command.build_path(first_app_config)
-        == tmp_path / "base_path" / "build" / "first-app" / vendor
+        == tmp_path / "base_path/build/first-app" / vendor
     )
 
 
@@ -51,7 +51,7 @@ def test_bundle_path(
 
     assert (
         create_command.bundle_path(first_app_config)
-        == tmp_path / "base_path" / "build" / "first-app" / vendor / codename
+        == tmp_path / "base_path/build/first-app" / vendor / codename
     )
 
 
@@ -105,7 +105,7 @@ def test_distribution_path(
 
     assert (
         create_command.distribution_path(first_app_config)
-        == tmp_path / "base_path" / "dist" / filename
+        == tmp_path / "base_path/dist" / filename
     )
 
 

--- a/tests/platforms/linux/system/test_package.py
+++ b/tests/platforms/linux/system/test_package.py
@@ -90,7 +90,7 @@ def test_distribution_path(
 
     assert (
         package_command.distribution_path(first_app)
-        == tmp_path / "base_path" / "dist" / filename
+        == tmp_path / "base_path/dist" / filename
     )
 
     # Confirm ABI was requested from build env

--- a/tests/platforms/linux/system/test_package__deb.py
+++ b/tests/platforms/linux/system/test_package__deb.py
@@ -124,18 +124,14 @@ def test_verify_docker(monkeypatch, package_command, first_app_deb):
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build debs on Windows")
 def test_deb_package(package_command, first_app_deb, tmp_path):
     """A deb app can be packaged."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Package the app
     package_command.package_app(first_app_deb)
 
     # The control file is written
-    assert (bundle_path / "first-app-0.0.1" / "DEBIAN" / "control").exists()
-    with (bundle_path / "first-app-0.0.1" / "DEBIAN" / "control").open(
-        encoding="utf-8"
-    ) as f:
+    assert (bundle_path / "first-app-0.0.1/DEBIAN/control").exists()
+    with (bundle_path / "first-app-0.0.1/DEBIAN/control").open(encoding="utf-8") as f:
         assert (
             f.read()
             == "\n".join(
@@ -181,23 +177,17 @@ def test_deb_package(package_command, first_app_deb, tmp_path):
 
 def test_deb_re_package(package_command, first_app_deb, tmp_path):
     """A deb app that has previously been packaged can be re-packaged."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Create an old control file that will be overwritten.
-    create_file(
-        bundle_path / "first-app-0.0.1" / "DEBIAN" / "control", "Old control content"
-    )
+    create_file(bundle_path / "first-app-0.0.1/DEBIAN/control", "Old control content")
 
     # Package the app
     package_command.package_app(first_app_deb)
 
     # The control file is re-written
-    assert (bundle_path / "first-app-0.0.1" / "DEBIAN" / "control").exists()
-    with (bundle_path / "first-app-0.0.1" / "DEBIAN" / "control").open(
-        encoding="utf-8"
-    ) as f:
+    assert (bundle_path / "first-app-0.0.1/DEBIAN/control").exists()
+    with (bundle_path / "first-app-0.0.1/DEBIAN/control").open(encoding="utf-8") as f:
         assert (
             f.read()
             == "\n".join(
@@ -243,9 +233,7 @@ def test_deb_re_package(package_command, first_app_deb, tmp_path):
 
 def test_deb_package_no_long_description(package_command, first_app_deb, tmp_path):
     """A deb app without a long description raises an error."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Delete the long description
     first_app_deb.long_description = None
@@ -258,7 +246,7 @@ def test_deb_package_no_long_description(package_command, first_app_deb, tmp_pat
         package_command.package_app(first_app_deb)
 
     # The control file won't be written
-    assert not (bundle_path / "first-app-0.0.1" / "DEBIAN" / "control").exists()
+    assert not (bundle_path / "first-app-0.0.1/DEBIAN/control").exists()
 
 
 @pytest.mark.parametrize(
@@ -279,9 +267,7 @@ def test_multiline_long_description(input, output):
 def test_deb_package_extra_requirements(package_command, first_app_deb, tmp_path):
     """A deb app can be packaged with extra runtime requirements and configuration
     options."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Add system requirements and other optional settings.
     first_app_deb.system_runtime_requires = ["first", "second (>=1.2.3)"]
@@ -292,10 +278,8 @@ def test_deb_package_extra_requirements(package_command, first_app_deb, tmp_path
     package_command.package_app(first_app_deb)
 
     # The control file is written
-    assert (bundle_path / "first-app-0.0.1" / "DEBIAN" / "control").exists()
-    with (bundle_path / "first-app-0.0.1" / "DEBIAN" / "control").open(
-        encoding="utf-8"
-    ) as f:
+    assert (bundle_path / "first-app-0.0.1/DEBIAN/control").exists()
+    with (bundle_path / "first-app-0.0.1/DEBIAN/control").open(encoding="utf-8") as f:
         assert (
             f.read()
             == "\n".join(
@@ -341,9 +325,7 @@ def test_deb_package_extra_requirements(package_command, first_app_deb, tmp_path
 
 def test_deb_package_failure(package_command, first_app_deb, tmp_path):
     """If a packaging doesn't succeed, an error is raised."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Mock a packaging failure
     package_command.tools.app_tools[
@@ -359,10 +341,8 @@ def test_deb_package_failure(package_command, first_app_deb, tmp_path):
         package_command.package_app(first_app_deb)
 
     # The control file is written
-    assert (bundle_path / "first-app-0.0.1" / "DEBIAN" / "control").exists()
-    with (bundle_path / "first-app-0.0.1" / "DEBIAN" / "control").open(
-        encoding="utf-8"
-    ) as f:
+    assert (bundle_path / "first-app-0.0.1/DEBIAN/control").exists()
+    with (bundle_path / "first-app-0.0.1/DEBIAN/control").open(encoding="utf-8") as f:
         assert (
             f.read()
             == "\n".join(

--- a/tests/platforms/linux/system/test_package__pkg.py
+++ b/tests/platforms/linux/system/test_package__pkg.py
@@ -69,14 +69,14 @@ def first_app_pkg(first_app, tmp_path):
     )
 
     # Create the binary
-    create_file(usr_dir / "bin" / "first-app", "binary")
+    create_file(usr_dir / "bin/first-app", "binary")
 
     # Files in an app-named folder
-    create_file(usr_dir / "share" / "doc" / "first-app" / "license", "license")
-    create_file(usr_dir / "share" / "doc" / "first-app" / "UserManual", "manual")
+    create_file(usr_dir / "share/doc/first-app/license", "license")
+    create_file(usr_dir / "share/doc/first-app/UserManual", "manual")
 
     # A share file in an app-named folder
-    create_file(usr_dir / "share" / "man" / "man1" / "first-app.1.gz", "man")
+    create_file(usr_dir / "share/man/man1/first-app.1.gz", "man")
 
     return first_app
 
@@ -152,19 +152,17 @@ def test_verify_docker(monkeypatch, package_command, first_app_pkg):
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build PKGs on Windows")
 def test_pkg_package(package_command, first_app_pkg, tmp_path):
     """A pkg app can be packaged."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Package the app
     package_command.package_app(first_app_pkg)
 
     # The CHANGELOG file is copied
-    assert (bundle_path / "pkgbuild" / "CHANGELOG").exists()
+    assert (bundle_path / "pkgbuild/CHANGELOG").exists()
 
     # The PKGBUILD file is written
-    assert (bundle_path / "pkgbuild" / "PKGBUILD").exists()
-    with (bundle_path / "pkgbuild" / "PKGBUILD").open(encoding="utf-8") as f:
+    assert (bundle_path / "pkgbuild/PKGBUILD").exists()
+    with (bundle_path / "pkgbuild/PKGBUILD").open(encoding="utf-8") as f:
         assert f.read() == "\n".join(
             [
                 "# Maintainer: Megacorp <maintainer@example.com>",
@@ -188,7 +186,7 @@ def test_pkg_package(package_command, first_app_pkg, tmp_path):
         )
 
     # A source tarball was created with the right content
-    archive_file = bundle_path / "pkgbuild" / "first-app-0.0.1.tar.gz"
+    archive_file = bundle_path / "pkgbuild/first-app-0.0.1.tar.gz"
     assert archive_file.exists()
     with tarfile.open(archive_file, "r:gz") as archive:
         assert sorted(archive.getnames()) == [
@@ -232,25 +230,23 @@ def test_pkg_package(package_command, first_app_pkg, tmp_path):
 
     # The pkg was moved into the final location
     package_command.tools.shutil.move.assert_called_once_with(
-        bundle_path / "pkgbuild" / "first-app-0.0.1-1-wonky.pkg.tar.zst",
-        tmp_path / "base_path" / "dist" / "first-app-0.0.1-1-wonky.pkg.tar.zst",
+        bundle_path / "pkgbuild/first-app-0.0.1-1-wonky.pkg.tar.zst",
+        tmp_path / "base_path/dist/first-app-0.0.1-1-wonky.pkg.tar.zst",
     )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build PKGs on Windows")
 def test_pkg_re_package(package_command, first_app_pkg, tmp_path):
     """A pkg app that has previously been packaged can be re-packaged."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Create an old PKGBUILD file and tarball that will be overwritten.
     create_file(
-        bundle_path / "pkgbuild" / "PKGBUILD",
+        bundle_path / "pkgbuild/PKGBUILD",
         "Old PKGBUILD content",
     )
     create_tgz_file(
-        bundle_path / "pkgbuild" / "first-app-0.0.1.tar.gz",
+        bundle_path / "pkgbuild/first-app-0.0.1.tar.gz",
         [("old.txt", "old content")],
     )
 
@@ -258,11 +254,11 @@ def test_pkg_re_package(package_command, first_app_pkg, tmp_path):
     package_command.package_app(first_app_pkg)
 
     # The CHANGELOG file is copied
-    assert (bundle_path / "pkgbuild" / "CHANGELOG").exists()
+    assert (bundle_path / "pkgbuild/CHANGELOG").exists()
 
     # The PKGBUILD file is written
-    assert (bundle_path / "pkgbuild" / "PKGBUILD").exists()
-    with (bundle_path / "pkgbuild" / "PKGBUILD").open(encoding="utf-8") as f:
+    assert (bundle_path / "pkgbuild/PKGBUILD").exists()
+    with (bundle_path / "pkgbuild/PKGBUILD").open(encoding="utf-8") as f:
         assert f.read() == "\n".join(
             [
                 "# Maintainer: Megacorp <maintainer@example.com>",
@@ -286,7 +282,7 @@ def test_pkg_re_package(package_command, first_app_pkg, tmp_path):
         )
 
     # A source tarball was created with the right content
-    archive_file = bundle_path / "pkgbuild" / "first-app-0.0.1.tar.gz"
+    archive_file = bundle_path / "pkgbuild/first-app-0.0.1.tar.gz"
     assert archive_file.exists()
     with tarfile.open(archive_file, "r:gz") as archive:
         assert sorted(archive.getnames()) == [
@@ -330,17 +326,15 @@ def test_pkg_re_package(package_command, first_app_pkg, tmp_path):
 
     # The pkg was moved into the final location
     package_command.tools.shutil.move.assert_called_once_with(
-        bundle_path / "pkgbuild" / "first-app-0.0.1-1-wonky.pkg.tar.zst",
-        tmp_path / "base_path" / "dist" / "first-app-0.0.1-1-wonky.pkg.tar.zst",
+        bundle_path / "pkgbuild/first-app-0.0.1-1-wonky.pkg.tar.zst",
+        tmp_path / "base_path/dist/first-app-0.0.1-1-wonky.pkg.tar.zst",
     )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build PKGs on Windows")
 def test_pkg_package_no_description(package_command, first_app_pkg, tmp_path):
     """A pkg app without a description raises an error."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Delete the long description
     first_app_pkg.description = None
@@ -353,17 +347,15 @@ def test_pkg_package_no_description(package_command, first_app_pkg, tmp_path):
         package_command.package_app(first_app_pkg)
 
     # The CHANGELOG file, PKGBUILD file and tarball won't be written
-    assert not (bundle_path / "pkgbuild" / "CHANGELOG").exists()
-    assert not (bundle_path / "pkgbuild" / "PKGBUILD").exists()
-    assert not (bundle_path / "pkgbuild" / "first-app-0.0.1.tar.gz").exists()
+    assert not (bundle_path / "pkgbuild/CHANGELOG").exists()
+    assert not (bundle_path / "pkgbuild/PKGBUILD").exists()
+    assert not (bundle_path / "pkgbuild/first-app-0.0.1.tar.gz").exists()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build PKGs on Windows")
 def test_pkg_package_extra_requirements(package_command, first_app_pkg, tmp_path):
     """A pkg app can be packaged with extra runtime requirements and config features."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Add system requirements and other optional settings.
     first_app_pkg.system_runtime_requires = ["first", "second"]
@@ -374,11 +366,11 @@ def test_pkg_package_extra_requirements(package_command, first_app_pkg, tmp_path
     package_command.package_app(first_app_pkg)
 
     # The CHANGELOG file is copied
-    assert (bundle_path / "pkgbuild" / "CHANGELOG").exists()
+    assert (bundle_path / "pkgbuild/CHANGELOG").exists()
 
     # The PKGBUILD file is written
-    assert (bundle_path / "pkgbuild" / "PKGBUILD").exists()
-    with (bundle_path / "pkgbuild" / "PKGBUILD").open(encoding="utf-8") as f:
+    assert (bundle_path / "pkgbuild/PKGBUILD").exists()
+    with (bundle_path / "pkgbuild/PKGBUILD").open(encoding="utf-8") as f:
         assert f.read() == "\n".join(
             [
                 "# Maintainer: Megacorp <maintainer@example.com>",
@@ -402,7 +394,7 @@ def test_pkg_package_extra_requirements(package_command, first_app_pkg, tmp_path
         )
 
     # A source tarball was created
-    archive_file = bundle_path / "pkgbuild" / "first-app-0.0.1.tar.gz"
+    archive_file = bundle_path / "pkgbuild/first-app-0.0.1.tar.gz"
     assert archive_file.exists()
 
     # makepkg was invoked
@@ -419,17 +411,15 @@ def test_pkg_package_extra_requirements(package_command, first_app_pkg, tmp_path
 
     # The pkg was moved into the final location
     package_command.tools.shutil.move.assert_called_once_with(
-        bundle_path / "pkgbuild" / "first-app-0.0.1-1-wonky.pkg.tar.zst",
-        tmp_path / "base_path" / "dist" / "first-app-0.0.1-1-wonky.pkg.tar.zst",
+        bundle_path / "pkgbuild/first-app-0.0.1-1-wonky.pkg.tar.zst",
+        tmp_path / "base_path/dist/first-app-0.0.1-1-wonky.pkg.tar.zst",
     )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build PKGs on Windows")
 def test_pkg_package_failure(package_command, first_app_pkg, tmp_path):
     """If a packaging doesn't succeed, an error is raised."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Mock a packaging failure
     package_command.tools.app_tools[
@@ -446,13 +436,13 @@ def test_pkg_package_failure(package_command, first_app_pkg, tmp_path):
         package_command.package_app(first_app_pkg)
 
     # The CHANGELOG file is copied
-    assert (bundle_path / "pkgbuild" / "CHANGELOG").exists()
+    assert (bundle_path / "pkgbuild/CHANGELOG").exists()
 
     # The PKGBUILD file is written
-    assert (bundle_path / "pkgbuild" / "PKGBUILD").exists()
+    assert (bundle_path / "pkgbuild/PKGBUILD").exists()
 
     # A source tarball was created
-    archive_file = bundle_path / "pkgbuild" / "first-app-0.0.1.tar.gz"
+    archive_file = bundle_path / "pkgbuild/first-app-0.0.1.tar.gz"
     assert archive_file.exists()
 
     # makepkg was invoked
@@ -474,12 +464,10 @@ def test_pkg_package_failure(package_command, first_app_pkg, tmp_path):
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build PKGs on Windows")
 def test_no_changelog(package_command, first_app_pkg, tmp_path):
     """If a packaging doesn't succeed, an error is raised."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Remove the changelog file
-    (tmp_path / "base_path" / "CHANGELOG").unlink()
+    (tmp_path / "base_path/CHANGELOG").unlink()
 
     # Package the app; this will fail
     with pytest.raises(
@@ -488,13 +476,13 @@ def test_no_changelog(package_command, first_app_pkg, tmp_path):
         package_command.package_app(first_app_pkg)
 
     # The CHANGELOG file will not be copied
-    assert not (bundle_path / "pkgbuild" / "CHANGELOG").exists()
+    assert not (bundle_path / "pkgbuild/CHANGELOG").exists()
 
     # The PKGBUILD file will not exist (as existence of changelog is checked before writing the PKGBUILD file)
-    assert not (bundle_path / "pkgbuild" / "PKGBUILD").exists()
+    assert not (bundle_path / "pkgbuild/PKGBUILD").exists()
 
     # No source tarball was created
-    archive_file = bundle_path / "pkgbuild" / "first-app-0.0.1.tar.gz"
+    archive_file = bundle_path / "pkgbuild/first-app-0.0.1.tar.gz"
     assert not archive_file.exists()
 
     # makepkg wasn't invoked

--- a/tests/platforms/linux/system/test_package__rpm.py
+++ b/tests/platforms/linux/system/test_package__rpm.py
@@ -67,14 +67,14 @@ def first_app_rpm(first_app, tmp_path):
     )
 
     # Create the binary
-    create_file(usr_dir / "bin" / "first-app", "binary")
+    create_file(usr_dir / "bin/first-app", "binary")
 
     # Files in an app-named folder
-    create_file(usr_dir / "share" / "doc" / "first-app" / "license", "license")
-    create_file(usr_dir / "share" / "doc" / "first-app" / "UserManual", "manual")
+    create_file(usr_dir / "share/doc/first-app/license", "license")
+    create_file(usr_dir / "share/doc/first-app/UserManual", "manual")
 
     # A share file in an app-named folder
-    create_file(usr_dir / "share" / "man" / "man1" / "first-app.1.gz", "man")
+    create_file(usr_dir / "share/man/man1/first-app.1.gz", "man")
 
     return first_app
 
@@ -150,26 +150,22 @@ def test_verify_docker(monkeypatch, package_command, first_app_rpm):
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build RPMs on Windows")
 def test_rpm_package(package_command, first_app_rpm, tmp_path):
     """A rpm app can be packaged."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Package the app
     package_command.package_app(first_app_rpm)
 
     # rpmbuild layout has been generated
-    assert (bundle_path / "rpmbuild" / "BUILD").exists()
-    assert (bundle_path / "rpmbuild" / "BUILDROOT").exists()
-    assert (bundle_path / "rpmbuild" / "RPMS").exists()
-    assert (bundle_path / "rpmbuild" / "SOURCES").exists()
-    assert (bundle_path / "rpmbuild" / "SRPMS").exists()
-    assert (bundle_path / "rpmbuild" / "SPECS").exists()
+    assert (bundle_path / "rpmbuild/BUILD").exists()
+    assert (bundle_path / "rpmbuild/BUILDROOT").exists()
+    assert (bundle_path / "rpmbuild/RPMS").exists()
+    assert (bundle_path / "rpmbuild/SOURCES").exists()
+    assert (bundle_path / "rpmbuild/SRPMS").exists()
+    assert (bundle_path / "rpmbuild/SPECS").exists()
 
     # The spec file is written
-    assert (bundle_path / "rpmbuild" / "SPECS" / "first-app.spec").exists()
-    with (bundle_path / "rpmbuild" / "SPECS" / "first-app.spec").open(
-        encoding="utf-8"
-    ) as f:
+    assert (bundle_path / "rpmbuild/SPECS/first-app.spec").exists()
+    with (bundle_path / "rpmbuild/SPECS/first-app.spec").open(encoding="utf-8") as f:
         assert f.read() == "\n".join(
             [
                 "%global __brp_mangle_shebangs %{nil}",
@@ -231,7 +227,7 @@ def test_rpm_package(package_command, first_app_rpm, tmp_path):
         )
 
     # A source tarball was created with the right content
-    archive_file = bundle_path / "rpmbuild" / "SOURCES" / "first-app-0.0.1.tar.gz"
+    archive_file = bundle_path / "rpmbuild/SOURCES/first-app-0.0.1.tar.gz"
     assert archive_file.exists()
     with tarfile.open(archive_file, "r:gz") as archive:
         assert sorted(archive.getnames()) == [
@@ -283,24 +279,22 @@ def test_rpm_package(package_command, first_app_rpm, tmp_path):
         / "RPMS"
         / "wonky"
         / "first-app-0.0.1-1.fcXX.wonky.rpm",
-        tmp_path / "base_path" / "dist" / "first-app-0.0.1-1.fcXX.wonky.rpm",
+        tmp_path / "base_path/dist/first-app-0.0.1-1.fcXX.wonky.rpm",
     )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build RPMs on Windows")
 def test_rpm_re_package(package_command, first_app_rpm, tmp_path):
     """A rpm app that has previously been packaged can be re-packaged."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Create an old spec file and tarball that will be overwritten.
     create_file(
-        bundle_path / "rpmbuild" / "SPECS" / "first-app.spec",
+        bundle_path / "rpmbuild/SPECS/first-app.spec",
         "Old spec content",
     )
     create_tgz_file(
-        bundle_path / "rpmbuild" / "SOURCES" / "first-app-0.0.1.tar.gz",
+        bundle_path / "rpmbuild/SOURCES/first-app-0.0.1.tar.gz",
         [("old.txt", "old content")],
     )
 
@@ -308,18 +302,16 @@ def test_rpm_re_package(package_command, first_app_rpm, tmp_path):
     package_command.package_app(first_app_rpm)
 
     # rpmbuild layout has been generated
-    assert (bundle_path / "rpmbuild" / "BUILD").exists()
-    assert (bundle_path / "rpmbuild" / "BUILDROOT").exists()
-    assert (bundle_path / "rpmbuild" / "RPMS").exists()
-    assert (bundle_path / "rpmbuild" / "SOURCES").exists()
-    assert (bundle_path / "rpmbuild" / "SRPMS").exists()
-    assert (bundle_path / "rpmbuild" / "SPECS").exists()
+    assert (bundle_path / "rpmbuild/BUILD").exists()
+    assert (bundle_path / "rpmbuild/BUILDROOT").exists()
+    assert (bundle_path / "rpmbuild/RPMS").exists()
+    assert (bundle_path / "rpmbuild/SOURCES").exists()
+    assert (bundle_path / "rpmbuild/SRPMS").exists()
+    assert (bundle_path / "rpmbuild/SPECS").exists()
 
     # The spec file is written
-    assert (bundle_path / "rpmbuild" / "SPECS" / "first-app.spec").exists()
-    with (bundle_path / "rpmbuild" / "SPECS" / "first-app.spec").open(
-        encoding="utf-8"
-    ) as f:
+    assert (bundle_path / "rpmbuild/SPECS/first-app.spec").exists()
+    with (bundle_path / "rpmbuild/SPECS/first-app.spec").open(encoding="utf-8") as f:
         assert f.read() == "\n".join(
             [
                 "%global __brp_mangle_shebangs %{nil}",
@@ -381,7 +373,7 @@ def test_rpm_re_package(package_command, first_app_rpm, tmp_path):
         )
 
     # A source tarball was created with the right content
-    archive_file = bundle_path / "rpmbuild" / "SOURCES" / "first-app-0.0.1.tar.gz"
+    archive_file = bundle_path / "rpmbuild/SOURCES/first-app-0.0.1.tar.gz"
     assert archive_file.exists()
     with tarfile.open(archive_file, "r:gz") as archive:
         assert sorted(archive.getnames()) == [
@@ -433,16 +425,14 @@ def test_rpm_re_package(package_command, first_app_rpm, tmp_path):
         / "RPMS"
         / "wonky"
         / "first-app-0.0.1-1.fcXX.wonky.rpm",
-        tmp_path / "base_path" / "dist" / "first-app-0.0.1-1.fcXX.wonky.rpm",
+        tmp_path / "base_path/dist/first-app-0.0.1-1.fcXX.wonky.rpm",
     )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build RPMs on Windows")
 def test_rpm_package_no_long_description(package_command, first_app_rpm, tmp_path):
     """A rpm app without a long description raises an error."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Delete the long description
     first_app_rpm.long_description = None
@@ -455,18 +445,14 @@ def test_rpm_package_no_long_description(package_command, first_app_rpm, tmp_pat
         package_command.package_app(first_app_rpm)
 
     # The spec file and tarball won't be written
-    assert not (bundle_path / "rpmbuild" / "SPECS" / "first-app.spec").exists()
-    assert not (
-        bundle_path / "rpmbuild" / "SOURCES" / "first-app-0.0.1.tar.gz"
-    ).exists()
+    assert not (bundle_path / "rpmbuild/SPECS/first-app.spec").exists()
+    assert not (bundle_path / "rpmbuild/SOURCES/first-app-0.0.1.tar.gz").exists()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build RPMs on Windows")
 def test_rpm_package_extra_requirements(package_command, first_app_rpm, tmp_path):
     """A rpm app can be packaged with extra runtime requirements and config features."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Add system requirements and other optional settings.
     first_app_rpm.system_runtime_requires = ["first", "second"]
@@ -477,18 +463,16 @@ def test_rpm_package_extra_requirements(package_command, first_app_rpm, tmp_path
     package_command.package_app(first_app_rpm)
 
     # rpmbuild layout has been generated
-    assert (bundle_path / "rpmbuild" / "BUILD").exists()
-    assert (bundle_path / "rpmbuild" / "BUILDROOT").exists()
-    assert (bundle_path / "rpmbuild" / "RPMS").exists()
-    assert (bundle_path / "rpmbuild" / "SOURCES").exists()
-    assert (bundle_path / "rpmbuild" / "SRPMS").exists()
-    assert (bundle_path / "rpmbuild" / "SPECS").exists()
+    assert (bundle_path / "rpmbuild/BUILD").exists()
+    assert (bundle_path / "rpmbuild/BUILDROOT").exists()
+    assert (bundle_path / "rpmbuild/RPMS").exists()
+    assert (bundle_path / "rpmbuild/SOURCES").exists()
+    assert (bundle_path / "rpmbuild/SRPMS").exists()
+    assert (bundle_path / "rpmbuild/SPECS").exists()
 
     # The spec file is written
-    assert (bundle_path / "rpmbuild" / "SPECS" / "first-app.spec").exists()
-    with (bundle_path / "rpmbuild" / "SPECS" / "first-app.spec").open(
-        encoding="utf-8"
-    ) as f:
+    assert (bundle_path / "rpmbuild/SPECS/first-app.spec").exists()
+    with (bundle_path / "rpmbuild/SPECS/first-app.spec").open(encoding="utf-8") as f:
         assert f.read() == "\n".join(
             [
                 "%global __brp_mangle_shebangs %{nil}",
@@ -552,7 +536,7 @@ def test_rpm_package_extra_requirements(package_command, first_app_rpm, tmp_path
         )
 
     # A source tarball was created
-    archive_file = bundle_path / "rpmbuild" / "SOURCES" / "first-app-0.0.1.tar.gz"
+    archive_file = bundle_path / "rpmbuild/SOURCES/first-app-0.0.1.tar.gz"
     assert archive_file.exists()
 
     # rpmbuild was invoked
@@ -577,16 +561,14 @@ def test_rpm_package_extra_requirements(package_command, first_app_rpm, tmp_path
         / "RPMS"
         / "wonky"
         / "first-app-0.0.1-42.fcXX.wonky.rpm",
-        tmp_path / "base_path" / "dist" / "first-app-0.0.1-42.fcXX.wonky.rpm",
+        tmp_path / "base_path/dist/first-app-0.0.1-42.fcXX.wonky.rpm",
     )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build RPMs on Windows")
 def test_rpm_package_failure(package_command, first_app_rpm, tmp_path):
     """If an packaging doesn't succeed, an error is raised."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Mock a packaging failure
     package_command.tools.app_tools[
@@ -602,18 +584,18 @@ def test_rpm_package_failure(package_command, first_app_rpm, tmp_path):
         package_command.package_app(first_app_rpm)
 
     # rpmbuild layout has been generated
-    assert (bundle_path / "rpmbuild" / "BUILD").exists()
-    assert (bundle_path / "rpmbuild" / "BUILDROOT").exists()
-    assert (bundle_path / "rpmbuild" / "RPMS").exists()
-    assert (bundle_path / "rpmbuild" / "SOURCES").exists()
-    assert (bundle_path / "rpmbuild" / "SRPMS").exists()
-    assert (bundle_path / "rpmbuild" / "SPECS").exists()
+    assert (bundle_path / "rpmbuild/BUILD").exists()
+    assert (bundle_path / "rpmbuild/BUILDROOT").exists()
+    assert (bundle_path / "rpmbuild/RPMS").exists()
+    assert (bundle_path / "rpmbuild/SOURCES").exists()
+    assert (bundle_path / "rpmbuild/SRPMS").exists()
+    assert (bundle_path / "rpmbuild/SPECS").exists()
 
     # The spec file is written
-    assert (bundle_path / "rpmbuild" / "SPECS" / "first-app.spec").exists()
+    assert (bundle_path / "rpmbuild/SPECS/first-app.spec").exists()
 
     # A source tarball was created
-    archive_file = bundle_path / "rpmbuild" / "SOURCES" / "first-app-0.0.1.tar.gz"
+    archive_file = bundle_path / "rpmbuild/SOURCES/first-app-0.0.1.tar.gz"
     assert archive_file.exists()
 
     # rpmbuild was invoked
@@ -638,12 +620,10 @@ def test_rpm_package_failure(package_command, first_app_rpm, tmp_path):
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build RPMs on Windows")
 def test_no_changelog(package_command, first_app_rpm, tmp_path):
     """If an packaging doesn't succeed, an error is raised."""
-    bundle_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "somevendor" / "surprising"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Remove the changelog file
-    (tmp_path / "base_path" / "CHANGELOG").unlink()
+    (tmp_path / "base_path/CHANGELOG").unlink()
 
     # Package the app; this will fail
     with pytest.raises(
@@ -652,18 +632,18 @@ def test_no_changelog(package_command, first_app_rpm, tmp_path):
         package_command.package_app(first_app_rpm)
 
     # rpmbuild layout has been generated
-    assert (bundle_path / "rpmbuild" / "BUILD").exists()
-    assert (bundle_path / "rpmbuild" / "BUILDROOT").exists()
-    assert (bundle_path / "rpmbuild" / "RPMS").exists()
-    assert (bundle_path / "rpmbuild" / "SOURCES").exists()
-    assert (bundle_path / "rpmbuild" / "SRPMS").exists()
-    assert (bundle_path / "rpmbuild" / "SPECS").exists()
+    assert (bundle_path / "rpmbuild/BUILD").exists()
+    assert (bundle_path / "rpmbuild/BUILDROOT").exists()
+    assert (bundle_path / "rpmbuild/RPMS").exists()
+    assert (bundle_path / "rpmbuild/SOURCES").exists()
+    assert (bundle_path / "rpmbuild/SRPMS").exists()
+    assert (bundle_path / "rpmbuild/SPECS").exists()
 
     # The spec file will exist (however, it will be incomplete)
-    assert (bundle_path / "rpmbuild" / "SPECS" / "first-app.spec").exists()
+    assert (bundle_path / "rpmbuild/SPECS/first-app.spec").exists()
 
     # No source tarball was created
-    archive_file = bundle_path / "rpmbuild" / "SOURCES" / "first-app-0.0.1.tar.gz"
+    archive_file = bundle_path / "rpmbuild/SOURCES/first-app-0.0.1.tar.gz"
     assert not archive_file.exists()
 
     # rpmbuild wasn't invoked

--- a/tests/platforms/linux/test_DockerOpenCommand.py
+++ b/tests/platforms/linux/test_DockerOpenCommand.py
@@ -123,7 +123,7 @@ def test_open_no_docker_linux(open_command, first_app_config, tmp_path):
     open_command.tools.subprocess.Popen.assert_called_once_with(
         [
             "xdg-open",
-            tmp_path / "base_path" / "build" / "first-app" / "linux" / "appimage",
+            tmp_path / "base_path/build/first-app/linux/appimage",
         ]
     )
 
@@ -147,6 +147,6 @@ def test_open_no_docker_macOS(open_command, first_app_config, tmp_path):
     open_command.tools.subprocess.Popen.assert_called_once_with(
         [
             "open",
-            tmp_path / "base_path" / "build" / "first-app" / "linux" / "appimage",
+            tmp_path / "base_path/build/first-app/linux/appimage",
         ]
     )

--- a/tests/platforms/linux/test_LocalRequirementsMixin.py
+++ b/tests/platforms/linux/test_LocalRequirementsMixin.py
@@ -100,43 +100,43 @@ def create_command(no_docker_create_command, first_app_config, tmp_path):
 def first_package(tmp_path):
     # Create a local package to be built
     create_file(
-        tmp_path / "local" / "first" / "setup.py",
+        tmp_path / "local/first/setup.py",
         content="Python config",
     )
     create_file(
-        tmp_path / "local" / "first" / "first.py",
+        tmp_path / "local/first/first.py",
         content="Python source",
     )
 
-    return str(tmp_path / "local" / "first")
+    return str(tmp_path / "local/first")
 
 
 @pytest.fixture
 def second_package(tmp_path):
     # Create a local pre-built sdist
     create_tgz_file(
-        tmp_path / "local" / "second-2.3.4.tar.gz",
+        tmp_path / "local/second-2.3.4.tar.gz",
         content=[
             ("setup.py", "Python config"),
             ("second.py", "Python source"),
         ],
     )
 
-    return str(tmp_path / "local" / "second-2.3.4.tar.gz")
+    return str(tmp_path / "local/second-2.3.4.tar.gz")
 
 
 @pytest.fixture
 def third_package(tmp_path):
     # Create a local pre-built wheel
     create_zip_file(
-        tmp_path / "local" / "third-3.4.5-py3-none-any.whl",
+        tmp_path / "local/third-3.4.5-py3-none-any.whl",
         content=[
             ("MANIFEST.in", "Wheel config"),
             ("third.py", "Python source"),
         ],
     )
 
-    return str(tmp_path / "local" / "third-3.4.5-py3-none-any.whl")
+    return str(tmp_path / "local/third-3.4.5-py3-none-any.whl")
 
 
 @pytest.fixture
@@ -309,7 +309,7 @@ def test_install_app_requirements_with_locals(
             / "tester"
             / "dummy"
             / "_requirements",
-            str(tmp_path / "local" / "first"),
+            str(tmp_path / "local/first"),
         ],
         encoding="UTF-8",
     )
@@ -317,7 +317,7 @@ def test_install_app_requirements_with_locals(
     # An attempt was made to copy the prebuilt packages
     create_command.tools.shutil.copy.mock_calls = [
         call(
-            str(tmp_path / "local" / "second-2.3.4.tar.gz"),
+            str(tmp_path / "local/second-2.3.4.tar.gz"),
             tmp_path
             / "base_path"
             / "build"
@@ -327,7 +327,7 @@ def test_install_app_requirements_with_locals(
             / "_requirements",
         ),
         call(
-            str(tmp_path / "local" / "third-3.4.5-py3-none-any.whl"),
+            str(tmp_path / "local/third-3.4.5-py3-none-any.whl"),
             tmp_path
             / "base_path"
             / "build"
@@ -428,7 +428,7 @@ def test_install_app_requirements_with_bad_local(
             / "tester"
             / "dummy"
             / "_requirements",
-            str(tmp_path / "local" / "first"),
+            str(tmp_path / "local/first"),
         ],
         encoding="UTF-8",
     )
@@ -453,7 +453,7 @@ def test_install_app_requirements_with_missing_local_build(
     """If the app references a requirement that needs to be built, but is missing, an
     error is raised."""
     # Define a local requirement, but don't create the files it points at
-    first_app_config.requires.append(str(tmp_path / "local" / "first"))
+    first_app_config.requires.append(str(tmp_path / "local/first"))
 
     # Install requirements
     with pytest.raises(
@@ -485,7 +485,7 @@ def test_install_app_requirements_with_bad_local_file(
     """If the app references a local requirement file that doesn't exist, an error is
     raised."""
     # Add a local requirement that doesn't exist
-    first_app_config.requires.append(str(tmp_path / "local" / "missing-2.3.4.tar.gz"))
+    first_app_config.requires.append(str(tmp_path / "local/missing-2.3.4.tar.gz"))
 
     # Install requirements
     with pytest.raises(
@@ -496,7 +496,7 @@ def test_install_app_requirements_with_bad_local_file(
 
     # An attempt was made to copy the package
     create_command.tools.shutil.copy.assert_called_once_with(
-        str(tmp_path / "local" / "missing-2.3.4.tar.gz"),
+        str(tmp_path / "local/missing-2.3.4.tar.gz"),
         tmp_path
         / "base_path"
         / "build"

--- a/tests/platforms/macOS/app/conftest.py
+++ b/tests/platforms/macOS/app/conftest.py
@@ -38,7 +38,7 @@ entitlements_path="Entitlements.plist"
 
     # Create the plist file for the app
     create_plist_file(
-        app_path / "Contents" / "Info.plist",
+        app_path / "Contents/Info.plist",
         {
             "MainModule": "first_app",
         },
@@ -60,8 +60,8 @@ entitlements_path="Entitlements.plist"
     )
 
     # Create some folders that need to exist.
-    (app_path / "Contents" / "Resources" / "app_packages").mkdir(parents=True)
-    (app_path / "Contents" / "Frameworks").mkdir(parents=True)
+    (app_path / "Contents/Resources/app_packages").mkdir(parents=True)
+    (app_path / "Contents/Frameworks").mkdir(parents=True)
 
     # Select dmg packaging by default
     first_app_config.packaging_format = "dmg"
@@ -82,14 +82,14 @@ def first_app_with_binaries(first_app_templated, first_app_config, tmp_path):
     )
 
     # Create some libraries that need to be signed.
-    lib_path = app_path / "Contents" / "Resources" / "app_packages"
-    frameworks_path = app_path / "Contents" / "Frameworks"
+    lib_path = app_path / "Contents/Resources/app_packages"
+    frameworks_path = app_path / "Contents/Frameworks"
 
     for lib in [
         "first_so.so",
-        Path("subfolder") / "second_so.so",
+        Path("subfolder/second_so.so"),
         "first_dylib.dylib",
-        Path("subfolder") / "second_dylib.dylib",
+        Path("subfolder/second_dylib.dylib"),
         "other_binary",
     ]:
         (lib_path / lib).parent.mkdir(parents=True, exist_ok=True)
@@ -102,17 +102,13 @@ def first_app_with_binaries(first_app_templated, first_app_config, tmp_path):
     os.chmod(lib_path / "special.binary", 0o755)
 
     # An embedded app
-    (lib_path / "Extras.app" / "Contents" / "MacOS").mkdir(parents=True, exist_ok=True)
-    with (lib_path / "Extras.app" / "Contents" / "MacOS" / "Extras").open("wb") as f:
+    (lib_path / "Extras.app/Contents/MacOS").mkdir(parents=True, exist_ok=True)
+    with (lib_path / "Extras.app/Contents/MacOS/Extras").open("wb") as f:
         f.write(b"\xCA\xFE\xBA\xBEBinary content here")
 
     # An embedded framework
-    (frameworks_path / "Extras.framework" / "Resources").mkdir(
-        parents=True, exist_ok=True
-    )
-    with (frameworks_path / "Extras.framework" / "Resources" / "extras.dylib").open(
-        "wb"
-    ) as f:
+    (frameworks_path / "Extras.framework/Resources").mkdir(parents=True, exist_ok=True)
+    with (frameworks_path / "Extras.framework/Resources/extras.dylib").open("wb") as f:
         f.write(b"\xCA\xFE\xBA\xBEBinary content here")
 
     # Make sure there are some files in the bundle that *don't* need to be signed...

--- a/tests/platforms/macOS/app/test_create.py
+++ b/tests/platforms/macOS/app/test_create.py
@@ -42,7 +42,7 @@ def test_install_app_packages(
     other_arch,
 ):
     """A 2-pass install of app packages is performed."""
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "macos" / "app"
+    bundle_path = tmp_path / "base_path/build/first-app/macos/app"
 
     create_command.tools.host_arch = host_arch
     first_app_templated.requires = ["first", "second==1.2.3", "third>=3.2.1"]
@@ -119,7 +119,7 @@ def test_install_app_packages(
             encoding="UTF-8",
             env={
                 "PYTHONPATH": str(
-                    bundle_path / "support" / "platform-site" / f"macosx.{other_arch}"
+                    bundle_path / "support/platform-site" / f"macosx.{other_arch}"
                 )
             },
         ),
@@ -164,7 +164,7 @@ def test_install_app_packages_no_binary(
     other_arch,
 ):
     """If there's no binaries in the first pass, the second pass isn't performed."""
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "macos" / "app"
+    bundle_path = tmp_path / "base_path/build/first-app/macos/app"
 
     # Create pre-existing other-arch content
     create_installed_package(bundle_path / f"app_packages.{other_arch}", "legacy")
@@ -240,7 +240,7 @@ def test_install_app_packages_no_binary(
 
 def test_install_app_packages_failure(create_command, first_app_templated, tmp_path):
     """If the install of other-arch binaries fails, an exception is raised."""
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "macos" / "app"
+    bundle_path = tmp_path / "base_path/build/first-app/macos/app"
 
     # Create pre-existing other-arch content
     create_installed_package(bundle_path / "app_packages.x86_64", "legacy")
@@ -335,9 +335,7 @@ def test_install_app_packages_failure(create_command, first_app_templated, tmp_p
             check=True,
             encoding="UTF-8",
             env={
-                "PYTHONPATH": str(
-                    bundle_path / "support" / "platform-site" / "macosx.x86_64"
-                )
+                "PYTHONPATH": str(bundle_path / "support/platform-site/macosx.x86_64")
             },
         ),
     ]
@@ -368,7 +366,7 @@ def test_install_app_packages_non_universal(
 ):
     """If the app is non-universal, only a single install pass occurs, followed by
     thinning."""
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "macos" / "app"
+    bundle_path = tmp_path / "base_path/build/first-app/macos/app"
 
     create_command.tools.host_arch = host_arch
     first_app_templated.requires = ["first", "second==1.2.3", "third>=3.2.1"]
@@ -415,7 +413,7 @@ def test_install_app_packages_non_universal(
 
     # An attempt was made to thin the app packages
     create_command.thin_app_packages.assert_called_once_with(
-        bundle_path / "First App.app" / "Contents" / "Resources" / "app_packages",
+        bundle_path / "First App.app/Contents/Resources/app_packages",
         arch=host_arch,
     )
 
@@ -443,14 +441,12 @@ def test_install_support_package(
     # Mock the thin command so we can confirm if it was invoked.
     create_command.ensure_thin_binary = mock.Mock()
 
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "macos" / "app"
-    runtime_support_path = (
-        bundle_path / "First App.app" / "Contents" / "Resources" / "support"
-    )
+    bundle_path = tmp_path / "base_path/build/first-app/macos/app"
+    runtime_support_path = bundle_path / "First App.app/Contents/Resources/support"
 
     if pre_existing:
         create_file(
-            runtime_support_path / "python-stdlib" / "old-stdlib",
+            runtime_support_path / "python-stdlib/old-stdlib",
             "Legacy stdlib file",
         )
 
@@ -477,34 +473,34 @@ def test_install_support_package(
     create_command.install_app_support_package(first_app_templated)
 
     # Confirm that the support files have been unpacked into the bundle location
-    assert (bundle_path / "support" / "python-stdlib" / "stdlib.txt").exists()
+    assert (bundle_path / "support/python-stdlib/stdlib.txt").exists()
     assert (
-        bundle_path / "support" / "platform-site" / "macosx.arm64" / "sitecustomize.py"
+        bundle_path / "support/platform-site/macosx.arm64/sitecustomize.py"
     ).exists()
     assert (
-        bundle_path / "support" / "platform-site" / "macosx.x86_64" / "sitecustomize.py"
+        bundle_path / "support/platform-site/macosx.x86_64/sitecustomize.py"
     ).exists()
-    assert (bundle_path / "support" / "Python.xcframework" / "info.plist").exists()
+    assert (bundle_path / "support/Python.xcframework/info.plist").exists()
 
     # The standard library has been copied to the app...
-    assert (runtime_support_path / "python-stdlib" / "stdlib.txt").exists()
+    assert (runtime_support_path / "python-stdlib/stdlib.txt").exists()
     # ... but the other support files have not.
     assert not (
-        runtime_support_path / "platform-site" / "macosx.arm64" / "sitecustomize.py"
+        runtime_support_path / "platform-site/macosx.arm64/sitecustomize.py"
     ).exists()
     assert not (
-        runtime_support_path / "platform-site" / "macosx.x86_64" / "sitecustomize.py"
+        runtime_support_path / "platform-site/macosx.x86_64/sitecustomize.py"
     ).exists()
-    assert not (runtime_support_path / "Python.xcframework" / "info.plist").exists()
+    assert not (runtime_support_path / "Python.xcframework/info.plist").exists()
 
     # The legacy content has been purged
-    assert not (runtime_support_path / "python-stdlib" / "old-stdlib").exists()
+    assert not (runtime_support_path / "python-stdlib/old-stdlib").exists()
 
     # Only thin if this is a non-universal app
     if universal_build:
         create_command.ensure_thin_binary.assert_not_called()
     else:
         create_command.ensure_thin_binary.assert_called_once_with(
-            bundle_path / "First App.app" / "Contents" / "MacOS" / "First App",
+            bundle_path / "First App.app/Contents/MacOS/First App",
             arch="gothic",
         )

--- a/tests/platforms/macOS/app/test_mixin.py
+++ b/tests/platforms/macOS/app/test_mixin.py
@@ -73,7 +73,7 @@ def test_distribution_path_app(package_command, first_app_config, tmp_path):
     first_app_config.packaging_format = "app"
     distribution_path = package_command.distribution_path(first_app_config)
 
-    expected_path = tmp_path / "base_path" / "dist" / "First App-0.0.1.app.zip"
+    expected_path = tmp_path / "base_path/dist/First App-0.0.1.app.zip"
     assert distribution_path == expected_path
 
 
@@ -81,5 +81,5 @@ def test_distribution_path_dmg(package_command, first_app_config, tmp_path):
     first_app_config.packaging_format = "dmg"
     distribution_path = package_command.distribution_path(first_app_config)
 
-    expected_path = tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg"
+    expected_path = tmp_path / "base_path/dist/First App-0.0.1.dmg"
     assert distribution_path == expected_path

--- a/tests/platforms/macOS/app/test_open.py
+++ b/tests/platforms/macOS/app/test_open.py
@@ -30,7 +30,7 @@ def test_open(open_command, first_app_config, tmp_path):
     """On macOS, Open starts the finder on the Content folder."""
     # Create the binary that would be in the project bundle.
     create_file(
-        open_command.project_path(first_app_config) / "MacOS" / "First App",
+        open_command.project_path(first_app_config) / "MacOS/First App",
         "binary",
     )
 

--- a/tests/platforms/macOS/app/test_package.py
+++ b/tests/platforms/macOS/app/test_package.py
@@ -68,7 +68,7 @@ def test_package_app(package_command, first_app_with_binaries, tmp_path, capsys)
 
     # The DMG has been built as expected
     package_command.dmgbuild.build_dmg.assert_called_once_with(
-        filename=os.fsdecode(tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg"),
+        filename=os.fsdecode(tmp_path / "base_path/dist/First App-0.0.1.dmg"),
         volume_name="First App 0.0.1",
         settings={
             "files": [
@@ -97,13 +97,13 @@ def test_package_app(package_command, first_app_with_binaries, tmp_path, capsys)
     # This ignores the calls that would have been made transitively
     # by calling sign_app()
     package_command.sign_file.assert_called_once_with(
-        tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg",
+        tmp_path / "base_path/dist/First App-0.0.1.dmg",
         identity="CAFEBEEF",
     )
 
     # A request was made to notarize the DMG
     package_command.notarize.assert_called_once_with(
-        tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg",
+        tmp_path / "base_path/dist/First App-0.0.1.dmg",
         team_id="DEADBEEF",
     )
 
@@ -135,7 +135,7 @@ def test_package_app_no_notarization(
 
     # The DMG has been built as expected
     package_command.dmgbuild.build_dmg.assert_called_once_with(
-        filename=os.fsdecode(tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg"),
+        filename=os.fsdecode(tmp_path / "base_path/dist/First App-0.0.1.dmg"),
         volume_name="First App 0.0.1",
         settings={
             "files": [
@@ -164,7 +164,7 @@ def test_package_app_no_notarization(
     # This ignores the calls that would have been made transitively
     # by calling sign_app()
     package_command.sign_file.assert_called_once_with(
-        tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg",
+        tmp_path / "base_path/dist/First App-0.0.1.dmg",
         identity="CAFEBEEF",
     )
 
@@ -282,7 +282,7 @@ def test_package_app_adhoc_signed_via_prompt(
 
     # The DMG has been built as expected
     package_command.dmgbuild.build_dmg.assert_called_once_with(
-        filename=os.fsdecode(tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg"),
+        filename=os.fsdecode(tmp_path / "base_path/dist/First App-0.0.1.dmg"),
         volume_name="First App 0.0.1",
         settings={
             "files": [
@@ -311,7 +311,7 @@ def test_package_app_adhoc_signed_via_prompt(
     # This ignores the calls that would have been made transitively
     # by calling sign_app()
     package_command.sign_file.assert_called_once_with(
-        tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg",
+        tmp_path / "base_path/dist/First App-0.0.1.dmg",
         identity="-",
     )
 
@@ -338,7 +338,7 @@ def test_package_app_adhoc_sign(package_command, first_app_with_binaries, tmp_pa
 
     # The DMG has been built as expected
     package_command.dmgbuild.build_dmg.assert_called_once_with(
-        filename=os.fsdecode(tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg"),
+        filename=os.fsdecode(tmp_path / "base_path/dist/First App-0.0.1.dmg"),
         volume_name="First App 0.0.1",
         settings={
             "files": [
@@ -367,7 +367,7 @@ def test_package_app_adhoc_sign(package_command, first_app_with_binaries, tmp_pa
     # This ignores the calls that would have been made transitively
     # by calling sign_app()
     package_command.sign_file.assert_called_once_with(
-        tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg",
+        tmp_path / "base_path/dist/First App-0.0.1.dmg",
         identity="-",
     )
 
@@ -395,7 +395,7 @@ def test_package_app_adhoc_sign_default_notarization(
 
     # The DMG has been built as expected
     package_command.dmgbuild.build_dmg.assert_called_once_with(
-        filename=os.fsdecode(tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg"),
+        filename=os.fsdecode(tmp_path / "base_path/dist/First App-0.0.1.dmg"),
         volume_name="First App 0.0.1",
         settings={
             "files": [
@@ -424,7 +424,7 @@ def test_package_app_adhoc_sign_default_notarization(
     # This ignores the calls that would have been made transitively
     # by calling sign_app()
     package_command.sign_file.assert_called_once_with(
-        tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg",
+        tmp_path / "base_path/dist/First App-0.0.1.dmg",
         identity="-",
     )
 
@@ -474,7 +474,7 @@ def test_package_bare_app(package_command, first_app_with_binaries, tmp_path):
 
     # The packaged archive exists, and contains all the files,
     # contained in the `.app` bundle.
-    archive_file = tmp_path / "base_path" / "dist" / "First App-0.0.1.app.zip"
+    archive_file = tmp_path / "base_path/dist/First App-0.0.1.app.zip"
     assert archive_file.exists()
     with ZipFile(archive_file) as archive:
         assert sorted(archive.namelist()) == [
@@ -544,7 +544,7 @@ def test_dmg_with_installer_icon(package_command, first_app_with_binaries, tmp_p
     """An installer icon can be specified for a DMG."""
     # Specify an installer icon, and create the matching file.
     first_app_with_binaries.installer_icon = "pretty"
-    with open(tmp_path / "base_path" / "pretty.icns", "wb") as f:
+    with open(tmp_path / "base_path/pretty.icns", "wb") as f:
         f.write(b"A pretty installer icon")
 
     # Package the app without signing or notarization
@@ -556,7 +556,7 @@ def test_dmg_with_installer_icon(package_command, first_app_with_binaries, tmp_p
 
     # The DMG has been built as expected
     package_command.dmgbuild.build_dmg.assert_called_once_with(
-        filename=os.fsdecode(tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg"),
+        filename=os.fsdecode(tmp_path / "base_path/dist/First App-0.0.1.dmg"),
         volume_name="First App 0.0.1",
         settings={
             "files": [
@@ -578,7 +578,7 @@ def test_dmg_with_installer_icon(package_command, first_app_with_binaries, tmp_p
             "window_rect": ((600, 600), (350, 150)),
             "icon_size": 64,
             "text_size": 12,
-            "icon": os.fsdecode(tmp_path / "base_path" / "pretty.icns"),
+            "icon": os.fsdecode(tmp_path / "base_path/pretty.icns"),
         },
     )
 
@@ -604,7 +604,7 @@ def test_dmg_with_missing_installer_icon(
 
     # The DMG has been built as expected
     package_command.dmgbuild.build_dmg.assert_called_once_with(
-        filename=os.fsdecode(tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg"),
+        filename=os.fsdecode(tmp_path / "base_path/dist/First App-0.0.1.dmg"),
         volume_name="First App 0.0.1",
         settings={
             "files": [
@@ -644,7 +644,7 @@ def test_dmg_with_app_installer_icon(
     """An installer will fall back to an app icon for a DMG."""
     # Specify an app icon, and create the matching file.
     first_app_with_binaries.icon = "pretty_app"
-    with open(tmp_path / "base_path" / "pretty_app.icns", "wb") as f:
+    with open(tmp_path / "base_path/pretty_app.icns", "wb") as f:
         f.write(b"A pretty app icon")
 
     # Package the app without signing or notarization
@@ -656,7 +656,7 @@ def test_dmg_with_app_installer_icon(
 
     # The DMG has been built as expected
     package_command.dmgbuild.build_dmg.assert_called_once_with(
-        filename=os.fsdecode(tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg"),
+        filename=os.fsdecode(tmp_path / "base_path/dist/First App-0.0.1.dmg"),
         volume_name="First App 0.0.1",
         settings={
             "files": [
@@ -678,7 +678,7 @@ def test_dmg_with_app_installer_icon(
             "window_rect": ((600, 600), (350, 150)),
             "icon_size": 64,
             "text_size": 12,
-            "icon": os.fsdecode(tmp_path / "base_path" / "pretty_app.icns"),
+            "icon": os.fsdecode(tmp_path / "base_path/pretty_app.icns"),
         },
     )
 
@@ -703,7 +703,7 @@ def test_dmg_with_missing_app_installer_icon(
 
     # The DMG has been built as expected
     package_command.dmgbuild.build_dmg.assert_called_once_with(
-        filename=os.fsdecode(tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg"),
+        filename=os.fsdecode(tmp_path / "base_path/dist/First App-0.0.1.dmg"),
         volume_name="First App 0.0.1",
         settings={
             "files": [
@@ -743,7 +743,7 @@ def test_dmg_with_installer_background(
     """An installer can be built with an installer background."""
     # Specify an installer background, and create the matching file.
     first_app_with_binaries.installer_background = "pretty_background"
-    with open(tmp_path / "base_path" / "pretty_background.png", "wb") as f:
+    with open(tmp_path / "base_path/pretty_background.png", "wb") as f:
         f.write(b"A pretty background")
 
     # Package the app without signing or notarization
@@ -755,7 +755,7 @@ def test_dmg_with_installer_background(
 
     # The DMG has been built as expected
     package_command.dmgbuild.build_dmg.assert_called_once_with(
-        filename=os.fsdecode(tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg"),
+        filename=os.fsdecode(tmp_path / "base_path/dist/First App-0.0.1.dmg"),
         volume_name="First App 0.0.1",
         settings={
             "files": [
@@ -777,7 +777,7 @@ def test_dmg_with_installer_background(
             "window_rect": ((600, 600), (350, 150)),
             "icon_size": 64,
             "text_size": 12,
-            "background": os.fsdecode(tmp_path / "base_path" / "pretty_background.png"),
+            "background": os.fsdecode(tmp_path / "base_path/pretty_background.png"),
         },
     )
 
@@ -803,7 +803,7 @@ def test_dmg_with_missing_installer_background(
 
     # The DMG has been built as expected
     package_command.dmgbuild.build_dmg.assert_called_once_with(
-        filename=os.fsdecode(tmp_path / "base_path" / "dist" / "First App-0.0.1.dmg"),
+        filename=os.fsdecode(tmp_path / "base_path/dist/First App-0.0.1.dmg"),
         volume_name="First App 0.0.1",
         settings={
             "files": [

--- a/tests/platforms/macOS/app/test_package__notarize.py
+++ b/tests/platforms/macOS/app/test_package__notarize.py
@@ -29,7 +29,7 @@ def package_command(tmp_path):
 
 @pytest.fixture
 def first_app_dmg(tmp_path):
-    dmg_path = tmp_path / "base_path" / "dist" / "First App.dmg"
+    dmg_path = tmp_path / "base_path/dist/First App.dmg"
     dmg_path.parent.mkdir(parents=True)
     with dmg_path.open("w", encoding="utf-8") as f:
         f.write("DMG content here")
@@ -48,9 +48,7 @@ def test_notarize_app(package_command, first_app_with_binaries, tmp_path):
         / "app"
         / "First App.app"
     )
-    archive_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "macos" / "app" / "archive.zip"
-    )
+    archive_path = tmp_path / "base_path/build/first-app/macos/app/archive.zip"
     package_command.notarize(app_path, team_id="DEADBEEF")
 
     # As a result of mocking os.unlink, the zip archive won't be
@@ -156,7 +154,7 @@ def test_notarize_dmg(package_command, first_app_dmg):
 
 def test_notarize_unknown_format(package_command, tmp_path):
     """Attempting to notarize a file of unknown format raises an error."""
-    pkg_path = tmp_path / "base_path" / "dist" / "First App.pkg"
+    pkg_path = tmp_path / "base_path/dist/First App.pkg"
 
     # The notarization call will fail with an error
     with pytest.raises(
@@ -257,9 +255,7 @@ def test_credential_storage_failure_app(
         / "app"
         / "First App.app"
     )
-    archive_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "macos" / "app" / "archive.zip"
-    )
+    archive_path = tmp_path / "base_path/build/first-app/macos/app/archive.zip"
 
     # Set up subprocess to fail on the first notarization attempt,
     # then fail on the storage of credentials
@@ -392,9 +388,7 @@ def test_credential_storage_disabled_input_app(
         / "app"
         / "First App.app"
     )
-    archive_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "macos" / "app" / "archive.zip"
-    )
+    archive_path = tmp_path / "base_path/build/first-app/macos/app/archive.zip"
 
     # Set up subprocess to fail on the first notarization attempt.
     package_command.tools.subprocess.run.side_effect = [
@@ -570,9 +564,7 @@ def test_app_notarization_failure_with_credentials(
         / "app"
         / "First App.app"
     )
-    archive_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "macos" / "app" / "archive.zip"
-    )
+    archive_path = tmp_path / "base_path/build/first-app/macos/app/archive.zip"
 
     # Set up subprocess to fail on the first notarization attempt
     # for a reason other than credentials

--- a/tests/platforms/macOS/app/test_run.py
+++ b/tests/platforms/macOS/app/test_run.py
@@ -50,7 +50,7 @@ def test_run_app(run_command, first_app_config, sleep_zero, tmp_path, monkeypatc
 
     # Calls were made to start the app and to start a log stream.
     bin_path = run_command.binary_path(first_app_config)
-    sender = bin_path / "Contents" / "MacOS" / "First App"
+    sender = bin_path / "Contents/MacOS/First App"
     run_command.tools.subprocess.Popen.assert_called_with(
         [
             "log",
@@ -113,7 +113,7 @@ def test_run_app_with_passthrough(
 
     # Calls were made to start the app and to start a log stream.
     bin_path = run_command.binary_path(first_app_config)
-    sender = bin_path / "Contents" / "MacOS" / "First App"
+    sender = bin_path / "Contents/MacOS/First App"
     run_command.tools.subprocess.Popen.assert_called_with(
         [
             "log",
@@ -163,7 +163,7 @@ def test_run_app_failed(run_command, first_app_config, sleep_zero, tmp_path):
 
     # Calls were made to start the app and to start a log stream.
     bin_path = run_command.binary_path(first_app_config)
-    sender = bin_path / "Contents" / "MacOS" / "First App"
+    sender = bin_path / "Contents/MacOS/First App"
     run_command.tools.subprocess.Popen.assert_called_with(
         [
             "log",
@@ -210,7 +210,7 @@ def test_run_app_find_pid_failed(
 
     # Calls were made to start the app and to start a log stream.
     bin_path = run_command.binary_path(first_app_config)
-    sender = bin_path / "Contents" / "MacOS" / "First App"
+    sender = bin_path / "Contents/MacOS/First App"
     run_command.tools.subprocess.Popen.assert_called_with(
         [
             "log",
@@ -261,7 +261,7 @@ def test_run_app_test_mode(
 
     # Calls were made to start the app and to start a log stream.
     bin_path = run_command.binary_path(first_app_config)
-    sender = bin_path / "Contents" / "MacOS" / "First App"
+    sender = bin_path / "Contents/MacOS/First App"
     run_command.tools.subprocess.Popen.assert_called_with(
         [
             "log",

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -242,14 +242,14 @@ def test_sign_file_adhoc_identity(dummy_command, verbose, tmp_path, capsys):
         dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Sign the file with an ad-hoc identity
-    dummy_command.sign_file(tmp_path / "base_path" / "random.file", identity="-")
+    dummy_command.sign_file(tmp_path / "base_path/random.file", identity="-")
 
     # An attempt to codesign was made without the runtime option
     dummy_command.tools.subprocess.run.assert_has_calls(
         [
             sign_call(
                 tmp_path,
-                tmp_path / "base_path" / "random.file",
+                tmp_path / "base_path/random.file",
                 identity="-",
                 entitlements=False,
                 runtime=False,
@@ -271,7 +271,7 @@ def test_sign_file_entitlements(dummy_command, verbose, tmp_path, capsys):
 
     # Sign the file with an ad-hoc identity
     dummy_command.sign_file(
-        tmp_path / "base_path" / "random.file",
+        tmp_path / "base_path/random.file",
         identity="Sekrit identity (DEADBEEF)",
         entitlements=tmp_path
         / "base_path"
@@ -285,7 +285,7 @@ def test_sign_file_entitlements(dummy_command, verbose, tmp_path, capsys):
     # An attempt to codesign was made without the runtime option
     dummy_command.tools.subprocess.run.assert_has_calls(
         [
-            sign_call(tmp_path, tmp_path / "base_path" / "random.file"),
+            sign_call(tmp_path, tmp_path / "base_path/random.file"),
         ],
         any_order=False,
     )
@@ -308,7 +308,7 @@ def test_sign_file_deep_sign(dummy_command, verbose, tmp_path, capsys):
 
     # Sign the file
     dummy_command.sign_file(
-        tmp_path / "base_path" / "random.file", identity="Sekrit identity (DEADBEEF)"
+        tmp_path / "base_path/random.file", identity="Sekrit identity (DEADBEEF)"
     )
 
     # 2 attempt to codesign was made; the second enabled the deep argument.
@@ -316,12 +316,12 @@ def test_sign_file_deep_sign(dummy_command, verbose, tmp_path, capsys):
         [
             sign_call(
                 tmp_path,
-                tmp_path / "base_path" / "random.file",
+                tmp_path / "base_path/random.file",
                 entitlements=False,
             ),
             sign_call(
                 tmp_path,
-                tmp_path / "base_path" / "random.file",
+                tmp_path / "base_path/random.file",
                 entitlements=False,
                 deep=True,
             ),
@@ -355,7 +355,7 @@ def test_sign_file_deep_sign_failure(dummy_command, verbose, tmp_path, capsys):
     # Sign the file
     with pytest.raises(BriefcaseCommandError, match="Unable to deep code sign "):
         dummy_command.sign_file(
-            tmp_path / "base_path" / "random.file",
+            tmp_path / "base_path/random.file",
             identity="Sekrit identity (DEADBEEF)",
         )
 
@@ -364,7 +364,7 @@ def test_sign_file_deep_sign_failure(dummy_command, verbose, tmp_path, capsys):
         [
             sign_call(
                 tmp_path,
-                tmp_path / "base_path" / "random.file",
+                tmp_path / "base_path/random.file",
                 entitlements=False,
             ),
         ],
@@ -394,7 +394,7 @@ def test_sign_file_unsupported_format(dummy_command, verbose, tmp_path, capsys):
 
     # Sign the file
     dummy_command.sign_file(
-        tmp_path / "base_path" / "random.file",
+        tmp_path / "base_path/random.file",
         identity="Sekrit identity (DEADBEEF)",
     )
 
@@ -403,7 +403,7 @@ def test_sign_file_unsupported_format(dummy_command, verbose, tmp_path, capsys):
         [
             sign_call(
                 tmp_path,
-                tmp_path / "base_path" / "random.file",
+                tmp_path / "base_path/random.file",
                 entitlements=False,
             ),
         ],
@@ -433,7 +433,7 @@ def test_sign_file_unknown_bundle_format(dummy_command, verbose, tmp_path, capsy
 
     # Sign the file
     dummy_command.sign_file(
-        tmp_path / "base_path" / "random.file",
+        tmp_path / "base_path/random.file",
         identity="Sekrit identity (DEADBEEF)",
     )
 
@@ -442,7 +442,7 @@ def test_sign_file_unknown_bundle_format(dummy_command, verbose, tmp_path, capsy
         [
             sign_call(
                 tmp_path,
-                tmp_path / "base_path" / "random.file",
+                tmp_path / "base_path/random.file",
                 entitlements=False,
             ),
         ],
@@ -469,7 +469,7 @@ def test_sign_file_unknown_error(dummy_command, verbose, tmp_path, capsys):
 
     with pytest.raises(BriefcaseCommandError, match="Unable to code sign "):
         dummy_command.sign_file(
-            tmp_path / "base_path" / "random.file",
+            tmp_path / "base_path/random.file",
             identity="Sekrit identity (DEADBEEF)",
         )
 
@@ -478,7 +478,7 @@ def test_sign_file_unknown_error(dummy_command, verbose, tmp_path, capsys):
         [
             sign_call(
                 tmp_path,
-                tmp_path / "base_path" / "random.file",
+                tmp_path / "base_path/random.file",
                 entitlements=False,
             ),
         ],
@@ -518,23 +518,21 @@ def test_sign_app(dummy_command, first_app_with_binaries, verbose, tmp_path, cap
         / "app"
         / "First App.app"
     )
-    lib_path = app_path / "Contents" / "Resources" / "app_packages"
-    frameworks_path = app_path / "Contents" / "Frameworks"
+    lib_path = app_path / "Contents/Resources/app_packages"
+    frameworks_path = app_path / "Contents/Frameworks"
     dummy_command.tools.subprocess.run.assert_has_calls(
         [
-            sign_call(tmp_path, lib_path / "subfolder" / "second_so.so"),
-            sign_call(tmp_path, lib_path / "subfolder" / "second_dylib.dylib"),
+            sign_call(tmp_path, lib_path / "subfolder/second_so.so"),
+            sign_call(tmp_path, lib_path / "subfolder/second_dylib.dylib"),
             sign_call(tmp_path, lib_path / "special.binary"),
             sign_call(tmp_path, lib_path / "other_binary"),
             sign_call(tmp_path, lib_path / "first_so.so"),
             sign_call(tmp_path, lib_path / "first_dylib.dylib"),
-            sign_call(
-                tmp_path, lib_path / "Extras.app" / "Contents" / "MacOS" / "Extras"
-            ),
+            sign_call(tmp_path, lib_path / "Extras.app/Contents/MacOS/Extras"),
             sign_call(tmp_path, lib_path / "Extras.app"),
             sign_call(
                 tmp_path,
-                frameworks_path / "Extras.framework" / "Resources" / "extras.dylib",
+                frameworks_path / "Extras.framework/Resources/extras.dylib",
             ),
             sign_call(tmp_path, frameworks_path / "Extras.framework"),
             sign_call(tmp_path, app_path),

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__ensure_thin_binary.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__ensure_thin_binary.py
@@ -15,7 +15,7 @@ def test_thin_binary(dummy_command, verbose, tmp_path, capsys):
         dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
-    create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-original")
+    create_file(tmp_path / "path/to/file.dylib", "dylib-original")
 
     # Mock the result of the "lipo info" call.
     dummy_command.tools.subprocess.check_output.return_value = (
@@ -24,7 +24,7 @@ def test_thin_binary(dummy_command, verbose, tmp_path, capsys):
 
     # Thin the binary; this is effectively a no-op
     dummy_command.ensure_thin_binary(
-        tmp_path / "path" / "to" / "file.dylib",
+        tmp_path / "path/to/file.dylib",
         arch="gothic",
     )
 
@@ -33,7 +33,7 @@ def test_thin_binary(dummy_command, verbose, tmp_path, capsys):
         [
             "lipo",
             "-info",
-            tmp_path / "path" / "to" / "file.dylib",
+            tmp_path / "path/to/file.dylib",
         ],
     )
 
@@ -41,7 +41,7 @@ def test_thin_binary(dummy_command, verbose, tmp_path, capsys):
     dummy_command.tools.subprocess.run.assert_not_called()
 
     # The original file is unmodified.
-    assert file_content(tmp_path / "path" / "to" / "file.dylib") == "dylib-original"
+    assert file_content(tmp_path / "path/to/file.dylib") == "dylib-original"
 
     # Output only happens if in debug mode
     output = capsys.readouterr().out.split("\n")
@@ -55,7 +55,7 @@ def test_fat_dylib(dummy_command, verbose, tmp_path, capsys):
         dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
-    create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
+    create_file(tmp_path / "path/to/file.dylib", "dylib-fat")
 
     # Mock the result of the "lipo info" call.
     dummy_command.tools.subprocess.check_output.return_value = (
@@ -70,7 +70,7 @@ def test_fat_dylib(dummy_command, verbose, tmp_path, capsys):
 
     # Thin the binary to the "gothic" architecture
     dummy_command.ensure_thin_binary(
-        tmp_path / "path" / "to" / "file.dylib",
+        tmp_path / "path/to/file.dylib",
         arch="gothic",
     )
 
@@ -79,7 +79,7 @@ def test_fat_dylib(dummy_command, verbose, tmp_path, capsys):
         [
             "lipo",
             "-info",
-            tmp_path / "path" / "to" / "file.dylib",
+            tmp_path / "path/to/file.dylib",
         ],
     )
 
@@ -90,14 +90,14 @@ def test_fat_dylib(dummy_command, verbose, tmp_path, capsys):
             "-thin",
             "gothic",
             "-output",
-            tmp_path / "path" / "to" / "file.dylib.gothic",
-            tmp_path / "path" / "to" / "file.dylib",
+            tmp_path / "path/to/file.dylib.gothic",
+            tmp_path / "path/to/file.dylib",
         ],
         check=True,
     )
 
     # The original file now has the thinned content.
-    assert file_content(tmp_path / "path" / "to" / "file.dylib") == "dylib-thin"
+    assert file_content(tmp_path / "path/to/file.dylib") == "dylib-thin"
 
     # Output only happens if in debug mode
     output = capsys.readouterr().out.split("\n")
@@ -111,7 +111,7 @@ def test_fat_dylib_arch_mismatch(dummy_command, verbose, tmp_path, capsys):
         dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
-    create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
+    create_file(tmp_path / "path/to/file.dylib", "dylib-fat")
 
     # Mock the result of the "lipo info" call.
     dummy_command.tools.subprocess.check_output.return_value = (
@@ -124,7 +124,7 @@ def test_fat_dylib_arch_mismatch(dummy_command, verbose, tmp_path, capsys):
         match=r"file\.dylib does not contain a gothic slice",
     ):
         dummy_command.ensure_thin_binary(
-            tmp_path / "path" / "to" / "file.dylib",
+            tmp_path / "path/to/file.dylib",
             arch="gothic",
         )
 
@@ -133,7 +133,7 @@ def test_fat_dylib_arch_mismatch(dummy_command, verbose, tmp_path, capsys):
         [
             "lipo",
             "-info",
-            tmp_path / "path" / "to" / "file.dylib",
+            tmp_path / "path/to/file.dylib",
         ],
     )
 
@@ -149,7 +149,7 @@ def test_fat_dylib_unknown_info(dummy_command, verbose, tmp_path, capsys):
         dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
-    create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
+    create_file(tmp_path / "path/to/file.dylib", "dylib-fat")
 
     # Mock the result of the "lipo info" call.
     dummy_command.tools.subprocess.check_output.return_value = (
@@ -162,7 +162,7 @@ def test_fat_dylib_unknown_info(dummy_command, verbose, tmp_path, capsys):
         match=r"Unable to determine architectures in .*file\.dylib",
     ):
         dummy_command.ensure_thin_binary(
-            tmp_path / "path" / "to" / "file.dylib",
+            tmp_path / "path/to/file.dylib",
             arch="gothic",
         )
 
@@ -171,7 +171,7 @@ def test_fat_dylib_unknown_info(dummy_command, verbose, tmp_path, capsys):
         [
             "lipo",
             "-info",
-            tmp_path / "path" / "to" / "file.dylib",
+            tmp_path / "path/to/file.dylib",
         ],
     )
 
@@ -182,7 +182,7 @@ def test_fat_dylib_unknown_info(dummy_command, verbose, tmp_path, capsys):
 def test_lipo_info_fail(dummy_command, tmp_path):
     """If lipo can't inspect a binary, an error is raised."""
     # Create a source binary.
-    create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
+    create_file(tmp_path / "path/to/file.dylib", "dylib-fat")
 
     # Mock the result of the "lipo info" call.
     dummy_command.tools.subprocess.check_output.side_effect = (
@@ -194,7 +194,7 @@ def test_lipo_info_fail(dummy_command, tmp_path):
         BriefcaseCommandError, match=r"Unable to inspect architectures in .*file\.dylib"
     ):
         dummy_command.ensure_thin_binary(
-            tmp_path / "path" / "to" / "file.dylib",
+            tmp_path / "path/to/file.dylib",
             arch="gothic",
         )
 
@@ -203,7 +203,7 @@ def test_lipo_info_fail(dummy_command, tmp_path):
         [
             "lipo",
             "-info",
-            tmp_path / "path" / "to" / "file.dylib",
+            tmp_path / "path/to/file.dylib",
         ],
     )
 
@@ -218,7 +218,7 @@ def test_lipo_thin_fail(dummy_command, verbose, tmp_path, capsys):
         dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
-    create_file(tmp_path / "path" / "to" / "file.dylib", "dylib-fat")
+    create_file(tmp_path / "path/to/file.dylib", "dylib-fat")
 
     # Mock the result of the "lipo -info" call.
     dummy_command.tools.subprocess.check_output.return_value = (
@@ -236,7 +236,7 @@ def test_lipo_thin_fail(dummy_command, verbose, tmp_path, capsys):
         match=r"Unable to create thin binary from .*file.dylib",
     ):
         dummy_command.ensure_thin_binary(
-            tmp_path / "path" / "to" / "file.dylib",
+            tmp_path / "path/to/file.dylib",
             arch="gothic",
         )
 
@@ -245,7 +245,7 @@ def test_lipo_thin_fail(dummy_command, verbose, tmp_path, capsys):
         [
             "lipo",
             "-info",
-            tmp_path / "path" / "to" / "file.dylib",
+            tmp_path / "path/to/file.dylib",
         ],
     )
 
@@ -256,14 +256,14 @@ def test_lipo_thin_fail(dummy_command, verbose, tmp_path, capsys):
             "-thin",
             "gothic",
             "-output",
-            tmp_path / "path" / "to" / "file.dylib.gothic",
-            tmp_path / "path" / "to" / "file.dylib",
+            tmp_path / "path/to/file.dylib.gothic",
+            tmp_path / "path/to/file.dylib",
         ],
         check=True,
     )
 
     # The original file is unmodified.
-    assert file_content(tmp_path / "path" / "to" / "file.dylib") == "dylib-fat"
+    assert file_content(tmp_path / "path/to/file.dylib") == "dylib-fat"
 
     # Output only happens if in debug mode
     output = capsys.readouterr().out.split("\n")

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__lipo_dylib.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__lipo_dylib.py
@@ -16,13 +16,13 @@ def test_lipo_dylib(dummy_command, verbose, tmp_path, capsys):
         dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create 3 source binaries.
-    create_file(tmp_path / "source-1" / "path" / "to" / "file.dylib", "dylib-1")
-    create_file(tmp_path / "source-2" / "path" / "to" / "file.dylib", "dylib-2")
-    create_file(tmp_path / "source-3" / "path" / "to" / "file.dylib", "dylib-3")
+    create_file(tmp_path / "source-1/path/to/file.dylib", "dylib-1")
+    create_file(tmp_path / "source-2/path/to/file.dylib", "dylib-2")
+    create_file(tmp_path / "source-3/path/to/file.dylib", "dylib-3")
 
     # Merge the libraries
     dummy_command.lipo_dylib(
-        Path("path") / "to" / "file.dylib",
+        Path("path/to/file.dylib"),
         tmp_path / "target",
         [
             tmp_path / "source-1",
@@ -37,16 +37,16 @@ def test_lipo_dylib(dummy_command, verbose, tmp_path, capsys):
             "lipo",
             "-create",
             "-output",
-            tmp_path / "target" / "path" / "to" / "file.dylib",
-            tmp_path / "source-1" / "path" / "to" / "file.dylib",
-            tmp_path / "source-2" / "path" / "to" / "file.dylib",
-            tmp_path / "source-3" / "path" / "to" / "file.dylib",
+            tmp_path / "target/path/to/file.dylib",
+            tmp_path / "source-1/path/to/file.dylib",
+            tmp_path / "source-2/path/to/file.dylib",
+            tmp_path / "source-3/path/to/file.dylib",
         ],
         check=True,
     )
 
     # The target directory exists.
-    assert (tmp_path / "target" / "path" / "to").is_dir()
+    assert (tmp_path / "target/path/to").is_dir()
 
     # Output only happens if in debug mode
     output = capsys.readouterr().out.split("\n")
@@ -60,12 +60,12 @@ def test_lipo_dylib_partial(dummy_command, verbose, tmp_path, capsys):
         dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create 2 source binaries. Source-2 doesn't have the binary.
-    create_file(tmp_path / "source-1" / "path" / "to" / "file.dylib", "dylib-1")
-    create_file(tmp_path / "source-3" / "path" / "to" / "file.dylib", "dylib-3")
+    create_file(tmp_path / "source-1/path/to/file.dylib", "dylib-1")
+    create_file(tmp_path / "source-3/path/to/file.dylib", "dylib-3")
 
     # Merge the libraries
     dummy_command.lipo_dylib(
-        Path("path") / "to" / "file.dylib",
+        Path("path/to/file.dylib"),
         tmp_path / "target",
         [
             tmp_path / "source-1",
@@ -79,15 +79,15 @@ def test_lipo_dylib_partial(dummy_command, verbose, tmp_path, capsys):
             "lipo",
             "-create",
             "-output",
-            tmp_path / "target" / "path" / "to" / "file.dylib",
-            tmp_path / "source-1" / "path" / "to" / "file.dylib",
-            tmp_path / "source-3" / "path" / "to" / "file.dylib",
+            tmp_path / "target/path/to/file.dylib",
+            tmp_path / "source-1/path/to/file.dylib",
+            tmp_path / "source-3/path/to/file.dylib",
         ],
         check=True,
     )
 
     # The target directory exists.
-    assert (tmp_path / "target" / "path" / "to").is_dir()
+    assert (tmp_path / "target/path/to").is_dir()
 
     # Output only happens if in debug mode
     output = capsys.readouterr().out.split("\n")
@@ -101,9 +101,9 @@ def test_lipo_dylib_merge_error(dummy_command, verbose, tmp_path, capsys):
         dummy_command.logger.verbosity = LogLevel.VERBOSE
 
     # Create 3 source binaries.
-    create_file(tmp_path / "source-1" / "path" / "to" / "file.dylib", "dylib-1")
-    create_file(tmp_path / "source-2" / "path" / "to" / "file.dylib", "dylib-2")
-    create_file(tmp_path / "source-3" / "path" / "to" / "file.dylib", "dylib-3")
+    create_file(tmp_path / "source-1/path/to/file.dylib", "dylib-1")
+    create_file(tmp_path / "source-2/path/to/file.dylib", "dylib-2")
+    create_file(tmp_path / "source-3/path/to/file.dylib", "dylib-3")
 
     # lipo raises an exception.
     dummy_command.tools.subprocess.run.side_effect = subprocess.CalledProcessError(
@@ -116,7 +116,7 @@ def test_lipo_dylib_merge_error(dummy_command, verbose, tmp_path, capsys):
         match=r"Unable to create fat library for path[/\\]to[/\\]file\.dylib",
     ):
         dummy_command.lipo_dylib(
-            Path("path") / "to" / "file.dylib",
+            Path("path/to/file.dylib"),
             tmp_path / "target",
             [
                 tmp_path / "source-1",
@@ -131,16 +131,16 @@ def test_lipo_dylib_merge_error(dummy_command, verbose, tmp_path, capsys):
             "lipo",
             "-create",
             "-output",
-            tmp_path / "target" / "path" / "to" / "file.dylib",
-            tmp_path / "source-1" / "path" / "to" / "file.dylib",
-            tmp_path / "source-2" / "path" / "to" / "file.dylib",
-            tmp_path / "source-3" / "path" / "to" / "file.dylib",
+            tmp_path / "target/path/to/file.dylib",
+            tmp_path / "source-1/path/to/file.dylib",
+            tmp_path / "source-2/path/to/file.dylib",
+            tmp_path / "source-3/path/to/file.dylib",
         ],
         check=True,
     )
 
     # The target directory exists.
-    assert (tmp_path / "target" / "path" / "to").is_dir()
+    assert (tmp_path / "target/path/to").is_dir()
 
     # Output only happens if in debug mode
     output = capsys.readouterr().out.split("\n")

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__merge_app_packages.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__merge_app_packages.py
@@ -154,7 +154,7 @@ def test_merge(dummy_command, pre_existing, tmp_path):
     }
 
     # Check that the embedded binary has executable permissions
-    assert os.access(merged_path / "second" / "some-binary", os.X_OK)
+    assert os.access(merged_path / "second/some-binary", os.X_OK)
 
 
 def test_merge_problem(dummy_command, tmp_path):

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__thin_app_packages.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__thin_app_packages.py
@@ -40,9 +40,9 @@ def test_thin_app_packages(dummy_command, tmp_path):
     dummy_command.thin_app_packages(app_packages, arch="gothic")
 
     # All libraries have been thinned
-    assert file_content(app_packages / "pkg" / "sub1" / "module1.dylib") == "dylib-thin"
-    assert file_content(app_packages / "pkg" / "sub1" / "module2.so") == "dylib-thin"
-    assert file_content(app_packages / "pkg" / "sub2" / "module3.dylib") == "dylib-thin"
+    assert file_content(app_packages / "pkg/sub1/module1.dylib") == "dylib-thin"
+    assert file_content(app_packages / "pkg/sub1/module2.so") == "dylib-thin"
+    assert file_content(app_packages / "pkg/sub2/module3.dylib") == "dylib-thin"
 
 
 def test_thin_app_packages_problem(dummy_command, tmp_path):

--- a/tests/platforms/macOS/xcode/conftest.py
+++ b/tests/platforms/macOS/xcode/conftest.py
@@ -7,7 +7,7 @@ from ....utils import create_file, create_plist_file
 def first_app_generated(first_app_config, tmp_path):
     # Create the briefcase.toml file
     create_file(
-        tmp_path / "base_path" / "macos" / "xcode" / "First App" / "briefcase.toml",
+        tmp_path / "base_path/macos/xcode/First App/briefcase.toml",
         """
 [paths]
 app_packages_path="app_packages"
@@ -17,7 +17,7 @@ info_plist_path="Info.plist"
     )
 
     create_plist_file(
-        tmp_path / "base_path" / "macos" / "xcode" / "First App" / "Info.plist",
+        tmp_path / "base_path/macos/xcode/First App/Info.plist",
         {
             "MainModule": "first_app",
         },

--- a/tests/platforms/macOS/xcode/test_run.py
+++ b/tests/platforms/macOS/xcode/test_run.py
@@ -52,7 +52,7 @@ def test_run_app(run_command, first_app_config, sleep_zero, tmp_path, monkeypatc
 
     # Calls were made to start the app and to start a log stream.
     bin_path = run_command.binary_path(first_app_config)
-    sender = bin_path / "Contents" / "MacOS" / "First App"
+    sender = bin_path / "Contents/MacOS/First App"
     run_command.tools.subprocess.Popen.assert_called_with(
         [
             "log",
@@ -115,7 +115,7 @@ def test_run_app_with_passthrough(
 
     # Calls were made to start the app and to start a log stream.
     bin_path = run_command.binary_path(first_app_config)
-    sender = bin_path / "Contents" / "MacOS" / "First App"
+    sender = bin_path / "Contents/MacOS/First App"
     run_command.tools.subprocess.Popen.assert_called_with(
         [
             "log",
@@ -173,7 +173,7 @@ def test_run_app_test_mode(
 
     # Calls were made to start the app and to start a log stream.
     bin_path = run_command.binary_path(first_app_config)
-    sender = bin_path / "Contents" / "MacOS" / "First App"
+    sender = bin_path / "Contents/MacOS/First App"
     run_command.tools.subprocess.Popen.assert_called_with(
         [
             "log",
@@ -237,7 +237,7 @@ def test_run_app_test_mode_with_passthrough(
 
     # Calls were made to start the app and to start a log stream.
     bin_path = run_command.binary_path(first_app_config)
-    sender = bin_path / "Contents" / "MacOS" / "First App"
+    sender = bin_path / "Contents/MacOS/First App"
     run_command.tools.subprocess.Popen.assert_called_with(
         [
             "log",

--- a/tests/platforms/web/static/conftest.py
+++ b/tests/platforms/web/static/conftest.py
@@ -6,7 +6,7 @@ from ....utils import create_file, create_wheel
 @pytest.fixture
 def first_app_generated(first_app_config, tmp_path):
     # Create the briefcase.toml file
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "web" / "static"
+    bundle_path = tmp_path / "base_path/build/first-app/web/static"
     create_file(
         bundle_path / "briefcase.toml",
         """
@@ -17,11 +17,11 @@ app_requirements_path="requirements.txt"
     )
 
     # Create index.html
-    create_file(bundle_path / "www" / "index.html", "<html></html>")
+    create_file(bundle_path / "www/index.html", "<html></html>")
 
     # Create the initial briefcase.css
     create_file(
-        bundle_path / "www" / "static" / "css" / "briefcase.css",
+        bundle_path / "www/static/css/briefcase.css",
         """
 #pyconsole {
   display: None;
@@ -32,22 +32,22 @@ app_requirements_path="requirements.txt"
     )
 
     # Create an empty wheels folder
-    (bundle_path / "www" / "static" / "wheels").mkdir(parents=True)
+    (bundle_path / "www/static/wheels").mkdir(parents=True)
 
     return first_app_config
 
 
 @pytest.fixture
 def first_app_built(first_app_generated, tmp_path):
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "web" / "static"
+    bundle_path = tmp_path / "base_path/build/first-app/web/static"
 
     # Create pyscript.toml
     create_file(
-        bundle_path / "www" / "pyscript.toml",
+        bundle_path / "www/pyscript.toml",
         'packages = ["dummy-1.2.3-py3-none-all.whl"]',
     )
 
     # Create an app wheel
-    create_wheel(bundle_path / "www" / "static" / "wheels")
+    create_wheel(bundle_path / "www/static/wheels")
 
     return first_app_generated

--- a/tests/platforms/web/static/test_build.py
+++ b/tests/platforms/web/static/test_build.py
@@ -34,13 +34,13 @@ def build_command(tmp_path):
 
 def test_build_app(build_command, first_app_generated, tmp_path):
     """An app can be built."""
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "web" / "static"
+    bundle_path = tmp_path / "base_path/build/first-app/web/static"
 
     # Invoking build will create wheels as a side effect.
     def mock_run(*args, **kwargs):
         if args[0][5] == "wheel":
             create_wheel(
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
                 "first_app",
                 extra_content=[
                     ("dependency/static/style.css", "span { margin: 10px; }\n"),
@@ -48,14 +48,14 @@ def test_build_app(build_command, first_app_generated, tmp_path):
             ),
         elif args[0][5] == "pip":
             create_wheel(
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
                 "dependency",
                 extra_content=[
                     ("dependency/static/style.css", "div { margin: 10px; }\n"),
                 ],
             ),
             create_wheel(
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
                 "other",
                 extra_content=[
                     ("other/static/style.css", "div { padding: 10px; }\n"),
@@ -68,7 +68,7 @@ def test_build_app(build_command, first_app_generated, tmp_path):
 
     # Mock the side effect of invoking shutil
     build_command.tools.shutil.rmtree.side_effect = lambda *args: shutil.rmtree(
-        bundle_path / "www" / "static" / "wheels"
+        bundle_path / "www/static/wheels"
     )
 
     # Build the web app.
@@ -76,7 +76,7 @@ def test_build_app(build_command, first_app_generated, tmp_path):
 
     # The old wheel folder was removed
     build_command.tools.shutil.rmtree.assert_called_once_with(
-        bundle_path / "www" / "static" / "wheels"
+        bundle_path / "www/static/wheels"
     )
 
     # `wheel pack` and `pip wheel` was invoked
@@ -92,7 +92,7 @@ def test_build_app(build_command, first_app_generated, tmp_path):
                 "pack",
                 bundle_path / "app",
                 "--dest-dir",
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
             ],
             check=True,
             encoding="UTF-8",
@@ -107,7 +107,7 @@ def test_build_app(build_command, first_app_generated, tmp_path):
                 "pip",
                 "wheel",
                 "--wheel-dir",
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
                 "-r",
                 bundle_path / "requirements.txt",
             ],
@@ -117,7 +117,7 @@ def test_build_app(build_command, first_app_generated, tmp_path):
     ]
 
     # Pyscript.toml has been written
-    with (bundle_path / "www" / "pyscript.toml").open("rb") as f:
+    with (bundle_path / "www/pyscript.toml").open("rb") as f:
         assert tomllib.load(f) == {
             "name": "First App",
             "description": "The first simple app \\ demonstration",
@@ -132,9 +132,7 @@ def test_build_app(build_command, first_app_generated, tmp_path):
         }
 
     # briefcase.css has been appended
-    with (bundle_path / "www" / "static" / "css" / "briefcase.css").open(
-        encoding="utf-8"
-    ) as f:
+    with (bundle_path / "www/static/css/briefcase.css").open(encoding="utf-8") as f:
         assert (
             f.read()
             == "\n".join(
@@ -171,7 +169,7 @@ def test_build_app(build_command, first_app_generated, tmp_path):
 
 def test_build_app_custom_pyscript_toml(build_command, first_app_generated, tmp_path):
     """An app with extra pyscript.toml content can be written."""
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "web" / "static"
+    bundle_path = tmp_path / "base_path/build/first-app/web/static"
 
     first_app_generated.extra_pyscript_toml_content = (
         "\n".join(
@@ -193,14 +191,14 @@ def test_build_app_custom_pyscript_toml(build_command, first_app_generated, tmp_
 
     # Mock the side effect of invoking shutil
     build_command.tools.shutil.rmtree.side_effect = lambda *args: shutil.rmtree(
-        bundle_path / "www" / "static" / "wheels"
+        bundle_path / "www/static/wheels"
     )
 
     # Build the web app.
     build_command.build_app(first_app_generated)
 
     # Pyscript.toml has been written
-    with (bundle_path / "www" / "pyscript.toml").open("rb") as f:
+    with (bundle_path / "www/pyscript.toml").open("rb") as f:
         assert tomllib.load(f) == {
             "name": "First App",
             "description": "The first simple app \\ demonstration",
@@ -219,13 +217,13 @@ def test_build_app_invalid_custom_pyscript_toml(
     build_command, first_app_generated, tmp_path
 ):
     """An app with invalid extra pyscript.toml content raises an error."""
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "web" / "static"
+    bundle_path = tmp_path / "base_path/build/first-app/web/static"
 
     first_app_generated.extra_pyscript_toml_content = "This isn't toml"
 
     # Mock the side effect of invoking shutil
     build_command.tools.shutil.rmtree.side_effect = lambda *args: shutil.rmtree(
-        bundle_path / "www" / "static" / "wheels"
+        bundle_path / "www/static/wheels"
     )
 
     # Building the web app raises an error
@@ -238,10 +236,10 @@ def test_build_app_invalid_custom_pyscript_toml(
 
 def test_build_app_missing_wheel_dir(build_command, first_app_generated, tmp_path):
     """If the template is corrupted, the wheels folder is still created."""
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "web" / "static"
+    bundle_path = tmp_path / "base_path/build/first-app/web/static"
 
     # Remove the wheels folder
-    shutil.rmtree(bundle_path / "www" / "static" / "wheels")
+    shutil.rmtree(bundle_path / "www/static/wheels")
 
     # Build the web app.
     build_command.build_app(first_app_generated)
@@ -262,7 +260,7 @@ def test_build_app_missing_wheel_dir(build_command, first_app_generated, tmp_pat
                 "pack",
                 bundle_path / "app",
                 "--dest-dir",
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
             ],
             check=True,
             encoding="UTF-8",
@@ -277,7 +275,7 @@ def test_build_app_missing_wheel_dir(build_command, first_app_generated, tmp_pat
                 "pip",
                 "wheel",
                 "--wheel-dir",
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
                 "-r",
                 bundle_path / "requirements.txt",
             ],
@@ -287,25 +285,25 @@ def test_build_app_missing_wheel_dir(build_command, first_app_generated, tmp_pat
     ]
 
     # Wheels folder exists
-    assert (bundle_path / "www" / "static" / "wheels").is_dir()
+    assert (bundle_path / "www/static/wheels").is_dir()
 
     # Pyscript.toml has been written
-    assert (bundle_path / "www" / "pyscript.toml").exists()
+    assert (bundle_path / "www/pyscript.toml").exists()
 
     # briefcase.css has been appended
     # (just check for existence; a full check is done in other tests)
-    assert (bundle_path / "www" / "static" / "css" / "briefcase.css").exists()
+    assert (bundle_path / "www/static/css/briefcase.css").exists()
 
 
 def test_build_app_no_requirements(build_command, first_app_generated, tmp_path):
     """An app with no requirements can be built."""
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "web" / "static"
+    bundle_path = tmp_path / "base_path/build/first-app/web/static"
 
     # Invoking build will create wheels as a side effect.
     def mock_run(*args, **kwargs):
         if args[0][5] == "wheel":
             create_wheel(
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
                 "first_app",
                 extra_content=[
                     ("dependency/static/style.css", "span { margin: 10px; }\n"),
@@ -320,7 +318,7 @@ def test_build_app_no_requirements(build_command, first_app_generated, tmp_path)
 
     # Mock the side effect of invoking shutil
     build_command.tools.shutil.rmtree.side_effect = lambda *args: shutil.rmtree(
-        bundle_path / "www" / "static" / "wheels"
+        bundle_path / "www/static/wheels"
     )
 
     # Build the web app.
@@ -328,7 +326,7 @@ def test_build_app_no_requirements(build_command, first_app_generated, tmp_path)
 
     # The old wheel folder was removed
     build_command.tools.shutil.rmtree.assert_called_once_with(
-        bundle_path / "www" / "static" / "wheels"
+        bundle_path / "www/static/wheels"
     )
 
     # `wheel pack` and `pip wheel` was invoked
@@ -344,7 +342,7 @@ def test_build_app_no_requirements(build_command, first_app_generated, tmp_path)
                 "pack",
                 bundle_path / "app",
                 "--dest-dir",
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
             ],
             check=True,
             encoding="UTF-8",
@@ -359,7 +357,7 @@ def test_build_app_no_requirements(build_command, first_app_generated, tmp_path)
                 "pip",
                 "wheel",
                 "--wheel-dir",
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
                 "-r",
                 bundle_path / "requirements.txt",
             ],
@@ -369,7 +367,7 @@ def test_build_app_no_requirements(build_command, first_app_generated, tmp_path)
     ]
 
     # Pyscript.toml has been written
-    with (bundle_path / "www" / "pyscript.toml").open("rb") as f:
+    with (bundle_path / "www/pyscript.toml").open("rb") as f:
         assert tomllib.load(f) == {
             "name": "First App",
             "description": "The first simple app \\ demonstration",
@@ -382,9 +380,7 @@ def test_build_app_no_requirements(build_command, first_app_generated, tmp_path)
         }
 
     # briefcase.css has been appended
-    with (bundle_path / "www" / "static" / "css" / "briefcase.css").open(
-        encoding="utf-8"
-    ) as f:
+    with (bundle_path / "www/static/css/briefcase.css").open(encoding="utf-8") as f:
         assert (
             f.read()
             == "\n".join(
@@ -409,11 +405,11 @@ def test_build_app_no_requirements(build_command, first_app_generated, tmp_path)
 
 def test_app_package_fail(build_command, first_app_generated, tmp_path):
     """If the app can't be packaged as a wheel,an error is raised."""
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "web" / "static"
+    bundle_path = tmp_path / "base_path/build/first-app/web/static"
 
     # Mock the side effect of invoking shutil
     build_command.tools.shutil.rmtree.side_effect = lambda *args: shutil.rmtree(
-        bundle_path / "www" / "static" / "wheels"
+        bundle_path / "www/static/wheels"
     )
 
     # Mock the side effect of a successful package build, but failure
@@ -431,7 +427,7 @@ def test_app_package_fail(build_command, first_app_generated, tmp_path):
 
     # The old wheel folder was removed
     build_command.tools.shutil.rmtree.assert_called_once_with(
-        bundle_path / "www" / "static" / "wheels"
+        bundle_path / "www/static/wheels"
     )
 
     # `wheel pack` was invoked
@@ -447,7 +443,7 @@ def test_app_package_fail(build_command, first_app_generated, tmp_path):
                 "pack",
                 bundle_path / "app",
                 "--dest-dir",
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
             ],
             check=True,
             encoding="UTF-8",
@@ -455,19 +451,19 @@ def test_app_package_fail(build_command, first_app_generated, tmp_path):
     ]
 
     # Wheels folder still exists
-    assert (bundle_path / "www" / "static" / "wheels").is_dir()
+    assert (bundle_path / "www/static/wheels").is_dir()
 
     # Pyscript.toml was not written
-    assert not (bundle_path / "www" / "pyscript.toml").exists()
+    assert not (bundle_path / "www/pyscript.toml").exists()
 
 
 def test_dependency_fail(build_command, first_app_generated, tmp_path):
     """If dependencies can't be downloaded, an error is raised."""
-    bundle_path = tmp_path / "base_path" / "build" / "first-app" / "web" / "static"
+    bundle_path = tmp_path / "base_path/build/first-app/web/static"
 
     # Mock the side effect of invoking shutil
     build_command.tools.shutil.rmtree.side_effect = lambda *args: shutil.rmtree(
-        bundle_path / "www" / "static" / "wheels"
+        bundle_path / "www/static/wheels"
     )
 
     # Mock the side effect of a successful package build, but failure
@@ -486,7 +482,7 @@ def test_dependency_fail(build_command, first_app_generated, tmp_path):
 
     # The old wheel folder was removed
     build_command.tools.shutil.rmtree.assert_called_once_with(
-        bundle_path / "www" / "static" / "wheels"
+        bundle_path / "www/static/wheels"
     )
 
     # `wheel pack` and `pip wheel` was invoked
@@ -502,7 +498,7 @@ def test_dependency_fail(build_command, first_app_generated, tmp_path):
                 "pack",
                 bundle_path / "app",
                 "--dest-dir",
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
             ],
             check=True,
             encoding="UTF-8",
@@ -517,7 +513,7 @@ def test_dependency_fail(build_command, first_app_generated, tmp_path):
                 "pip",
                 "wheel",
                 "--wheel-dir",
-                bundle_path / "www" / "static" / "wheels",
+                bundle_path / "www/static/wheels",
                 "-r",
                 bundle_path / "requirements.txt",
             ],
@@ -527,7 +523,7 @@ def test_dependency_fail(build_command, first_app_generated, tmp_path):
     ]
 
     # Wheels folder still exists
-    assert (bundle_path / "www" / "static" / "wheels").is_dir()
+    assert (bundle_path / "www/static/wheels").is_dir()
 
     # Pyscript.toml was not written
-    assert not (bundle_path / "www" / "pyscript.toml").exists()
+    assert not (bundle_path / "www/pyscript.toml").exists()

--- a/tests/platforms/web/static/test_mixin.py
+++ b/tests/platforms/web/static/test_mixin.py
@@ -17,9 +17,7 @@ def create_command(tmp_path):
 def test_project_path(create_command, first_app_config, tmp_path):
     project_path = create_command.project_path(first_app_config)
 
-    assert project_path == (
-        tmp_path / "base_path" / "build" / "first-app" / "web" / "static" / "www"
-    )
+    assert project_path == (tmp_path / "base_path/build/first-app/web/static/www")
 
 
 def test_binary_path(create_command, first_app_config, tmp_path):
@@ -56,6 +54,4 @@ def test_wheel_path(create_command, first_app_config, tmp_path):
 def test_distribution_path(create_command, first_app_config, tmp_path):
     distribution_path = create_command.distribution_path(first_app_config)
 
-    assert distribution_path == (
-        tmp_path / "base_path" / "dist" / "First App-0.0.1.web.zip"
-    )
+    assert distribution_path == (tmp_path / "base_path/dist/First App-0.0.1.web.zip")

--- a/tests/platforms/web/static/test_package.py
+++ b/tests/platforms/web/static/test_package.py
@@ -33,7 +33,7 @@ def test_package_app(package_command, first_app_built, tmp_path):
 
     # The packaged archive exists, and contains all the www files,
     # but without the www prefix.
-    archive_file = tmp_path / "base_path" / "dist" / "First App-0.0.1.web.zip"
+    archive_file = tmp_path / "base_path/dist/First App-0.0.1.web.zip"
     assert archive_file.exists()
     with ZipFile(archive_file) as archive:
         assert sorted(archive.namelist()) == [

--- a/tests/platforms/web/static/test_run.py
+++ b/tests/platforms/web/static/test_run.py
@@ -447,7 +447,7 @@ def test_served_paths(monkeypatch, tmp_path):
     # Invoke this as a static method because we don't want to
     # instantiate a full server just to verify that URL rewriting works.
     assert handler.translate_path("/static/css/briefcase.css") == str(
-        tmp_path / "base_path" / "static" / "css" / "briefcase.css"
+        tmp_path / "base_path/static/css/briefcase.css"
     )
 
 

--- a/tests/platforms/windows/app/test_build.py
+++ b/tests/platforms/windows/app/test_build.py
@@ -102,7 +102,7 @@ def test_build_app_without_windows_sdk(build_command, first_app_config, tmp_path
     # update the app binary resources
     build_command.tools.subprocess.run.assert_called_once_with(
         [
-            tmp_path / "briefcase" / "tools" / "rcedit-x64.exe",
+            tmp_path / "briefcase/tools/rcedit-x64.exe",
             Path("src/First App.exe"),
             "--set-version-string",
             "CompanyName",
@@ -129,7 +129,7 @@ def test_build_app_without_windows_sdk(build_command, first_app_config, tmp_path
             "icon.ico",
         ],
         check=True,
-        cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+        cwd=tmp_path / "base_path/build/first-app/windows/app",
     )
 
 
@@ -147,17 +147,17 @@ def test_build_app_with_windows_sdk(
     # remove any digital signatures on the app binary
     build_command.tools.subprocess.check_output.assert_called_once_with(
         [
-            tmp_path / "win_sdk" / "bin" / "86.1.1" / "x64" / "signtool.exe",
+            tmp_path / "win_sdk/bin/86.1.1/x64/signtool.exe",
             "remove",
             "-s",
             Path("src/First App.exe"),
         ],
-        cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+        cwd=tmp_path / "base_path/build/first-app/windows/app",
     )
     # update the app binary resources
     build_command.tools.subprocess.run.assert_called_once_with(
         [
-            tmp_path / "briefcase" / "tools" / "rcedit-x64.exe",
+            tmp_path / "briefcase/tools/rcedit-x64.exe",
             Path("src/First App.exe"),
             "--set-version-string",
             "CompanyName",
@@ -184,7 +184,7 @@ def test_build_app_with_windows_sdk(
             "icon.ico",
         ],
         check=True,
-        cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+        cwd=tmp_path / "base_path/build/first-app/windows/app",
     )
 
 
@@ -213,17 +213,17 @@ def test_build_app_without_any_digital_signatures(
     # remove any digital signatures on the app binary
     build_command.tools.subprocess.check_output.assert_called_once_with(
         [
-            tmp_path / "win_sdk" / "bin" / "86.1.1" / "x64" / "signtool.exe",
+            tmp_path / "win_sdk/bin/86.1.1/x64/signtool.exe",
             "remove",
             "-s",
             Path("src/First App.exe"),
         ],
-        cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+        cwd=tmp_path / "base_path/build/first-app/windows/app",
     )
     # update the app binary resources
     build_command.tools.subprocess.run.assert_called_once_with(
         [
-            tmp_path / "briefcase" / "tools" / "rcedit-x64.exe",
+            tmp_path / "briefcase/tools/rcedit-x64.exe",
             Path("src/First App.exe"),
             "--set-version-string",
             "CompanyName",
@@ -250,7 +250,7 @@ def test_build_app_without_any_digital_signatures(
             "icon.ico",
         ],
         check=True,
-        cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+        cwd=tmp_path / "base_path/build/first-app/windows/app",
     )
 
 
@@ -287,12 +287,12 @@ def test_build_app_error_remove_signature(
     # remove any digital signatures on the app binary
     build_command.tools.subprocess.check_output.assert_called_once_with(
         [
-            tmp_path / "win_sdk" / "bin" / "86.1.1" / "x64" / "signtool.exe",
+            tmp_path / "win_sdk/bin/86.1.1/x64/signtool.exe",
             "remove",
             "-s",
             Path("src/First App.exe"),
         ],
-        cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+        cwd=tmp_path / "base_path/build/first-app/windows/app",
     )
     # update the app binary resources not called
     build_command.tools.subprocess.run.assert_not_called()
@@ -334,7 +334,7 @@ def test_build_app_with_support_package_update(
 
     # Fake the existence of some source files.
     create_file(
-        tmp_path / "base_path" / "src" / "first_app" / "app.py",
+        tmp_path / "base_path/src/first_app/app.py",
         "print('an app')",
     )
 
@@ -360,7 +360,7 @@ def test_build_app_with_support_package_update(
     # update the app binary resources
     build_command.tools.subprocess.run.assert_called_once_with(
         [
-            tmp_path / "briefcase" / "tools" / "rcedit-x64.exe",
+            tmp_path / "briefcase/tools/rcedit-x64.exe",
             Path("src/First App.exe"),
             "--set-version-string",
             "CompanyName",
@@ -387,7 +387,7 @@ def test_build_app_with_support_package_update(
             "icon.ico",
         ],
         check=True,
-        cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+        cwd=tmp_path / "base_path/build/first-app/windows/app",
     )
 
     # No attempt was made to clean up the support package.

--- a/tests/platforms/windows/app/test_mixin.py
+++ b/tests/platforms/windows/app/test_mixin.py
@@ -35,12 +35,12 @@ def test_project_path(create_command, first_app_config, tmp_path):
     project_path = create_command.project_path(first_app_config)
     bundle_path = create_command.bundle_path(first_app_config)
 
-    expected_path = tmp_path / "base_path" / "build" / "first-app" / "windows" / "app"
+    expected_path = tmp_path / "base_path/build/first-app/windows/app"
     assert expected_path == project_path == bundle_path
 
 
 def test_distribution_path(create_command, first_app_config, tmp_path):
     distribution_path = create_command.distribution_path(first_app_config)
 
-    expected_path = tmp_path / "base_path" / "dist" / "First App-0.0.1.msi"
+    expected_path = tmp_path / "base_path/dist/First App-0.0.1.msi"
     assert distribution_path == expected_path

--- a/tests/platforms/windows/app/test_open.py
+++ b/tests/platforms/windows/app/test_open.py
@@ -31,5 +31,5 @@ def test_open_windows(open_command, first_app_config, tmp_path):
     open_command(first_app_config)
 
     open_command.tools.os.startfile.assert_called_once_with(
-        tmp_path / "base_path" / "build" / "first-app" / "windows" / "app"
+        tmp_path / "base_path/build/first-app/windows/app"
     )

--- a/tests/platforms/windows/app/test_package.py
+++ b/tests/platforms/windows/app/test_package.py
@@ -38,10 +38,8 @@ def package_command(tmp_path):
 @pytest.fixture
 def package_command_with_files(package_command, tmp_path):
     # Build the paths for the source and the distribution folders:
-    src_path = (
-        tmp_path / "base_path" / "build" / "first-app" / "windows" / "app" / "src"
-    )
-    dist_path = tmp_path / "base_path" / "dist"
+    src_path = tmp_path / "base_path/build/first-app/windows/app/src"
+    dist_path = tmp_path / "base_path/dist"
     src_path.mkdir(parents=True)
     dist_path.mkdir(parents=True)
 
@@ -51,11 +49,11 @@ def package_command_with_files(package_command, tmp_path):
         src_path / "python.exe",
         src_path / "python3.dll",
         src_path / "vcruntime140.dll",
-        src_path / "app/first-app" / "app.py",
-        src_path / "app/first-app" / "resources" / "__init__.py",
-        src_path / "app/first-app-0.0.1.dist-info" / "top_level.txt",
-        src_path / "app_packages" / "clr.py",
-        src_path / "app_packages" / "toga_winforms" / "command.py",
+        src_path / "app/first-app/app.py",
+        src_path / "app/first-app/resources/__init__.py",
+        src_path / "app/first-app-0.0.1.dist-info/top_level.txt",
+        src_path / "app_packages/clr.py",
+        src_path / "app_packages/toga_winforms/command.py",
     )
     for file in files:
         create_file(file, "")
@@ -213,7 +211,7 @@ def test_package_msi(package_command, first_app_config, kwargs, tmp_path):
         # Collect manifest
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "heat.exe",
+                tmp_path / "wix/bin/heat.exe",
                 "dir",
                 "src",
                 "-nologo",
@@ -232,12 +230,12 @@ def test_package_msi(package_command, first_app_config, kwargs, tmp_path):
                 "first-app-manifest.wxs",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
         # Compile MSI
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "candle.exe",
+                tmp_path / "wix/bin/candle.exe",
                 "-nologo",
                 "-ext",
                 "WixUtilExtension",
@@ -250,12 +248,12 @@ def test_package_msi(package_command, first_app_config, kwargs, tmp_path):
                 "first-app-manifest.wxs",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
         # Link MSI
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "light.exe",
+                tmp_path / "wix/bin/light.exe",
                 "-nologo",
                 "-ext",
                 "WixUtilExtension",
@@ -264,12 +262,12 @@ def test_package_msi(package_command, first_app_config, kwargs, tmp_path):
                 "-loc",
                 "unicode.wxl",
                 "-o",
-                tmp_path / "base_path" / "dist" / "First App-0.0.1.msi",
+                tmp_path / "base_path/dist/First App-0.0.1.msi",
                 "first-app.wixobj",
                 "first-app-manifest.wixobj",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
     ]
 
@@ -290,7 +288,7 @@ def test_package_zip(package_command_with_files, first_app_config, kwargs, tmp_p
     # No signing was performed
     assert package_command_with_files.tools.subprocess.run.mock_calls == []
 
-    archive_file = tmp_path / "base_path" / "dist" / "First App-0.0.1.zip"
+    archive_file = tmp_path / "base_path/dist/First App-0.0.1.zip"
     source_folders_and_files = (
         "app/",
         "app/first-app/",
@@ -389,7 +387,7 @@ def test_package_msi_with_codesigning(
         # Collect manifest
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "heat.exe",
+                tmp_path / "wix/bin/heat.exe",
                 "dir",
                 "src",
                 "-nologo",
@@ -408,12 +406,12 @@ def test_package_msi_with_codesigning(
                 "first-app-manifest.wxs",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
         # Compile MSI
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "candle.exe",
+                tmp_path / "wix/bin/candle.exe",
                 "-nologo",
                 "-ext",
                 "WixUtilExtension",
@@ -426,12 +424,12 @@ def test_package_msi_with_codesigning(
                 "first-app-manifest.wxs",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
         # Link MSI
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "light.exe",
+                tmp_path / "wix/bin/light.exe",
                 "-nologo",
                 "-ext",
                 "WixUtilExtension",
@@ -440,12 +438,12 @@ def test_package_msi_with_codesigning(
                 "-loc",
                 "unicode.wxl",
                 "-o",
-                tmp_path / "base_path" / "dist" / "First App-0.0.1.msi",
+                tmp_path / "base_path/dist/First App-0.0.1.msi",
                 "first-app.wixobj",
                 "first-app-manifest.wixobj",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
         # Codesign app MSI
         mock.call(
@@ -473,7 +471,7 @@ def test_package_msi_with_codesigning(
                 "sha56",
             ]
             + additional_args
-            + [tmp_path / "base_path" / "dist" / "First App-0.0.1.msi"],
+            + [tmp_path / "base_path/dist/First App-0.0.1.msi"],
             check=True,
         ),
     ]
@@ -628,7 +626,7 @@ def test_package_msi_failed_manifest(package_command, first_app_config, tmp_path
         # Collect manifest
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "heat.exe",
+                tmp_path / "wix/bin/heat.exe",
                 "dir",
                 "src",
                 "-nologo",
@@ -647,7 +645,7 @@ def test_package_msi_failed_manifest(package_command, first_app_config, tmp_path
                 "first-app-manifest.wxs",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
     ]
 
@@ -670,7 +668,7 @@ def test_package_msi_failed_compile(package_command, first_app_config, tmp_path)
         # Collect manifest
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "heat.exe",
+                tmp_path / "wix/bin/heat.exe",
                 "dir",
                 "src",
                 "-nologo",
@@ -689,12 +687,12 @@ def test_package_msi_failed_compile(package_command, first_app_config, tmp_path)
                 "first-app-manifest.wxs",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
         # Compile MSI
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "candle.exe",
+                tmp_path / "wix/bin/candle.exe",
                 "-nologo",
                 "-ext",
                 "WixUtilExtension",
@@ -707,7 +705,7 @@ def test_package_msi_failed_compile(package_command, first_app_config, tmp_path)
                 "first-app-manifest.wxs",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
     ]
 
@@ -731,7 +729,7 @@ def test_package_msi_failed_link(package_command, first_app_config, tmp_path):
         # Collect manifest
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "heat.exe",
+                tmp_path / "wix/bin/heat.exe",
                 "dir",
                 "src",
                 "-nologo",
@@ -750,12 +748,12 @@ def test_package_msi_failed_link(package_command, first_app_config, tmp_path):
                 "first-app-manifest.wxs",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
         # Compile MSI
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "candle.exe",
+                tmp_path / "wix/bin/candle.exe",
                 "-nologo",
                 "-ext",
                 "WixUtilExtension",
@@ -768,12 +766,12 @@ def test_package_msi_failed_link(package_command, first_app_config, tmp_path):
                 "first-app-manifest.wxs",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
         # Link MSI
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "light.exe",
+                tmp_path / "wix/bin/light.exe",
                 "-nologo",
                 "-ext",
                 "WixUtilExtension",
@@ -782,12 +780,12 @@ def test_package_msi_failed_link(package_command, first_app_config, tmp_path):
                 "-loc",
                 "unicode.wxl",
                 "-o",
-                tmp_path / "base_path" / "dist" / "First App-0.0.1.msi",
+                tmp_path / "base_path/dist/First App-0.0.1.msi",
                 "first-app.wixobj",
                 "first-app-manifest.wixobj",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
     ]
 
@@ -852,7 +850,7 @@ def test_package_msi_failed_signing_msi(package_command, first_app_config, tmp_p
         # Collect manifest
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "heat.exe",
+                tmp_path / "wix/bin/heat.exe",
                 "dir",
                 "src",
                 "-nologo",
@@ -871,12 +869,12 @@ def test_package_msi_failed_signing_msi(package_command, first_app_config, tmp_p
                 "first-app-manifest.wxs",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
         # Compile MSI
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "candle.exe",
+                tmp_path / "wix/bin/candle.exe",
                 "-nologo",
                 "-ext",
                 "WixUtilExtension",
@@ -889,12 +887,12 @@ def test_package_msi_failed_signing_msi(package_command, first_app_config, tmp_p
                 "first-app-manifest.wxs",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
         # Link MSI
         mock.call(
             [
-                tmp_path / "wix" / "bin" / "light.exe",
+                tmp_path / "wix/bin/light.exe",
                 "-nologo",
                 "-ext",
                 "WixUtilExtension",
@@ -903,12 +901,12 @@ def test_package_msi_failed_signing_msi(package_command, first_app_config, tmp_p
                 "-loc",
                 "unicode.wxl",
                 "-o",
-                tmp_path / "base_path" / "dist" / "First App-0.0.1.msi",
+                tmp_path / "base_path/dist/First App-0.0.1.msi",
                 "first-app.wixobj",
                 "first-app-manifest.wixobj",
             ],
             check=True,
-            cwd=tmp_path / "base_path" / "build" / "first-app" / "windows" / "app",
+            cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
         # Codesign app MSI
         mock.call(
@@ -934,7 +932,7 @@ def test_package_msi_failed_signing_msi(package_command, first_app_config, tmp_p
                 "http://freetimestamps.com",
                 "-td",
                 "sha56",
-                tmp_path / "base_path" / "dist" / "First App-0.0.1.msi",
+                tmp_path / "base_path/dist/First App-0.0.1.msi",
             ],
             check=True,
         ),

--- a/tests/platforms/windows/visualstudio/test_build.py
+++ b/tests/platforms/windows/visualstudio/test_build.py
@@ -23,7 +23,7 @@ def build_command(tmp_path):
     command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
     command.tools.visualstudio = VisualStudio(
         tools=command.tools,
-        msbuild_path=tmp_path / "Visual Studio" / "MSBuild.exe",
+        msbuild_path=tmp_path / "Visual Studio/MSBuild.exe",
     )
     return command
 
@@ -60,7 +60,7 @@ def test_build_app(build_command, first_app_config, tool_debug_mode, tmp_path):
             # Collect manifest
             mock.call(
                 [
-                    Path(tmp_path) / "Visual Studio" / "MSBuild.exe",
+                    Path(tmp_path) / "Visual Studio/MSBuild.exe",
                     "First App.sln",
                     "-target:restore",
                     "-property:RestorePackagesConfig=true",

--- a/tests/platforms/windows/visualstudio/test_mixin.py
+++ b/tests/platforms/windows/visualstudio/test_mixin.py
@@ -63,4 +63,4 @@ def test_project_path(create_command, first_app_config, tmp_path):
 def test_distribution_path(create_command, first_app_config, tmp_path):
     distribution_path = create_command.distribution_path(first_app_config)
 
-    assert distribution_path == tmp_path / "base_path" / "dist" / "First App-0.0.1.msi"
+    assert distribution_path == tmp_path / "base_path/dist/First App-0.0.1.msi"

--- a/tests/platforms/windows/visualstudio/test_package.py
+++ b/tests/platforms/windows/visualstudio/test_package.py
@@ -36,9 +36,9 @@ def test_package_msi(package_command, first_app_config, tmp_path):
             # Collect manifest
             mock.call(
                 [
-                    tmp_path / "wix" / "bin" / "heat.exe",
+                    tmp_path / "wix/bin/heat.exe",
                     "dir",
-                    os.fsdecode(Path("x64") / "Release"),
+                    os.fsdecode(Path("x64/Release")),
                     "-nologo",
                     "-gg",
                     "-sfrag",
@@ -65,7 +65,7 @@ def test_package_msi(package_command, first_app_config, tmp_path):
             # Compile MSI
             mock.call(
                 [
-                    tmp_path / "wix" / "bin" / "candle.exe",
+                    tmp_path / "wix/bin/candle.exe",
                     "-nologo",
                     "-ext",
                     "WixUtilExtension",
@@ -73,7 +73,7 @@ def test_package_msi(package_command, first_app_config, tmp_path):
                     "WixUIExtension",
                     "-arch",
                     "x64",
-                    f'-dSourceDir={os.fsdecode(Path("x64") / "Release")}',
+                    f'-dSourceDir={os.fsdecode(Path("x64/Release"))}',
                     "first-app.wxs",
                     "first-app-manifest.wxs",
                 ],
@@ -88,7 +88,7 @@ def test_package_msi(package_command, first_app_config, tmp_path):
             # Link MSI
             mock.call(
                 [
-                    tmp_path / "wix" / "bin" / "light.exe",
+                    tmp_path / "wix/bin/light.exe",
                     "-nologo",
                     "-ext",
                     "WixUtilExtension",
@@ -97,7 +97,7 @@ def test_package_msi(package_command, first_app_config, tmp_path):
                     "-loc",
                     "unicode.wxl",
                     "-o",
-                    tmp_path / "base_path" / "dist" / "First App-0.0.1.msi",
+                    tmp_path / "base_path/dist/First App-0.0.1.msi",
                     "first-app.wixobj",
                     "first-app-manifest.wixobj",
                 ],

--- a/tests/test_mainline.py
+++ b/tests/test_mainline.py
@@ -59,10 +59,8 @@ def test_command(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
 
     # Create a dummy empty template to use in the new command
-    create_file(tmp_path / "template" / "cookiecutter.json", '{"app_name": "app_name"}')
-    create_file(
-        tmp_path / "template" / "{{ cookiecutter.app_name }}" / "app", "content"
-    )
+    create_file(tmp_path / "template/cookiecutter.json", '{"app_name": "app_name"}')
+    create_file(tmp_path / "template/{{ cookiecutter.app_name }}/app", "content")
 
     # Set the test command line
     monkeypatch.setattr(


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Like [Toga #2246](https://github.com/beeware/toga/pull/2246), this simplifies Path declarations by removing unnecessary `/` operators.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
