### PR TITLE
Bump black-pre-commit-mirror from 23.12.1 to 24.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: docformatter
         args: [--in-place, --black]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
+    rev: 24.1.1
     hooks:
       - id: black
         language_version: python3

--- a/changes/1624.misc.rst
+++ b/changes/1624.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``black-pre-commit-mirror`` was updated to its latest version.

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -47,32 +47,34 @@ def titlecase(s):
     :returns: A capitalized string.
     """
     return " ".join(
-        word
-        if (
-            word.isupper()
-            or word
-            in {
-                "a",
-                "an",
-                "and",
-                "as",
-                "at",
-                "but",
-                "by",
-                "en",
-                "for",
-                "if",
-                "in",
-                "of",
-                "on",
-                "or",
-                "the",
-                "to",
-                "via",
-                "vs",
-            }
+        (
+            word
+            if (
+                word.isupper()
+                or word
+                in {
+                    "a",
+                    "an",
+                    "and",
+                    "as",
+                    "at",
+                    "but",
+                    "by",
+                    "en",
+                    "for",
+                    "if",
+                    "in",
+                    "of",
+                    "on",
+                    "or",
+                    "the",
+                    "to",
+                    "via",
+                    "vs",
+                }
+            )
+            else word.capitalize()
         )
-        else word.capitalize()
         for word in s.split(" ")
     )
 

--- a/tests/commands/create/test_install_app_requirements.py
+++ b/tests/commands/create/test_install_app_requirements.py
@@ -201,10 +201,10 @@ def test_app_packages_invalid_requires(
     # Unfortunately, no way to tell the difference between "offline" and
     # "your requirements are invalid"; pip returns status code 1 for all
     # failures.
-    create_command.tools[
-        myapp
-    ].app_context.run.side_effect = subprocess.CalledProcessError(
-        cmd=["python", "-u", "-m", "pip", "..."], returncode=1
+    create_command.tools[myapp].app_context.run.side_effect = (
+        subprocess.CalledProcessError(
+            cmd=["python", "-u", "-m", "pip", "..."], returncode=1
+        )
     )
 
     with pytest.raises(RequirementsInstallError):
@@ -248,10 +248,10 @@ def test_app_packages_offline(
     # Unfortunately, no way to tell the difference between "offline" and
     # "your requirements are invalid"; pip returns status code 1 for all
     # failures.
-    create_command.tools[
-        myapp
-    ].app_context.run.side_effect = subprocess.CalledProcessError(
-        cmd=["python", "-u", "-m", "pip", "..."], returncode=1
+    create_command.tools[myapp].app_context.run.side_effect = (
+        subprocess.CalledProcessError(
+            cmd=["python", "-u", "-m", "pip", "..."], returncode=1
+        )
     )
 
     with pytest.raises(RequirementsInstallError):
@@ -297,10 +297,8 @@ def test_app_packages_install_requirements(
     myapp.requires = ["first", "second", "third"]
 
     # The side effect of calling pip is creating installation artefacts
-    create_command.tools[
-        myapp
-    ].app_context.run.side_effect = create_installation_artefacts(
-        app_packages_path, myapp.requires
+    create_command.tools[myapp].app_context.run.side_effect = (
+        create_installation_artefacts(app_packages_path, myapp.requires)
     )
 
     # Install the requirements
@@ -356,10 +354,8 @@ def test_app_packages_replace_existing_requirements(
     myapp.requires = ["first", "second", "third"]
 
     # The side effect of calling pip is creating installation artefacts
-    create_command.tools[
-        myapp
-    ].app_context.run.side_effect = create_installation_artefacts(
-        app_packages_path, myapp.requires
+    create_command.tools[myapp].app_context.run.side_effect = (
+        create_installation_artefacts(app_packages_path, myapp.requires)
     )
 
     # Install the requirements

--- a/tests/platforms/linux/system/test_build.py
+++ b/tests/platforms/linux/system/test_build.py
@@ -86,10 +86,8 @@ def test_build_app(build_command, first_app, tmp_path):
 def test_build_bootstrap_failed(build_command, first_app, tmp_path):
     """If the bootstrap binary can't be compiled, an error is raised."""
     # Mock a build failure
-    build_command.tools[
-        first_app
-    ].app_context.run.side_effect = subprocess.CalledProcessError(
-        cmd=["make ..."], returncode=-1
+    build_command.tools[first_app].app_context.run.side_effect = (
+        subprocess.CalledProcessError(cmd=["make ..."], returncode=-1)
     )
 
     # Build the app; it will fail

--- a/tests/platforms/linux/system/test_package__deb.py
+++ b/tests/platforms/linux/system/test_package__deb.py
@@ -336,10 +336,8 @@ def test_deb_package_failure(package_command, first_app_deb, tmp_path):
     bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Mock a packaging failure
-    package_command.tools.app_tools[
-        first_app_deb
-    ].app_context.run.side_effect = subprocess.CalledProcessError(
-        cmd="dpkg-deb ...", returncode=-1
+    package_command.tools.app_tools[first_app_deb].app_context.run.side_effect = (
+        subprocess.CalledProcessError(cmd="dpkg-deb ...", returncode=-1)
     )
 
     # Package the app

--- a/tests/platforms/linux/system/test_package__pkg.py
+++ b/tests/platforms/linux/system/test_package__pkg.py
@@ -430,10 +430,8 @@ def test_pkg_package_failure(package_command, first_app_pkg, tmp_path):
     bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Mock a packaging failure
-    package_command.tools.app_tools[
-        first_app_pkg
-    ].app_context.run.side_effect = subprocess.CalledProcessError(
-        cmd="makepkg ...", returncode=-1
+    package_command.tools.app_tools[first_app_pkg].app_context.run.side_effect = (
+        subprocess.CalledProcessError(cmd="makepkg ...", returncode=-1)
     )
 
     # Package the app; this will fail

--- a/tests/platforms/linux/system/test_package__rpm.py
+++ b/tests/platforms/linux/system/test_package__rpm.py
@@ -579,10 +579,8 @@ def test_rpm_package_failure(package_command, first_app_rpm, tmp_path):
     bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
     # Mock a packaging failure
-    package_command.tools.app_tools[
-        first_app_rpm
-    ].app_context.run.side_effect = subprocess.CalledProcessError(
-        cmd="rpmbuild ...", returncode=-1
+    package_command.tools.app_tools[first_app_rpm].app_context.run.side_effect = (
+        subprocess.CalledProcessError(cmd="rpmbuild ...", returncode=-1)
     )
 
     # Package the app; this will fail


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 23.12.1 to 24.1.1 and ran the update against the repo.