### PR TITLE
Bump JDK from 17.0.8.1+1 to 17.0.10+7

### DIFF
--- a/changes/1611.feature.rst
+++ b/changes/1611.feature.rst
@@ -1,0 +1,1 @@
+The Java JDK was upgraded from 17.0.8.1+1 to 17.0.10+7. Run ``briefcase upgrade java`` to upgrade existing Briefcase installations.

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -19,8 +19,8 @@ class JDK(ManagedTool):
 
     # Latest OpenJDK as of September 2023: https://adoptium.net/temurin/releases/
     JDK_MAJOR_VER = "17"
-    JDK_RELEASE = "17.0.8.1"
-    JDK_BUILD = "1"
+    JDK_RELEASE = "17.0.10"
+    JDK_BUILD = "7"
     JDK_INSTALL_DIR_NAME = f"java{JDK_MAJOR_VER}"
 
     def __init__(self, tools: ToolCache, java_home: Path):

--- a/tests/integrations/java/conftest.py
+++ b/tests/integrations/java/conftest.py
@@ -6,8 +6,8 @@ from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.subprocess import Subprocess
 
-JDK_RELEASE = "17.0.8.1"
-JDK_BUILD = "1"
+JDK_RELEASE = "17.0.10"
+JDK_BUILD = "7"
 
 
 @pytest.fixture

--- a/tests/integrations/java/test_JDK__verify.py
+++ b/tests/integrations/java/test_JDK__verify.py
@@ -1,10 +1,12 @@
 import os
+import platform
 import shutil
 import subprocess
 from pathlib import Path
 from unittest import mock
 
 import pytest
+import requests
 
 from briefcase.exceptions import (
     BriefcaseCommandError,
@@ -518,6 +520,15 @@ def test_successful_jdk_download(
     )
     # The original archive was deleted
     archive.unlink.assert_called_once_with()
+
+
+def test_jdk_url_exists(mock_tools, tmp_path):
+    """The JDK download URL is resolvable for the platform."""
+    # ensure the system hasn't been mocked
+    mock_tools.host_arch = platform.machine()
+    mock_tools.host_os = platform.system()
+
+    requests.head(JDK(mock_tools, tmp_path).OpenJDK_download_url).raise_for_status()
 
 
 def test_not_installed(mock_tools, tmp_path):


### PR DESCRIPTION
## Changes
- Bumps JDK from 17.0.8.1+1 to [17.0.10+7](https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.10%2B7)
- Adds a test to ensure the JDK URL is resolvable

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct