### PR TITLE
Remove prefix from `build_gradle_dependencies` warning

### DIFF
--- a/changes/1628.misc.rst
+++ b/changes/1628.misc.rst
@@ -1,0 +1,1 @@
+The warning for missing ``build_gradle_dependencies`` in pyproject.toml is now printed without the app title prefix.

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -177,8 +177,7 @@ class GradleCreateCommand(GradleMixin, CreateCommand):
             dependencies = app.build_gradle_dependencies
         except AttributeError:
             self.logger.warning(
-                (
-                    """
+                """
 *************************************************************************
 ** WARNING: App does not define build_gradle_dependencies              **
 *************************************************************************
@@ -201,9 +200,8 @@ class GradleCreateCommand(GradleMixin, CreateCommand):
     for more information.
 
 *************************************************************************
+
 """
-                ),
-                prefix=app.app_name,
             )
             dependencies = [
                 "androidx.appcompat:appcompat:1.0.2",


### PR DESCRIPTION
## Changes
- The new warning for `build_gradle_dependencies` caught me off guard with the prefix...so, I removed it.
- Logging these boxed warnings without a prefix is more in line with other uses; feel free to close if you disagree.

Before:
```
[androidrequests] Generating application template...

[androidrequests] 
[androidrequests] *************************************************************************
[androidrequests] ** WARNING: App does not define build_gradle_dependencies              **
[androidrequests] *************************************************************************
[androidrequests] 
[androidrequests]     The Android configuration for this app does not contain a
[androidrequests]     `build_gradle_dependencies` definition. Briefcase will use a default
[androidrequests]     value of:
[androidrequests] 
[androidrequests]         build_gradle_dependencies = [
[androidrequests]             "androidx.appcompat:appcompat:1.0.2",
[androidrequests]             "androidx.constraintlayout:constraintlayout:1.1.3",
[androidrequests]             "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
[androidrequests]         ]
[androidrequests] 
[androidrequests]     You should add this definition to the Android configuration
[androidrequests]     of your project's pyproject.toml file. See:
[androidrequests] 
[androidrequests]         https://briefcase.readthedocs.io/en/stable/reference/platforms/android.html#build_gradle-dependencies
[androidrequests] 
[androidrequests]     for more information.
[androidrequests] 
[androidrequests] *************************************************************************
Using app template: https://github.com/beeware/briefcase-android-gradle-template.git, branch v0.3.17
```

After:
```
[androidrequests] Generating application template...

*************************************************************************
** WARNING: App does not define build_gradle_dependencies              **
*************************************************************************

    The Android configuration for this app does not contain a
    `build_gradle_dependencies` definition. Briefcase will use a default
    value of:

        build_gradle_dependencies = [
            "androidx.appcompat:appcompat:1.0.2",
            "androidx.constraintlayout:constraintlayout:1.1.3",
            "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
        ]

    You should add this definition to the Android configuration
    of your project's pyproject.toml file. See:

        https://briefcase.readthedocs.io/en/stable/reference/platforms/android.html#build_gradle-dependencies

    for more information.

*************************************************************************

Using app template: https://github.com/beeware/briefcase-android-gradle-template.git, branch v0.3.17
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct