### PR TITLE
Fix macOS android device parsing

### DIFF
--- a/changes/1627.bugfix.rst
+++ b/changes/1627.bugfix.rst
@@ -1,0 +1,1 @@
+The detection of physical Android devices on macOS was made more resilient.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -864,8 +864,12 @@ connection.
 
                     details = {}
                     for part in parts[2:]:
-                        key, value = part.split(":")
-                        details[key] = value
+                        try:
+                            key, value = part.split(":")
+                            details[key] = value
+                        except ValueError:
+                            # Ignore any entry that isn't in "key:value" format.
+                            pass
 
                     if parts[1] == "device":
                         try:

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -881,7 +881,7 @@ connection.
                         name = "Unknown device (offline)"
                         authorized = False
                     else:
-                        name = "Unknown device (not authorized for development)"
+                        name = f"Device not available for development ({' '.join(parts[1:])})"
                         authorized = False
 
                     devices[parts[0]] = {

--- a/tests/integrations/android_sdk/AndroidSDK/devices/no_permissions.out
+++ b/tests/integrations/android_sdk/AndroidSDK/devices/no_permissions.out
@@ -1,0 +1,3 @@
+List of devices attached
+200ABCDEFGHIJK         no permissions (user russell is not in the plugdev group); see [http://developer.android.com/tools/device.html] usb:5-4.4.1 transport_id:1
+300ABCDEFGHIJK         no permissions (missing udev rules? user is in the plugdev group); see [http://developer.android.com/tools/device.html] usb:5-4.4.1 transport_id:1

--- a/tests/integrations/android_sdk/AndroidSDK/devices/physical_device_macOS.out
+++ b/tests/integrations/android_sdk/AndroidSDK/devices/physical_device_macOS.out
@@ -1,0 +1,2 @@
+List of devices attached
+200ABCDEFGHIJK         device 231-1 product:panther model:Pixel_7 device:panther transport_id:1

--- a/tests/integrations/android_sdk/AndroidSDK/test_devices.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_devices.py
@@ -81,3 +81,17 @@ def test_daemon_start(mock_tools, android_sdk):
     mock_tools.subprocess.check_output.return_value = devices_result("daemon_start")
 
     assert android_sdk.devices() == {}
+
+
+def test_physical_device_macOS(mock_tools, android_sdk):
+    """An extra piece of device detail is returned on macOS for physical devices."""
+    mock_tools.subprocess.check_output.return_value = devices_result(
+        "physical_device_macOS"
+    )
+
+    assert android_sdk.devices() == {
+        "200ABCDEFGHIJK": {
+            "authorized": True,
+            "name": "Pixel 7",
+        }
+    }

--- a/tests/integrations/android_sdk/AndroidSDK/test_devices.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_devices.py
@@ -48,7 +48,10 @@ def test_multiple_devices(mock_tools, android_sdk):
 
     assert android_sdk.devices() == {
         "041234567892009a": {
-            "name": "Unknown device (not authorized for development)",
+            "name": (
+                "Device not available for development "
+                "(unauthorized usb:336675328X transport_id:2)"
+            ),
             "authorized": False,
         },
         "KABCDABCDA1513": {
@@ -94,4 +97,31 @@ def test_physical_device_macOS(mock_tools, android_sdk):
             "authorized": True,
             "name": "Pixel 7",
         }
+    }
+
+
+def test_device_permissions(mock_tools, android_sdk):
+    """If AndroidSDK doesn't have access to the device, the error message can be
+    parsed."""
+    mock_tools.subprocess.check_output.return_value = devices_result("no_permissions")
+
+    assert android_sdk.devices() == {
+        "200ABCDEFGHIJK": {
+            "authorized": False,
+            "name": (
+                "Device not available for development (no permissions "
+                "(user russell is not in the plugdev group); "
+                "see [http://developer.android.com/tools/device.html] "
+                "usb:5-4.4.1 transport_id:1)"
+            ),
+        },
+        "300ABCDEFGHIJK": {
+            "authorized": False,
+            "name": (
+                "Device not available for development (no permissions "
+                "(missing udev rules? user is in the plugdev group); "
+                "see [http://developer.android.com/tools/device.html] "
+                "usb:5-4.4.1 transport_id:1)"
+            ),
+        },
     }


### PR DESCRIPTION
Fixes #1627.

On macOS, it appears that some physical devices now return an extra integer code that can't be parsed. This adds parsing (well... the value is ignored) for the extra content. It also improves error reporting when a device isn't authorised, reporting the literal error and hint returned by Android SDK.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
