### PR TITLE
Improve Android emulator startup failure messages

### DIFF
--- a/changes/1630.feature.rst
+++ b/changes/1630.feature.rst
@@ -1,0 +1,1 @@
+When the Android emulator fails to start up properly, users are now presented with additional resources to help resolve any issues.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1378,13 +1378,16 @@ You can also start the emulator manually by running:
                         # Try again in 2 seconds...
                         self.sleep(2)
         except BaseException as e:
-            self.tools.logger.info("Emulator output log", prefix=self.name)
+            self.tools.logger.warning(
+                "Emulator output log for startup failure",
+                prefix=self.name,
+            )
             try:
                 # if the emulator exited, this should return its output immediately
                 self.tools.logger.info(emulator_popen.communicate(timeout=1)[0])
             except subprocess.TimeoutExpired:
                 self.tools.logger.info(
-                    "> Briefcase failed to retrieve emulator output "
+                    "Briefcase failed to retrieve emulator output "
                     "(this is expected if the emulator is running)"
                 )
 

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -8,7 +8,6 @@ import shutil
 import subprocess
 import sys
 import time
-from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 
@@ -1306,20 +1305,25 @@ In future, you can specify this device by running:
             for arg in map(str, emulator_popen.args)
         )
 
-        error_msg = (
-            "{prologue}"
-            + f"""
+        general_error_msg = f"""
+Review the emulator output above for:
+ - Troubleshooting or resolution steps such as enabling hardware acceleration
+ - Other errors or warnings that may be suggesting the cause of the startup failure
 
-Try starting the emulator manually by running:
+Ensure your Android SDK is up-to-date by running:
+
+    $ briefcase update {AndroidSDK.name}
+
+To review Google's general troubleshooting steps for the emulator, visit:
+
+    https://developer.android.com/studio/run/emulator-troubleshooting
+
+You can also start the emulator manually by running:
 
     $ {emulator_command}
-
-Resolve any problems you discover, then try running your app again. You may
-find this page helpful in diagnosing emulator problems.
-
-    https://developer.android.com/studio/run/emulator-acceleration#accel-vm
 """
-        )
+
+        failed_startup_error_msg = f"{{prologue}}\n{general_error_msg}"
 
         # The boot process happens in 2 phases.
         # First, the emulator appears in the device list. However, it's
@@ -1335,7 +1339,7 @@ find this page helpful in diagnosing emulator problems.
                 while adb is None:
                     if emulator_popen.poll() is not None:
                         raise BriefcaseCommandError(
-                            error_msg.format(
+                            failed_startup_error_msg.format(
                                 prologue="Android emulator was unable to start!"
                             )
                         )
@@ -1366,7 +1370,7 @@ find this page helpful in diagnosing emulator problems.
                     while not adb.has_booted():
                         if emulator_popen.poll() is not None:
                             raise BriefcaseCommandError(
-                                error_msg.format(
+                                failed_startup_error_msg.format(
                                     prologue="Android emulator was unable to boot!"
                                 )
                             )
@@ -1374,19 +1378,29 @@ find this page helpful in diagnosing emulator problems.
                         # Try again in 2 seconds...
                         self.sleep(2)
         except BaseException as e:
-            # if the emulator exited, this should return its output immediately;
-            # if it is still running, this will quickly time out and print nothing.
-            with suppress(subprocess.TimeoutExpired):
+            self.tools.logger.info("Emulator output log", prefix=self.name)
+            try:
+                # if the emulator exited, this should return its output immediately
                 self.tools.logger.info(emulator_popen.communicate(timeout=1)[0])
+            except subprocess.TimeoutExpired:
+                self.tools.logger.info(
+                    "> Briefcase failed to retrieve emulator output "
+                    "(this is expected if the emulator is running)"
+                )
 
             # Provide troubleshooting steps if user gives up on the emulator starting
             if isinstance(e, KeyboardInterrupt):
-                self.tools.logger.warning()
                 self.tools.logger.warning(
-                    error_msg.format(
-                        prologue="Is the Android emulator not starting up properly?"
-                    )
+                    "Is the Android emulator not starting up properly?",
+                    prefix=self.name,
                 )
+                self.tools.logger.info(
+                    """
+If the emulator opened after pressing CTRL+C, then leave the emulator open and
+run Briefcase again. The running emulator can then be selected from the list.
+"""
+                )
+                self.tools.logger.info(general_error_msg)
 
             raise
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -426,10 +426,13 @@ def test_emulator_fail_to_boot(mock_tools, android_sdk):
 @pytest.mark.parametrize(
     "emulator_comm, expected_log",
     [
-        (("This is stdout", "this is stderr"), "Emulator output log\nThis is stdout"),
+        (
+            ("This is stdout", "this is stderr"),
+            "Emulator output log for startup failure\nThis is stdout",
+        ),
         (
             subprocess.TimeoutExpired(cmd="emulator", timeout=1),
-            "Emulator output log\n> Briefcase failed",
+            "Emulator output log for startup failure\nBriefcase failed",
         ),
     ],
 )


### PR DESCRIPTION
## Changes
- Updates handling and management of information presented to the user when the Android emulator fails to start
- Related issues:
  - #1036
  - #1573

## UX
- Conceptually, I broke the errors in to two categories:
  - Briefcase detects the emulator closed
  - The user aborts the start up process
- In the first case, the emulator's output probably includes the recommended steps for the user.
- In the second case, Briefcase probably won't be able to retrieve the emulator's output because the emulator will likely still be running....and retrieving `stdout` from a running process without blocking is non-trivial....but potentially really valuable here

Presentation when Briefcase detects startup failure:
![image](https://github.com/beeware/briefcase/assets/387848/68f1ca21-ff04-45df-ab96-9dfa55fb7688)

Presentation when the User aborts the startup:
![image](https://github.com/beeware/briefcase/assets/387848/5735d8f2-6db7-4782-bc31-74ac9c920b7c)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct