### PR TITLE
 Colorize ADB logcat by default

### DIFF
--- a/changes/1572.feature.rst
+++ b/changes/1572.feature.rst
@@ -1,0 +1,1 @@
+The output from an Android device while running an app is now colorized

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -29,6 +29,9 @@ from briefcase import __version__
 # Regex to identify settings likely to contain sensitive information
 SENSITIVE_SETTING_RE = re.compile(r"API|TOKEN|KEY|SECRET|PASS|SIGNATURE", flags=re.I)
 
+# Regex to remove ANSI color from text. from stackoverflow.com/a/38662876
+ANSI_ESCAPE = re.compile(r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]")
+
 
 class InputDisabled(Exception):
     def __init__(self):
@@ -114,7 +117,8 @@ class Printer:
     @classmethod
     def export_log(cls):
         """Export the text of the entire log."""
-        return cls.log.export_text()
+
+        return ANSI_ESCAPE.sub("", cls.log.export_text())
 
 
 class RichLoggingStream:

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1606,6 +1606,8 @@ Activity class not found while starting app.
                     self.device,
                     "logcat",
                     "--format=tag",
+                    "-v",
+                    "color",
                     "-t",
                     since.strftime("%m-%d %H:%M:%S.000000"),
                     "-s",

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1576,6 +1576,8 @@ Activity class not found while starting app.
                 self.device,
                 "logcat",
                 "--format=tag",
+                "-v",
+                "color",
                 "--pid",  # This option is available since API level 24.
                 pid,
             ]

--- a/tests/integrations/android_sdk/ADB/test_logcat.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat.py
@@ -20,6 +20,8 @@ def test_logcat(mock_tools, adb):
             "exampleDevice",
             "logcat",
             "--format=tag",
+            "-v",
+            "color",
             "--pid",
             "1234",
             "EGL_emulation:S",

--- a/tests/integrations/android_sdk/ADB/test_logcat_tail.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat_tail.py
@@ -21,6 +21,8 @@ def test_logcat_tail(mock_tools, adb):
             "exampleDevice",
             "logcat",
             "--format=tag",
+            "-v",
+            "color",
             "-t",
             "11-10 09:08:07.000000",
             "-s",


### PR DESCRIPTION
This PR adds the [ADB argument](https://developer.android.com/tools/logcat#formatmodify) for colored output. (`-v color`)
it automatically makes the ADB logcat to print with color highlighting (e.g. errors in red, info in green and so on) which I think provide better user experience 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
