### PR TITLE
Print message when Wait Bar is started non-interactively

### DIFF
--- a/changes/1649.feature.rst
+++ b/changes/1649.feature.rst
@@ -1,0 +1,1 @@
+In non-interactive environments, such as CI, a message is now printed to signify a task has begun where an animated bar would be displayed in interactive console sessions.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1337,7 +1337,7 @@ You can also start the emulator manually by running:
         # Phase 1: Wait for the device to appear so we can get an
         # ADB instance for the new device.
         try:
-            with self.tools.input.wait_bar("Starting emulator..."):
+            with self.tools.input.wait_bar("Starting emulator...") as keep_alive:
                 adb = None
                 known_devices = set()
                 while adb is None:
@@ -1366,11 +1366,12 @@ You can also start the emulator manually by running:
 
                     # If we haven't found a device, try again in 2 seconds...
                     if adb is None:
+                        keep_alive.update()
                         self.sleep(2)
 
             # Phase 2: Wait for the boot process to complete
             if not adb.has_booted():
-                with self.tools.input.wait_bar("Booting emulator..."):
+                with self.tools.input.wait_bar("Booting emulator...") as keep_alive:
                     while not adb.has_booted():
                         if emulator_popen.poll() is not None:
                             raise BriefcaseCommandError(
@@ -1380,6 +1381,7 @@ You can also start the emulator manually by running:
                             )
 
                         # Try again in 2 seconds...
+                        keep_alive.update()
                         self.sleep(2)
         except BaseException as e:
             self.tools.logger.warning(

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -427,9 +427,8 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         super().__init__(*args, **kwargs)
 
         # External service APIs.
-        # These are abstracted to enable testing without patching.
+        # This is abstracted to enable testing without patching.
         self.get_device_state = get_device_state
-        self.sleep = time.sleep
 
     def run_app(
         self,
@@ -471,7 +470,7 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         if device_state not in {DeviceState.SHUTDOWN, DeviceState.BOOTED}:
             with self.input.wait_bar("Waiting for simulator shutdown..."):
                 while device_state not in {DeviceState.SHUTDOWN, DeviceState.BOOTED}:
-                    self.sleep(2)
+                    time.sleep(2)
                     device_state = self.get_device_state(self.tools, udid)
 
         # We now know the simulator is either shut down or booted;
@@ -512,28 +511,34 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         # Try to uninstall the app first. If the app hasn't been installed
         # before, this will still succeed.
         self.logger.info(f"Installing {label}...", prefix=app.app_name)
-        try:
-            with self.input.wait_bar("Uninstalling any existing app version..."):
-                self.tools.subprocess.run(
-                    ["xcrun", "simctl", "uninstall", udid, app.bundle_identifier],
-                    check=True,
+        with self.input.wait_bar(
+            "Uninstalling any existing app version..."
+        ) as keep_alive:
+            uninstall_popen = self.tools.subprocess.Popen(
+                ["xcrun", "simctl", "uninstall", udid, app.bundle_identifier]
+            )
+            with uninstall_popen:
+                while (ret_code := uninstall_popen.poll()) is None:
+                    keep_alive.update()
+                    time.sleep(0.25)
+            if ret_code != 0:
+                raise BriefcaseCommandError(
+                    f"Unable to uninstall old version of app {app.app_name}."
                 )
-        except subprocess.CalledProcessError as e:
-            raise BriefcaseCommandError(
-                f"Unable to uninstall old version of app {app.app_name}."
-            ) from e
 
         # Install the app.
-        try:
-            with self.input.wait_bar(f"Installing new {label} version..."):
-                self.tools.subprocess.run(
-                    ["xcrun", "simctl", "install", udid, self.binary_path(app)],
-                    check=True,
+        with self.input.wait_bar(f"Installing new {label} version..."):
+            install_popen = self.tools.subprocess.Popen(
+                ["xcrun", "simctl", "install", udid, self.binary_path(app)]
+            )
+            with install_popen:
+                while (ret_code := install_popen.poll()) is None:
+                    keep_alive.update()
+                    time.sleep(0.25)
+            if ret_code != 0:
+                raise BriefcaseCommandError(
+                    f"Unable to install new version of app {app.app_name}."
                 )
-        except subprocess.CalledProcessError as e:
-            raise BriefcaseCommandError(
-                f"Unable to install new version of app {app.app_name}."
-            ) from e
 
         # Start log stream for the app.
         # The following sets up a log stream filter that looks for:
@@ -571,7 +576,7 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         )
 
         # Wait for the log stream start up
-        self.sleep(0.25)
+        time.sleep(0.25)
 
         try:
             self.logger.info(f"Starting {label}...", prefix=app.app_name)

--- a/tests/commands/create/test_cleanup_app_content.py
+++ b/tests/commands/create/test_cleanup_app_content.py
@@ -42,7 +42,7 @@ def test_no_cleanup(create_command, myapp_unrolled, support_path, debug, capsys)
     # whether debug is enabled.
     output = capsys.readouterr().out.split("\n")
     assert output[-3] == "Removing unneeded app bundle content... done"
-    assert len(output) == (4 if debug else 3)
+    assert len(output) == (5 if debug else 4)
 
 
 @pytest.mark.parametrize("debug", [True, False])
@@ -65,7 +65,7 @@ def test_dir_cleanup(create_command, myapp_unrolled, support_path, debug, capsys
     # whether debug is enabled.
     output = capsys.readouterr().out.split("\n")
     assert output[-3] == "Removing unneeded app bundle content... done"
-    assert len(output) == (4 if debug else 3)
+    assert len(output) == (5 if debug else 4)
 
 
 @pytest.mark.parametrize("debug", [True, False])
@@ -91,7 +91,7 @@ def test_file_cleanup(create_command, myapp_unrolled, support_path, debug, capsy
     # whether debug is enabled.
     output = capsys.readouterr().out.split("\n")
     assert output[-3] == "Removing unneeded app bundle content... done"
-    assert len(output) == (5 if debug else 3)
+    assert len(output) == (6 if debug else 4)
 
 
 @pytest.mark.parametrize("debug", [True, False])
@@ -121,7 +121,7 @@ def test_all_files_in_dir_cleanup(
     # whether debug is enabled.
     output = capsys.readouterr().out.split("\n")
     assert output[-3] == "Removing unneeded app bundle content... done"
-    assert len(output) == (7 if debug else 3)
+    assert len(output) == (8 if debug else 4)
 
 
 @pytest.mark.parametrize("debug", [True, False])
@@ -144,7 +144,7 @@ def test_dir_glob_cleanup(create_command, myapp_unrolled, support_path, debug, c
     # whether debug is enabled.
     output = capsys.readouterr().out.split("\n")
     assert output[-3] == "Removing unneeded app bundle content... done"
-    assert len(output) == (5 if debug else 3)
+    assert len(output) == (6 if debug else 4)
 
 
 @pytest.mark.parametrize("debug", [True, False])
@@ -170,7 +170,7 @@ def test_file_glob_cleanup(create_command, myapp_unrolled, support_path, debug, 
     # whether debug is enabled.
     output = capsys.readouterr().out.split("\n")
     assert output[-3] == "Removing unneeded app bundle content... done"
-    assert len(output) == (6 if debug else 3)
+    assert len(output) == (7 if debug else 4)
 
 
 @pytest.mark.parametrize("debug", [True, False])
@@ -197,7 +197,7 @@ def test_deep_glob_cleanup(create_command, myapp_unrolled, support_path, debug, 
     # whether debug is enabled.
     output = capsys.readouterr().out.split("\n")
     assert output[-3] == "Removing unneeded app bundle content... done"
-    assert len(output) == (7 if debug else 3)
+    assert len(output) == (8 if debug else 4)
 
 
 @pytest.mark.parametrize("debug", [True, False])
@@ -232,7 +232,7 @@ def test_template_glob_cleanup(
     # whether debug is enabled.
     output = capsys.readouterr().out.split("\n")
     assert output[-3] == "Removing unneeded app bundle content... done"
-    assert len(output) == (7 if debug else 3)
+    assert len(output) == (8 if debug else 4)
 
 
 @pytest.mark.parametrize("debug", [True, False])
@@ -272,4 +272,4 @@ def test_non_existent_cleanup(
     # whether debug is enabled.
     output = capsys.readouterr().out.split("\n")
     assert output[-3] == "Removing unneeded app bundle content... done"
-    assert len(output) == (5 if debug else 3)
+    assert len(output) == (6 if debug else 4)

--- a/tests/commands/create/test_install_image.py
+++ b/tests/commands/create/test_install_image.py
@@ -60,7 +60,10 @@ def test_no_requested_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "Installing input/original.png as sample image... done\n\n"
+    expected = (
+        "Installing input/original.png as sample image... started\n"
+        "Installing input/original.png as sample image... done\n\n"
+    )
     assert capsys.readouterr().out == expected
 
     # The file was copied into position
@@ -114,7 +117,10 @@ def test_requested_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "Installing input/original-3742.png as 3742px sample image... done\n\n"
+    expected = (
+        "Installing input/original-3742.png as 3742px sample image... started\n"
+        "Installing input/original-3742.png as 3742px sample image... done\n\n"
+    )
     assert capsys.readouterr().out == expected
 
     # The file was copied into position
@@ -170,7 +176,10 @@ def test_variant_with_no_requested_size(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "Installing input/original.png as round sample image... done\n\n"
+    expected = (
+        "Installing input/original.png as round sample image... started\n"
+        "Installing input/original.png as round sample image... done\n\n"
+    )
     assert capsys.readouterr().out == expected
 
     # The file was copied into position
@@ -265,6 +274,7 @@ def test_variant_with_size(create_command, tmp_path, capsys):
 
     # The right message was written to output
     expected = (
+        "Installing input/original-3742.png as 3742px round sample image... started\n"
         "Installing input/original-3742.png as 3742px round sample image... done\n\n"
     )
     assert capsys.readouterr().out == expected
@@ -361,7 +371,10 @@ def test_unsized_variant(create_command, tmp_path, capsys):
     )
 
     # The right message was written to output
-    expected = "Installing input/original.png as round sample image... done\n\n"
+    expected = (
+        "Installing input/original.png as round sample image... started\n"
+        "Installing input/original.png as round sample image... done\n\n"
+    )
     assert capsys.readouterr().out == expected
 
     # The file was copied into position

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import inspect
 import os
 import subprocess
 import time
-from unittest.mock import ANY
+from unittest.mock import ANY, MagicMock
 
 import pytest
 
@@ -50,7 +50,7 @@ def no_print(monkeypatch):
 @pytest.fixture
 def sleep_zero(monkeypatch):
     """Replace all calls to ``time.sleep(x)`` with ``time.sleep(0)``."""
-    monkeypatch.setattr(time, "sleep", lambda x: _sleep(0))
+    monkeypatch.setattr(time, "sleep", MagicMock(wraps=lambda x: _sleep(0)))
 
 
 @pytest.fixture

--- a/tests/console/Console/test_progress_bar.py
+++ b/tests/console/Console/test_progress_bar.py
@@ -1,6 +1,6 @@
-def test_wait_bar_always_interactive(interactive_console):
+def test_wait_bar_always_interactive(console):
     """Progress Bar is not disabled when console is interactive."""
-    with interactive_console.progress_bar() as bar:
+    with console.progress_bar() as bar:
         assert bar.disable is False
 
 

--- a/tests/console/Console/test_properties.py
+++ b/tests/console/Console/test_properties.py
@@ -1,6 +1,3 @@
-import os
-import sys
-
 from briefcase.console import Console
 
 
@@ -28,17 +25,10 @@ def test_enable(disabled_console):
 def test_disable():
     """A disabled console can be enabled."""
     console = Console()
-
     assert console.enabled
 
     console.enabled = False
-
     assert not console.enabled
-
-
-def test_is_interactive_is_tty(console):
-    """Interactivity should match whether a tty is attached to stdout."""
-    assert console.is_interactive is os.isatty(sys.stdout.fileno())
 
 
 def test_is_interactive_non_interactive(non_interactive_console):
@@ -46,6 +36,6 @@ def test_is_interactive_non_interactive(non_interactive_console):
     assert non_interactive_console.is_interactive is False
 
 
-def test_is_interactive_always_interactive(interactive_console):
+def test_is_interactive_always_interactive(console):
     """Console is interactive when stdout has a tty."""
-    assert interactive_console.is_interactive is True
+    assert console.is_interactive is True

--- a/tests/console/Console/test_release_console_control.py
+++ b/tests/console/Console/test_release_console_control.py
@@ -27,11 +27,8 @@ def test_console_is_not_controlled():
     assert console.is_console_controlled is False
 
 
-def test_wait_bar_is_active(interactive_console):
+def test_wait_bar_is_active(console):
     """An active Wait Bar is stopped."""
-    # Always run in interactive mode; otherwise, is_started is will never be True
-    console = interactive_console
-
     with console.wait_bar("Testing..."):
         # Wrap the Wait Bar stop and start methods
         console._wait_bar.stop = Mock(wraps=console._wait_bar.stop)

--- a/tests/console/Console/test_wait_bar.py
+++ b/tests/console/Console/test_wait_bar.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def test_wait_bar_done_message(console, capsys):
+def test_wait_bar_done_message_interactive(console, capsys):
     """Custom done_message is printed when wait bar normally exits."""
     with console.wait_bar("Wait message...", done_message="finished"):
         pass
@@ -9,13 +9,40 @@ def test_wait_bar_done_message(console, capsys):
     assert capsys.readouterr().out == "Wait message... finished\n\n"
 
 
-def test_wait_bar_done_message_nested(console, capsys):
+def test_wait_bar_done_message_non_interactive(non_interactive_console, capsys):
+    """Custom done_message is printed when wait bar normally exits."""
+    with non_interactive_console.wait_bar("Wait message...", done_message="finished"):
+        pass
+
+    assert capsys.readouterr().out == (
+        "Wait message... started\n" "Wait message... finished\n\n"
+    )
+
+
+def test_wait_bar_done_message_nested_interactive(console, capsys):
     """Custom done_message is printed when wait bar normally exits."""
     with console.wait_bar("Wait message 1...", done_message="finished"):
         with console.wait_bar("Wait message 2...", done_message="finished"):
             pass
 
-    expected = "Wait message 2... finished\nWait message 1... finished\n\n"
+    expected = "Wait message 2... finished\n" "Wait message 1... finished\n\n"
+    assert capsys.readouterr().out == expected
+
+
+def test_wait_bar_done_message_nested_non_interactive(non_interactive_console, capsys):
+    """Custom done_message is printed when wait bar normally exits."""
+    with non_interactive_console.wait_bar("Wait message 1...", done_message="finished"):
+        with non_interactive_console.wait_bar(
+            "Wait message 2...", done_message="finished"
+        ):
+            pass
+
+    expected = (
+        "Wait message 1... started\n"
+        "Wait message 2... started\n"
+        "Wait message 2... finished\n"
+        "Wait message 1... finished\n\n"
+    )
     assert capsys.readouterr().out == expected
 
 
@@ -28,9 +55,32 @@ def test_wait_bar_done_message_nested(console, capsys):
         ("", True, "\n"),
     ),
 )
-def test_wait_bar_transient(console, message, transient, output, capsys):
+def test_wait_bar_transient_interactive(console, message, transient, output, capsys):
     """Output is present or absent based on presence of message and transient value."""
     with console.wait_bar(message, transient=transient):
+        pass
+
+    assert capsys.readouterr().out == output
+
+
+@pytest.mark.parametrize(
+    ("message", "transient", "output"),
+    (
+        ("Wait message...", False, "Wait message... started\nWait message... done\n\n"),
+        ("", False, "\n"),
+        ("Wait message...", True, "Wait message... started\nWait message... done\n\n"),
+        ("", True, "\n"),
+    ),
+)
+def test_wait_bar_transient_non_interactive(
+    non_interactive_console,
+    message,
+    transient,
+    output,
+    capsys,
+):
+    """Output is present or absent based on presence of message and transient value."""
+    with non_interactive_console.wait_bar(message, transient=transient):
         pass
 
     assert capsys.readouterr().out == output
@@ -50,7 +100,7 @@ def test_wait_bar_transient(console, message, transient, output, capsys):
         ("", "", True, "\n"),
     ),
 )
-def test_wait_bar_transient_nested(
+def test_wait_bar_transient_nested_interactive(
     console,
     message_one,
     message_two,
@@ -67,19 +117,103 @@ def test_wait_bar_transient_nested(
 
 
 @pytest.mark.parametrize(
+    ("message_one", "message_two", "transient", "output"),
+    (
+        (
+            "Wait message 1...",
+            "Wait message 2...",
+            False,
+            (
+                "Wait message 1... started\n"
+                "Wait message 2... started\n"
+                "Wait message 2... done\n"
+                "Wait message 1... done\n\n"
+            ),
+        ),
+        ("", "", False, "\n"),
+        (
+            "Wait message 1...",
+            "Wait message 2...",
+            True,
+            (
+                "Wait message 1... started\n"
+                "Wait message 2... started\n"
+                "Wait message 2... done\n"
+                "Wait message 1... done\n\n"
+            ),
+        ),
+        ("", "", True, "\n"),
+    ),
+)
+def test_wait_bar_transient_nested_non_interactive(
+    non_interactive_console,
+    message_one,
+    message_two,
+    transient,
+    output,
+    capsys,
+):
+    """Output is present or absent based on presence of message and transient value."""
+    with non_interactive_console.wait_bar(message_one, transient=transient):
+        with non_interactive_console.wait_bar(message_two, transient=transient):
+            pass
+
+    assert capsys.readouterr().out == output
+
+
+@pytest.mark.parametrize(
     ("message", "transient", "output"),
     (
-        ("Wait message...", False, "Wait message...\n\n"),
+        ("Wait message...", False, "Wait message... aborted\n\n"),
         ("", False, "\n"),
         ("Wait Message...", True, "\n"),
         ("", True, "\n"),
     ),
 )
-def test_wait_bar_keyboard_interrupt(console, message, transient, output, capsys):
+def test_wait_bar_keyboard_interrupt_interactive(
+    console,
+    message,
+    transient,
+    output,
+    capsys,
+):
     """If the wait bar is interrupted, output is present or absent based on presence of
     message and transient value."""
     with pytest.raises(KeyboardInterrupt):
         with console.wait_bar(message, transient=transient):
+            raise KeyboardInterrupt
+
+    assert capsys.readouterr().out == output
+
+
+@pytest.mark.parametrize(
+    ("message", "transient", "output"),
+    (
+        (
+            "Wait message...",
+            False,
+            "Wait message... started\nWait message... aborted\n\n",
+        ),
+        ("", False, "\n"),
+        (
+            "Wait message...",
+            True,
+            "Wait message... started\nWait message... aborted\n\n",
+        ),
+        ("", True, "\n"),
+    ),
+)
+def test_wait_bar_keyboard_interrupt_non_interactive(
+    non_interactive_console,
+    message,
+    transient,
+    output,
+    capsys,
+):
+    """If the wait bar is interrupted, output is present or absent based on presence of
+    message and transient value."""
+    with pytest.raises(KeyboardInterrupt):
+        with non_interactive_console.wait_bar(message, transient=transient):
             raise KeyboardInterrupt
 
     assert capsys.readouterr().out == output
@@ -92,14 +226,14 @@ def test_wait_bar_keyboard_interrupt(console, message, transient, output, capsys
             "Wait message 1...",
             "Wait message 2...",
             False,
-            "Wait message 2...\nWait message 1...\n\n",
+            "Wait message 2... aborted\nWait message 1... aborted\n\n",
         ),
         ("", "", False, "\n"),
         ("Wait message 1...", "Wait message 2...", True, "\n"),
         ("", "", True, "\n"),
     ),
 )
-def test_wait_bar_keyboard_interrupt_nested(
+def test_wait_bar_keyboard_interrupt_nested_interactive(
     console,
     message_one,
     message_two,
@@ -117,12 +251,59 @@ def test_wait_bar_keyboard_interrupt_nested(
     assert capsys.readouterr().out == output
 
 
-def test_wait_bar_always_interactive(interactive_console):
+@pytest.mark.parametrize(
+    ("message_one", "message_two", "transient", "output"),
+    (
+        (
+            "Wait message 1...",
+            "Wait message 2...",
+            False,
+            (
+                "Wait message 1... started\n"
+                "Wait message 2... started\n"
+                "Wait message 2... aborted\n"
+                "Wait message 1... aborted\n\n"
+            ),
+        ),
+        ("", "", False, "\n"),
+        (
+            "Wait message 1...",
+            "Wait message 2...",
+            True,
+            (
+                "Wait message 1... started\n"
+                "Wait message 2... started\n"
+                "Wait message 2... aborted\n"
+                "Wait message 1... aborted\n\n"
+            ),
+        ),
+        ("", "", True, "\n"),
+    ),
+)
+def test_wait_bar_keyboard_interrupt_nested_non_interactive(
+    non_interactive_console,
+    message_one,
+    message_two,
+    transient,
+    output,
+    capsys,
+):
+    """If the wait bar is interrupted, output is present or absent based on presence of
+    message and transient value."""
+    with pytest.raises(KeyboardInterrupt):
+        with non_interactive_console.wait_bar(message_one, transient=transient):
+            with non_interactive_console.wait_bar(message_two, transient=transient):
+                raise KeyboardInterrupt
+
+    assert capsys.readouterr().out == output
+
+
+def test_wait_bar_always_interactive(console):
     """Wait Bar is not disabled when console is interactive."""
-    with interactive_console.wait_bar():
-        assert interactive_console._wait_bar.disable is False
-        with interactive_console.wait_bar():
-            assert interactive_console._wait_bar.disable is False
+    with console.wait_bar():
+        assert console._wait_bar.disable is False
+        with console.wait_bar():
+            assert console._wait_bar.disable is False
 
 
 def test_wait_bar_non_interactive(non_interactive_console):

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -7,9 +7,11 @@ from briefcase.console import Console
 
 
 @pytest.fixture
-def console() -> Console:
+def console(monkeypatch) -> Console:
     console = Console()
     console.input = mock.MagicMock(spec_set=input)
+    # default console is always interactive
+    monkeypatch.setattr(sys.__stdout__, "isatty", lambda: True)
     return console
 
 
@@ -22,11 +24,5 @@ def disabled_console() -> Console:
 
 @pytest.fixture
 def non_interactive_console(console, monkeypatch) -> Console:
-    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
-    yield console
-
-
-@pytest.fixture
-def interactive_console(console, monkeypatch) -> Console:
-    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr(sys.__stdout__, "isatty", lambda: False)
     yield console

--- a/tests/console/test_NotDeadYet.py
+++ b/tests/console/test_NotDeadYet.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock
+
+import briefcase.console
+from briefcase.console import NotDeadYet, Printer
+
+
+def test_update(capsys, monkeypatch):
+    """The message is only printed once for each interval."""
+    # initialization will set interval to 0 + 10
+    # update() will see time either at 5 or 15 and print the message accordingly
+    # then interval is reset back to 0 + 10
+    monkeypatch.setattr(
+        briefcase.console.time,
+        "time",
+        MagicMock(side_effect=[0] + [10 - 5, 10 + 5, 0] * 3),
+    )
+
+    keep_alive = NotDeadYet(printer=Printer())
+
+    for _ in range(3):
+        keep_alive.update()
+        keep_alive.update()
+
+    assert capsys.readouterr().out == (
+        "... still waiting\n... still waiting\n... still waiting\n"
+    )
+
+
+def test_reset(capsys, monkeypatch):
+    """Calling reset always puts the interval in the future and nothing prints."""
+    # initialization will set interval to 0 + 10
+    # the reset updates the interval to 10 + 10
+    # the update sees a time of 15 and doesn't print or reset
+    monkeypatch.setattr(
+        briefcase.console.time,
+        "time",
+        MagicMock(side_effect=[0] + [10, 15] * 10),
+    )
+
+    keep_alive = NotDeadYet(printer=Printer())
+
+    for _ in range(10):
+        keep_alive.reset()
+        keep_alive.update()
+
+    assert capsys.readouterr().out == ""

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -92,9 +92,11 @@ def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
     )
 
     # Mock the uninstall, install, and log stream Popen processes
-    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    uninstall_popen.__enter__.return_value = uninstall_popen
     uninstall_popen.poll.side_effect = [None, None, 0]
     install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.__enter__.return_value = install_popen
     install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
     run_command.tools.subprocess.Popen.side_effect = [
@@ -221,9 +223,11 @@ def test_run_app_simulator_booted_underscore(
     )
 
     # Mock the uninstall, install, and log stream Popen processes
-    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    uninstall_popen.__enter__.return_value = uninstall_popen
     uninstall_popen.poll.side_effect = [None, None, 0]
     install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.__enter__.return_value = install_popen
     install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
     run_command.tools.subprocess.Popen.side_effect = [
@@ -342,9 +346,11 @@ def test_run_app_with_passthrough(run_command, first_app_config, tmp_path):
     )
 
     # Mock the uninstall, install, and log stream Popen processes
-    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    uninstall_popen.__enter__.return_value = uninstall_popen
     uninstall_popen.poll.side_effect = [None, None, 0]
     install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.__enter__.return_value = install_popen
     install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
     run_command.tools.subprocess.Popen.side_effect = [
@@ -475,9 +481,11 @@ def test_run_app_simulator_shut_down(
     )
 
     # Mock the uninstall, install, and log stream Popen processes
-    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    uninstall_popen.__enter__.return_value = uninstall_popen
     uninstall_popen.poll.side_effect = [None, None, 0]
     install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.__enter__.return_value = install_popen
     install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
     run_command.tools.subprocess.Popen.side_effect = [
@@ -614,9 +622,11 @@ def test_run_app_simulator_shutting_down(run_command, first_app_config, tmp_path
     )
 
     # Mock the uninstall, install, and log stream Popen processes
-    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    uninstall_popen.__enter__.return_value = uninstall_popen
     uninstall_popen.poll.side_effect = [None, None, 0]
     install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.__enter__.return_value = install_popen
     install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
     run_command.tools.subprocess.Popen.side_effect = [
@@ -830,7 +840,8 @@ def test_run_app_simulator_uninstall_failure(run_command, first_app_config):
     run_command.get_device_state = mock.MagicMock(return_value=DeviceState.SHUTDOWN)
 
     # Call uninstall fails
-    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    uninstall_popen.__enter__.return_value = uninstall_popen
     uninstall_popen.poll.side_effect = [None, None, 1]
     run_command.tools.subprocess.Popen.side_effect = [uninstall_popen]
 
@@ -895,9 +906,11 @@ def test_run_app_simulator_install_failure(run_command, first_app_config, tmp_pa
     run_command.get_device_state = mock.MagicMock(return_value=DeviceState.SHUTDOWN)
 
     # Call to install fails
-    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    uninstall_popen.__enter__.return_value = uninstall_popen
     uninstall_popen.poll.side_effect = [None, None, 0]
     install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.__enter__.return_value = install_popen
     install_popen.poll.side_effect = [None, None, 1]
     run_command.tools.subprocess.Popen.side_effect = [
         uninstall_popen,
@@ -984,9 +997,11 @@ def test_run_app_simulator_launch_failure(run_command, first_app_config, tmp_pat
     )
 
     # Mock the uninstall, install, and log stream Popen processes
-    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    uninstall_popen.__enter__.return_value = uninstall_popen
     uninstall_popen.poll.side_effect = [None, None, 0]
     install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.__enter__.return_value = install_popen
     install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
     run_command.tools.subprocess.Popen.side_effect = [
@@ -1102,9 +1117,11 @@ def test_run_app_simulator_no_pid(run_command, first_app_config, tmp_path):
     run_command.tools.subprocess.check_output.return_value = "No PID returned"
 
     # Mock the uninstall, install, and log stream Popen processes
-    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    uninstall_popen.__enter__.return_value = uninstall_popen
     uninstall_popen.poll.side_effect = [None, None, 0]
     install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.__enter__.return_value = install_popen
     install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
     run_command.tools.subprocess.Popen.side_effect = [
@@ -1222,9 +1239,11 @@ def test_run_app_simulator_non_integer_pid(run_command, first_app_config, tmp_pa
     )
 
     # Mock the uninstall, install, and log stream Popen processes
-    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    uninstall_popen.__enter__.return_value = uninstall_popen
     uninstall_popen.poll.side_effect = [None, None, 0]
     install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.__enter__.return_value = install_popen
     install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
     run_command.tools.subprocess.Popen.side_effect = [
@@ -1342,9 +1361,11 @@ def test_run_app_test_mode(run_command, first_app_config, tmp_path):
     )
 
     # Mock the uninstall, install, and log stream Popen processes
-    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    uninstall_popen.__enter__.return_value = uninstall_popen
     uninstall_popen.poll.side_effect = [None, None, 0]
     install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.__enter__.return_value = install_popen
     install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
     run_command.tools.subprocess.Popen.side_effect = [
@@ -1449,9 +1470,11 @@ def test_run_app_test_mode_with_passthrough(run_command, first_app_config, tmp_p
     )
 
     # Mock the uninstall, install, and log stream Popen processes
-    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    uninstall_popen.__enter__.return_value = uninstall_popen
     uninstall_popen.poll.side_effect = [None, None, 0]
     install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.__enter__.return_value = install_popen
     install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
     run_command.tools.subprocess.Popen.side_effect = [

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -24,9 +24,6 @@ def run_command(tmp_path):
     command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
     command._stream_app_logs = mock.MagicMock()
 
-    # Disable sleeps
-    command.sleep = mock.MagicMock(side_effect=lambda x: time.sleep(0))
-
     # To satisfy coverage, the stop function must be invoked
     # at least once when streaming app logs.
     def mock_stream_app_logs(app, stop_func, **kwargs):
@@ -78,6 +75,7 @@ def test_run_multiple_devices_input_disabled(run_command, first_app_config):
         run_command.run_app(first_app_config, test_mode=False, passthrough=[])
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
     """An iOS App can be started when the simulator is already booted."""
     # A valid target device will be selected.
@@ -93,9 +91,17 @@ def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
         "com.example.first-app: 1234\n"
     )
 
-    # Mock the log stream
+    # Mock the uninstall, install, and log stream Popen processes
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen.poll.side_effect = [None, None, 0]
+    install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
-    run_command.tools.subprocess.Popen.return_value = log_stream_process
+    run_command.tools.subprocess.Popen.side_effect = [
+        uninstall_popen,
+        install_popen,
+        log_stream_process,
+    ]
 
     # Run the app
     run_command.run_app(first_app_config, test_mode=False, passthrough=[])
@@ -115,36 +121,6 @@ def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
                 ],
                 check=True,
             ),
-            # Uninstall the old app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "uninstall",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    "com.example.first-app",
-                ],
-                check=True,
-            ),
-            # Install the new app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "install",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "build"
-                    / "Debug-iphonesimulator"
-                    / "First App.app",
-                ],
-                check=True,
-            ),
         ]
     )
     # Launch the new app
@@ -158,26 +134,54 @@ def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
         ],
     )
 
-    # Start the log stream
-    run_command.tools.subprocess.Popen.assert_called_once_with(
+    # slept 4 times for uninstall/install and 1 time for log stream start
+    assert time.sleep.call_count == 4 + 1
+
+    # Start the uninstall, install, and  log stream
+    run_command.tools.subprocess.Popen.assert_has_calls(
         [
-            "xcrun",
-            "simctl",
-            "spawn",
-            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-            "log",
-            "stream",
-            "--style",
-            "compact",
-            "--predicate",
-            'senderImagePath ENDSWITH "/First App"'
-            ' OR (processImagePath ENDSWITH "/First App"'
-            ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-            ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
+            # Uninstall the old app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "uninstall",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "com.example.first-app",
+                ],
+            ),
+            # Install the new app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "install",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    tmp_path
+                    / "base_path/build/first-app/ios/xcode/build/Debug-iphonesimulator/First App.app",
+                ],
+            ),
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "spawn",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "log",
+                    "stream",
+                    "--style",
+                    "compact",
+                    "--predicate",
+                    'senderImagePath ENDSWITH "/First App"'
+                    ' OR (processImagePath ENDSWITH "/First App"'
+                    ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                bufsize=1,
+            ),
+        ]
     )
 
     # Log stream monitoring was started
@@ -192,6 +196,7 @@ def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
     )
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_simulator_booted_underscore(
     run_command,
     underscore_app_config,
@@ -215,12 +220,23 @@ def test_run_app_simulator_booted_underscore(
         "com.example.first-app: 1234\n"
     )
 
-    # Mock the log stream
+    # Mock the uninstall, install, and log stream Popen processes
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen.poll.side_effect = [None, None, 0]
+    install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
-    run_command.tools.subprocess.Popen.return_value = log_stream_process
+    run_command.tools.subprocess.Popen.side_effect = [
+        uninstall_popen,
+        install_popen,
+        log_stream_process,
+    ]
 
     # Run the app
     run_command.run_app(underscore_app_config, test_mode=False, passthrough=[])
+
+    # slept 4 times for uninstall/install and 1 time for log stream start
+    assert time.sleep.call_count == 4 + 1
 
     # The correct sequence of commands was issued.
     run_command.tools.subprocess.run.assert_has_calls(
@@ -234,36 +250,6 @@ def test_run_app_simulator_booted_underscore(
                     "--args",
                     "-CurrentDeviceUDID",
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                ],
-                check=True,
-            ),
-            # Uninstall the old app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "uninstall",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    "com.example.first-app",
-                ],
-                check=True,
-            ),
-            # Install the new app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "install",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first_app"
-                    / "ios"
-                    / "xcode"
-                    / "build"
-                    / "Debug-iphonesimulator"
-                    / "First App.app",
                 ],
                 check=True,
             ),
@@ -280,26 +266,51 @@ def test_run_app_simulator_booted_underscore(
         ],
     )
 
-    # Start the log stream
-    run_command.tools.subprocess.Popen.assert_called_once_with(
+    # Start the uninstall, install, and  log stream
+    run_command.tools.subprocess.Popen.assert_has_calls(
         [
-            "xcrun",
-            "simctl",
-            "spawn",
-            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-            "log",
-            "stream",
-            "--style",
-            "compact",
-            "--predicate",
-            'senderImagePath ENDSWITH "/First App"'
-            ' OR (processImagePath ENDSWITH "/First App"'
-            ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-            ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
+            # Uninstall the old app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "uninstall",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "com.example.first-app",
+                ],
+            ),
+            # Install the new app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "install",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    tmp_path
+                    / "base_path/build/first_app/ios/xcode/build/Debug-iphonesimulator/First App.app",
+                ],
+            ),
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "spawn",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "log",
+                    "stream",
+                    "--style",
+                    "compact",
+                    "--predicate",
+                    'senderImagePath ENDSWITH "/First App"'
+                    ' OR (processImagePath ENDSWITH "/First App"'
+                    ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                bufsize=1,
+            ),
+        ]
     )
 
     # Log stream monitoring was started
@@ -314,6 +325,7 @@ def test_run_app_simulator_booted_underscore(
     )
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_with_passthrough(run_command, first_app_config, tmp_path):
     """An iOS App can be started with passthrough args."""
     # A valid target device will be selected.
@@ -329,9 +341,17 @@ def test_run_app_with_passthrough(run_command, first_app_config, tmp_path):
         "com.example.first-app: 1234\n"
     )
 
-    # Mock the log stream
+    # Mock the uninstall, install, and log stream Popen processes
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen.poll.side_effect = [None, None, 0]
+    install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
-    run_command.tools.subprocess.Popen.return_value = log_stream_process
+    run_command.tools.subprocess.Popen.side_effect = [
+        uninstall_popen,
+        install_popen,
+        log_stream_process,
+    ]
 
     # Run the app with passthrough args.
     run_command.run_app(
@@ -339,6 +359,9 @@ def test_run_app_with_passthrough(run_command, first_app_config, tmp_path):
         test_mode=False,
         passthrough=["foo", "--bar"],
     )
+
+    # slept 4 times for uninstall/install and 1 time for log stream start
+    assert time.sleep.call_count == 4 + 1
 
     # The correct sequence of commands was issued.
     run_command.tools.subprocess.run.assert_has_calls(
@@ -352,36 +375,6 @@ def test_run_app_with_passthrough(run_command, first_app_config, tmp_path):
                     "--args",
                     "-CurrentDeviceUDID",
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                ],
-                check=True,
-            ),
-            # Uninstall the old app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "uninstall",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    "com.example.first-app",
-                ],
-                check=True,
-            ),
-            # Install the new app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "install",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "build"
-                    / "Debug-iphonesimulator"
-                    / "First App.app",
                 ],
                 check=True,
             ),
@@ -400,26 +393,51 @@ def test_run_app_with_passthrough(run_command, first_app_config, tmp_path):
         ],
     )
 
-    # Start the log stream
-    run_command.tools.subprocess.Popen.assert_called_once_with(
+    # Start the uninstall, install, and  log stream
+    run_command.tools.subprocess.Popen.assert_has_calls(
         [
-            "xcrun",
-            "simctl",
-            "spawn",
-            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-            "log",
-            "stream",
-            "--style",
-            "compact",
-            "--predicate",
-            'senderImagePath ENDSWITH "/First App"'
-            ' OR (processImagePath ENDSWITH "/First App"'
-            ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-            ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
+            # Uninstall the old app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "uninstall",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "com.example.first-app",
+                ],
+            ),
+            # Install the new app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "install",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    tmp_path
+                    / "base_path/build/first-app/ios/xcode/build/Debug-iphonesimulator/First App.app",
+                ],
+            ),
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "spawn",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "log",
+                    "stream",
+                    "--style",
+                    "compact",
+                    "--predicate",
+                    'senderImagePath ENDSWITH "/First App"'
+                    ' OR (processImagePath ENDSWITH "/First App"'
+                    ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                bufsize=1,
+            ),
+        ]
     )
 
     # Log stream monitoring was started
@@ -434,7 +452,12 @@ def test_run_app_with_passthrough(run_command, first_app_config, tmp_path):
     )
 
 
-def test_run_app_simulator_shut_down(run_command, first_app_config, tmp_path):
+@pytest.mark.usefixtures("sleep_zero")
+def test_run_app_simulator_shut_down(
+    run_command,
+    first_app_config,
+    tmp_path,
+):
     """An iOS App can be started when the simulator is shut down."""
     # A valid target device will be selected.
     run_command.select_target_device = mock.MagicMock(
@@ -451,12 +474,23 @@ def test_run_app_simulator_shut_down(run_command, first_app_config, tmp_path):
         "com.example.first-app: 1234\n"
     )
 
-    # Mock the log stream
+    # Mock the uninstall, install, and log stream Popen processes
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen.poll.side_effect = [None, None, 0]
+    install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
-    run_command.tools.subprocess.Popen.return_value = log_stream_process
+    run_command.tools.subprocess.Popen.side_effect = [
+        uninstall_popen,
+        install_popen,
+        log_stream_process,
+    ]
 
     # Run the app
     run_command.run_app(first_app_config, test_mode=False, passthrough=[])
+
+    # slept 4 times for uninstall/install and 1 time for log stream start
+    assert time.sleep.call_count == 4 + 1
 
     # The correct sequence of commands was issued.
     run_command.tools.subprocess.run.assert_has_calls(
@@ -478,36 +512,6 @@ def test_run_app_simulator_shut_down(run_command, first_app_config, tmp_path):
                 ],
                 check=True,
             ),
-            # Uninstall the old app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "uninstall",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    "com.example.first-app",
-                ],
-                check=True,
-            ),
-            # Install the new app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "install",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "build"
-                    / "Debug-iphonesimulator"
-                    / "First App.app",
-                ],
-                check=True,
-            ),
         ]
     )
 
@@ -522,26 +526,51 @@ def test_run_app_simulator_shut_down(run_command, first_app_config, tmp_path):
         ],
     )
 
-    # Start the log stream
-    run_command.tools.subprocess.Popen.assert_called_once_with(
+    # Start the uninstall, install, and  log stream
+    run_command.tools.subprocess.Popen.assert_has_calls(
         [
-            "xcrun",
-            "simctl",
-            "spawn",
-            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-            "log",
-            "stream",
-            "--style",
-            "compact",
-            "--predicate",
-            'senderImagePath ENDSWITH "/First App"'
-            ' OR (processImagePath ENDSWITH "/First App"'
-            ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-            ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
+            # Uninstall the old app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "uninstall",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "com.example.first-app",
+                ],
+            ),
+            # Install the new app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "install",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    tmp_path
+                    / "base_path/build/first-app/ios/xcode/build/Debug-iphonesimulator/First App.app",
+                ],
+            ),
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "spawn",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "log",
+                    "stream",
+                    "--style",
+                    "compact",
+                    "--predicate",
+                    'senderImagePath ENDSWITH "/First App"'
+                    ' OR (processImagePath ENDSWITH "/First App"'
+                    ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                bufsize=1,
+            ),
+        ]
     )
 
     # Log stream monitoring was started
@@ -556,6 +585,7 @@ def test_run_app_simulator_shut_down(run_command, first_app_config, tmp_path):
     )
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_simulator_shutting_down(run_command, first_app_config, tmp_path):
     """An iOS App can be started when the simulator is shutting down."""
     # A valid target device will be selected.
@@ -583,15 +613,23 @@ def test_run_app_simulator_shutting_down(run_command, first_app_config, tmp_path
         "com.example.first-app: 1234\n"
     )
 
-    # Mock the log stream
+    # Mock the uninstall, install, and log stream Popen processes
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen.poll.side_effect = [None, None, 0]
+    install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
-    run_command.tools.subprocess.Popen.return_value = log_stream_process
+    run_command.tools.subprocess.Popen.side_effect = [
+        uninstall_popen,
+        install_popen,
+        log_stream_process,
+    ]
 
     # Run the app
     run_command.run_app(first_app_config, test_mode=False, passthrough=[])
 
-    # We should have slept 4 times
-    assert run_command.sleep.call_count == 4
+    # We should have slept 4 times for shutting down and 4 time for uninstall/install
+    assert time.sleep.call_count == 4 + 4
 
     # The correct sequence of commands was issued.
     run_command.tools.subprocess.run.assert_has_calls(
@@ -613,36 +651,6 @@ def test_run_app_simulator_shutting_down(run_command, first_app_config, tmp_path
                 ],
                 check=True,
             ),
-            # Uninstall the old app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "uninstall",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    "com.example.first-app",
-                ],
-                check=True,
-            ),
-            # Install the new app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "install",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "build"
-                    / "Debug-iphonesimulator"
-                    / "First App.app",
-                ],
-                check=True,
-            ),
         ]
     )
 
@@ -657,26 +665,51 @@ def test_run_app_simulator_shutting_down(run_command, first_app_config, tmp_path
         ],
     )
 
-    # Start the log stream
-    run_command.tools.subprocess.Popen.assert_called_once_with(
+    # Start the uninstall, install, and  log stream
+    run_command.tools.subprocess.Popen.assert_has_calls(
         [
-            "xcrun",
-            "simctl",
-            "spawn",
-            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-            "log",
-            "stream",
-            "--style",
-            "compact",
-            "--predicate",
-            'senderImagePath ENDSWITH "/First App"'
-            ' OR (processImagePath ENDSWITH "/First App"'
-            ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-            ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
+            # Uninstall the old app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "uninstall",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "com.example.first-app",
+                ],
+            ),
+            # Install the new app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "install",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    tmp_path
+                    / "base_path/build/first-app/ios/xcode/build/Debug-iphonesimulator/First App.app",
+                ],
+            ),
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "spawn",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "log",
+                    "stream",
+                    "--style",
+                    "compact",
+                    "--predicate",
+                    'senderImagePath ENDSWITH "/First App"'
+                    ' OR (processImagePath ENDSWITH "/First App"'
+                    ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                bufsize=1,
+            ),
+        ]
     )
 
     # Log stream monitoring was started
@@ -691,6 +724,7 @@ def test_run_app_simulator_shutting_down(run_command, first_app_config, tmp_path
     )
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_simulator_boot_failure(run_command, first_app_config):
     """If the simulator fails to boot, raise an error."""
     # A valid target device will be selected.
@@ -710,6 +744,9 @@ def test_run_app_simulator_boot_failure(run_command, first_app_config):
     with pytest.raises(BriefcaseCommandError):
         run_command.run_app(first_app_config, test_mode=False, passthrough=[])
 
+    # No sleeps
+    assert time.sleep.call_count == 0
+
     # The correct sequence of commands was issued.
     run_command.tools.subprocess.run.assert_has_calls(
         [
@@ -726,6 +763,7 @@ def test_run_app_simulator_boot_failure(run_command, first_app_config):
     run_command._stream_app_logs.assert_not_called()
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_simulator_open_failure(run_command, first_app_config):
     """If the simulator can't be opened, raise an error."""
     # A valid target device will be selected.
@@ -750,6 +788,9 @@ def test_run_app_simulator_open_failure(run_command, first_app_config):
     with pytest.raises(BriefcaseCommandError):
         run_command.run_app(first_app_config, test_mode=False, passthrough=[])
 
+    # No sleeps
+    assert time.sleep.call_count == 0
+
     # The correct sequence of commands was issued.
     run_command.tools.subprocess.run.assert_has_calls(
         [
@@ -777,6 +818,7 @@ def test_run_app_simulator_open_failure(run_command, first_app_config):
     run_command._stream_app_logs.assert_not_called()
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_simulator_uninstall_failure(run_command, first_app_config):
     """If the old app can't be uninstalled, raise an error."""
     # A valid target device will be selected.
@@ -787,19 +829,17 @@ def test_run_app_simulator_uninstall_failure(run_command, first_app_config):
     # Simulator is shut down
     run_command.get_device_state = mock.MagicMock(return_value=DeviceState.SHUTDOWN)
 
-    # Call to boot and open simulator succeed, but uninstall fails.
-    run_command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
-    run_command.tools.subprocess.run.side_effect = [
-        0,
-        0,
-        subprocess.CalledProcessError(
-            cmd=["xcrun", "simctl", "uninstall", "..."], returncode=1
-        ),
-    ]
+    # Call uninstall fails
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen.poll.side_effect = [None, None, 1]
+    run_command.tools.subprocess.Popen.side_effect = [uninstall_popen]
 
     # Run the app
     with pytest.raises(BriefcaseCommandError):
         run_command.run_app(first_app_config, test_mode=False, passthrough=[])
+
+    # Sleep twice for uninstall failure
+    assert time.sleep.call_count == 2
 
     # The correct sequence of commands was issued.
     run_command.tools.subprocess.run.assert_has_calls(
@@ -821,6 +861,11 @@ def test_run_app_simulator_uninstall_failure(run_command, first_app_config):
                 ],
                 check=True,
             ),
+        ]
+    )
+    # Start the uninstall
+    run_command.tools.subprocess.Popen.assert_has_calls(
+        [
             # Uninstall the old app
             mock.call(
                 [
@@ -830,15 +875,15 @@ def test_run_app_simulator_uninstall_failure(run_command, first_app_config):
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                     "com.example.first-app",
                 ],
-                check=True,
             ),
         ]
     )
+
     # The log will not be tailed
-    run_command.tools.subprocess.Popen.assert_not_called()
     run_command._stream_app_logs.assert_not_called()
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_simulator_install_failure(run_command, first_app_config, tmp_path):
     """If the app fails to install in the simulator, raise an error."""
     # A valid target device will be selected.
@@ -849,20 +894,22 @@ def test_run_app_simulator_install_failure(run_command, first_app_config, tmp_pa
     # Simulator is shut down
     run_command.get_device_state = mock.MagicMock(return_value=DeviceState.SHUTDOWN)
 
-    # Call to boot and open simulator, and uninstall succeed, but install fails.
-    run_command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
-    run_command.tools.subprocess.run.side_effect = [
-        0,
-        0,
-        0,
-        subprocess.CalledProcessError(
-            cmd=["xcrun", "simctl", "uninstall", "..."], returncode=1
-        ),
+    # Call to install fails
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen.poll.side_effect = [None, None, 0]
+    install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.poll.side_effect = [None, None, 1]
+    run_command.tools.subprocess.Popen.side_effect = [
+        uninstall_popen,
+        install_popen,
     ]
 
     # Run the app
     with pytest.raises(BriefcaseCommandError):
         run_command.run_app(first_app_config, test_mode=False, passthrough=[])
+
+    # Sleep twice for uninstall and twice for install failure
+    assert time.sleep.call_count == 4
 
     # The correct sequence of commands was issued.
     run_command.tools.subprocess.run.assert_has_calls(
@@ -884,6 +931,12 @@ def test_run_app_simulator_install_failure(run_command, first_app_config, tmp_pa
                 ],
                 check=True,
             ),
+        ]
+    )
+
+    # Start the uninstall and install
+    run_command.tools.subprocess.Popen.assert_has_calls(
+        [
             # Uninstall the old app
             mock.call(
                 [
@@ -893,7 +946,6 @@ def test_run_app_simulator_install_failure(run_command, first_app_config, tmp_pa
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                     "com.example.first-app",
                 ],
-                check=True,
             ),
             # Install the new app
             mock.call(
@@ -903,24 +955,17 @@ def test_run_app_simulator_install_failure(run_command, first_app_config, tmp_pa
                     "install",
                     "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
                     tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "build"
-                    / "Debug-iphonesimulator"
-                    / "First App.app",
+                    / "base_path/build/first-app/ios/xcode/build/Debug-iphonesimulator/First App.app",
                 ],
-                check=True,
             ),
         ]
     )
+
     # The log will not be tailed
-    run_command.tools.subprocess.Popen.assert_not_called()
     run_command._stream_app_logs.assert_not_called()
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_simulator_launch_failure(run_command, first_app_config, tmp_path):
     """If the app fails to launch, raise an error."""
     # A valid target device will be selected.
@@ -931,15 +976,6 @@ def test_run_app_simulator_launch_failure(run_command, first_app_config, tmp_pat
     # Simulator is shut down
     run_command.get_device_state = mock.MagicMock(return_value=DeviceState.SHUTDOWN)
 
-    # Call to boot and open simulator, uninstall and install succeed.
-    run_command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
-    run_command.tools.subprocess.run.side_effect = [
-        0,
-        0,
-        0,
-        0,
-    ]
-
     # Mock a process ID for the app
     run_command.tools.subprocess.check_output.side_effect = (
         subprocess.CalledProcessError(
@@ -947,13 +983,24 @@ def test_run_app_simulator_launch_failure(run_command, first_app_config, tmp_pat
         )
     )
 
-    # Mock the log stream
-    log_stream_process = mock.MagicMock()
-    run_command.tools.subprocess.Popen.return_value = log_stream_process
+    # Mock the uninstall, install, and log stream Popen processes
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen.poll.side_effect = [None, None, 0]
+    install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.poll.side_effect = [None, None, 0]
+    log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
+    run_command.tools.subprocess.Popen.side_effect = [
+        uninstall_popen,
+        install_popen,
+        log_stream_process,
+    ]
 
     # Run the app
     with pytest.raises(BriefcaseCommandError):
         run_command.run_app(first_app_config, test_mode=False, passthrough=[])
+
+    # Sleep four times for uninstall/install and once for log stream start
+    assert time.sleep.call_count == 4 + 1
 
     # The correct sequence of commands was issued.
     run_command.tools.subprocess.run.assert_has_calls(
@@ -975,36 +1022,6 @@ def test_run_app_simulator_launch_failure(run_command, first_app_config, tmp_pat
                 ],
                 check=True,
             ),
-            # Uninstall the old app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "uninstall",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    "com.example.first-app",
-                ],
-                check=True,
-            ),
-            # Install the new app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "install",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "build"
-                    / "Debug-iphonesimulator"
-                    / "First App.app",
-                ],
-                check=True,
-            ),
         ]
     )
 
@@ -1019,32 +1036,58 @@ def test_run_app_simulator_launch_failure(run_command, first_app_config, tmp_pat
         ],
     )
 
-    # Start the log stream
-    run_command.tools.subprocess.Popen.assert_called_once_with(
+    # Start the uninstall, install, and  log stream
+    run_command.tools.subprocess.Popen.assert_has_calls(
         [
-            "xcrun",
-            "simctl",
-            "spawn",
-            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-            "log",
-            "stream",
-            "--style",
-            "compact",
-            "--predicate",
-            'senderImagePath ENDSWITH "/First App"'
-            ' OR (processImagePath ENDSWITH "/First App"'
-            ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-            ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
+            # Uninstall the old app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "uninstall",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "com.example.first-app",
+                ],
+            ),
+            # Install the new app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "install",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    tmp_path
+                    / "base_path/build/first-app/ios/xcode/build/Debug-iphonesimulator/First App.app",
+                ],
+            ),
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "spawn",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "log",
+                    "stream",
+                    "--style",
+                    "compact",
+                    "--predicate",
+                    'senderImagePath ENDSWITH "/First App"'
+                    ' OR (processImagePath ENDSWITH "/First App"'
+                    ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                bufsize=1,
+            ),
+        ]
     )
 
     # Log stream failed, so it won't be monitored
     run_command._stream_app_logs.assert_not_called()
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_simulator_no_pid(run_command, first_app_config, tmp_path):
     """If the app fails to provide a meaningful PID on launch, raise an error."""
     # A valid target device will be selected.
@@ -1055,25 +1098,27 @@ def test_run_app_simulator_no_pid(run_command, first_app_config, tmp_path):
     # Simulator is shut down
     run_command.get_device_state = mock.MagicMock(return_value=DeviceState.SHUTDOWN)
 
-    # Call to boot and open simulator, uninstall and install succeed.
-    run_command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
-    run_command.tools.subprocess.run.side_effect = [
-        0,
-        0,
-        0,
-        0,
-    ]
-
     # Mock a bad return value for the PID
     run_command.tools.subprocess.check_output.return_value = "No PID returned"
 
-    # Mock the log stream
-    log_stream_process = mock.MagicMock()
-    run_command.tools.subprocess.Popen.return_value = log_stream_process
+    # Mock the uninstall, install, and log stream Popen processes
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen.poll.side_effect = [None, None, 0]
+    install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.poll.side_effect = [None, None, 0]
+    log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
+    run_command.tools.subprocess.Popen.side_effect = [
+        uninstall_popen,
+        install_popen,
+        log_stream_process,
+    ]
 
     # Run the app
     with pytest.raises(BriefcaseCommandError):
         run_command.run_app(first_app_config, test_mode=False, passthrough=[])
+
+    # Sleep four times for uninstall/install and once for log stream start
+    assert time.sleep.call_count == 4 + 1
 
     # The correct sequence of commands was issued.
     run_command.tools.subprocess.run.assert_has_calls(
@@ -1095,36 +1140,6 @@ def test_run_app_simulator_no_pid(run_command, first_app_config, tmp_path):
                 ],
                 check=True,
             ),
-            # Uninstall the old app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "uninstall",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    "com.example.first-app",
-                ],
-                check=True,
-            ),
-            # Install the new app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "install",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "build"
-                    / "Debug-iphonesimulator"
-                    / "First App.app",
-                ],
-                check=True,
-            ),
         ]
     )
 
@@ -1139,32 +1154,58 @@ def test_run_app_simulator_no_pid(run_command, first_app_config, tmp_path):
         ],
     )
 
-    # Start the log stream
-    run_command.tools.subprocess.Popen.assert_called_once_with(
+    # Start the uninstall, install, and  log stream
+    run_command.tools.subprocess.Popen.assert_has_calls(
         [
-            "xcrun",
-            "simctl",
-            "spawn",
-            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-            "log",
-            "stream",
-            "--style",
-            "compact",
-            "--predicate",
-            'senderImagePath ENDSWITH "/First App"'
-            ' OR (processImagePath ENDSWITH "/First App"'
-            ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-            ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
+            # Uninstall the old app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "uninstall",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "com.example.first-app",
+                ],
+            ),
+            # Install the new app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "install",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    tmp_path
+                    / "base_path/build/first-app/ios/xcode/build/Debug-iphonesimulator/First App.app",
+                ],
+            ),
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "spawn",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "log",
+                    "stream",
+                    "--style",
+                    "compact",
+                    "--predicate",
+                    'senderImagePath ENDSWITH "/First App"'
+                    ' OR (processImagePath ENDSWITH "/First App"'
+                    ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                bufsize=1,
+            ),
+        ]
     )
 
     # PID detection failed, so it won't be monitored
     run_command._stream_app_logs.assert_not_called()
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_simulator_non_integer_pid(run_command, first_app_config, tmp_path):
     """If the PID returned isn't an integer, raise an error."""
     # A valid target device will be selected.
@@ -1175,27 +1216,29 @@ def test_run_app_simulator_non_integer_pid(run_command, first_app_config, tmp_pa
     # Simulator is shut down
     run_command.get_device_state = mock.MagicMock(return_value=DeviceState.SHUTDOWN)
 
-    # Call to boot and open simulator, uninstall and install succeed.
-    run_command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
-    run_command.tools.subprocess.run.side_effect = [
-        0,
-        0,
-        0,
-        0,
-    ]
-
     # Mock a bad process ID for the app
     run_command.tools.subprocess.check_output.return_value = (
         "com.example.first-app: NOT A PID\n"
     )
 
-    # Mock the log stream
-    log_stream_process = mock.MagicMock()
-    run_command.tools.subprocess.Popen.return_value = log_stream_process
+    # Mock the uninstall, install, and log stream Popen processes
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen.poll.side_effect = [None, None, 0]
+    install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.poll.side_effect = [None, None, 0]
+    log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
+    run_command.tools.subprocess.Popen.side_effect = [
+        uninstall_popen,
+        install_popen,
+        log_stream_process,
+    ]
 
     # Run the app
     with pytest.raises(BriefcaseCommandError):
         run_command.run_app(first_app_config, test_mode=False, passthrough=[])
+
+    # Sleep four times for uninstall/install and once for log stream start
+    assert time.sleep.call_count == 4 + 1
 
     # The correct sequence of commands was issued.
     run_command.tools.subprocess.run.assert_has_calls(
@@ -1217,36 +1260,6 @@ def test_run_app_simulator_non_integer_pid(run_command, first_app_config, tmp_pa
                 ],
                 check=True,
             ),
-            # Uninstall the old app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "uninstall",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    "com.example.first-app",
-                ],
-                check=True,
-            ),
-            # Install the new app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "install",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "build"
-                    / "Debug-iphonesimulator"
-                    / "First App.app",
-                ],
-                check=True,
-            ),
         ]
     )
 
@@ -1261,32 +1274,58 @@ def test_run_app_simulator_non_integer_pid(run_command, first_app_config, tmp_pa
         ],
     )
 
-    # Start the log stream
-    run_command.tools.subprocess.Popen.assert_called_once_with(
+    # Start the uninstall, install, and  log stream
+    run_command.tools.subprocess.Popen.assert_has_calls(
         [
-            "xcrun",
-            "simctl",
-            "spawn",
-            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-            "log",
-            "stream",
-            "--style",
-            "compact",
-            "--predicate",
-            'senderImagePath ENDSWITH "/First App"'
-            ' OR (processImagePath ENDSWITH "/First App"'
-            ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-            ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
+            # Uninstall the old app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "uninstall",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "com.example.first-app",
+                ],
+            ),
+            # Install the new app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "install",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    tmp_path
+                    / "base_path/build/first-app/ios/xcode/build/Debug-iphonesimulator/First App.app",
+                ],
+            ),
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "spawn",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "log",
+                    "stream",
+                    "--style",
+                    "compact",
+                    "--predicate",
+                    'senderImagePath ENDSWITH "/First App"'
+                    ' OR (processImagePath ENDSWITH "/First App"'
+                    ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                bufsize=1,
+            ),
+        ]
     )
 
     # PID detection failed, so it won't be called
     run_command._stream_app_logs.assert_not_called()
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_test_mode(run_command, first_app_config, tmp_path):
     """An iOS App can be started in test mode."""
     # A valid target device will be selected.
@@ -1302,49 +1341,26 @@ def test_run_app_test_mode(run_command, first_app_config, tmp_path):
         "com.example.first-app: 1234\n"
     )
 
-    # Mock the log stream
+    # Mock the uninstall, install, and log stream Popen processes
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen.poll.side_effect = [None, None, 0]
+    install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
-    run_command.tools.subprocess.Popen.return_value = log_stream_process
+    run_command.tools.subprocess.Popen.side_effect = [
+        uninstall_popen,
+        install_popen,
+        log_stream_process,
+    ]
 
     # Run the app
     run_command.run_app(first_app_config, test_mode=True, passthrough=[])
 
-    # The correct sequence of commands was issued.
-    run_command.tools.subprocess.run.assert_has_calls(
-        [
-            # Simulator doesn't need to be opened.
-            # Uninstall the old app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "uninstall",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    "com.example.first-app",
-                ],
-                check=True,
-            ),
-            # Install the new app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "install",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "build"
-                    / "Debug-iphonesimulator"
-                    / "First App.app",
-                ],
-                check=True,
-            ),
-        ]
-    )
+    # Sleep four times for uninstall/install and once for log stream start
+    assert time.sleep.call_count == 4 + 1
+
+    # Open command was not called
+    run_command.tools.subprocess.run.assert_not_called()
 
     # Launch the new app
     run_command.tools.subprocess.check_output.assert_called_once_with(
@@ -1357,26 +1373,51 @@ def test_run_app_test_mode(run_command, first_app_config, tmp_path):
         ],
     )
 
-    # Start the log stream
-    run_command.tools.subprocess.Popen.assert_called_once_with(
+    # Start the uninstall, install, and  log stream
+    run_command.tools.subprocess.Popen.assert_has_calls(
         [
-            "xcrun",
-            "simctl",
-            "spawn",
-            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-            "log",
-            "stream",
-            "--style",
-            "compact",
-            "--predicate",
-            'senderImagePath ENDSWITH "/First App"'
-            ' OR (processImagePath ENDSWITH "/First App"'
-            ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-            ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
+            # Uninstall the old app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "uninstall",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "com.example.first-app",
+                ],
+            ),
+            # Install the new app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "install",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    tmp_path
+                    / "base_path/build/first-app/ios/xcode/build/Debug-iphonesimulator/First App.app",
+                ],
+            ),
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "spawn",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "log",
+                    "stream",
+                    "--style",
+                    "compact",
+                    "--predicate",
+                    'senderImagePath ENDSWITH "/First App"'
+                    ' OR (processImagePath ENDSWITH "/First App"'
+                    ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                bufsize=1,
+            ),
+        ]
     )
 
     # Log stream monitoring was started
@@ -1391,6 +1432,7 @@ def test_run_app_test_mode(run_command, first_app_config, tmp_path):
     )
 
 
+@pytest.mark.usefixtures("sleep_zero")
 def test_run_app_test_mode_with_passthrough(run_command, first_app_config, tmp_path):
     """An iOS App can be started in test mode with passthrough args."""
     # A valid target device will be selected.
@@ -1406,9 +1448,17 @@ def test_run_app_test_mode_with_passthrough(run_command, first_app_config, tmp_p
         "com.example.first-app: 1234\n"
     )
 
-    # Mock the log stream
+    # Mock the uninstall, install, and log stream Popen processes
+    uninstall_popen = mock.MagicMock(spec_set=subprocess.Popen, name="asdf")
+    uninstall_popen.poll.side_effect = [None, None, 0]
+    install_popen = mock.MagicMock(spec_set=subprocess.Popen)
+    install_popen.poll.side_effect = [None, None, 0]
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
-    run_command.tools.subprocess.Popen.return_value = log_stream_process
+    run_command.tools.subprocess.Popen.side_effect = [
+        uninstall_popen,
+        install_popen,
+        log_stream_process,
+    ]
 
     # Run the app with args.
     run_command.run_app(
@@ -1417,42 +1467,11 @@ def test_run_app_test_mode_with_passthrough(run_command, first_app_config, tmp_p
         passthrough=["foo", "--bar"],
     )
 
-    # The correct sequence of commands was issued.
-    run_command.tools.subprocess.run.assert_has_calls(
-        [
-            # Simulator doesn't need to be opened.
-            # Uninstall the old app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "uninstall",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    "com.example.first-app",
-                ],
-                check=True,
-            ),
-            # Install the new app
-            mock.call(
-                [
-                    "xcrun",
-                    "simctl",
-                    "install",
-                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "build"
-                    / "Debug-iphonesimulator"
-                    / "First App.app",
-                ],
-                check=True,
-            ),
-        ]
-    )
+    # Sleep four times for uninstall/install and once for log stream start
+    assert time.sleep.call_count == 4 + 1
+
+    # Open command was not called
+    run_command.tools.subprocess.run.assert_not_called()
 
     # Launch the new app
     run_command.tools.subprocess.check_output.assert_called_once_with(
@@ -1467,26 +1486,51 @@ def test_run_app_test_mode_with_passthrough(run_command, first_app_config, tmp_p
         ],
     )
 
-    # Start the log stream
-    run_command.tools.subprocess.Popen.assert_called_once_with(
+    # Start the uninstall, install, and  log stream
+    run_command.tools.subprocess.Popen.assert_has_calls(
         [
-            "xcrun",
-            "simctl",
-            "spawn",
-            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
-            "log",
-            "stream",
-            "--style",
-            "compact",
-            "--predicate",
-            'senderImagePath ENDSWITH "/First App"'
-            ' OR (processImagePath ENDSWITH "/First App"'
-            ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-            ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
+            # Uninstall the old app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "uninstall",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "com.example.first-app",
+                ],
+            ),
+            # Install the new app
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "install",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    tmp_path
+                    / "base_path/build/first-app/ios/xcode/build/Debug-iphonesimulator/First App.app",
+                ],
+            ),
+            mock.call(
+                [
+                    "xcrun",
+                    "simctl",
+                    "spawn",
+                    "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D",
+                    "log",
+                    "stream",
+                    "--style",
+                    "compact",
+                    "--predicate",
+                    'senderImagePath ENDSWITH "/First App"'
+                    ' OR (processImagePath ENDSWITH "/First App"'
+                    ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                bufsize=1,
+            ),
+        ]
     )
 
     # Log stream monitoring was started


### PR DESCRIPTION
## Changes
- When Briefcase runs non-interactively, such as in CI, the Wait Bar is not rendered; therefore, it may not be clear which task is currently running. For instance, starting the Android emulator requires several Wait Bars but there is only output when the Wait Bar finishes.
- This prints the Wait Bar's message when the Wait Bar starts if Briefcase is running non-interactively.
- This new Wait Bar start message as well as the outcome message is always included in the log file now.
- Additionally, a new keep-alive spinner is available as a return from the Wait Bar.
  - This spinner was be used to periodically print `... still waiting` while a background runs that doesn't include any console output.
  - The is currently implemented for the start up process of the Android emulator.

This is an example of non-interactive output:
```
[helloworld] Starting emulator beePhone...
Starting emulator... started
Starting emulator... done

[helloworld] Starting app on https://github.com/beephone (running emulator) (device ID emulator-5554)

[helloworld] Installing app...
Stopping old versions of the app... started
Stopping old versions of the app... done

Installing new app version... started
Installing new app version... done

Launching app... started
Launching app... done

[helloworld] Following device log output (type CTRL-C to stop log)...
===========================================================================
```

This is akin to what `pip` does when run non-interactively:
```
❯ python -m pip install pygobject --no-cache | cat
Collecting pygobject
  Downloading PyGObject-3.46.0.tar.gz (723 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 723.4/723.4 kB 3.7 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting pycairo>=1.16.0 (from pygobject)
  Downloading pycairo-1.26.0.tar.gz (346 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 346.9/346.9 kB 39.3 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Building wheels for collected packages: pygobject, pycairo
  Building wheel for pygobject (pyproject.toml): started
  Building wheel for pygobject (pyproject.toml): finished with status 'done'
  Created wheel for pygobject: filename=PyGObject-3.46.0-cp310-cp310-linux_x86_64.whl size=780934 sha256=adaf291713960cd7c5020defbb5294742c95a2cc03240157053fd801b60eefc3
  Stored in directory: /tmp/pip-ephem-wheel-cache-8d96807b/wheels/2b/d7/f7/1f4c5631b6d31c5a0f377754294700bf3d7df1ceee00617404
  Building wheel for pycairo (pyproject.toml): started
  Building wheel for pycairo (pyproject.toml): finished with status 'done'
  Created wheel for pycairo: filename=pycairo-1.26.0-cp310-cp310-linux_x86_64.whl size=320989 sha256=07a26626db22ee48e253c5669be0d2227091599db2abe5f695391a697033e90d
  Stored in directory: /tmp/pip-ephem-wheel-cache-8d96807b/wheels/e3/46/83/453eb7915b034ce1a9fee5a6023def2030633f6a73dc6d2de8
Successfully built pygobject pycairo
Installing collected packages: pycairo, pygobject
Successfully installed pycairo-1.26.0 pygobject-3.46.0
```

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
