### PR TITLE
Bump PursuedPyBear from 1.1 to 3.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.egg-info
 /dist
 /build
+automation/build
 docs/_build/
 distribute-*
 .DS_Store

--- a/changes/1592.feature.rst
+++ b/changes/1592.feature.rst
@@ -1,0 +1,1 @@
+The version of PursuedPyBear for new projects was bumped from 1.1 to 3.2.0.

--- a/src/briefcase/bootstraps/pursuedpybear.py
+++ b/src/briefcase/bootstraps/pursuedpybear.py
@@ -51,8 +51,7 @@ def main():
         return """
 
 requires = [
-    "ppb~=1.1",
-    "pysdl2-dll==2.0.22",
+    "ppb~=3.2.0",
 ]
 test_requires = [
 {%- if cookiecutter.test_framework == "pytest" %}

--- a/src/briefcase/bootstraps/pursuedpybear.py
+++ b/src/briefcase/bootstraps/pursuedpybear.py
@@ -77,44 +77,63 @@ requires = [
     def pyproject_table_linux_system_debian(self):
         return """
 system_requires = [
-# ?? FIXME
 ]
 
 system_runtime_requires = [
-# ?? FIXME
+    "libsdl2-2.0-0",
+    "libsdl2-mixer-2.0-0",
+    "libsdl2-image-2.0-0",
+    "libsdl2-gfx-1.0-0",
+    "libsdl2-ttf-2.0-0",
 ]
 """
 
     def pyproject_table_linux_system_rhel(self):
         return """
 system_requires = [
-# ?? FIXME
 ]
 
 system_runtime_requires = [
-# ?? FIXME
+    "SDL2",
+    "SDL2_ttf",
+    "SDL2_image",
+    "SDL2_gfx",
+    "SDL2_mixer",
+    "libmodplug",
 ]
 """
 
     def pyproject_table_linux_system_suse(self):
         return """
 system_requires = [
-# ?? FIXME
 ]
 
 system_runtime_requires = [
-# ?? FIXME
+    "SDL2",
+    "SDL2_gfx",
+    "SDL2_ttf",
+    "SDL2_image",
+    "SDL2_mixer",
+    "libmodplug1",
 ]
 """
 
     def pyproject_table_linux_system_arch(self):
         return """
 system_requires = [
-# ?? FIXME
+    "sdl2",
+    "sdl2_ttf",
+    "sdl2_image",
+    "sdl2_gfx",
+    "sdl2_mixer",
 ]
 
 system_runtime_requires = [
-# ?? FIXME
+    "sdl2",
+    "sdl2_ttf",
+    "sdl2_image",
+    "sdl2_gfx",
+    "sdl2_mixer",
 ]
 """
 
@@ -123,7 +142,6 @@ system_runtime_requires = [
 manylinux = "manylinux_2_28"
 
 system_requires = [
-# ?? FIXME
 ]
 
 linuxdeploy_plugins = [

--- a/tests/commands/new/test_build_context.py
+++ b/tests/commands/new/test_build_context.py
@@ -522,8 +522,7 @@ def main():
         pyproject_table_briefcase_app_extra_content="""
 
 requires = [
-    "ppb~=1.1",
-    "pysdl2-dll==2.0.22",
+    "ppb~=3.2.0",
 ]
 test_requires = [
 {%- if cookiecutter.test_framework == "pytest" %}

--- a/tests/commands/new/test_build_context.py
+++ b/tests/commands/new/test_build_context.py
@@ -542,45 +542,63 @@ requires = [
 """,
         pyproject_table_linux_system_debian="""
 system_requires = [
-# ?? FIXME
 ]
 
 system_runtime_requires = [
-# ?? FIXME
+    "libsdl2-2.0-0",
+    "libsdl2-mixer-2.0-0",
+    "libsdl2-image-2.0-0",
+    "libsdl2-gfx-1.0-0",
+    "libsdl2-ttf-2.0-0",
 ]
 """,
         pyproject_table_linux_system_rhel="""
 system_requires = [
-# ?? FIXME
 ]
 
 system_runtime_requires = [
-# ?? FIXME
+    "SDL2",
+    "SDL2_ttf",
+    "SDL2_image",
+    "SDL2_gfx",
+    "SDL2_mixer",
+    "libmodplug",
 ]
 """,
         pyproject_table_linux_system_suse="""
 system_requires = [
-# ?? FIXME
 ]
 
 system_runtime_requires = [
-# ?? FIXME
+    "SDL2",
+    "SDL2_gfx",
+    "SDL2_ttf",
+    "SDL2_image",
+    "SDL2_mixer",
+    "libmodplug1",
 ]
 """,
         pyproject_table_linux_system_arch="""
 system_requires = [
-# ?? FIXME
+    "sdl2",
+    "sdl2_ttf",
+    "sdl2_image",
+    "sdl2_gfx",
+    "sdl2_mixer",
 ]
 
 system_runtime_requires = [
-# ?? FIXME
+    "sdl2",
+    "sdl2_ttf",
+    "sdl2_image",
+    "sdl2_gfx",
+    "sdl2_mixer",
 ]
 """,
         pyproject_table_linux_appimage="""
 manylinux = "manylinux_2_28"
 
 system_requires = [
-# ?? FIXME
 ]
 
 linuxdeploy_plugins = [


### PR DESCRIPTION
## Changes
- New projects for PursuedPyBear will use 3.2.0
- This also removes the pinned `pysdl2-dll` since ppb is managing this version now
- `pyproject.toml` now contains Linux system requirements for new projects for ppb

FYI: @pathunstrom

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct