### PR TITLE
Use latest WiX - v3.14

### DIFF
--- a/changes/1660.feature.rst
+++ b/changes/1660.feature.rst
@@ -1,0 +1,1 @@
+WiX v3.14 is now used to package Windows apps. Run ``briefcase upgrade wix`` to start using this version.

--- a/src/briefcase/integrations/wix.py
+++ b/src/briefcase/integrations/wix.py
@@ -37,7 +37,7 @@ class WiX(ManagedTool):
 
     @property
     def download_url(self) -> str:
-        return "https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip"
+        return "https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip"
 
     @property
     def heat_exe(self) -> Path:

--- a/tests/integrations/wix/conftest.py
+++ b/tests/integrations/wix/conftest.py
@@ -7,7 +7,9 @@ from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.subprocess import Subprocess
 
-WIX_DOWNLOAD_URL = "https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip"
+WIX_DOWNLOAD_URL = (
+    "https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip"
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Changes
- Use [WiX v3.14](https://github.com/wixtoolset/wix3/releases/tag/wix314rtm)
- I was super confused looking at their releases....they reverted the previous release we were using to `pre-release`

```
❯ gh release list -R wixtoolset/wix3
TITLE                TYPE         TAG NAME    PUBLISHED        
WiX Toolset v3.14    Latest       wix314rtm   about 12 days ago
WiX Toolset v3.11.2  Pre-release  wix3112rtm  about 4 years ago
WiX Toolset v3.11.1  Pre-release  wix3111rtm  about 6 years ago
WiX Toolset v3.10.4  Pre-release  wix3104rtm  about 6 years ago
WiX Toolset v3.11    Pre-release  wix311rtm   about 6 years ago
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
