### PR TITLE
Upgrade `upload-artifact` and `download-artifact` actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
 
   package:
     name: Python package
-#    uses: beeware/.github/.github/workflows/python-package-create.yml@main
-    uses: rmartin16/.github-beeware/.github/workflows/python-package-create.yml@artifacts
+    uses: beeware/.github/.github/workflows/python-package-create.yml@main
     with:
       tox-factors: -with-automation
 
@@ -149,8 +148,7 @@ jobs:
   verify-projects:
     name: Verify project
     needs: unit-tests
-#    uses: beeware/.github/.github/workflows/app-create-verify.yml@main
-    uses: rmartin16/.github-beeware/.github/workflows/app-create-verify.yml@artifacts
+    uses: beeware/.github/.github/workflows/app-create-verify.yml@main
     with:
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -163,8 +161,7 @@ jobs:
   verify-apps:
     name: Build app
     needs: unit-tests
-#    uses: beeware/.github/.github/workflows/app-build-verify.yml@main
-    uses: rmartin16/.github-beeware/.github/workflows/app-build-verify.yml@artifacts
+    uses: beeware/.github/.github/workflows/app-build-verify.yml@main
     with:
       # This *must* be the version of Python that is the system Python on the
       # Ubuntu version used to run Linux tests. We use a fixed ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
 
   package:
     name: Python package
-    uses: beeware/.github/.github/workflows/python-package-create.yml@main
+#    uses: beeware/.github/.github/workflows/python-package-create.yml@main
+    uses: rmartin16/.github-beeware/.github/workflows/python-package-create.yml@artifacts
     with:
       tox-factors: -with-automation
 
@@ -148,7 +149,8 @@ jobs:
   verify-projects:
     name: Verify project
     needs: unit-tests
-    uses: beeware/.github/.github/workflows/app-create-verify.yml@main
+#    uses: beeware/.github/.github/workflows/app-create-verify.yml@main
+    uses: rmartin16/.github-beeware/.github/workflows/app-create-verify.yml@artifacts
     with:
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -161,7 +163,8 @@ jobs:
   verify-apps:
     name: Build app
     needs: unit-tests
-    uses: beeware/.github/.github/workflows/app-build-verify.yml@main
+#    uses: beeware/.github/.github/workflows/app-build-verify.yml@main
+    uses: rmartin16/.github-beeware/.github/workflows/app-build-verify.yml@artifacts
     with:
       # This *must* be the version of Python that is the system Python on the
       # Ubuntu version used to run Linux tests. We use a fixed ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Get Packages
-      uses: actions/download-artifact@v3.0.2
+      uses: actions/download-artifact@v4.1.0
       with:
         name: ${{ needs.package.outputs.artifact-name }}
         path: dist
@@ -84,9 +84,9 @@ jobs:
 
     - name: Store Coverage Data
       if: always() && contains('success,failure', steps.test.outcome)
-      uses: actions/upload-artifact@v3.1.3
+      uses: actions/upload-artifact@v4.0.0
       with:
-        name: coverage-data
+        name: coverage-data-${{ matrix.platform }}-${{ matrix.python-version }}
         path: ".coverage.*"
         if-no-files-found: ignore
 
@@ -122,9 +122,10 @@ jobs:
         python -m install_requirement tox --extra dev
 
     - name: Retrieve Coverage Data
-      uses: actions/download-artifact@v3.0.2
+      uses: actions/download-artifact@v4.1.0
       with:
-        name: coverage-data
+        pattern: coverage-data-*
+        merge-multiple: true
 
     - name: Platform Coverage Reports
       id: platform-coverage
@@ -139,7 +140,7 @@ jobs:
 
     - name: Upload Project Coverage HTML Report
       if: always() && steps.project-coverage.outcome == 'failure'
-      uses: actions/upload-artifact@v3.1.3
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: html-coverage-report-project
         path: htmlcov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: "3.x"
 
       - name: Get packages
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.0
         with:
           name: ${{ needs.ci.outputs.artifact-name }}
           path: dist

--- a/changes/1589.misc.rst
+++ b/changes/1589.misc.rst
@@ -1,0 +1,1 @@
+The ``upload-artifact`` and ``download-artifact`` CI actions were upgraded to v4.


### PR DESCRIPTION
## Changes
- RE: https://github.com/beeware/.github/issues/77
- Bump `upload-artifact` and `download-artifact` actions to v4
- To accommodate v4:
  - Artifacts must have unique names since multiple uploads cannot contribute to a single artifact
  - Use a wildcard pattern to download all artifacts and merge in to a single directory
- 🚨 Dependent on https://github.com/beeware/.github/pull/78 🚨 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct