### PR TITLE
Update android.rst to include explanation on packaging apks

### DIFF
--- a/docs/how-to/publishing/android.rst
+++ b/docs/how-to/publishing/android.rst
@@ -48,7 +48,8 @@ Use Briefcase to build a release bundle for your application:
 
 This will result in an Android App Bundle file being generated. An `Android App
 Bundle <https://developer.android.com/guide/app-bundle>`__ is a publishing
-format that includes all your app’s compiled code and resources.
+format that includes all your app’s compiled code and resources. 
+To generate a release APK instead of an AAB, you can add the `-p apk` option.
 
 .. admonition:: AAB and APK
 


### PR DESCRIPTION
While abb's are the primary distribution method of android apps. APK's are still needed to distritbute packages that are not hosted in the play store

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
