### PR TITLE
Fix moving openSUSE rpm package to `dist` directory

### DIFF
--- a/changes/1595.bugfix.rst
+++ b/changes/1595.bugfix.rst
@@ -1,0 +1,1 @@
+Linux System RPM packaging for openSUSE Tumbleweed no longer errors with ``FileNotFoundError``.

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -118,7 +118,7 @@ system_runtime_requires = [
     # Needed to provide GTK
     "gtk3",
     # Needed to support Python bindings to GTK
-    "gobject-introspection", "typelib(Gtk)=3.0",
+    "gobject-introspection", "typelib(Gtk) = 3.0",
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-0",
     # Needed to provide WebKit2 at runtime

--- a/tests/commands/new/test_build_context.py
+++ b/tests/commands/new/test_build_context.py
@@ -162,7 +162,7 @@ system_runtime_requires = [
     # Needed to provide GTK
     "gtk3",
     # Needed to support Python bindings to GTK
-    "gobject-introspection", "typelib(Gtk)=3.0",
+    "gobject-introspection", "typelib(Gtk) = 3.0",
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-0",
     # Needed to provide WebKit2 at runtime
@@ -1159,7 +1159,7 @@ system_runtime_requires = [
     # Needed to provide GTK
     "gtk3",
     # Needed to support Python bindings to GTK
-    "gobject-introspection", "typelib(Gtk)=3.0",
+    "gobject-introspection", "typelib(Gtk) = 3.0",
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-0",
     # Needed to provide WebKit2 at runtime

--- a/tests/platforms/linux/system/test_mixin__properties.py
+++ b/tests/platforms/linux/system/test_mixin__properties.py
@@ -80,23 +80,28 @@ def test_binary_path(create_command, first_app_config, tmp_path):
 
 
 @pytest.mark.parametrize(
-    "packaging_format, filename",
+    "packaging_format, vendor_base, filename",
     [
-        ("deb", "first-app_0.0.1-1~somevendor-surprising_wonky.deb"),
-        ("rpm", "first-app-0.0.1-1.elsurprising.wonky.rpm"),
-        ("pkg", "first-app-0.0.1-1-wonky.pkg.tar.zst"),
+        ("deb", "debian", "first-app_0.0.1-1~somevendor-surprising_wonky.deb"),
+        ("rpm", "fedora", "first-app-0.0.1-1.elsurprising.wonky.rpm"),
+        ("rpm", "suse", "first-app-0.0.1-1.wonky.rpm"),
+        ("pkg", "arch", "first-app-0.0.1-1-wonky.pkg.tar.zst"),
     ],
 )
 def test_distribution_path(
     create_command,
     first_app_config,
     packaging_format,
+    vendor_base,
     filename,
     tmp_path,
 ):
     """The distribution path contains vendor details."""
     # Mock return value for ABI from packaging system
     create_command._build_env_abi = MagicMock(return_value="wonky")
+
+    # Set vendor base (RPM package naming changes for openSUSE)
+    first_app_config.target_vendor_base = vendor_base
 
     # Force a dummy vendor:codename for test purposes.
     first_app_config.target_vendor = "somevendor"

--- a/tests/platforms/linux/system/test_package.py
+++ b/tests/platforms/linux/system/test_package.py
@@ -27,9 +27,7 @@ def package_command(monkeypatch, first_app, tmp_path):
     command.verify_system_packages = mock.MagicMock()
 
     # Mock the packaging tools.
-    command._verify_deb_tools = mock.MagicMock()
-    command._verify_rpm_tools = mock.MagicMock()
-    command._verify_pkg_tools = mock.MagicMock()
+    command._verify_packaging_tools = mock.MagicMock()
 
     return command
 

--- a/tests/platforms/linux/system/test_package__deb.py
+++ b/tests/platforms/linux/system/test_package__deb.py
@@ -1,4 +1,3 @@
-import re
 import shutil
 import subprocess
 import sys
@@ -59,50 +58,49 @@ def test_verify_no_docker(monkeypatch, package_command, first_app_deb):
     # Mock not using docker
     package_command.target_image = None
 
-    # Mock the path of dpkg-deb
-    dpkg_deb = mock.MagicMock()
-    dpkg_deb.exists.return_value = True
-
-    mock_Path = mock.MagicMock(return_value=dpkg_deb)
-    monkeypatch.setattr(system, "Path", mock_Path)
+    # Mock the existence of dpkg-deb
+    package_command.tools.shutil.which = mock.MagicMock(return_value="/mybin/dpkg-deb")
 
     # App tools can be verified
     package_command.verify_app_tools(first_app_deb)
 
     # dpkg_deb was inspected
-    dpkg_deb.exists.assert_called_once()
+    package_command.tools.shutil.which.assert_called_once_with("dpkg-deb")
 
 
 @pytest.mark.parametrize(
-    "vendor_base, installer", [("debian", "apt install"), (None, "[system installer]")]
+    "vendor_base, error_msg",
+    [
+        (
+            "debian",
+            "Can't find the dpkg tools. Try running `sudo apt install dpkg-dev`.",
+        ),
+        (None, "Can't find the dpkg-deb tool. Install this first to package the deb."),
+    ],
 )
 def test_verify_dpkg_deb_missing(
-    monkeypatch, package_command, first_app_deb, vendor_base, installer
+    monkeypatch,
+    package_command,
+    first_app_deb,
+    vendor_base,
+    error_msg,
 ):
-    """If dpkg_deb isn't installed, an error is raised."""
+    """If dpkg-deb isn't installed, an error is raised."""
+    # Mock distro so packager is found or not appropriately
     first_app_deb.target_vendor_base = vendor_base
+
+    # Mock packager as missing
+    package_command.tools.shutil.which = mock.MagicMock(return_value="")
 
     # Mock not using docker
     package_command.target_image = None
 
-    # Mock the path of dpkg-deb
-    dpkg_deb = mock.MagicMock()
-    dpkg_deb.exists.return_value = False
-
-    mock_Path = mock.MagicMock(return_value=dpkg_deb)
-    monkeypatch.setattr(system, "Path", mock_Path)
-
     # Verifying app tools will raise an error
-    with pytest.raises(
-        BriefcaseCommandError,
-        match=re.escape(
-            rf"Can't find the dpkg tools. Try running `sudo {installer} dpkg-dev`."
-        ),
-    ):
+    with pytest.raises(BriefcaseCommandError, match=error_msg):
         package_command.verify_app_tools(first_app_deb)
 
-    # dpkg_deb was inspected
-    dpkg_deb.exists.assert_called_once()
+    # which was called for dpkg-deb
+    package_command.tools.shutil.which.assert_called_once_with("dpkg-deb")
 
 
 def test_verify_docker(monkeypatch, package_command, first_app_deb):

--- a/tests/platforms/linux/system/test_package__rpm.py
+++ b/tests/platforms/linux/system/test_package__rpm.py
@@ -1,4 +1,3 @@
-import re
 import shutil
 import subprocess
 import sys
@@ -85,50 +84,49 @@ def test_verify_no_docker(monkeypatch, package_command, first_app_rpm):
     # Mock not using docker
     package_command.target_image = None
 
-    # Mock the path of rpmbuild
-    rpmbuild = mock.MagicMock()
-    rpmbuild.exists.return_value = True
-
-    mock_Path = mock.MagicMock(return_value=rpmbuild)
-    monkeypatch.setattr(system, "Path", mock_Path)
+    # Mock the existence of rpmbuild
+    package_command.tools.shutil.which = mock.MagicMock(return_value="/mybin/rpmbuild")
 
     # App tools can be verified
     package_command.verify_app_tools(first_app_rpm)
 
     # rpmbuild was inspected
-    rpmbuild.exists.assert_called_once()
+    package_command.tools.shutil.which.assert_called_once_with("rpmbuild")
 
 
 @pytest.mark.parametrize(
-    "vendor_base, installer", [("rhel", "dnf install"), (None, "[system installer]")]
+    "vendor_base, error_msg",
+    [
+        (
+            "rhel",
+            "Can't find the rpm-build tools. Try running `sudo dnf install rpmbuild`.",
+        ),
+        (None, "Can't find the rpmbuild tool. Install this first to package the rpm."),
+    ],
 )
 def test_verify_rpmbuild_missing(
-    monkeypatch, package_command, first_app_rpm, vendor_base, installer
+    monkeypatch,
+    package_command,
+    first_app_rpm,
+    vendor_base,
+    error_msg,
 ):
     """If rpmbuild isn't installed, an error is raised."""
+    # Mock distro so packager is found or not appropriately
     first_app_rpm.target_vendor_base = vendor_base
+
+    # Mock packager as missing
+    package_command.tools.shutil.which = mock.MagicMock(return_value="")
 
     # Mock not using docker
     package_command.target_image = None
 
-    # Mock the path of rpmbuild
-    rpmbuild = mock.MagicMock()
-    rpmbuild.exists.return_value = False
-
-    mock_Path = mock.MagicMock(return_value=rpmbuild)
-    monkeypatch.setattr(system, "Path", mock_Path)
-
     # Verifying app tools will raise an error
-    with pytest.raises(
-        BriefcaseCommandError,
-        match=re.escape(
-            rf"Can't find the rpm-build tools. Try running `sudo {installer} rpm-build`."
-        ),
-    ):
+    with pytest.raises(BriefcaseCommandError, match=error_msg):
         package_command.verify_app_tools(first_app_rpm)
 
     # rpmbuild was inspected
-    rpmbuild.exists.assert_called_once()
+    package_command.tools.shutil.which.assert_called_once_with("rpmbuild")
 
 
 def test_verify_docker(monkeypatch, package_command, first_app_rpm):


### PR DESCRIPTION
## Changes
- Closes https://github.com/beeware/briefcase/issues/1595

## Notes
- Tested this with openSUSE tumbleweed, Fedora 39/38/37/36, and AlmaLinux.
- Almalinux requires using the `gobject-introspection` package instead of `gobject-introspection-devel`.
- I tried Rocky Linux again but I rather quickly gave up trying to find the headers package for GObject.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct