### PR TITLE
Add support to pass arguments through to Docker image build

### DIFF
--- a/changes/1661.feature.rst
+++ b/changes/1661.feature.rst
@@ -1,0 +1,1 @@
+Additional options can now be passed to the ``docker build`` command for building native Linux packages and AppImages via the ``--Xdocker-build`` argument.

--- a/docs/reference/platforms/linux/appimage.rst
+++ b/docs/reference/platforms/linux/appimage.rst
@@ -97,6 +97,8 @@ AppImages.
 
 Use native execution, rather than using Docker to start a container.
 
+.. include:: docker_build_options.rst
+
 Application configuration
 =========================
 

--- a/docs/reference/platforms/linux/docker_build_options.rst
+++ b/docs/reference/platforms/linux/docker_build_options.rst
@@ -1,0 +1,12 @@
+``--Xdocker-build=<value>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A configuration argument to be passed to the Docker build command for the app
+image. For example, to provide an additional build argument to the Dockerfile,
+specify ``--Xdocker-build=--build-arg=ARG=value``. See `the Docker build
+documentation
+<https://docs.docker.com/engine/reference/commandline/image_build/#options>`__
+for details on the full list of options that can be provided.
+
+You may specify multiple ``--Xdocker-build`` arguments; each one specifies a
+single argument to pass to Docker, in the order they are specified.

--- a/docs/reference/platforms/linux/system.rst
+++ b/docs/reference/platforms/linux/system.rst
@@ -111,14 +111,16 @@ supported by the vendor, and system Python is Python 3.8 or later.
 
 The following Linux vendors are known to work as Docker targets:
 
-* Debian (e.g., ``debian:bullseye`` or ``debian:11``)
+* Debian (e.g., ``debian:bookworm`` or ``debian:12``)
 * Ubuntu (e.g., ``ubuntu:jammy`` or ``ubuntu:22.04``)
-* Fedora (e.g, ``fedora:37``)
+* Fedora (e.g, ``fedora:39``)
 * AlmaLinux (e.g., ``almalinux:9``)
 * Red Hat Enterprise Linux (e.g., ``redhat/ubi9:9``)
 * openSUSE Tumbleweed (e.g., ``"opensuse/tumbleweed:latest"``)
 * Arch Linux (e.g., ``archlinux:latest``)
 * Manjaro Linux (e.g., ``manjarolinux/base:latest``)
+
+.. include:: docker_build_options.rst
 
 Application configuration
 =========================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,9 @@ dependencies = [
     # Dependencies required at runtime are set as ranges to ensure maximum
     # compatibility with the end-user's development environment.
     #
-    # Any dependency that is part of the "core python toolchain" (e.g. pip,
-    # wheel) specify a minimum version, but no maximum, because we always want
-    # the most recent version.
+    # Any dependency that is part of the "core python toolchain" (e.g. pip, wheel)
+    # specify a minimum version, but no maximum, because we always want the most
+    # recent version.
     #
     # limited to <=3.9 for the `group` argument for `entry_points()`
     "importlib_metadata >= 4.4; python_version <= '3.9'",
@@ -73,13 +73,15 @@ dependencies = [
     "setuptools >= 60",
     "wheel >= 0.37",
     "build >= 0.10",
-    # For the remaining packages: We set the lower version limit to the lowest
-    # possible version that satisfies our API needs. If the package uses semver,
-    # we set a limit to prevent the next major version (which will potentially
-    # cause API breakages). If the package uses calver, we don't pin the upper
-    # version, as the upper version provides no basis for determining API
-    # stability.
-    "cookiecutter >= 2.3.1, < 3.0",
+    #
+    # For the remaining packages: We set the lower version limit to the lowest possible
+    # version that satisfies our API needs. If the package uses semver, we set a limit
+    # to prevent the next major version (which will potentially cause API breakages).
+    # If the package uses calver, we don't pin the upper version, as the upper version
+    # provides no basis for determining API stability.
+    #
+    # See beeware/briefcase#1663 to bump <2.6.0 pin
+    "cookiecutter >= 2.3.1, < 2.6.0",
     "dmgbuild >= 1.6, < 2.0; sys_platform == 'darwin'",
     "GitPython >= 3.1, < 4.0",
     "platformdirs >= 2.6, < 5.0",

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -839,6 +839,7 @@ class DockerAppContext(Tool):
         host_bundle_path: Path,
         host_data_path: Path,
         python_version: str,
+        extra_build_args: list[str] | None = None,
         **kwargs,
     ) -> DockerAppContext:  # pragma: no-cover-if-is-windows
         """Verify that docker is available as an app-bound tool.
@@ -870,6 +871,7 @@ class DockerAppContext(Tool):
             host_bundle_path=host_bundle_path,
             host_data_path=host_data_path,
             python_version=python_version,
+            extra_build_args=extra_build_args,
         )
         return tools[app].app_context
 
@@ -881,6 +883,7 @@ class DockerAppContext(Tool):
         host_bundle_path: Path,
         host_data_path: Path,
         python_version: str,
+        extra_build_args: list[str] | None = None,
     ):
         """Create/update the Docker image from the app's Dockerfile."""
         self.app_base_path = app_base_path
@@ -904,7 +907,9 @@ class DockerAppContext(Tool):
                     self.tools.subprocess.run(
                         [
                             "docker",
+                            "buildx",
                             "build",
+                            "--load",
                             "--progress",
                             "plain",
                             "--tag",
@@ -921,7 +926,8 @@ class DockerAppContext(Tool):
                                 self.app_base_path,
                                 *self.app.sources[0].split("/")[:-1],
                             ),
-                        ],
+                        ]
+                        + (extra_build_args if extra_build_args is not None else []),
                         check=True,
                     )
                 except subprocess.CalledProcessError as e:

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -67,17 +67,26 @@ class LinuxAppImagePassiveMixin(LinuxMixin):
             help="Don't use Docker for building the AppImage",
             required=False,
         )
+        parser.add_argument(
+            "--Xdocker-build",
+            action="append",
+            dest="extra_docker_build_args",
+            help="Additional arguments to use when building the Docker image",
+            required=False,
+        )
 
     def parse_options(self, extra):
         """Extract the use_docker option."""
         options, overrides = super().parse_options(extra)
         self.use_docker = options.pop("use_docker")
+        self.extra_docker_build_args = options.pop("extra_docker_build_args")
         return options, overrides
 
     def clone_options(self, command):
         """Clone the use_docker option."""
         super().clone_options(command)
         self.use_docker = command.use_docker
+        self.extra_docker_build_args = command.extra_docker_build_args
 
     def finalize_app_config(self, app: AppConfig):
         """If we're *not* using Docker, warn the user about portability."""
@@ -149,6 +158,7 @@ class LinuxAppImageMostlyPassiveMixin(LinuxAppImagePassiveMixin):
                 host_bundle_path=self.bundle_path(app),
                 host_data_path=self.data_path,
                 python_version=self.python_version_tag,
+                extra_build_args=self.extra_docker_build_args,
             )
         else:
             NativeAppContext.verify(tools=self.tools, app=app)

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -56,11 +56,19 @@ class LinuxSystemPassiveMixin(LinuxMixin):
             help="Docker base image tag for the distribution to target for the build (e.g., `ubuntu:jammy`)",
             required=False,
         )
+        parser.add_argument(
+            "--Xdocker-build",
+            action="append",
+            dest="extra_docker_build_args",
+            help="Additional arguments to use when building the Docker image",
+            required=False,
+        )
 
     def parse_options(self, extra):
         """Extract the target_image option."""
         options, overrides = super().parse_options(extra)
         self.target_image = options.pop("target")
+        self.extra_docker_build_args = options.pop("extra_docker_build_args")
 
         return options, overrides
 
@@ -377,6 +385,7 @@ class LinuxSystemMostlyPassiveMixin(LinuxSystemPassiveMixin):
         """Clone the target_image option."""
         super().clone_options(command)
         self.target_image = command.target_image
+        self.extra_docker_build_args = command.extra_docker_build_args
 
     def verify_python(self, app: AppConfig):
         """Verify that the version of Python being used to build the app in Docker is
@@ -577,6 +586,7 @@ to install the missing dependencies, and re-run Briefcase.
                 host_bundle_path=self.bundle_path(app),
                 host_data_path=self.data_path,
                 python_version=app.python_version_tag,
+                extra_build_args=self.extra_docker_build_args,
             )
 
             # Check the system Python on the target system to see if it is

--- a/tests/integrations/docker/test_DockerAppContext__verify.py
+++ b/tests/integrations/docker/test_DockerAppContext__verify.py
@@ -18,6 +18,7 @@ def verify_kwargs():
         host_bundle_path=Path("/host/bundle"),
         host_data_path=Path("/host/data"),
         python_version="py3.X",
+        extra_build_args=["--option-one", "--option-two"],
     )
 
 
@@ -57,7 +58,9 @@ def test_success(mock_tools, first_app_config, verify_kwargs, sub_stream_kw):
     mock_tools.subprocess._subprocess.Popen.assert_called_with(
         [
             "docker",
+            "buildx",
             "build",
+            "--load",
             "--progress",
             "plain",
             "--tag",
@@ -71,6 +74,8 @@ def test_success(mock_tools, first_app_config, verify_kwargs, sub_stream_kw):
             "--build-arg",
             "HOST_GID=42",
             "/app/base/src",
+            "--option-one",
+            "--option-two",
         ],
         **sub_stream_kw,
     )

--- a/tests/platforms/linux/appimage/test_mixin.py
+++ b/tests/platforms/linux/appimage/test_mixin.py
@@ -35,12 +35,7 @@ def test_binary_path(create_command, first_app_config, tmp_path):
     assert (
         binary_path
         == tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "linux"
-        / "appimage"
-        / "First_App-0.0.1-x86_64.AppImage"
+        / "base_path/build/first-app/linux/appimage/First_App-0.0.1-x86_64.AppImage"
     )
 
 
@@ -105,10 +100,11 @@ def test_verify_linux_no_docker(create_command, first_app_config, tmp_path):
     assert not hasattr(create_command.tools, "docker")
 
 
-def test_verify_linux_docker(create_command, tmp_path, first_app_config, monkeypatch):
+def test_verify_linux_docker(create_command, first_app_config, tmp_path, monkeypatch):
     """If Docker is enabled on Linux, the Docker alias is set."""
     create_command.tools.host_os = "Linux"
     create_command.use_docker = True
+    create_command.extra_docker_build_args = ["--option-one", "--option-two"]
 
     # Mock Docker tool verification
     mock__version_compat = MagicMock(spec=Docker._version_compat)
@@ -157,21 +153,12 @@ def test_verify_linux_docker(create_command, tmp_path, first_app_config, monkeyp
         app=first_app_config,
         image_tag="briefcase/com.example.first-app:appimage",
         dockerfile_path=tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "linux"
-        / "appimage"
-        / "Dockerfile",
+        / "base_path/build/first-app/linux/appimage/Dockerfile",
         app_base_path=tmp_path / "base_path",
-        host_bundle_path=tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "linux"
-        / "appimage",
+        host_bundle_path=tmp_path / "base_path/build/first-app/linux/appimage",
         host_data_path=tmp_path / "briefcase",
         python_version=f"3.{sys.version_info.minor}",
+        extra_build_args=["--option-one", "--option-two"],
     )
 
 
@@ -184,6 +171,7 @@ def test_verify_non_linux_docker(
     """If Docker is enabled on non-Linux, the Docker alias is set."""
     create_command.tools.host_os = "Darwin"
     create_command.use_docker = True
+    create_command.extra_docker_build_args = ["--option-one", "--option-two"]
 
     # Mock Docker tool verification
     mock__version_compat = MagicMock(spec=Docker._version_compat)
@@ -232,21 +220,12 @@ def test_verify_non_linux_docker(
         app=first_app_config,
         image_tag="briefcase/com.example.first-app:appimage",
         dockerfile_path=tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "linux"
-        / "appimage"
-        / "Dockerfile",
+        / "base_path/build/first-app/linux/appimage/Dockerfile",
         app_base_path=tmp_path / "base_path",
-        host_bundle_path=tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "linux"
-        / "appimage",
+        host_bundle_path=tmp_path / "base_path/build/first-app/linux/appimage",
         host_data_path=tmp_path / "briefcase",
         python_version=f"3.{sys.version_info.minor}",
+        extra_build_args=["--option-one", "--option-two"],
     )
 
 
@@ -259,9 +238,11 @@ def test_clone_options(tmp_path):
         data_path=tmp_path / "briefcase",
     )
     build_command.use_docker = True
+    build_command.extra_docker_build_args = ["--option-one", "--option-two"]
 
     create_command = build_command.create_command
 
     # Confirm the use_docker option has been cloned
     assert create_command.is_clone
     assert create_command.use_docker
+    assert create_command.extra_docker_build_args == ["--option-one", "--option-two"]

--- a/tests/platforms/linux/appimage/test_package.py
+++ b/tests/platforms/linux/appimage/test_package.py
@@ -29,12 +29,7 @@ def test_package_app(package_command, first_app_config, tmp_path):
     # Create the app binary
     create_file(
         tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "linux"
-        / "appimage"
-        / "First_App-0.0.1-x86_64.AppImage",
+        / "base_path/build/first-app/linux/appimage/First_App-0.0.1-x86_64.AppImage",
         "AppImage",
     )
 

--- a/tests/platforms/linux/appimage/test_run.py
+++ b/tests/platforms/linux/appimage/test_run.py
@@ -58,12 +58,7 @@ def test_run_app(run_command, first_app_config, tmp_path):
         [
             os.fsdecode(
                 tmp_path
-                / "base_path"
-                / "build"
-                / "first-app"
-                / "linux"
-                / "appimage"
-                / "First_App-0.0.1-x86_64.AppImage"
+                / "base_path/build/first-app/linux/appimage/First_App-0.0.1-x86_64.AppImage"
             )
         ],
         cwd=tmp_path / "home",
@@ -99,12 +94,7 @@ def test_run_app_with_passthrough(run_command, first_app_config, tmp_path):
         [
             os.fsdecode(
                 tmp_path
-                / "base_path"
-                / "build"
-                / "first-app"
-                / "linux"
-                / "appimage"
-                / "First_App-0.0.1-x86_64.AppImage"
+                / "base_path/build/first-app/linux/appimage/First_App-0.0.1-x86_64.AppImage"
             ),
             "foo",
             "--bar",
@@ -136,12 +126,7 @@ def test_run_app_failed(run_command, first_app_config, tmp_path):
         [
             os.fsdecode(
                 tmp_path
-                / "base_path"
-                / "build"
-                / "first-app"
-                / "linux"
-                / "appimage"
-                / "First_App-0.0.1-x86_64.AppImage"
+                / "base_path/build/first-app/linux/appimage/First_App-0.0.1-x86_64.AppImage"
             )
         ],
         cwd=tmp_path / "home",
@@ -168,12 +153,7 @@ def test_run_app_test_mode(run_command, first_app_config, tmp_path):
         [
             os.fsdecode(
                 tmp_path
-                / "base_path"
-                / "build"
-                / "first-app"
-                / "linux"
-                / "appimage"
-                / "First_App-0.0.1-x86_64.AppImage"
+                / "base_path/build/first-app/linux/appimage/First_App-0.0.1-x86_64.AppImage"
             )
         ],
         cwd=tmp_path / "home",
@@ -210,12 +190,7 @@ def test_run_app_test_mode_with_args(run_command, first_app_config, tmp_path):
         [
             os.fsdecode(
                 tmp_path
-                / "base_path"
-                / "build"
-                / "first-app"
-                / "linux"
-                / "appimage"
-                / "First_App-0.0.1-x86_64.AppImage"
+                / "base_path/build/first-app/linux/appimage/First_App-0.0.1-x86_64.AppImage"
             ),
             "foo",
             "--bar",

--- a/tests/platforms/linux/system/test_create.py
+++ b/tests/platforms/linux/system/test_create.py
@@ -18,13 +18,19 @@ def test_default_options(create_command):
 def test_options(create_command):
     """The extra options can be parsed."""
     options, overrides = create_command.parse_options(
-        ["--target", "somevendor:surprising"]
+        [
+            "--target",
+            "somevendor:surprising",
+            "--Xdocker-build=--option-one",
+            "--Xdocker-build=--option-two",
+        ]
     )
 
     assert options == {}
     assert overrides == {}
 
     assert create_command.target_image == "somevendor:surprising"
+    assert create_command.extra_docker_build_args == ["--option-one", "--option-two"]
 
 
 @pytest.mark.parametrize("host_os", ["Windows", "WeirdOS"])

--- a/tests/platforms/linux/system/test_mixin__properties.py
+++ b/tests/platforms/linux/system/test_mixin__properties.py
@@ -67,15 +67,7 @@ def test_binary_path(create_command, first_app_config, tmp_path):
     assert (
         create_command.binary_path(first_app_config)
         == tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "somevendor"
-        / "surprising"
-        / "first-app-0.0.1"
-        / "usr"
-        / "bin"
-        / "first-app"
+        / "base_path/build/first-app/somevendor/surprising/first-app-0.0.1/usr/bin/first-app"
     )
 
 
@@ -178,9 +170,11 @@ def test_clone_options(create_command, tmp_path):
         data_path=tmp_path / "briefcase",
     )
     build_command.target_image = "somevendor:surprising"
+    build_command.extra_docker_build_args = ["--option-one", "--option-two"]
 
     create_command = build_command.create_command
 
     # Confirm the use_docker option has been cloned.
     assert create_command.is_clone
     assert create_command.target_image == "somevendor:surprising"
+    assert create_command.extra_docker_build_args == ["--option-one", "--option-two"]

--- a/tests/platforms/linux/system/test_mixin__verify.py
+++ b/tests/platforms/linux/system/test_mixin__verify.py
@@ -5,7 +5,7 @@ from briefcase.integrations.docker import Docker, DockerAppContext
 from briefcase.integrations.subprocess import Subprocess
 
 
-def test_linux_no_docker(monkeypatch, create_command, first_app_config):
+def test_linux_no_docker(create_command, first_app_config, monkeypatch):
     """If Docker is disabled on Linux, the app_context is Subprocess."""
     create_command.tools.host_os = "Linux"
     create_command.target_image = None
@@ -37,10 +37,11 @@ def test_linux_no_docker(monkeypatch, create_command, first_app_config):
     create_command.verify_system_python.assert_not_called()
 
 
-def test_linux_docker(create_command, tmp_path, first_app_config, monkeypatch):
+def test_linux_docker(create_command, first_app_config, tmp_path, monkeypatch):
     """If Docker is enabled on Linux, the Docker alias is set."""
     create_command.tools.host_os = "Linux"
     create_command.target_image = "somevendor:surprising"
+    create_command.extra_docker_build_args = ["--option-one", "--option-two"]
 
     # Force a dummy vendor:codename for test purposes.
     first_app_config.target_vendor = "somevendor"
@@ -96,21 +97,12 @@ def test_linux_docker(create_command, tmp_path, first_app_config, monkeypatch):
         app=first_app_config,
         image_tag="briefcase/com.example.first-app:somevendor-surprising",
         dockerfile_path=tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "somevendor"
-        / "surprising"
-        / "Dockerfile",
+        / "base_path/build/first-app/somevendor/surprising/Dockerfile",
         app_base_path=tmp_path / "base_path",
-        host_bundle_path=tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "somevendor"
-        / "surprising",
+        host_bundle_path=tmp_path / "base_path/build/first-app/somevendor/surprising",
         host_data_path=tmp_path / "briefcase",
         python_version="3",
+        extra_build_args=["--option-one", "--option-two"],
     )
 
     # Python was also verified
@@ -124,10 +116,11 @@ def test_linux_docker(create_command, tmp_path, first_app_config, monkeypatch):
     create_command.verify_python.assert_not_called()
 
 
-def test_non_linux_docker(create_command, first_app_config, monkeypatch, tmp_path):
+def test_non_linux_docker(create_command, first_app_config, tmp_path, monkeypatch):
     """If Docker is enabled on non-Linux, the Docker alias is set."""
     create_command.tools.host_os = "Darwin"
     create_command.target_image = "somevendor:surprising"
+    create_command.extra_docker_build_args = ["--option-one", "--option-two"]
 
     # Force a dummy vendor:codename for test purposes.
     first_app_config.target_vendor = "somevendor"
@@ -183,21 +176,12 @@ def test_non_linux_docker(create_command, first_app_config, monkeypatch, tmp_pat
         app=first_app_config,
         image_tag="briefcase/com.example.first-app:somevendor-surprising",
         dockerfile_path=tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "somevendor"
-        / "surprising"
-        / "Dockerfile",
+        / "base_path/build/first-app/somevendor/surprising/Dockerfile",
         app_base_path=tmp_path / "base_path",
-        host_bundle_path=tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "somevendor"
-        / "surprising",
+        host_bundle_path=tmp_path / "base_path/build/first-app/somevendor/surprising",
         host_data_path=tmp_path / "briefcase",
         python_version="3",
+        extra_build_args=["--option-one", "--option-two"],
     )
 
     # Python was also verified

--- a/tests/platforms/linux/system/test_run.py
+++ b/tests/platforms/linux/system/test_run.py
@@ -59,6 +59,7 @@ def run_command(tmp_path, first_app, monkeypatch):
 
     # Disable Docker by default
     command.target_image = None
+    command.extra_docker_build_args = []
 
     command.tools.subprocess._subprocess = mock.MagicMock(spec_set=subprocess)
     command.tools.subprocess.run = mock.MagicMock(spec_set=Subprocess.run)
@@ -248,15 +249,7 @@ def test_run_app(run_command, first_app, sub_kw, tmp_path):
         [
             os.fsdecode(
                 tmp_path
-                / "base_path"
-                / "build"
-                / "first-app"
-                / "somevendor"
-                / "surprising"
-                / "first-app-0.0.1"
-                / "usr"
-                / "bin"
-                / "first-app"
+                / "base_path/build/first-app/somevendor/surprising/first-app-0.0.1/usr/bin/first-app"
             )
         ],
         cwd=os.fsdecode(tmp_path / "home"),

--- a/tests/platforms/linux/test_DockerOpenCommand.py
+++ b/tests/platforms/linux/test_DockerOpenCommand.py
@@ -47,6 +47,7 @@ def test_open_docker(open_command, first_app_config, tmp_path, monkeypatch):
 
     # Enable docker
     open_command.use_docker = True
+    open_command.extra_docker_build_args = []
 
     # Provide Docker
     monkeypatch.setattr(
@@ -61,19 +62,9 @@ def test_open_docker(open_command, first_app_config, tmp_path, monkeypatch):
     open_command.tools[first_app_config].app_context.prepare(
         image_tag=f"briefcase/com.example.first-app:py3.{sys.version_info.minor}",
         dockerfile_path=tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "linux"
-        / "appimage"
-        / "Dockerfile",
+        / "base_path/build/first-app/linux/appimage/Dockerfile",
         app_base_path=tmp_path / "base_path",
-        host_bundle_path=tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "linux"
-        / "appimage",
+        host_bundle_path=tmp_path / "base_path/build/first-app/linux/appimage",
         host_data_path=tmp_path / "briefcase",
         python_version=f"3.{sys.version_info.minor}",
     )
@@ -83,8 +74,7 @@ def test_open_docker(open_command, first_app_config, tmp_path, monkeypatch):
     # Create the desktop file that would be in the project folder.
     create_file(
         open_command.project_path(first_app_config)
-        / "First App.AppDir"
-        / "com.example.firstapp.desktop",
+        / "First App.AppDir/com.example.firstapp.desktop",
         "FreeDesktop file",
     )
 
@@ -116,8 +106,7 @@ def test_open_no_docker_linux(open_command, first_app_config, tmp_path):
     # Create the desktop file that would be in the project folder.
     create_file(
         open_command.project_path(first_app_config)
-        / "First App.AppDir"
-        / "com.example.firstapp.desktop",
+        / "First App.AppDir/com.example.firstapp.desktop",
         "FreeDesktop file",
     )
 
@@ -140,8 +129,7 @@ def test_open_no_docker_macOS(open_command, first_app_config, tmp_path):
     # Create the desktop file that would be in the project folder.
     create_file(
         open_command.project_path(first_app_config)
-        / "First App.AppDir"
-        / "com.example.firstapp.desktop",
+        / "First App.AppDir/com.example.firstapp.desktop",
         "FreeDesktop file",
     )
 

--- a/tests/platforms/linux/test_LocalRequirementsMixin.py
+++ b/tests/platforms/linux/test_LocalRequirementsMixin.py
@@ -77,20 +77,9 @@ def create_command(no_docker_create_command, first_app_config, tmp_path, monkeyp
     )
     no_docker_create_command.tools[first_app_config].app_context.prepare(
         image_tag="briefcase/com.example.first-app:py3.X",
-        dockerfile_path=tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "tester"
-        / "dummy"
-        / "Dockerfile",
+        dockerfile_path=tmp_path / "base_path/build/first-app/tester/dummy/Dockerfile",
         app_base_path=tmp_path / "base_path",
-        host_bundle_path=tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "tester"
-        / "dummy",
+        host_bundle_path=tmp_path / "base_path/build/first-app/tester/dummy",
         host_data_path=tmp_path / "briefcase",
         python_version="3.X",
     )
@@ -173,7 +162,7 @@ def test_install_app_requirements_in_docker(create_command, first_app_config, tm
             "run",
             "--rm",
             "--volume",
-            f"{tmp_path / 'base_path' / 'build' / 'first-app' / 'tester' / 'dummy'}:/app:z",
+            f"{tmp_path / 'base_path/build/first-app/tester/dummy'}:/app:z",
             "--volume",
             f"{tmp_path / 'briefcase'}:/briefcase:z",
             "briefcase/com.example.first-app:py3.X",
@@ -247,7 +236,7 @@ def test_install_app_requirements_no_docker(
             "--no-python-version-warning",
             "--upgrade",
             "--no-user",
-            f"--target={tmp_path}/base_path/build/first-app/tester/dummy/path/to/app_packages",
+            f"--target={tmp_path / 'base_path/build/first-app/tester/dummy/path/to/app_packages'}",
             "foo==1.2.3",
             "bar>=4.5",
         ],
@@ -308,13 +297,7 @@ def test_install_app_requirements_with_locals(
             "build",
             "--sdist",
             "--outdir",
-            tmp_path
-            / "base_path"
-            / "build"
-            / "first-app"
-            / "tester"
-            / "dummy"
-            / "_requirements",
+            tmp_path / "base_path/build/first-app/tester/dummy/_requirements",
             str(tmp_path / "local/first"),
         ],
         encoding="UTF-8",
@@ -324,23 +307,11 @@ def test_install_app_requirements_with_locals(
     create_command.tools.shutil.copy.mock_calls = [
         call(
             str(tmp_path / "local/second-2.3.4.tar.gz"),
-            tmp_path
-            / "base_path"
-            / "build"
-            / "first-app"
-            / "tester"
-            / "dummy"
-            / "_requirements",
+            tmp_path / "base_path/build/first-app/tester/dummy/_requirements",
         ),
         call(
             str(tmp_path / "local/third-3.4.5-py3-none-any.whl"),
-            tmp_path
-            / "base_path"
-            / "build"
-            / "first-app"
-            / "tester"
-            / "dummy"
-            / "_requirements",
+            tmp_path / "base_path/build/first-app/tester/dummy/_requirements",
         ),
     ]
 
@@ -351,7 +322,7 @@ def test_install_app_requirements_with_locals(
             "run",
             "--rm",
             "--volume",
-            f"{tmp_path / 'base_path' / 'build' / 'first-app' / 'tester' / 'dummy'}:/app:z",
+            f"{tmp_path / 'base_path/build/first-app/tester/dummy'}:/app:z",
             "--volume",
             f"{tmp_path / 'briefcase'}:/briefcase:z",
             "briefcase/com.example.first-app:py3.X",
@@ -428,13 +399,7 @@ def test_install_app_requirements_with_bad_local(
             "build",
             "--sdist",
             "--outdir",
-            tmp_path
-            / "base_path"
-            / "build"
-            / "first-app"
-            / "tester"
-            / "dummy"
-            / "_requirements",
+            tmp_path / "base_path/build/first-app/tester/dummy/_requirements",
             str(tmp_path / "local/first"),
         ],
         encoding="UTF-8",
@@ -504,13 +469,7 @@ def test_install_app_requirements_with_bad_local_file(
     # An attempt was made to copy the package
     create_command.tools.shutil.copy.assert_called_once_with(
         str(tmp_path / "local/missing-2.3.4.tar.gz"),
-        tmp_path
-        / "base_path"
-        / "build"
-        / "first-app"
-        / "tester"
-        / "dummy"
-        / "_requirements",
+        tmp_path / "base_path/build/first-app/tester/dummy/_requirements",
     )
 
     # No attempt was made to build the sdist


### PR DESCRIPTION
## Changes
- Allow passing arguments to `docker build`
- RE: https://github.com/beeware/.github/pull/99

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct