### PR TITLE
Soft Ruff implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,15 +8,6 @@ repos:
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.1
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
   - repo: https://github.com/PyCQA/docformatter
     rev: v1.7.5
     hooks:
@@ -27,10 +18,11 @@ repos:
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.2
     hooks:
-      - id: flake8
+      - id: ruff
+        args: [--fix]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/automation/src/automation/bootstraps/pursuedpybear.py
+++ b/automation/src/automation/bootstraps/pursuedpybear.py
@@ -1,5 +1,6 @@
-from automation.bootstraps import BRIEFCASE_EXIT_SUCCESS_SIGNAL, EXIT_SUCCESS_NOTIFY
 from briefcase.bootstraps import PursuedPyBearGuiBootstrap
+
+from automation.bootstraps import BRIEFCASE_EXIT_SUCCESS_SIGNAL, EXIT_SUCCESS_NOTIFY
 
 
 class PursuedPyBearAutomationBootstrap(PursuedPyBearGuiBootstrap):

--- a/automation/src/automation/bootstraps/pygame.py
+++ b/automation/src/automation/bootstraps/pygame.py
@@ -1,5 +1,6 @@
-from automation.bootstraps import BRIEFCASE_EXIT_SUCCESS_SIGNAL, EXIT_SUCCESS_NOTIFY
 from briefcase.bootstraps import PygameGuiBootstrap
+
+from automation.bootstraps import BRIEFCASE_EXIT_SUCCESS_SIGNAL, EXIT_SUCCESS_NOTIFY
 
 
 class PygameAutomationBootstrap(PygameGuiBootstrap):

--- a/automation/src/automation/bootstraps/pyside6.py
+++ b/automation/src/automation/bootstraps/pyside6.py
@@ -1,5 +1,6 @@
-from automation.bootstraps import BRIEFCASE_EXIT_SUCCESS_SIGNAL, EXIT_SUCCESS_NOTIFY
 from briefcase.bootstraps import PySide6GuiBootstrap
+
+from automation.bootstraps import BRIEFCASE_EXIT_SUCCESS_SIGNAL, EXIT_SUCCESS_NOTIFY
 
 
 class PySide6AutomationBootstrap(PySide6GuiBootstrap):

--- a/automation/src/automation/bootstraps/toga.py
+++ b/automation/src/automation/bootstraps/toga.py
@@ -1,5 +1,6 @@
-from automation.bootstraps import BRIEFCASE_EXIT_SUCCESS_SIGNAL, EXIT_SUCCESS_NOTIFY
 from briefcase.bootstraps import TogaGuiBootstrap
+
+from automation.bootstraps import BRIEFCASE_EXIT_SUCCESS_SIGNAL, EXIT_SUCCESS_NOTIFY
 
 
 class TogaAutomationBootstrap(TogaGuiBootstrap):

--- a/changes/1662.misc.rst
+++ b/changes/1662.misc.rst
@@ -1,0 +1,1 @@
+The linting tools pyupgrade, isort, and flake8 were replaced with Ruff.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,6 @@
 
 import os
 import sys
-
 from importlib.metadata import version as metadata_version
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/install_requirement.py
+++ b/install_requirement.py
@@ -48,7 +48,7 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from pathlib import Path
 from shutil import get_terminal_size
 
-from build.util import project_wheel_metadata
+from build.util import project_wheel_metadata  # ruff: isort: skip
 from packaging.requirements import Requirement
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,15 +217,6 @@ no-cover-if-is-py310 = "python_version == '3.10' and os_environ.get('COVERAGE_EX
 no-cover-if-lt-py310 = "sys_version_info < (3, 10) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-gte-py310 = "sys_version_info > (3, 10) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 
-[tool.isort]
-profile = "black"
-skip_glob = [
-    "docs/conf.py",
-    "venv*",
-    "local",
-]
-multi_line_output = 3
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 filterwarnings = [
@@ -254,11 +245,33 @@ type = [
     { directory = "removal", name = "Backward Incompatible Changes", showcontent = true },
     { directory = "doc", name = "Documentation", showcontent = true },
     { directory = "misc", name = "Misc", showcontent = false },
- ]
+]
+
+[tool.ruff]
+line-length = 119
+target-version = "py38"
+
+[tool.ruff.lint]
+ignore = [
+]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    #"B",
+    # flake8-simplify
+    #"SIM",
+    # isort
+    "I",
+]
 
 [tool.codespell]
 skip = '.git,*.pdf,*.svg'
-# the way to make case sensitive skips of words etc
+# the way to make case-sensitive skips of words etc
 ignore-regex = '\bNd\b'
-# case insensitive
+# case-insensitive
 # ignore-words-list = ''

--- a/src/briefcase/cmdline.py
+++ b/src/briefcase/cmdline.py
@@ -101,7 +101,7 @@ def parse_cmdline(args):
     # actually used to register the platform. This function maps the lower-case
     # version of the registered name to the actual registered name.
     def normalize(name):
-        return {n.lower(): n for n in platforms.keys()}.get(name.lower(), name)
+        return {n.lower(): n for n in platforms}.get(name.lower(), name)
 
     # argparse handles `--` specially, so make the passthrough args bypass the parser.
     def parse_known_args(args):

--- a/src/briefcase/integrations/base.py
+++ b/src/briefcase/integrations/base.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, DefaultDict, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import requests
 from cookiecutter.main import cookiecutter
@@ -202,7 +202,7 @@ class ToolCache(Mapping):
         # Python is 32bit if its pointers can only address with 32 bits or fewer
         self.is_32bit_python = self.sys.maxsize <= 2**32
 
-        self.app_tools: DefaultDict[AppConfig, ToolCache] = defaultdict(
+        self.app_tools: defaultdict[AppConfig, ToolCache] = defaultdict(
             lambda: ToolCache(
                 logger=self.logger,
                 console=self.input,

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -325,7 +325,7 @@ Delete this file and run Briefcase again.
             ) from e
 
         # If the file is not owned by `root`, then Docker is mapping usernames
-        is_user_mapped = 0 != self.tools.os.stat(host_write_test_path).st_uid
+        is_user_mapped = self.tools.os.stat(host_write_test_path).st_uid != 0
 
         # Delete the file inside the container since it may be owned by root on the host
         try:
@@ -711,7 +711,7 @@ Briefcase will proceed, but if access to the display is rejected, this may be wh
             sock.settimeout(3)
             try:
                 # returns 0 only if the connection is successful
-                return 0 == sock.connect_ex(("localhost", 6000 + display_num))
+                return sock.connect_ex(("localhost", 6000 + display_num)) == 0
             except OSError:
                 return False
 

--- a/tests/commands/base/conftest.py
+++ b/tests/commands/base/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands.base import BaseCommand
 from briefcase.config import AppConfig
 from briefcase.console import Console, Log

--- a/tests/commands/base/test_app_module_path.py
+++ b/tests/commands/base/test_app_module_path.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/commands/base/test_cookiecutter_logging.py
+++ b/tests/commands/base/test_cookiecutter_logging.py
@@ -1,7 +1,6 @@
 import logging
 
 import pytest
-
 from briefcase.console import LogLevel, RichLoggingHandler
 
 cookiecutter_logger = logging.getLogger("cookiecutter")

--- a/tests/commands/base/test_finalize.py
+++ b/tests/commands/base/test_finalize.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.config import AppConfig
 
 from .conftest import DummyCommand

--- a/tests/commands/base/test_parse_config.py
+++ b/tests/commands/base/test_parse_config.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import BriefcaseConfigError
 
 from ...utils import create_file

--- a/tests/commands/base/test_parse_config_overrides.py
+++ b/tests/commands/base/test_parse_config_overrides.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands.base import parse_config_overrides
 from briefcase.exceptions import BriefcaseConfigError
 

--- a/tests/commands/base/test_parse_options.py
+++ b/tests/commands/base/test_parse_options.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import LogLevel
 
 

--- a/tests/commands/base/test_paths.py
+++ b/tests/commands/base/test_paths.py
@@ -5,7 +5,6 @@ from contextlib import suppress
 from pathlib import Path
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 from .conftest import DummyCommand

--- a/tests/commands/base/test_update_cookiecutter_cache.py
+++ b/tests/commands/base/test_update_cookiecutter_cache.py
@@ -1,10 +1,9 @@
 from unittest import mock
 
 import pytest
-from git import exc as git_exceptions
-
 from briefcase.commands.base import cookiecutter_cache_path
 from briefcase.exceptions import BriefcaseCommandError, TemplateUnsupportedVersion
+from git import exc as git_exceptions
 
 
 def test_non_url(base_command, mock_git):

--- a/tests/commands/base/test_verify_host.py
+++ b/tests/commands/base/test_verify_host.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import UnsupportedHostError
 
 

--- a/tests/commands/base/test_verify_template.py
+++ b/tests/commands/base/test_verify_template.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 from ...utils import create_file

--- a/tests/commands/create/conftest.py
+++ b/tests/commands/create/conftest.py
@@ -4,13 +4,12 @@ from unittest import mock
 
 import pytest
 import tomli_w
-from cookiecutter.main import cookiecutter
-
 from briefcase.commands import CreateCommand
 from briefcase.config import AppConfig
 from briefcase.console import Console, Log
 from briefcase.integrations.base import Tool
 from briefcase.integrations.subprocess import Subprocess
+from cookiecutter.main import cookiecutter
 
 from ...utils import DummyConsole, create_file
 

--- a/tests/commands/create/test_call.py
+++ b/tests/commands/create/test_call.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands.create import Git
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/commands/create/test_cleanup_app_content.py
+++ b/tests/commands/create/test_cleanup_app_content.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import LogLevel
 
 from ...utils import create_file

--- a/tests/commands/create/test_cookiecutter_cache_path.py
+++ b/tests/commands/create/test_cookiecutter_cache_path.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-
 from briefcase.commands.create import cookiecutter_cache_path
 
 

--- a/tests/commands/create/test_create_app.py
+++ b/tests/commands/create/test_create_app.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.config import AppConfig
 from briefcase.exceptions import UnsupportedPlatform
 

--- a/tests/commands/create/test_generate_app_template.py
+++ b/tests/commands/create/test_generate_app_template.py
@@ -5,16 +5,15 @@ from datetime import date
 from pathlib import Path
 from unittest import mock
 
-import pytest
-from cookiecutter import exceptions as cookiecutter_exceptions
-from git import exc as git_exceptions
-
 import briefcase
+import pytest
 from briefcase.exceptions import (
     InvalidTemplateRepository,
     NetworkFailure,
     TemplateUnsupportedVersion,
 )
+from cookiecutter import exceptions as cookiecutter_exceptions
+from git import exc as git_exceptions
 
 
 @pytest.fixture

--- a/tests/commands/create/test_install_app_code.py
+++ b/tests/commands/create/test_install_app_code.py
@@ -2,9 +2,8 @@ import os
 import shutil
 from unittest import mock
 
-import pytest
-
 import briefcase
+import pytest
 from briefcase.exceptions import MissingAppSources
 
 from ...utils import create_file

--- a/tests/commands/create/test_install_app_requirements.py
+++ b/tests/commands/create/test_install_app_requirements.py
@@ -5,7 +5,6 @@ from unittest import mock
 
 import pytest
 import tomli_w
-
 from briefcase.commands.create import _is_local_requirement
 from briefcase.exceptions import BriefcaseCommandError, RequirementsInstallError
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/commands/create/test_install_app_support_package.py
+++ b/tests/commands/create/test_install_app_support_package.py
@@ -4,14 +4,13 @@ import sys
 from unittest import mock
 
 import pytest
-from requests import exceptions as requests_exceptions
-
 from briefcase.exceptions import (
     InvalidSupportPackage,
     MissingNetworkResourceError,
     MissingSupportPackage,
     NetworkFailure,
 )
+from requests import exceptions as requests_exceptions
 
 from ...utils import (
     create_zip_file,

--- a/tests/commands/create/test_properties.py
+++ b/tests/commands/create/test_properties.py
@@ -1,6 +1,5 @@
 import pytest
 import tomli_w
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/commands/dev/conftest.py
+++ b/tests/commands/dev/conftest.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-
 from briefcase.commands import DevCommand
 from briefcase.config import AppConfig
 from briefcase.console import Console, Log

--- a/tests/commands/dev/test_call.py
+++ b/tests/commands/dev/test_call.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands import DevCommand
 from briefcase.commands.base import full_options
 from briefcase.console import Console, Log

--- a/tests/commands/dev/test_install_dev_requirements.py
+++ b/tests/commands/dev/test_install_dev_requirements.py
@@ -2,7 +2,6 @@ import sys
 from subprocess import CalledProcessError
 
 import pytest
-
 from briefcase.exceptions import RequirementsInstallError
 
 

--- a/tests/commands/new/conftest.py
+++ b/tests/commands/new/conftest.py
@@ -1,8 +1,8 @@
 import pytest
-
 from briefcase.commands import NewCommand
 from briefcase.commands.base import full_options
 from briefcase.console import Console, Log
+
 from tests.utils import DummyConsole
 
 

--- a/tests/commands/new/test_build_context.py
+++ b/tests/commands/new/test_build_context.py
@@ -1,15 +1,14 @@
 from unittest.mock import MagicMock
 
-import pytest
-from packaging.version import Version
-
 import briefcase.commands.new
+import pytest
 from briefcase.bootstraps import (
     PursuedPyBearGuiBootstrap,
     PygameGuiBootstrap,
     PySide6GuiBootstrap,
     TogaGuiBootstrap,
 )
+from packaging.version import Version
 
 
 @pytest.fixture

--- a/tests/commands/new/test_call.py
+++ b/tests/commands/new/test_call.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands.create import Git
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/commands/new/test_input_text.py
+++ b/tests/commands/new/test_input_text.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/commands/new/test_new_app.py
+++ b/tests/commands/new/test_new_app.py
@@ -1,11 +1,8 @@
 import os
 from unittest import mock
 
-import pytest
-from cookiecutter import exceptions as cookiecutter_exceptions
-from cookiecutter.main import cookiecutter
-
 import briefcase
+import pytest
 from briefcase.commands import NewCommand
 from briefcase.console import Console, Log
 from briefcase.exceptions import (
@@ -13,6 +10,8 @@ from briefcase.exceptions import (
     InvalidTemplateRepository,
     TemplateUnsupportedVersion,
 )
+from cookiecutter import exceptions as cookiecutter_exceptions
+from cookiecutter.main import cookiecutter
 
 
 @pytest.fixture

--- a/tests/commands/new/test_parse_project_overrides.py
+++ b/tests/commands/new/test_parse_project_overrides.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands.new import parse_project_overrides
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/commands/new/test_titlecase.py
+++ b/tests/commands/new/test_titlecase.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands.new import titlecase
 
 

--- a/tests/commands/new/test_validate_override_for_selection.py
+++ b/tests/commands/new/test_validate_override_for_selection.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/commands/open/conftest.py
+++ b/tests/commands/open/conftest.py
@@ -2,7 +2,6 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.commands import OpenCommand
 from briefcase.commands.base import full_options
 from briefcase.config import AppConfig

--- a/tests/commands/package/conftest.py
+++ b/tests/commands/package/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands import PackageCommand
 from briefcase.commands.base import full_options
 from briefcase.config import AppConfig

--- a/tests/commands/publish/conftest.py
+++ b/tests/commands/publish/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands import PublishCommand
 from briefcase.commands.base import full_options
 from briefcase.config import AppConfig

--- a/tests/commands/publish/test_call.py
+++ b/tests/commands/publish/test_call.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/commands/run/conftest.py
+++ b/tests/commands/run/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands import RunCommand
 from briefcase.commands.base import full_options
 from briefcase.config import AppConfig

--- a/tests/commands/run/test_LogFilter.py
+++ b/tests/commands/run/test_LogFilter.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-
 from briefcase.commands.run import LogFilter
 from briefcase.integrations.subprocess import StopStreaming
 

--- a/tests/commands/run/test_LogFilter__test_filter.py
+++ b/tests/commands/run/test_LogFilter__test_filter.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands.run import LogFilter
 
 

--- a/tests/commands/run/test__stream_app_logs.py
+++ b/tests/commands/run/test__stream_app_logs.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-
 from briefcase.commands.run import LogFilter
 from briefcase.exceptions import BriefcaseCommandError, BriefcaseTestSuiteFailure
 

--- a/tests/commands/run/test_call.py
+++ b/tests/commands/run/test_call.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/commands/update/conftest.py
+++ b/tests/commands/update/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands import UpdateCommand
 from briefcase.config import AppConfig
 from briefcase.console import Console, Log

--- a/tests/commands/update/test_call.py
+++ b/tests/commands/update/test_call.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.commands.create import Git
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/commands/upgrade/conftest.py
+++ b/tests/commands/upgrade/conftest.py
@@ -1,8 +1,7 @@
 from unittest.mock import MagicMock
 
-import pytest
-
 import briefcase.commands.upgrade
+import pytest
 from briefcase.commands import UpgradeCommand
 from briefcase.console import Console, Log
 from briefcase.exceptions import MissingToolError

--- a/tests/commands/upgrade/test_call.py
+++ b/tests/commands/upgrade/test_call.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import UpgradeToolError
 
 from .conftest import (

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.config import AppConfig
 from briefcase.exceptions import BriefcaseConfigError
 

--- a/tests/config/test_GlobalConfig.py
+++ b/tests/config/test_GlobalConfig.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.config import GlobalConfig
 from briefcase.exceptions import BriefcaseConfigError
 

--- a/tests/config/test_is_pep440_version.py
+++ b/tests/config/test_is_pep440_version.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.config import is_pep440_canonical_version, parsed_version
 
 

--- a/tests/config/test_is_reserved_keyword.py
+++ b/tests/config/test_is_reserved_keyword.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.config import is_reserved_keyword
 
 

--- a/tests/config/test_is_valid_app_name.py
+++ b/tests/config/test_is_valid_app_name.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.config import is_valid_app_name
 
 

--- a/tests/config/test_is_valid_bundle_identifier.py
+++ b/tests/config/test_is_valid_bundle_identifier.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.config import is_valid_bundle_identifier
 
 

--- a/tests/config/test_make_class_name.py
+++ b/tests/config/test_make_class_name.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.config import make_class_name
 
 

--- a/tests/config/test_parse_config.py
+++ b/tests/config/test_parse_config.py
@@ -1,7 +1,6 @@
 from io import BytesIO
 
 import pytest
-
 from briefcase.config import parse_config
 from briefcase.exceptions import BriefcaseConfigError
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import time
 from unittest.mock import ANY
 
 import pytest
-
 from briefcase.config import AppConfig
 
 from .utils import create_file

--- a/tests/console/Console/test_boolean_input.py
+++ b/tests/console/Console/test_boolean_input.py
@@ -1,6 +1,6 @@
 import pytest
-
 from briefcase.console import InputDisabled
+
 from tests.utils import default_rich_prompt
 
 

--- a/tests/console/Console/test_call.py
+++ b/tests/console/Console/test_call.py
@@ -1,7 +1,7 @@
 import pytest
+from briefcase.console import InputDisabled
 from rich.markup import escape
 
-from briefcase.console import InputDisabled
 from tests.utils import default_rich_prompt
 
 

--- a/tests/console/Console/test_selection_input.py
+++ b/tests/console/Console/test_selection_input.py
@@ -1,8 +1,8 @@
 from unittest.mock import call
 
 import pytest
-
 from briefcase.console import InputDisabled
+
 from tests.utils import default_rich_prompt
 
 

--- a/tests/console/Console/test_text_input.py
+++ b/tests/console/Console/test_text_input.py
@@ -1,6 +1,6 @@
 import pytest
-
 from briefcase.console import InputDisabled
+
 from tests.utils import default_rich_prompt
 
 

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -2,7 +2,6 @@ import sys
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console
 
 

--- a/tests/console/test_Log.py
+++ b/tests/console/test_Log.py
@@ -3,13 +3,12 @@ import logging
 from io import TextIOBase
 from unittest.mock import MagicMock, PropertyMock, call
 
-import pytest
-from rich.traceback import Trace
-
 import briefcase
+import pytest
 from briefcase.commands.dev import DevCommand
 from briefcase.console import Console, Log, LogLevel, RichLoggingHandler
 from briefcase.exceptions import BriefcaseError
+from rich.traceback import Trace
 
 TRACEBACK_HEADER = "Traceback (most recent call last)"
 EXTRA_HEADER = "Extra information:"

--- a/tests/console/test_Printer.py
+++ b/tests/console/test_Printer.py
@@ -1,7 +1,6 @@
 import re
 
 import pytest
-
 from briefcase.console import Printer
 
 

--- a/tests/console/test_sanitize_text.py
+++ b/tests/console/test_sanitize_text.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import sanitize_text
 
 

--- a/tests/console/test_select_option.py
+++ b/tests/console/test_select_option.py
@@ -1,6 +1,6 @@
 import pytest
-
 from briefcase.console import select_option
+
 from tests.utils import DummyConsole
 
 

--- a/tests/integrations/android_sdk/ADB/conftest.py
+++ b/tests/integrations/android_sdk/ADB/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.integrations.base import ToolCache
 
 

--- a/tests/integrations/android_sdk/ADB/test_avd_name.py
+++ b/tests/integrations/android_sdk/ADB/test_avd_name.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 
 

--- a/tests/integrations/android_sdk/ADB/test_datetime.py
+++ b/tests/integrations/android_sdk/ADB/test_datetime.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from unittest.mock import Mock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/integrations/android_sdk/ADB/test_force_stop_app.py
+++ b/tests/integrations/android_sdk/ADB/test_force_stop_app.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 
 

--- a/tests/integrations/android_sdk/ADB/test_has_booted.py
+++ b/tests/integrations/android_sdk/ADB/test_has_booted.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 
 

--- a/tests/integrations/android_sdk/ADB/test_install_apk.py
+++ b/tests/integrations/android_sdk/ADB/test_install_apk.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 
 

--- a/tests/integrations/android_sdk/ADB/test_kill.py
+++ b/tests/integrations/android_sdk/ADB/test_kill.py
@@ -3,7 +3,6 @@ import subprocess
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/integrations/android_sdk/ADB/test_logcat_tail.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat_tail.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/integrations/android_sdk/ADB/test_pid_exists.py
+++ b/tests/integrations/android_sdk/ADB/test_pid_exists.py
@@ -23,5 +23,5 @@ def test_pid_does_not_exist(adb):
     not existing."""
     adb.run = Mock(side_effect=subprocess.CalledProcessError(returncode=1, cmd="test"))
 
-    assert not adb.pid_exists("9999") is None
+    assert adb.pid_exists("9999") is not None
     adb.run.assert_called_once_with("shell", "test", "-e", "/proc/9999")

--- a/tests/integrations/android_sdk/ADB/test_run.py
+++ b/tests/integrations/android_sdk/ADB/test_run.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 
 

--- a/tests/integrations/android_sdk/ADB/test_start_app.py
+++ b/tests/integrations/android_sdk/ADB/test_start_app.py
@@ -4,7 +4,6 @@ from subprocess import CalledProcessError
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
@@ -3,7 +3,6 @@ import subprocess
 from unittest.mock import ANY, MagicMock
 
 import pytest
-
 from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.android_sdk import AndroidSDK

--- a/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console
 from briefcase.integrations.android_sdk import AndroidSDK
 from briefcase.integrations.base import ToolCache

--- a/tests/integrations/android_sdk/AndroidSDK/test_devices.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_devices.py
@@ -2,7 +2,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_emulators.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_emulators.py
@@ -1,7 +1,6 @@
 import subprocess
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_list_packages.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_list_packages.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_properties.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_properties.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 from ....utils import assert_url_resolvable

--- a/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 from briefcase.integrations.android_sdk import (
     ADB,

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -3,7 +3,6 @@ import subprocess
 from unittest.mock import MagicMock, call
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 from briefcase.integrations.android_sdk import ADB, AndroidSDK
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_upgrade.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_upgrade.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -4,7 +4,6 @@ import shutil
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import LogLevel
 from briefcase.exceptions import (
     BriefcaseCommandError,

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_avd.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_avd.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
@@ -3,7 +3,6 @@ import subprocess
 import sys
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 from ....utils import create_file

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator_skin.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, NetworkFailure
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_license.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_license.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
@@ -3,7 +3,6 @@ import platform
 from subprocess import CalledProcessError
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/integrations/android_sdk/conftest.py
+++ b/tests/integrations/android_sdk/conftest.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.android_sdk import ADB, AndroidSDK
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download

--- a/tests/integrations/base/conftest.py
+++ b/tests/integrations/base/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.base import ToolCache
 

--- a/tests/integrations/base/test_ManagedTool.py
+++ b/tests/integrations/base/test_ManagedTool.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import (
     MissingToolError,
     NonManagedToolError,

--- a/tests/integrations/base/test_Tool.py
+++ b/tests/integrations/base/test_Tool.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.base import Tool
 

--- a/tests/integrations/base/test_ToolCache.py
+++ b/tests/integrations/base/test_ToolCache.py
@@ -7,13 +7,12 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import briefcase.integrations
 import pytest
 import requests
-from cookiecutter.main import cookiecutter
-
-import briefcase.integrations
 from briefcase.console import Console, Log
 from briefcase.integrations.base import ToolCache
+from cookiecutter.main import cookiecutter
 
 from .test_tool_registry import integrations_modules, tools_for_module
 

--- a/tests/integrations/base/test_tool_registry.py
+++ b/tests/integrations/base/test_tool_registry.py
@@ -3,9 +3,8 @@ import pkgutil
 import sys
 from typing import Dict, Set, Type
 
-import pytest
-
 import briefcase.integrations
+import pytest
 from briefcase.integrations.base import ManagedTool, Tool, tool_registry
 
 

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -5,12 +5,12 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.config import AppConfig
 from briefcase.console import Log
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.subprocess import Subprocess
+
 from tests.utils import DummyConsole
 
 

--- a/tests/integrations/cookiecutter/test_PListExtension.py
+++ b/tests/integrations/cookiecutter/test_PListExtension.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.cookiecutter import PListExtension
 
 

--- a/tests/integrations/cookiecutter/test_PythonVersionExtension.py
+++ b/tests/integrations/cookiecutter/test_PythonVersionExtension.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.cookiecutter import PythonVersionExtension
 
 

--- a/tests/integrations/cookiecutter/test_RGBExtension.py
+++ b/tests/integrations/cookiecutter/test_RGBExtension.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.cookiecutter import RGBExtension
 
 

--- a/tests/integrations/cookiecutter/test_TOMLEscape.py
+++ b/tests/integrations/cookiecutter/test_TOMLEscape.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.cookiecutter import TOMLEscape
 
 

--- a/tests/integrations/cookiecutter/test_XMLExtension.py
+++ b/tests/integrations/cookiecutter/test_XMLExtension.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.cookiecutter import XMLExtension
 
 

--- a/tests/integrations/docker/conftest.py
+++ b/tests/integrations/docker/conftest.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import MagicMock, call
 
-import pytest
-
 import briefcase
+import pytest
 from briefcase.config import AppConfig
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.docker import Docker, DockerAppContext

--- a/tests/integrations/docker/test_DockerAppContext__Popen.py
+++ b/tests/integrations/docker/test_DockerAppContext__Popen.py
@@ -1,7 +1,6 @@
 from unittest.mock import ANY
 
 import pytest
-
 from briefcase.console import LogLevel
 
 # These tests ignore the elsewhere-tested complexities of Dockerizing

--- a/tests/integrations/docker/test_DockerAppContext__check_output.py
+++ b/tests/integrations/docker/test_DockerAppContext__check_output.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest.mock import ANY
 
 import pytest
-
 from briefcase.console import LogLevel
 
 # These tests ignore the elsewhere-tested complexities of Dockerizing

--- a/tests/integrations/docker/test_DockerAppContext__prepare.py
+++ b/tests/integrations/docker/test_DockerAppContext__prepare.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.docker import DockerAppContext
 

--- a/tests/integrations/docker/test_DockerAppContext__run.py
+++ b/tests/integrations/docker/test_DockerAppContext__run.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest.mock import ANY
 
 import pytest
-
 from briefcase.console import LogLevel
 
 # These tests ignore the elsewhere-tested complexities of Dockerizing

--- a/tests/integrations/docker/test_DockerAppContext__verify.py
+++ b/tests/integrations/docker/test_DockerAppContext__verify.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.integrations.docker import Docker, DockerAppContext
 

--- a/tests/integrations/docker/test_Docker__cache_image.py
+++ b/tests/integrations/docker/test_Docker__cache_image.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest.mock import call
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/integrations/docker/test_Docker__verify.py
+++ b/tests/integrations/docker/test_Docker__verify.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, call
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.docker import Docker

--- a/tests/integrations/docker/test_Docker__x11_passthrough.py
+++ b/tests/integrations/docker/test_Docker__x11_passthrough.py
@@ -5,7 +5,6 @@ from pathlib import Path, PosixPath, PurePosixPath
 from unittest.mock import MagicMock, call
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.docker import XauthDatabaseCreationFailure
 

--- a/tests/integrations/download/test_Download__file.py
+++ b/tests/integrations/download/test_Download__file.py
@@ -8,14 +8,13 @@ from unittest import mock
 import pytest
 import requests
 import requests.exceptions
-from urllib3._collections import HTTPHeaderDict
-
 from briefcase.exceptions import (
     BadNetworkResourceError,
     MissingNetworkResourceError,
     NetworkFailure,
 )
 from briefcase.integrations.base import ToolCache
+from urllib3._collections import HTTPHeaderDict
 
 TEMPORARY_DOWNLOAD_FILE_SUFFIX = ".download"
 

--- a/tests/integrations/download/test_Download__verify.py
+++ b/tests/integrations/download/test_Download__verify.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.download import Download
 

--- a/tests/integrations/flatpak/conftest.py
+++ b/tests/integrations/flatpak/conftest.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.flatpak import Flatpak

--- a/tests/integrations/flatpak/test_Flatpak__build.py
+++ b/tests/integrations/flatpak/test_Flatpak__build.py
@@ -1,7 +1,6 @@
 import subprocess
 
 import pytest
-
 from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/integrations/flatpak/test_Flatpak__bundle.py
+++ b/tests/integrations/flatpak/test_Flatpak__bundle.py
@@ -1,7 +1,6 @@
 import subprocess
 
 import pytest
-
 from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/integrations/flatpak/test_Flatpak__run.py
+++ b/tests/integrations/flatpak/test_Flatpak__run.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest import mock
 
 import pytest
-
 from briefcase.console import LogLevel
 
 

--- a/tests/integrations/flatpak/test_Flatpak__verify.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest import mock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.integrations.flatpak import Flatpak
 

--- a/tests/integrations/flatpak/test_Flatpak__verify_repo.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_repo.py
@@ -1,7 +1,6 @@
 import subprocess
 
 import pytest
-
 from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
@@ -1,7 +1,6 @@
 import subprocess
 
 import pytest
-
 from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/integrations/git/test_Git__verify.py
+++ b/tests/integrations/git/test_Git__verify.py
@@ -1,7 +1,6 @@
 import logging
 
 import pytest
-
 from briefcase.console import LogLevel, RichLoggingHandler
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.git import Git

--- a/tests/integrations/java/conftest.py
+++ b/tests/integrations/java/conftest.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/integrations/java/test_JDK__upgrade.py
+++ b/tests/integrations/java/test_JDK__upgrade.py
@@ -3,7 +3,6 @@ import shutil
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import (
     BriefcaseCommandError,
     MissingToolError,

--- a/tests/integrations/java/test_JDK__verify.py
+++ b/tests/integrations/java/test_JDK__verify.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from briefcase.exceptions import (
     BriefcaseCommandError,
     IncompatibleToolError,
@@ -193,7 +192,7 @@ def test_macos_provided_overrides_tool_java_home(mock_tools, capsys):
     # A single call to check output
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(Path("/path/to/java/bin/javac")), "-version"],
-    ),
+    )
 
     # No console output
     output = capsys.readouterr()
@@ -219,7 +218,7 @@ def test_valid_provided_java_home(mock_tools, capsys):
     # A single call to check output
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(Path("/path/to/java/bin/javac")), "-version"],
-    ),
+    )
 
     # No console output
     output = capsys.readouterr()
@@ -306,7 +305,7 @@ def test_no_javac(mock_tools, host_os, java_home, error_type, tmp_path, capsys):
     # A single call was made to check javac
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(Path("/path/to/nowhere/bin/javac")), "-version"],
-    ),
+    )
 
     # Warning is shown for invalid JAVA_HOME
     output = capsys.readouterr()
@@ -348,7 +347,7 @@ def test_javac_error(mock_tools, host_os, java_home, tmp_path, capsys):
     # A single call was made to check javac
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(Path("/path/to/nowhere/bin/javac")), "-version"],
-    ),
+    )
 
     # Warning is shown for invalid JAVA_HOME
     output = capsys.readouterr()
@@ -388,7 +387,7 @@ def test_unparseable_javac_version(mock_tools, host_os, java_home, tmp_path, cap
     # A single call was made to check javac
     mock_tools.subprocess.check_output.assert_called_once_with(
         [os.fsdecode(Path("/path/to/nowhere/bin/javac")), "-version"],
-    ),
+    )
 
     # No console output (because Briefcase JDK exists)
     output = capsys.readouterr()

--- a/tests/integrations/linuxdeploy/conftest.py
+++ b/tests/integrations/linuxdeploy/conftest.py
@@ -2,7 +2,6 @@ import shutil
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.linuxdeploy import LinuxDeploy

--- a/tests/integrations/linuxdeploy/test_LinuxDeployBase__patch_elf_binary.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployBase__patch_elf_binary.py
@@ -1,11 +1,11 @@
 import pytest
-
 from briefcase.exceptions import CorruptToolError
 from briefcase.integrations.linuxdeploy import (
     ELF_PATCH_OFFSET,
     ELF_PATCH_ORIGINAL_BYTES,
     ELF_PATCH_PATCHED_BYTES,
 )
+
 from tests.integrations.linuxdeploy.utils import create_mock_appimage
 
 

--- a/tests/integrations/linuxdeploy/test_LinuxDeployBase__upgrade.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployBase__upgrade.py
@@ -1,6 +1,6 @@
 import pytest
-
 from briefcase.exceptions import MissingToolError, NetworkFailure
+
 from tests.integrations.linuxdeploy.utils import side_effect_create_mock_appimage
 
 

--- a/tests/integrations/linuxdeploy/test_LinuxDeployBase__verify.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployBase__verify.py
@@ -1,8 +1,8 @@
 import pytest
-
 from briefcase.exceptions import MissingToolError, NetworkFailure, UnsupportedHostError
 from briefcase.integrations.base import ManagedTool
 from briefcase.integrations.linuxdeploy import LinuxDeployBase
+
 from tests.integrations.linuxdeploy.utils import (
     side_effect_create_mock_appimage,
     side_effect_create_mock_tool,

--- a/tests/integrations/linuxdeploy/test_LinuxDeployGtkPlugin__properties.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployGtkPlugin__properties.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.integrations.linuxdeploy import LinuxDeployGtkPlugin
 
 from ...utils import assert_url_resolvable

--- a/tests/integrations/linuxdeploy/test_LinuxDeployLocalFilePlugin__properties.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployLocalFilePlugin__properties.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.integrations.linuxdeploy import LinuxDeployLocalFilePlugin
 
 

--- a/tests/integrations/linuxdeploy/test_LinuxDeployLocalFilePlugin__verify.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployLocalFilePlugin__verify.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.integrations.linuxdeploy import LinuxDeployLocalFilePlugin
 

--- a/tests/integrations/linuxdeploy/test_LinuxDeployQtPlugin__properties.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployQtPlugin__properties.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.integrations.linuxdeploy import LinuxDeployQtPlugin
 
 from ...utils import assert_url_resolvable

--- a/tests/integrations/linuxdeploy/test_LinuxDeployURLPlugin__properties.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployURLPlugin__properties.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.integrations.linuxdeploy import LinuxDeployURLPlugin
 
 

--- a/tests/integrations/linuxdeploy/test_LinuxDeployURLPlugin__verify.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeployURLPlugin__verify.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import (
     BriefcaseCommandError,
     NetworkFailure,

--- a/tests/integrations/linuxdeploy/test_LinuxDeploy__properties.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeploy__properties.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.linuxdeploy import (
     LinuxDeploy,

--- a/tests/integrations/linuxdeploy/test_LinuxDeploy__verify_plugins.py
+++ b/tests/integrations/linuxdeploy/test_LinuxDeploy__verify_plugins.py
@@ -3,7 +3,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.linuxdeploy import (
     LinuxDeployGtkPlugin,
     LinuxDeployLocalFilePlugin,

--- a/tests/integrations/rcedit/conftest.py
+++ b/tests/integrations/rcedit/conftest.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.rcedit import RCEdit

--- a/tests/integrations/rcedit/test_RCEdit__upgrade.py
+++ b/tests/integrations/rcedit/test_RCEdit__upgrade.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import MissingToolError, NetworkFailure
 
 

--- a/tests/integrations/rcedit/test_RCEdit__verify.py
+++ b/tests/integrations/rcedit/test_RCEdit__verify.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import MissingToolError, NetworkFailure, UnsupportedHostError
 from briefcase.integrations.rcedit import RCEdit
 

--- a/tests/integrations/subprocess/conftest.py
+++ b/tests/integrations/subprocess/conftest.py
@@ -3,7 +3,6 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.subprocess import Subprocess
 
 # hardcoded here since subprocess will only include these constants if Python is literally on Windows

--- a/tests/integrations/subprocess/test_NativeAppContext__verify.py
+++ b/tests/integrations/subprocess/test_NativeAppContext__verify.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.subprocess import NativeAppContext, Subprocess
 

--- a/tests/integrations/subprocess/test_Subprocess__Popen.py
+++ b/tests/integrations/subprocess/test_Subprocess__Popen.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from unittest.mock import ANY
 
 import pytest
-
 from briefcase.console import LogLevel
 
 from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW

--- a/tests/integrations/subprocess/test_Subprocess__check_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__check_output.py
@@ -5,7 +5,6 @@ from subprocess import CalledProcessError
 from unittest.mock import ANY
 
 import pytest
-
 from briefcase.console import LogLevel
 
 from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW

--- a/tests/integrations/subprocess/test_Subprocess__parse_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__parse_output.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest.mock import ANY
 
 import pytest
-
 from briefcase.integrations.subprocess import CommandOutputParseError, ParseError
 
 

--- a/tests/integrations/subprocess/test_Subprocess__run__controlled_console.py
+++ b/tests/integrations/subprocess/test_Subprocess__run__controlled_console.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from unittest.mock import ANY
 
 import pytest
-
 from briefcase.console import LogLevel
 
 

--- a/tests/integrations/subprocess/test_Subprocess__run__stream_output__False.py
+++ b/tests/integrations/subprocess/test_Subprocess__run__stream_output__False.py
@@ -4,7 +4,6 @@ from subprocess import CalledProcessError
 from unittest.mock import ANY
 
 import pytest
-
 from briefcase.console import LogLevel
 
 from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW

--- a/tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py
+++ b/tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py
@@ -5,7 +5,6 @@ from subprocess import CalledProcessError
 from unittest.mock import ANY
 
 import pytest
-
 from briefcase.console import LogLevel
 
 from .conftest import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -4,7 +4,6 @@ from threading import Event
 from unittest import mock
 
 import pytest
-
 from briefcase.console import LogLevel
 from briefcase.integrations import subprocess
 

--- a/tests/integrations/subprocess/test_Subprocess__verify.py
+++ b/tests/integrations/subprocess/test_Subprocess__verify.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.subprocess import Subprocess
 

--- a/tests/integrations/subprocess/test_ensure_console_is_safe.py
+++ b/tests/integrations/subprocess/test_ensure_console_is_safe.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest.mock import MagicMock, Mock
 
 import pytest
-
 from briefcase.integrations.subprocess import Subprocess
 
 

--- a/tests/integrations/subprocess/test_ensure_str.py
+++ b/tests/integrations/subprocess/test_ensure_str.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.integrations.subprocess import ensure_str
 
 

--- a/tests/integrations/subprocess/test_get_process_id_by_command.py
+++ b/tests/integrations/subprocess/test_get_process_id_by_command.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 
 import pytest
-
 from briefcase.console import Log
 from briefcase.integrations.subprocess import get_process_id_by_command
 

--- a/tests/integrations/subprocess/test_is_process_dead.py
+++ b/tests/integrations/subprocess/test_is_process_dead.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.integrations.subprocess import is_process_dead
 
 

--- a/tests/integrations/subprocess/test_json_parser.py
+++ b/tests/integrations/subprocess/test_json_parser.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.integrations.subprocess import ParseError, json_parser
 
 

--- a/tests/integrations/visualstudio/conftest.py
+++ b/tests/integrations/visualstudio/conftest.py
@@ -2,7 +2,6 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.subprocess import Subprocess
 

--- a/tests/integrations/visualstudio/test_VisualStudio__properties.py
+++ b/tests/integrations/visualstudio/test_VisualStudio__properties.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.visualstudio import VisualStudio
 

--- a/tests/integrations/visualstudio/test_VisualStudio__verify.py
+++ b/tests/integrations/visualstudio/test_VisualStudio__verify.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest.mock import call
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.integrations.visualstudio import VisualStudio
 

--- a/tests/integrations/windows_sdk/conftest.py
+++ b/tests/integrations/windows_sdk/conftest.py
@@ -2,7 +2,6 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/integrations/windows_sdk/test_WindowsSDK___is_supported_version.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK___is_supported_version.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.integrations.windows_sdk import WindowsSDK
 
 

--- a/tests/integrations/windows_sdk/test_WindowsSDK___sdk_versions_from_bin.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK___sdk_versions_from_bin.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.integrations.windows_sdk import WindowsSDK
 
 from .test_WindowsSDK__verify import setup_winsdk_install

--- a/tests/integrations/windows_sdk/test_WindowsSDK___verify_signtool.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK___verify_signtool.py
@@ -1,7 +1,6 @@
 import subprocess
 
 import pytest
-
 from briefcase.integrations.windows_sdk import WindowsSDK
 
 from .test_WindowsSDK__verify import setup_winsdk_install

--- a/tests/integrations/windows_sdk/test_WindowsSDK__properties.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK__properties.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.integrations.windows_sdk import WindowsSDK
 
 

--- a/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.integrations import windows_sdk

--- a/tests/integrations/wix/conftest.py
+++ b/tests/integrations/wix/conftest.py
@@ -2,7 +2,6 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/integrations/wix/test_WiX__upgrade.py
+++ b/tests/integrations/wix/test_WiX__upgrade.py
@@ -2,7 +2,6 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import (
     BriefcaseCommandError,
     MissingToolError,

--- a/tests/integrations/wix/test_WiX__verify.py
+++ b/tests/integrations/wix/test_WiX__verify.py
@@ -2,7 +2,6 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import (
     BriefcaseCommandError,
     MissingToolError,

--- a/tests/integrations/xcode/conftest.py
+++ b/tests/integrations/xcode/conftest.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/integrations/xcode/test_XcodeCLITools__verify.py
+++ b/tests/integrations/xcode/test_XcodeCLITools__verify.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.xcode import XcodeCliTools
 

--- a/tests/integrations/xcode/test_Xcode__verify.py
+++ b/tests/integrations/xcode/test_Xcode__verify.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.xcode import Xcode
 

--- a/tests/integrations/xcode/test_confirm_xcode_license_accepted.py
+++ b/tests/integrations/xcode/test_confirm_xcode_license_accepted.py
@@ -1,7 +1,6 @@
 import subprocess
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.xcode import XcodeCliTools
 

--- a/tests/integrations/xcode/test_ensure_command_line_tools_are_installed.py
+++ b/tests/integrations/xcode/test_ensure_command_line_tools_are_installed.py
@@ -1,7 +1,6 @@
 import subprocess
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.xcode import XcodeCliTools
 

--- a/tests/integrations/xcode/test_ensure_xcode_is_installed.py
+++ b/tests/integrations/xcode/test_ensure_xcode_is_installed.py
@@ -3,7 +3,6 @@ import subprocess
 from unittest import mock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.xcode import Xcode
 

--- a/tests/integrations/xcode/test_get_device_state.py
+++ b/tests/integrations/xcode/test_get_device_state.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/integrations/xcode/test_get_identities.py
+++ b/tests/integrations/xcode/test_get_identities.py
@@ -2,7 +2,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.xcode import get_identities
 

--- a/tests/integrations/xcode/test_get_simulators.py
+++ b/tests/integrations/xcode/test_get_simulators.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console
 from briefcase.exceptions import BriefcaseError
 from briefcase.integrations.base import ToolCache

--- a/tests/platforms/android/gradle/conftest.py
+++ b/tests/platforms/android/gradle/conftest.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 import requests
-
 from briefcase.console import Console, Log
 from briefcase.integrations.android_sdk import AndroidSDK
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/android/gradle/test_android_log_clean_filter.py
+++ b/tests/platforms/android/gradle/test_android_log_clean_filter.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.platforms.android.gradle import android_log_clean_filter
 
 

--- a/tests/platforms/android/gradle/test_build.py
+++ b/tests/platforms/android/gradle/test_build.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 import requests
-
 from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.android_sdk import AndroidSDK

--- a/tests/platforms/android/gradle/test_create.py
+++ b/tests/platforms/android/gradle/test_create.py
@@ -2,7 +2,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.platforms.android.gradle import GradleCreateCommand

--- a/tests/platforms/android/gradle/test_open.py
+++ b/tests/platforms/android/gradle/test_open.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.android_sdk import AndroidSDK

--- a/tests/platforms/android/gradle/test_package__aab.py
+++ b/tests/platforms/android/gradle/test_package__aab.py
@@ -2,7 +2,6 @@ from subprocess import CalledProcessError
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/platforms/android/gradle/test_package__apk.py
+++ b/tests/platforms/android/gradle/test_package__apk.py
@@ -2,7 +2,6 @@ from subprocess import CalledProcessError
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/platforms/android/gradle/test_package__debug_apk.py
+++ b/tests/platforms/android/gradle/test_package__debug_apk.py
@@ -2,7 +2,6 @@ from subprocess import CalledProcessError
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -9,7 +9,6 @@ from unittest import mock
 
 import pytest
 import requests
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.android_sdk import ADB, AndroidSDK

--- a/tests/platforms/android/gradle/test_safe_formal_name.py
+++ b/tests/platforms/android/gradle/test_safe_formal_name.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.platforms.android.gradle import safe_formal_name
 
 

--- a/tests/platforms/conftest.py
+++ b/tests/platforms/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.config import AppConfig
 
 

--- a/tests/platforms/iOS/xcode/mixin/test_select_target_device.py
+++ b/tests/platforms/iOS/xcode/mixin/test_select_target_device.py
@@ -1,11 +1,11 @@
 from unittest import mock
 
 import pytest
-
 from briefcase.commands.base import BaseCommand
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 from briefcase.platforms.iOS.xcode import iOSXcodeMixin
+
 from tests.utils import DummyConsole
 
 

--- a/tests/platforms/iOS/xcode/test_build.py
+++ b/tests/platforms/iOS/xcode/test_build.py
@@ -3,7 +3,6 @@ import subprocess
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -2,7 +2,6 @@ import sys
 from unittest.mock import MagicMock, call
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/iOS/xcode/test_mixin.py
+++ b/tests/platforms/iOS/xcode/test_mixin.py
@@ -1,8 +1,7 @@
 from unittest.mock import MagicMock
 
-import pytest
-
 import briefcase.integrations.xcode
+import pytest
 from briefcase.console import Console, Log
 from briefcase.exceptions import NoDistributionArtefact
 from briefcase.platforms.iOS.xcode import iOSXcodeCreateCommand

--- a/tests/platforms/iOS/xcode/test_open.py
+++ b/tests/platforms/iOS/xcode/test_open.py
@@ -4,7 +4,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.iOS.xcode import iOSXcodeOpenCommand

--- a/tests/platforms/iOS/xcode/test_package.py
+++ b/tests/platforms/iOS/xcode/test_package.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.platforms.iOS.xcode import iOSXcodePackageCommand
 

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -3,7 +3,6 @@ import time
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/iOS/xcode/test_update.py
+++ b/tests/platforms/iOS/xcode/test_update.py
@@ -2,7 +2,6 @@ import sys
 from unittest.mock import MagicMock, call
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.iOS.xcode import iOSXcodeUpdateCommand

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import pytest
 import tomli_w
-
 from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import (
     BriefcaseCommandError,

--- a/tests/platforms/linux/appimage/test_create.py
+++ b/tests/platforms/linux/appimage/test_create.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseConfigError, UnsupportedHostError
 from briefcase.platforms.linux.appimage import LinuxAppImageCreateCommand

--- a/tests/platforms/linux/appimage/test_mixin.py
+++ b/tests/platforms/linux/appimage/test_mixin.py
@@ -1,9 +1,8 @@
 import sys
 from unittest.mock import MagicMock
 
-import pytest
-
 import briefcase.platforms.linux.appimage
+import pytest
 from briefcase.console import Console, Log
 from briefcase.integrations.docker import Docker, DockerAppContext
 from briefcase.integrations.linuxdeploy import LinuxDeploy

--- a/tests/platforms/linux/appimage/test_package.py
+++ b/tests/platforms/linux/appimage/test_package.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.platforms.linux.appimage import LinuxAppImagePackageCommand
 

--- a/tests/platforms/linux/appimage/test_run.py
+++ b/tests/platforms/linux/appimage/test_run.py
@@ -3,7 +3,6 @@ import subprocess
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/linux/conftest.py
+++ b/tests/platforms/linux/conftest.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.platforms.linux import LinuxMixin
 
 

--- a/tests/platforms/linux/flatpak/test_build.py
+++ b/tests/platforms/linux/flatpak/test_build.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseConfigError
 from briefcase.integrations.flatpak import Flatpak

--- a/tests/platforms/linux/flatpak/test_create.py
+++ b/tests/platforms/linux/flatpak/test_create.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseConfigError, UnsupportedHostError
 from briefcase.integrations.flatpak import Flatpak

--- a/tests/platforms/linux/flatpak/test_mixin.py
+++ b/tests/platforms/linux/flatpak/test_mixin.py
@@ -1,8 +1,7 @@
 from unittest.mock import MagicMock
 
-import pytest
-
 import briefcase.platforms.linux.flatpak
+import pytest
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseConfigError
 from briefcase.integrations.flatpak import Flatpak

--- a/tests/platforms/linux/flatpak/test_open.py
+++ b/tests/platforms/linux/flatpak/test_open.py
@@ -3,7 +3,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.linux.flatpak import LinuxFlatpakOpenCommand

--- a/tests/platforms/linux/flatpak/test_package.py
+++ b/tests/platforms/linux/flatpak/test_package.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.flatpak import Flatpak
 from briefcase.platforms.linux.flatpak import LinuxFlatpakPackageCommand

--- a/tests/platforms/linux/flatpak/test_run.py
+++ b/tests/platforms/linux/flatpak/test_run.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.flatpak import Flatpak
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/linux/system/conftest.py
+++ b/tests/platforms/linux/system/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.platforms.linux.system import LinuxSystemCreateCommand
 

--- a/tests/platforms/linux/system/test_build.py
+++ b/tests/platforms/linux/system/test_build.py
@@ -5,7 +5,6 @@ import sys
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux.system import LinuxSystemBuildCommand

--- a/tests/platforms/linux/system/test_create.py
+++ b/tests/platforms/linux/system/test_create.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import UnsupportedHostError
 
 

--- a/tests/platforms/linux/system/test_mixin__finalize_app_config.py
+++ b/tests/platforms/linux/system/test_mixin__finalize_app_config.py
@@ -2,7 +2,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux import parse_freedesktop_os_release

--- a/tests/platforms/linux/system/test_mixin__properties.py
+++ b/tests/platforms/linux/system/test_mixin__properties.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux.system import LinuxSystemBuildCommand

--- a/tests/platforms/linux/system/test_mixin__target_glibc_version.py
+++ b/tests/platforms/linux/system/test_mixin__target_glibc_version.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 

--- a/tests/platforms/linux/system/test_mixin__verify_python.py
+++ b/tests/platforms/linux/system/test_mixin__verify_python.py
@@ -2,7 +2,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.docker import DockerAppContext
 

--- a/tests/platforms/linux/system/test_mixin__verify_system_packages.py
+++ b/tests/platforms/linux/system/test_mixin__verify_system_packages.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest.mock import MagicMock, call
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux.system import LinuxSystemBuildCommand

--- a/tests/platforms/linux/system/test_mixin__verify_system_python.py
+++ b/tests/platforms/linux/system/test_mixin__verify_system_python.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux import system
 

--- a/tests/platforms/linux/system/test_package.py
+++ b/tests/platforms/linux/system/test_package.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/linux/system/test_package__deb.py
+++ b/tests/platforms/linux/system/test_package__deb.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux import system

--- a/tests/platforms/linux/system/test_package__pkg.py
+++ b/tests/platforms/linux/system/test_package__pkg.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux import system

--- a/tests/platforms/linux/system/test_package__rpm.py
+++ b/tests/platforms/linux/system/test_package__rpm.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux import system

--- a/tests/platforms/linux/system/test_run.py
+++ b/tests/platforms/linux/system/test_run.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.docker import Docker

--- a/tests/platforms/linux/test_DockerOpenCommand.py
+++ b/tests/platforms/linux/test_DockerOpenCommand.py
@@ -3,7 +3,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.docker import Docker, DockerAppContext
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/linux/test_LinuxMixin__vendor_details.py
+++ b/tests/platforms/linux/test_LinuxMixin__vendor_details.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.platforms.linux import parse_freedesktop_os_release
 
 from .os_release import OS_RELEASE

--- a/tests/platforms/linux/test_LocalRequirementsMixin.py
+++ b/tests/platforms/linux/test_LocalRequirementsMixin.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, call
 
 import pytest
-
 from briefcase.commands import CreateCommand
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError

--- a/tests/platforms/linux/test_parse_freedesktop_os_release.py
+++ b/tests/platforms/linux/test_parse_freedesktop_os_release.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.exceptions import ParseError
 from briefcase.platforms.linux import parse_freedesktop_os_release
 

--- a/tests/platforms/macOS/app/test_build.py
+++ b/tests/platforms/macOS/app/test_build.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.platforms.macOS.app import macOSAppBuildCommand
 

--- a/tests/platforms/macOS/app/test_create.py
+++ b/tests/platforms/macOS/app/test_create.py
@@ -3,7 +3,6 @@ import sys
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/macOS/app/test_mixin.py
+++ b/tests/platforms/macOS/app/test_mixin.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.platforms.macOS.app import macOSAppCreateCommand, macOSAppPackageCommand

--- a/tests/platforms/macOS/app/test_open.py
+++ b/tests/platforms/macOS/app/test_open.py
@@ -3,7 +3,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS.app import macOSAppOpenCommand

--- a/tests/platforms/macOS/app/test_package.py
+++ b/tests/platforms/macOS/app/test_package.py
@@ -3,9 +3,8 @@ import subprocess
 from unittest import mock
 from zipfile import ZipFile
 
-import pytest
-
 import briefcase.integrations.xcode
+import pytest
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.macOS.app import macOSAppPackageCommand

--- a/tests/platforms/macOS/app/test_package__notarize.py
+++ b/tests/platforms/macOS/app/test_package__notarize.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock
 from zipfile import ZipFile
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/macOS/app/test_package__team_id_from_identity.py
+++ b/tests/platforms/macOS/app/test_package__team_id_from_identity.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.macOS.app import macOSAppPackageCommand

--- a/tests/platforms/macOS/app/test_run.py
+++ b/tests/platforms/macOS/app/test_run.py
@@ -4,7 +4,6 @@ from signal import SIGTERM
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -5,13 +5,13 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from briefcase.commands.base import BaseCommand
 from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS import macOSSigningMixin
 from briefcase.platforms.macOS.app import macOSAppMixin
+
 from tests.utils import DummyConsole
 
 

--- a/tests/platforms/macOS/conftest.py
+++ b/tests/platforms/macOS/conftest.py
@@ -1,11 +1,11 @@
 from unittest import mock
 
 import pytest
-
 from briefcase.commands.base import BaseCommand
 from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS.app import macOSAppMixin, macOSCreateMixin
+
 from tests.utils import DummyConsole
 
 

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__ensure_thin_binary.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__ensure_thin_binary.py
@@ -1,7 +1,6 @@
 import subprocess
 
 import pytest
-
 from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__lipo_dylib.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__lipo_dylib.py
@@ -2,7 +2,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-
 from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__merge_app_packages.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__merge_app_packages.py
@@ -3,7 +3,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 from ...utils import create_file, create_installed_package, file_content

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__thin_app_packages.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__thin_app_packages.py
@@ -1,7 +1,6 @@
 import subprocess
 
 import pytest
-
 from briefcase.exceptions import BriefcaseCommandError
 
 from ...utils import create_file, create_installed_package, file_content

--- a/tests/platforms/macOS/test_XcodeBuildFilter.py
+++ b/tests/platforms/macOS/test_XcodeBuildFilter.py
@@ -2,7 +2,6 @@
 # for line length.
 # flake8: noqa: E501
 import pytest
-
 from briefcase.platforms.macOS.filters import XcodeBuildFilter
 
 

--- a/tests/platforms/macOS/test_macOS_log_clean_filter.py
+++ b/tests/platforms/macOS/test_macOS_log_clean_filter.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.platforms.macOS.filters import macOS_log_clean_filter
 
 

--- a/tests/platforms/macOS/xcode/test_build.py
+++ b/tests/platforms/macOS/xcode/test_build.py
@@ -2,7 +2,6 @@ import subprocess
 from unittest.mock import ANY, MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/macOS/xcode/test_mixin.py
+++ b/tests/platforms/macOS/xcode/test_mixin.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.platforms.macOS.xcode import macOSXcodeCreateCommand

--- a/tests/platforms/macOS/xcode/test_open.py
+++ b/tests/platforms/macOS/xcode/test_open.py
@@ -4,7 +4,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS.xcode import macOSXcodeOpenCommand

--- a/tests/platforms/macOS/xcode/test_package.py
+++ b/tests/platforms/macOS/xcode/test_package.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
-import pytest
-
 import briefcase.integrations.xcode
+import pytest
 from briefcase.console import Console, Log
 from briefcase.platforms.macOS.xcode import macOSXcodePackageCommand
 

--- a/tests/platforms/macOS/xcode/test_run.py
+++ b/tests/platforms/macOS/xcode/test_run.py
@@ -7,7 +7,6 @@ from signal import SIGTERM
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS import macOS_log_clean_filter

--- a/tests/platforms/web/static/test_build.py
+++ b/tests/platforms/web/static/test_build.py
@@ -9,7 +9,6 @@ else:  # pragma: no-cover-if-gte-py311
     import tomli as tomllib
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError, BriefcaseConfigError
 from briefcase.integrations.subprocess import Subprocess
@@ -45,7 +44,7 @@ def test_build_app(build_command, first_app_generated, tmp_path):
                 extra_content=[
                     ("dependency/static/style.css", "span { margin: 10px; }\n"),
                 ],
-            ),
+            )
         elif args[0][5] == "pip":
             create_wheel(
                 bundle_path / "www/static/wheels",
@@ -53,14 +52,14 @@ def test_build_app(build_command, first_app_generated, tmp_path):
                 extra_content=[
                     ("dependency/static/style.css", "div { margin: 10px; }\n"),
                 ],
-            ),
+            )
             create_wheel(
                 bundle_path / "www/static/wheels",
                 "other",
                 extra_content=[
                     ("other/static/style.css", "div { padding: 10px; }\n"),
                 ],
-            ),
+            )
         else:
             raise ValueError("Unknown command")
 
@@ -308,7 +307,7 @@ def test_build_app_no_requirements(build_command, first_app_generated, tmp_path)
                 extra_content=[
                     ("dependency/static/style.css", "span { margin: 10px; }\n"),
                 ],
-            ),
+            )
         elif args[0][5] == "pip":
             pass
         else:

--- a/tests/platforms/web/static/test_build__process_wheel.py
+++ b/tests/platforms/web/static/test_build__process_wheel.py
@@ -1,7 +1,6 @@
 from io import StringIO
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.platforms.web.static import StaticWebBuildCommand
 

--- a/tests/platforms/web/static/test_build__trim_file.py
+++ b/tests/platforms/web/static/test_build__trim_file.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.platforms.web.static import StaticWebBuildCommand
 

--- a/tests/platforms/web/static/test_create.py
+++ b/tests/platforms/web/static/test_create.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.platforms.web.static import StaticWebCreateCommand

--- a/tests/platforms/web/static/test_mixin.py
+++ b/tests/platforms/web/static/test_mixin.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.platforms.web.static import StaticWebCreateCommand
 

--- a/tests/platforms/web/static/test_package.py
+++ b/tests/platforms/web/static/test_package.py
@@ -1,7 +1,6 @@
 from zipfile import ZipFile
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.platforms.web.static import StaticWebPackageCommand
 

--- a/tests/platforms/web/static/test_run.py
+++ b/tests/platforms/web/static/test_run.py
@@ -4,7 +4,6 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.web.static import (

--- a/tests/platforms/windows/app/test_build.py
+++ b/tests/platforms/windows/app/test_build.py
@@ -4,10 +4,9 @@ import subprocess
 from pathlib import Path
 from unittest import mock
 
+import briefcase.platforms.windows.app
 import pytest
 import tomli_w
-
-import briefcase.platforms.windows.app
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.rcedit import RCEdit

--- a/tests/platforms/windows/app/test_create.py
+++ b/tests/platforms/windows/app/test_create.py
@@ -1,7 +1,6 @@
 import sys
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.platforms.windows.app import WindowsAppCreateCommand

--- a/tests/platforms/windows/app/test_mixin.py
+++ b/tests/platforms/windows/app/test_mixin.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.platforms.windows.app import WindowsAppCreateCommand
 

--- a/tests/platforms/windows/app/test_open.py
+++ b/tests/platforms/windows/app/test_open.py
@@ -3,7 +3,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.windows.app import WindowsAppOpenCommand

--- a/tests/platforms/windows/app/test_package.py
+++ b/tests/platforms/windows/app/test_package.py
@@ -2,9 +2,8 @@ from subprocess import CalledProcessError
 from unittest import mock
 from zipfile import ZipFile
 
-import pytest
-
 import briefcase.platforms.windows
+import pytest
 from briefcase.console import Console, Log
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/windows/app/test_run.py
+++ b/tests/platforms/windows/app/test_run.py
@@ -3,7 +3,6 @@ import subprocess
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.windows.app import WindowsAppRunCommand

--- a/tests/platforms/windows/visualstudio/test_build.py
+++ b/tests/platforms/windows/visualstudio/test_build.py
@@ -2,9 +2,8 @@ import subprocess
 from pathlib import Path
 from unittest import mock
 
-import pytest
-
 import briefcase.platforms.windows.visualstudio
+import pytest
 from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess

--- a/tests/platforms/windows/visualstudio/test_mixin.py
+++ b/tests/platforms/windows/visualstudio/test_mixin.py
@@ -1,5 +1,4 @@
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.platforms.windows.visualstudio import WindowsVisualStudioCreateCommand

--- a/tests/platforms/windows/visualstudio/test_open.py
+++ b/tests/platforms/windows/visualstudio/test_open.py
@@ -3,7 +3,6 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.windows.visualstudio import WindowsVisualStudioOpenCommand

--- a/tests/platforms/windows/visualstudio/test_package.py
+++ b/tests/platforms/windows/visualstudio/test_package.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.integrations.wix import WiX

--- a/tests/platforms/windows/visualstudio/test_run.py
+++ b/tests/platforms/windows/visualstudio/test_run.py
@@ -6,7 +6,6 @@ import subprocess
 from unittest import mock
 
 import pytest
-
 from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.windows.visualstudio import WindowsVisualStudioRunCommand

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -3,7 +3,6 @@ import sys
 from unittest import mock
 
 import pytest
-
 from briefcase import __version__, cmdline
 from briefcase.commands import DevCommand, NewCommand, UpgradeCommand
 from briefcase.console import Console, Log, LogLevel

--- a/tests/test_mainline.py
+++ b/tests/test_mainline.py
@@ -2,7 +2,6 @@ import sys
 from pathlib import Path
 
 import pytest
-
 from briefcase.__main__ import main
 from briefcase.commands.create import CreateCommand
 from briefcase.commands.run import RunCommand

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,11 +9,10 @@ from email.message import EmailMessage
 from pathlib import Path
 
 import requests
+from briefcase.console import Console, InputDisabled
 from requests.adapters import HTTPAdapter
 from rich.markup import escape
 from urllib3.util.retry import Retry
-
-from briefcase.console import Console, InputDisabled
 
 
 class DummyConsole(Console):

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,3 @@
-# Flake8 doesn't believe in pyproject.toml, so we put the configuration here.
-[flake8]
-# https://flake8.readthedocs.org/en/latest/
-exclude=\
-    venv*/*,\
-    local/*,\
-    docs/*,\
-    build/*,\
-    tests/apps/*,\
-    .eggs/*,\
-    .tox/*
-max-line-length = 119
-extend-ignore =
-    # whitespace before :
-    # See https://github.com/PyCQA/pycodestyle/issues/373
-    E203,
-
 [tox]
 envlist = towncrier-check,docs-lint,pre-commit,py{38,39,310,311,312,313},coverage
 labels =


### PR DESCRIPTION
## Changes
- Replace pyupgrade, isort, and flake8 with Ruff's linter

## Notes
- Another pitch to use Ruff.
- Other than 🚀, the benefit I see is using a single tool instead of several...and a seemingly well-received tool in the Python community.
- I'm considering this a soft implementation (right now anyway) because I didn't replace Black with Ruff's formatter.
  - This is primarily because I couldn't get Ruff to play nicely with a quirk we're taking advantage of.
    - Currently, Black ignores many lines that exceed its ~88 character limit....but we're currently using flake8 to catch excessively long lines over 119 characters
    - I haven't figured out how to get Ruff to do the same without adding a bunch of `noqa` or ignoring really long lines altogether
  - I also didn't want to spend too much more time with this if the team isn't interested right now.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct