### PR TITLE
Replace docs.beeware.io with docs.beeware.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ To install Briefcase, run::
    $ python -m pip install briefcase
 
 If you would like a full introduction to using Briefcase, try the `BeeWare tutorial
-<https://docs.beeware.io>`__. This tutorial walks you through the process of creating
+<https://docs.beeware.org>`__. This tutorial walks you through the process of creating
 and packaging a new application with Briefcase.
 
 Documentation

--- a/changes/1639.misc.rst
+++ b/changes/1639.misc.rst
@@ -1,0 +1,1 @@
+The hyperlink to the documentation in the README was corrected.


### PR DESCRIPTION
## Changes
- Update docs link from beeware.io to beeware.org
- https://docs.beeware.io doesn't return anything for me

I created this commit in the GitHub web UI; I guess it defaulted to the beeware repo instead of a fork since I have write access...

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct