### PR TITLE
Clarify imports that are dependent on the version of Python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,16 +8,15 @@ repos:
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
   - repo: https://github.com/PyCQA/docformatter
     rev: v1.7.5
     hooks:
@@ -36,4 +35,5 @@ repos:
     rev: v2.2.6
     hooks:
     - id: codespell
-      additional_dependencies: [tomli]
+      # remove toml extra once Python 3.10 is no longer supported
+      additional_dependencies: ['.[toml]']

--- a/changes/1557.misc.rst
+++ b/changes/1557.misc.rst
@@ -1,0 +1,1 @@
+Module imports that are dependent on the version of Python are now explicitly structured to declare the Python versions they are dependent on.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ dependencies = [
     # Any dependency that is part of the "core python toolchain" (e.g. pip,
     # wheel) specify a minimum version, but no maximum, because we always want
     # the most recent version.
+    #
+    # limited to <=3.9 for the `group` argument for `entry_points()`
     "importlib_metadata >= 4.4; python_version <= '3.9'",
     "packaging >= 22.0",
     "pip >= 23.1.1",

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import importlib.metadata
 import inspect
 import os
 import platform
 import shutil
 import subprocess
+import sys
 import textwrap
 from abc import ABC, abstractmethod
 from argparse import RawDescriptionHelpFormatter
@@ -17,14 +19,9 @@ from cookiecutter import exceptions as cookiecutter_exceptions
 from cookiecutter.repository import is_repo_url
 from platformdirs import PlatformDirs
 
-try:
-    import importlib_metadata
-except ImportError:  # pragma: no-cover-if-lt-py310
-    import importlib.metadata as importlib_metadata
-
-try:
+if sys.version_info >= (3, 11):  # pragma: no-cover-if-lt-py311
     import tomllib
-except ModuleNotFoundError:  # pragma: no-cover-if-gte-py310
+else:  # pragma: no-cover-if-gte-py311
     import tomli as tomllib
 
 from briefcase import __version__
@@ -520,7 +517,7 @@ a custom location for Briefcase's tools.
         # Native format is ">=3.8"
         return tuple(
             int(v)
-            for v in importlib_metadata.metadata("briefcase")["Requires-Python"]
+            for v in importlib.metadata.metadata("briefcase")["Requires-Python"]
             .split("=")[1]
             .strip()
             .split(".")

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -1,12 +1,13 @@
 import copy
 import keyword
 import re
+import sys
 import unicodedata
 from types import SimpleNamespace
 
-try:
+if sys.version_info >= (3, 11):  # pragma: no-cover-if-lt-py311
     import tomllib
-except ModuleNotFoundError:  # pragma: no-cover-if-gte-py310
+else:  # pragma: no-cover-if-gte-py311
     import tomli as tomllib
 
 from briefcase.platforms import get_output_formats, get_platforms

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -9,9 +9,9 @@ from zipfile import ZipFile
 
 from briefcase.console import Log
 
-try:
+if sys.version_info >= (3, 11):  # pragma: no-cover-if-lt-py311
     import tomllib
-except ModuleNotFoundError:  # pragma: no-cover-if-gte-py310
+else:  # pragma: no-cover-if-gte-py311
     import tomli as tomllib
 
 import tomli_w

--- a/tests/platforms/web/static/test_build.py
+++ b/tests/platforms/web/static/test_build.py
@@ -3,9 +3,9 @@ import subprocess
 import sys
 from unittest import mock
 
-try:
+if sys.version_info >= (3, 11):  # pragma: no-cover-if-lt-py311
     import tomllib
-except ModuleNotFoundError:
+else:  # pragma: no-cover-if-gte-py311
     import tomli as tomllib
 
 import pytest


### PR DESCRIPTION
## Changes
- For imports that are dependent on the version of Python, make that explicit and use a syntax that `pyupgrade` can automatically handle for Python EOLs
- Given that `pyupgrade` can change imports, run it before `isort` runs in pre-commit
- Installing `toml` package is no longer necessary to run `isort` in `pre-commit`
- Instead of assuming knowledge about `codespell`'s usage of TOML (such as the fact it uses the `tomli` package), instruct pre-commit to install the `toml` extra for `codespell`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
