### PR TITLE
Fix typo in rpm-build package name

### DIFF
--- a/changes/1638.bugfix.rst
+++ b/changes/1638.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed an typo in ``rpmbuild``'s package name from ``rpmbuild`` to  ``rpm-build`` for RPM based systems.
+When Briefcase can't find ``rpmbuild` on an RPM-based system, the message giving install instructions now uses the correct package name.

--- a/changes/1638.bugfix.rst
+++ b/changes/1638.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an typo in rpm-build's package name, from ``rpmbuild`` to ``rpm-build``, so that ``briefcase package`` will prompt the correct ``sudo dnf install rpm-build`` if not installed.

--- a/changes/1638.bugfix.rst
+++ b/changes/1638.bugfix.rst
@@ -1,1 +1,1 @@
-Fix an typo in rpm-build's package name, from ``rpmbuild`` to ``rpm-build``, so that ``briefcase package`` will prompt the correct ``sudo dnf install rpm-build`` if not installed.
+Fixed an typo in ``rpmbuild``'s package name from ``rpmbuild`` to  ``rpm-build`` for RPM based systems.

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -852,7 +852,7 @@ class LinuxSystemPackageCommand(LinuxSystemMixin, PackageCommand):
         """Verify that the local environment contains the packaging tools."""
         tool_name, executable_name, package_name = {
             "deb": ("dpkg", "dpkg-deb", "dpkg-dev"),
-            "rpm": ("rpm-build", "rpmbuild", "rpmbuild"),
+            "rpm": ("rpm-build", "rpmbuild", "rpm-build"),
             "pkg": ("makepkg", "makepkg", "pacman"),
         }[app.packaging_format]
 

--- a/tests/platforms/linux/system/test_package__rpm.py
+++ b/tests/platforms/linux/system/test_package__rpm.py
@@ -99,7 +99,7 @@ def test_verify_no_docker(monkeypatch, package_command, first_app_rpm):
     [
         (
             "rhel",
-            "Can't find the rpm-build tools. Try running `sudo dnf install rpmbuild`.",
+            "Can't find the rpm-build tools. Try running `sudo dnf install rpm-build`.",
         ),
         (None, "Can't find the rpmbuild tool. Install this first to package the rpm."),
     ],


### PR DESCRIPTION
Fix typo in rpm-build's package name, from "rpmbuild" to "rpm-build".

<!--- Describe your changes in detail -->
Changed src/briefcase/platform/linux/system.py, line 855.
Rename package name of rpm-build from "rpmbuild" to "rpm-build" to fix an typo.
<!--- What problem does this change solve? -->
On Fedora (or other distributions using RPM), briefcase will prompt for installing rpm-build is not present via ```sudo dnf install rpmbuild```. But currently there's a typo of the package name in the prompt. This fix changes the package name so that it will be ```sudo dnf install rpm-build```.

Sorry for that I don't know how to compile and test python module like this, so I'm leaving the checkbox below unchecked.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #1636 
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
