### PR TITLE
Ensure log does not contain ANSI sequences or control codes

### DIFF
--- a/changes/1604.bugfix.rst
+++ b/changes/1604.bugfix.rst
@@ -1,0 +1,1 @@
+Any ANSI escape sequences or console control codes are now stripped in all output captured in the Briefcase log file.

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -412,8 +412,7 @@ class Log:
         # build log header and export buffered log from Rich
         uname = platform.uname()
         sanitized_env_vars = "\n".join(
-            f"\t{env_var}="
-            f"{sanitize_text(value) if not SENSITIVE_SETTING_RE.search(env_var) else '********************'}"
+            f"\t{env_var}={value if not SENSITIVE_SETTING_RE.search(env_var) else '********************'}"
             for env_var, value in sorted(command.tools.os.environ.items())
         )
         return (

--- a/tests/console/test_Log.py
+++ b/tests/console/test_Log.py
@@ -167,7 +167,6 @@ def test_save_log_to_file_no_exception(mock_now, command, tmp_path):
     command.tools.os.environ = {
         "GITHUB_KEY": "super-secret-key",
         "ANDROID_HOME": "/androidsdk",
-        "ANSI_ENV_VAR": f"{chr(7)}this is sanitized env var: \u001b[31mred",
     }
 
     logger = Log(verbosity=LogLevel.DEBUG)
@@ -212,7 +211,6 @@ def test_save_log_to_file_no_exception(mock_now, command, tmp_path):
     assert "this is console output" not in log_contents
     # Environment variables are in the output
     assert "ANDROID_HOME=/androidsdk" in log_contents
-    assert "ANSI_ENV_VAR=this is sanitized env var: red" in log_contents
     assert "GITHUB_KEY=********************" in log_contents
     assert "GITHUB_KEY=super-secret-key" not in log_contents
     # Environment variables are sorted

--- a/tests/console/test_Log.py
+++ b/tests/console/test_Log.py
@@ -167,6 +167,7 @@ def test_save_log_to_file_no_exception(mock_now, command, tmp_path):
     command.tools.os.environ = {
         "GITHUB_KEY": "super-secret-key",
         "ANDROID_HOME": "/androidsdk",
+        "ANSI_ENV_VAR": f"{chr(7)}this is sanitized env var: \u001b[31mred",
     }
 
     logger = Log(verbosity=LogLevel.DEBUG)
@@ -177,6 +178,7 @@ def test_save_log_to_file_no_exception(mock_now, command, tmp_path):
     logger.error("this is error output")
     logger.print("this is print output")
     logger.print.to_log("this is log output")
+    logger.print.to_log(f"{chr(7)}this is sanitized log output: \u001b[31mred")
     logger.print.to_console("this is console output")
 
     logger.info("this is [bold]info output with markup[/bold]")
@@ -206,9 +208,11 @@ def test_save_log_to_file_no_exception(mock_now, command, tmp_path):
     assert "this is error output" in log_contents
     assert "this is print output" in log_contents
     assert "this is log output" in log_contents
+    assert "this is sanitized log output: red" in log_contents
     assert "this is console output" not in log_contents
     # Environment variables are in the output
     assert "ANDROID_HOME=/androidsdk" in log_contents
+    assert "ANSI_ENV_VAR=this is sanitized env var: red" in log_contents
     assert "GITHUB_KEY=********************" in log_contents
     assert "GITHUB_KEY=super-secret-key" not in log_contents
     # Environment variables are sorted

--- a/tests/console/test_sanitize_text.py
+++ b/tests/console/test_sanitize_text.py
@@ -1,0 +1,33 @@
+import pytest
+
+from briefcase.console import sanitize_text
+
+
+@pytest.mark.parametrize(
+    "input_text, sanitized_text",
+    [
+        (
+            "log output",
+            "log output",
+        ),
+        (
+            "ls\n\x1b[00m\x1b[01;31mexamplefile.zip\x1b[00m\n\x1b[01;31m",
+            "ls\nexamplefile.zip\n",
+        ),
+        (
+            "log output: \u001b[31mRed\u001B[0m",
+            "log output: Red",
+        ),
+        (
+            "\u001b[1mbold log output:\u001b[0m \u001b[4mUnderline\u001b[0m",
+            "bold log output: Underline",
+        ),
+        (
+            f"{chr(7)}{chr(8)}{chr(11)}{chr(12)}{chr(13)}log{chr(7)} output{chr(7)}",
+            "log output",
+        ),
+    ],
+)
+def test_sanitize_text(input_text, sanitized_text):
+    """Text is sanitized as expected."""
+    assert sanitize_text(input_text) == sanitized_text


### PR DESCRIPTION
## Changes
- ANSI escape sequences and console control codes are stripped from text before being written to the log

## Notes
- This was originally discussed as part of https://github.com/beeware/briefcase/pull/1572
  - Relatedly, I think that PR just needs a little direction to keep going; that is, should the regexes accommodate the ANSI sequences? Or could they be stripped for the purposes of Android log filtering?

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct