### PR TITLE
Respect and pass through `ANDROID_USER_HOME` and `ANDROID_AVD_HOME`

### DIFF
--- a/changes/1665.feature.rst
+++ b/changes/1665.feature.rst
@@ -1,0 +1,1 @@
+The environment variables ``ANDROID_USER_HOME`` and ``ANDROID_AVD_HOME`` are now respected and passed through to Android SDK commands. This allows for storing AVDs for the Android emulator outside of the home directory.

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -15,7 +15,24 @@ Gradle project
 
 When generating an Android project, Briefcase produces a Gradle project.
 
-Gradle requires an install of the Android SDK and a Java 17 JDK.
+Environment
+===========
+
+Gradle requires an install of a Java 17 JDK and the Android SDK.
+
+If the methods below fail to find an Android SDK or Java JDK, Briefcase will
+download and install an isolated copy in its data directory.
+
+Java JDK
+--------
+
+If you have an existing install of a Java 17 JDK, it will be used by Briefcase
+if the ``JAVA_HOME`` environment variable is set. On macOS, if ``JAVA_HOME`` is
+not set, Briefcase will use the ``/usr/libexec/java_home`` tool to find an
+existing JDK install.
+
+Android SDK
+-----------
 
 If you have an existing install of the Android SDK, it will be used by Briefcase
 if the ``ANDROID_HOME`` environment variable is set. If ``ANDROID_HOME`` is not
@@ -24,13 +41,16 @@ present in the environment, Briefcase will honor the deprecated
 must have version 9.0 of Command-line Tools installed; this version can be
 installed in the SDK Manager in Android Studio.
 
-If you have an existing install of a Java 17 JDK, it will be used by Briefcase
-if the ``JAVA_HOME`` environment variable is set. On macOS, if ``JAVA_HOME`` is
-not set, Briefcase will use the ``/usr/libexec/java_home`` tool to find an
-existing JDK install.
+Android Emulator
+----------------
 
-If the above methods fail to find an Android SDK or Java JDK, Briefcase will
-download and install an isolated copy in its data directory.
+By default, the Android emulator creates Android Virtual Devices (AVD) in the
+``.android`` directory in your user's home directory. As the AVDs can consume
+large amounts of disk space, they can be stored in an arbitrary directory via
+the ``ANDROID_USER_HOME`` and ``ANDROID_AVD_HOME`` environment variables.
+
+Packaging format
+================
 
 Briefcase supports three packaging formats for an Android app:
 
@@ -114,6 +134,61 @@ Android allows for some customization of the colors used by your app:
   status bar at the top of the screen.
 * ``splash_background_color`` is the color of the splash background that
   displays while an app is loading.
+
+Additional options
+==================
+
+The following options can be provided at the command line when producing
+Android projects:
+
+run
+---
+
+``-d <device>`` / ``--device <device>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The device or emulator to target. Can be specified as:
+
+* ``@`` followed by an AVD name (e.g., ``@beePhone``); or
+* a device ID (a hexadecimal identifier associated with a specific hardware device);
+  or
+* a JSON dictionary specifying the properties of a device that will be created.
+  This dictionary must have, at a minimum, an AVD name:
+
+.. code-block:: console
+
+     $ briefcase run -d '{"avd":"new-device"}'
+
+  You may also specify:
+
+  - ``device_type`` (e.g., ``pixel``) - the type of device to emulate
+  - ``skin`` (e.g., ``pixel_3a``) - the skin to apply to the emulator
+  - ``system_image`` (e.g., ``system-images;android-31;default;arm64-v8a``) - the Android
+    system image to use in the emulator.
+
+  If any of these attributes are *not* specified, they will fall back
+  to reasonable defaults.
+
+``--Xemulator=<value>``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A configuration argument to be passed to the emulator on startup. For example,
+to start the emulator in "headless" mode (i.e., without a display window),
+specify ``--Xemulator=-no-window``. See `the Android documentation
+<https://developer.android.com/studio/run/emulator-commandline>`__ for details
+on the full list of options that can be provided.
+
+You may specify multiple ``--Xemulator`` arguments; each one specifies a
+single argument to pass to the emulator, in the order they are specified.
+
+``--shutdown-on-exit``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instruct Briefcase to shut down the emulator when the run finishes. This is
+especially useful if you are running in headless mode, as the emulator will
+continue to run in the background, but there will be no visual manifestation
+that it is running. It may also be useful as a cleanup mechanism when running
+in a CI configuration.
 
 Application configuration
 =========================
@@ -234,61 +309,6 @@ significant digits of the final version code:
 If you want to manually specify a version code by defining ``version_code`` in
 your application configuration. If provided, this value will override any
 auto-generated value.
-
-Additional options
-==================
-
-The following options can be provided at the command line when producing
-Android projects:
-
-run
----
-
-``-d <device>`` / ``--device <device>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The device or emulator to target. Can be specified as:
-
-* ``@`` followed by an AVD name (e.g., ``@beePhone``); or
-* a device ID (a hexadecimal identifier associated with a specific hardware device);
-  or
-* a JSON dictionary specifying the properties of a device that will be created.
-  This dictionary must have, at a minimum, an AVD name:
-
-.. code-block:: console
-
-     $ briefcase run -d '{"avd":"new-device"}'
-
-  You may also specify:
-
-  - ``device_type`` (e.g., ``pixel``) - the type of device to emulate
-  - ``skin`` (e.g., ``pixel_3a``) - the skin to apply to the emulator
-  - ``system_image`` (e.g., ``system-images;android-31;default;arm64-v8a``) - the Android
-    system image to use in the emulator.
-
-  If any of these attributes are *not* specified, they will fall back
-  to reasonable defaults.
-
-``--Xemulator=<value>``
-~~~~~~~~~~~~~~~~~~~~~~~
-
-A configuration argument to be passed to the emulator on startup. For example,
-to start the emulator in "headless" mode (i.e., without a display window),
-specify ``--Xemulator=-no-window``. See `the Android documentation
-<https://developer.android.com/studio/run/emulator-commandline>`__ for details
-on the full list of options that can be provided.
-
-You may specify multiple ``--Xemulator`` arguments; each one specifies a
-single argument to pass to the emulator, in the order they are specified.
-
-``--shutdown-on-exit``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Instruct Briefcase to shut down the emulator when the run finishes. This is
-especially useful if you are running in headless mode, as the emulator will
-continue to run in the background, but there will be no visual manifestation
-that it is running. It may also be useful as a cleanup mechanism when running
-in a CI configuration.
 
 .. _android-permissions:
 

--- a/docs/reference/platforms/web/static.rst
+++ b/docs/reference/platforms/web/static.rst
@@ -48,6 +48,32 @@ Splash Image format
 
 Web projects do not support splash screens or installer images.
 
+Additional options
+==================
+
+The following options can be provided at the command line when producing
+web projects:
+
+run
+---
+
+``--host <ip or hostname>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The hostname or IP address that the development web server should be bound to.
+Defaults to ``localhost``.
+
+``-p <port>`` / ``--port <port>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The port that the development web server should be bound to. Defaults to ``8080``.
+If port ``8080`` is already in use, an arbitrary available port will be used.
+
+``--no-browser``
+~~~~~~~~~~~~~~~~
+
+Don't open a web browser after starting the development web server.
+
 Application configuration
 =========================
 
@@ -73,28 +99,3 @@ define a custom runtime, and change the default PyScript app name, you could use
     [[runtimes]]
     src = "https://example.com/custom/pyodide.js"
     """
-
-Additional options
-==================
-
-The following options can be provided at the command line when producing
-web projects:
-
-run
----
-
-``--host <ip or hostname>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The hostname or IP address that the development web server should be bound to.
-Defaults to ``localhost``.
-
-``-p <port>`` / ``--port <port>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The port that the development web server should be bound to. Defaults to ``8080``.
-
-``--no-browser``
-~~~~~~~~~~~~~~~~
-
-Don't open a web browser after starting the development web server.

--- a/tests/integrations/android_sdk/ADB/test_kill.py
+++ b/tests/integrations/android_sdk/ADB/test_kill.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from unittest.mock import MagicMock
 
@@ -15,12 +14,13 @@ def test_kill(mock_tools, adb):
     # Validate call parameters.
     mock_tools.subprocess.check_output.assert_called_once_with(
         [
-            os.fsdecode(mock_tools.android_sdk.adb_path),
+            mock_tools.android_sdk.adb_path,
             "-s",
             "exampleDevice",
             "emu",
             "kill",
         ],
+        env=mock_tools.android_sdk.env,
         quiet=False,
     )
 

--- a/tests/integrations/android_sdk/ADB/test_logcat.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from unittest import mock
 
@@ -15,7 +14,7 @@ def test_logcat(mock_tools, adb):
     # Validate call parameters.
     mock_tools.subprocess.Popen.assert_called_once_with(
         [
-            os.fsdecode(mock_tools.android_sdk.adb_path),
+            mock_tools.android_sdk.adb_path,
             "-s",
             "exampleDevice",
             "logcat",

--- a/tests/integrations/android_sdk/ADB/test_logcat_tail.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat_tail.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from datetime import datetime
 from unittest.mock import MagicMock
@@ -16,7 +15,7 @@ def test_logcat_tail(mock_tools, adb):
     # Validate call parameters.
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            os.fsdecode(mock_tools.android_sdk.adb_path),
+            mock_tools.android_sdk.adb_path,
             "-s",
             "exampleDevice",
             "logcat",

--- a/tests/integrations/android_sdk/ADB/test_run.py
+++ b/tests/integrations/android_sdk/ADB/test_run.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -15,17 +14,14 @@ def test_simple_command(mock_tools, adb, tmp_path):
     # Check that adb was invoked with the expected commands
     mock_tools.subprocess.check_output.assert_called_once_with(
         [
-            os.fsdecode(
-                tmp_path
-                / "sdk"
-                / "platform-tools"
-                / f"adb{'.exe' if sys.platform == 'win32' else ''}"
-            ),
+            tmp_path
+            / f"sdk/platform-tools/adb{'.exe' if sys.platform == 'win32' else ''}",
             "-s",
             "exampleDevice",
             "example",
             "command",
         ],
+        env=mock_tools.android_sdk.env,
         quiet=False,
     )
 
@@ -37,17 +33,14 @@ def test_quiet_command(mock_tools, adb, tmp_path):
     # Check that adb was invoked with the expected commands
     mock_tools.subprocess.check_output.assert_called_once_with(
         [
-            os.fsdecode(
-                tmp_path
-                / "sdk"
-                / "platform-tools"
-                / f"adb{'.exe' if sys.platform == 'win32' else ''}"
-            ),
+            tmp_path
+            / f"sdk/platform-tools/adb{'.exe' if sys.platform == 'win32' else ''}",
             "-s",
             "exampleDevice",
             "example",
             "command",
         ],
+        env=mock_tools.android_sdk.env,
         quiet=True,
     )
 
@@ -86,17 +79,14 @@ def test_error_handling(mock_tools, adb, name, exception, tmp_path):
     # Check that adb was invoked as expected
     mock_tools.subprocess.check_output.assert_called_once_with(
         [
-            os.fsdecode(
-                tmp_path
-                / "sdk"
-                / "platform-tools"
-                / f"adb{'.exe' if sys.platform == 'win32' else ''}"
-            ),
+            tmp_path
+            / f"sdk/platform-tools/adb{'.exe' if sys.platform == 'win32' else ''}",
             "-s",
             "exampleDevice",
             "example",
             "command",
         ],
+        env=mock_tools.android_sdk.env,
         quiet=False,
     )
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_emulators.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_emulators.py
@@ -5,8 +5,15 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError
 
 
+def test_no_avd_home(mock_tools, android_sdk):
+    """If the AVD home directory doesn't exist, an empty list is returned."""
+    assert not android_sdk.avd_home_path.is_dir()
+    assert android_sdk.emulators() == []
+
+
 def test_no_emulators(mock_tools, android_sdk):
     """If there are no emulators, an empty list is returned."""
+    android_sdk.avd_home_path.mkdir(parents=True, exist_ok=True)
     mock_tools.subprocess.check_output.return_value = ""
 
     assert android_sdk.emulators() == []
@@ -14,6 +21,7 @@ def test_no_emulators(mock_tools, android_sdk):
 
 def test_one_emulator(mock_tools, android_sdk):
     """If there is a single emulator, it is returned."""
+    android_sdk.avd_home_path.mkdir(parents=True, exist_ok=True)
     mock_tools.subprocess.check_output.return_value = "first\n"
 
     assert android_sdk.emulators() == ["first"]
@@ -21,6 +29,7 @@ def test_one_emulator(mock_tools, android_sdk):
 
 def test_multiple_emulators(mock_tools, android_sdk):
     """If there are multiple emulators, they are all returned."""
+    android_sdk.avd_home_path.mkdir(parents=True, exist_ok=True)
     mock_tools.subprocess.check_output.return_value = "first\nsecond\nthird\n"
 
     assert android_sdk.emulators() == ["first", "second", "third"]
@@ -28,8 +37,9 @@ def test_multiple_emulators(mock_tools, android_sdk):
 
 def test_adb_error(mock_tools, android_sdk):
     """If there is a problem invoking adb, an error is returned."""
+    android_sdk.avd_home_path.mkdir(parents=True, exist_ok=True)
     mock_tools.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        returncode=69, cmd="adb devices -l"
+        returncode=69, cmd="avdmanager list avd --compact"
     )
 
     with pytest.raises(BriefcaseCommandError):

--- a/tests/integrations/android_sdk/AndroidSDK/test_list_packages.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_list_packages.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 
 import pytest
@@ -11,7 +10,7 @@ def test_list_packages(mock_tools, android_sdk):
     android_sdk.list_packages()
 
     mock_tools.subprocess.check_output.assert_called_once_with(
-        [os.fsdecode(android_sdk.sdkmanager_path), "--list_installed"],
+        [android_sdk.sdkmanager_path, "--list_installed"],
         env=android_sdk.env,
     )
 
@@ -25,6 +24,6 @@ def test_list_packages_failure(mock_tools, android_sdk):
         android_sdk.list_packages()
 
     mock_tools.subprocess.check_output.assert_called_once_with(
-        [os.fsdecode(android_sdk.sdkmanager_path), "--list_installed"],
+        [android_sdk.sdkmanager_path, "--list_installed"],
         env=android_sdk.env,
     )

--- a/tests/integrations/android_sdk/AndroidSDK/test_properties.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_properties.py
@@ -86,8 +86,55 @@ def test_emulator_path(mock_tools, android_sdk, host_os, emulator_name):
     )
 
 
+def test_dot_android_path(mock_tools, android_sdk, tmp_path):
+    """Default user android path is $HOME/.android/avd."""
+    assert android_sdk.dot_android_path == tmp_path / "home/.android"
+
+
+def test_dot_android_path_env_var(mock_tools, android_sdk, monkeypatch):
+    """ANDROID_AVD_HOME is respected as AVD path."""
+    mock_tools.os.environ = {"ANDROID_USER_HOME": "/my/android"}
+    assert android_sdk.dot_android_path == Path("/my/android")
+
+
+def test_avd_home_path(mock_tools, android_sdk, tmp_path):
+    """Default AVD path is $HOME/.android/avd."""
+    assert android_sdk.avd_home_path == tmp_path / "home/.android/avd"
+
+
+def test_avd_home_path_env_var(mock_tools, android_sdk, monkeypatch):
+    """ANDROID_AVD_HOME is respected as AVD path."""
+    mock_tools.os.environ = {"ANDROID_AVD_HOME": "/my/avds"}
+    assert android_sdk.avd_home_path == Path("/my/avds")
+
+
 def test_avd_path(mock_tools, android_sdk, tmp_path):
-    assert android_sdk.avd_path == tmp_path / "home/.android/avd"
+    """Default path for AVD is correct."""
+    assert (
+        android_sdk.avd_path(avd="my-avd") == tmp_path / "home/.android/avd/my-avd.avd"
+    )
+
+
+def test_avd_path_env_var(mock_tools, android_sdk, tmp_path, monkeypatch):
+    """ANDROID_AVD_HOME is respected for AVD path."""
+    mock_tools.os.environ = {"ANDROID_AVD_HOME": "/my/avds"}
+    assert android_sdk.avd_path(avd="my-avd") == Path("/my/avds/my-avd.avd")
+
+
+def test_avd_config_filepath(mock_tools, android_sdk, tmp_path):
+    """Default AVD config file is correct."""
+    assert (
+        android_sdk.avd_config_filepath(avd="my-avd")
+        == tmp_path / "home/.android/avd/my-avd.avd/config.ini"
+    )
+
+
+def test_avd_config_filepath_env_var(mock_tools, android_sdk, tmp_path, monkeypatch):
+    """ANDROID_AVD_HOME is respected for AVD config filepath."""
+    mock_tools.os.environ = {"ANDROID_AVD_HOME": "/my/avds"}
+    assert android_sdk.avd_config_filepath(avd="my-avd") == Path(
+        "/my/avds/my-avd.avd/config.ini"
+    )
 
 
 def test_simple_env(mock_tools, android_sdk, tmp_path):
@@ -96,6 +143,8 @@ def test_simple_env(mock_tools, android_sdk, tmp_path):
         "JAVA_HOME": os.fsdecode(Path("/path/to/jdk")),
         "ANDROID_HOME": os.fsdecode(tmp_path / "sdk"),
         "ANDROID_SDK_ROOT": os.fsdecode(tmp_path / "sdk"),
+        "ANDROID_USER_HOME": os.fsdecode(tmp_path / "home/.android"),
+        "ANDROID_AVD_HOME": os.fsdecode(tmp_path / "home/.android/avd"),
     }
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from unittest.mock import MagicMock, call
 
@@ -109,7 +108,7 @@ def test_start_emulator(mock_tools, android_sdk):
     # The process was started.
     mock_tools.subprocess.Popen.assert_called_with(
         [
-            os.fsdecode(android_sdk.emulator_path),
+            android_sdk.emulator_path,
             "@idleEmulator",
             "-dns-server",
             "8.8.8.8",
@@ -190,7 +189,7 @@ def test_start_emulator_fast_start(mock_tools, android_sdk):
     # The process was started.
     mock_tools.subprocess.Popen.assert_called_with(
         [
-            os.fsdecode(android_sdk.emulator_path),
+            android_sdk.emulator_path,
             "@idleEmulator",
             "-dns-server",
             "8.8.8.8",
@@ -285,7 +284,7 @@ def test_emulator_fail_to_start(mock_tools, android_sdk):
     # The process was started.
     mock_tools.subprocess.Popen.assert_called_with(
         [
-            os.fsdecode(android_sdk.emulator_path),
+            android_sdk.emulator_path,
             "@idleEmulator",
             "-dns-server",
             "8.8.8.8",
@@ -389,7 +388,7 @@ def test_emulator_fail_to_boot(mock_tools, android_sdk):
     # The process was started.
     mock_tools.subprocess.Popen.assert_called_with(
         [
-            os.fsdecode(android_sdk.emulator_path),
+            android_sdk.emulator_path,
             "@idleEmulator",
             "-dns-server",
             "8.8.8.8",
@@ -458,7 +457,7 @@ def test_emulator_ctrl_c(mock_tools, android_sdk, emulator_comm, expected_log, c
     # The process was started.
     mock_tools.subprocess.Popen.assert_called_with(
         [
-            os.fsdecode(android_sdk.emulator_path),
+            android_sdk.emulator_path,
             "@idleEmulator",
             "-dns-server",
             "8.8.8.8",
@@ -524,7 +523,7 @@ def test_start_emulator_extra_args(mock_tools, android_sdk):
     # The process was started with the headless test options.
     mock_tools.subprocess.Popen.assert_called_with(
         [
-            os.fsdecode(android_sdk.emulator_path),
+            android_sdk.emulator_path,
             "@idleEmulator",
             "-dns-server",
             "8.8.8.8",

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import shutil
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -320,7 +321,7 @@ def test_user_provided_sdk_wrong_cmdline_tools_ver(
     # Create `sdkmanager` and the license file
     # for the *briefcase* managed version of the SDK.
     android_sdk_root_path = tmp_path / "tools/android_sdk"
-    tools_bin = android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
+    tools_bin = android_sdk_root_path / f"cmdline-tools/{SDK_MGR_VER}/bin"
     tools_bin.mkdir(parents=True, mode=0o755)
     (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
@@ -343,14 +344,16 @@ def test_user_provided_sdk_wrong_cmdline_tools_ver(
     # Required Command-line Tools installed
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            tmp_path
-            / "other_sdk"
-            / "cmdline-tools"
-            / "latest"
-            / "bin"
-            / SDKMANAGER_FILENAME,
+            tmp_path / f"other_sdk/cmdline-tools/latest/bin/{SDKMANAGER_FILENAME}",
             f"cmdline-tools;{SDK_MGR_VER}",
         ],
+        env={
+            "ANDROID_HOME": f"{tmp_path / 'other_sdk'}",
+            "ANDROID_SDK_ROOT": f"{tmp_path / 'other_sdk'}",
+            "ANDROID_USER_HOME": f"{tmp_path / 'home/.android'}",
+            "ANDROID_AVD_HOME": f"{tmp_path / 'home/.android/avd'}",
+            "JAVA_HOME": str(Path("/path/to/jdk")),
+        },
         check=True,
         stream_output=False,
     )
@@ -395,14 +398,10 @@ def test_user_provided_sdk_with_latest_cmdline_tools(
     # Required Command-line Tools installed
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            tmp_path
-            / "other_sdk"
-            / "cmdline-tools"
-            / "latest"
-            / "bin"
-            / SDKMANAGER_FILENAME,
+            tmp_path / f"other_sdk/cmdline-tools/latest/bin/{SDKMANAGER_FILENAME}",
             f"cmdline-tools;{SDK_MGR_VER}",
         ],
+        env=sdk.env,
         check=True,
         stream_output=False,
     )

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 import sys
 
@@ -62,7 +61,7 @@ def test_installs_android_emulator(mock_tools, android_sdk):
 
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            os.fsdecode(android_sdk.sdkmanager_path),
+            android_sdk.sdkmanager_path,
             "platform-tools",
             "emulator",
         ],
@@ -84,7 +83,7 @@ def test_partial_android_emulator_install(mock_tools, android_sdk):
 
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            os.fsdecode(android_sdk.sdkmanager_path),
+            android_sdk.sdkmanager_path,
             "platform-tools",
             "emulator",
         ],

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_license.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_license.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 
 import pytest
@@ -35,7 +34,7 @@ def test_verify_license_prompts_for_licenses_and_exits_if_you_agree(
     mock_tools.subprocess.run.side_effect = accept_license
     android_sdk.verify_license()
     mock_tools.subprocess.run.assert_called_once_with(
-        [os.fsdecode(android_sdk.sdkmanager_path), "--licenses"],
+        [android_sdk.sdkmanager_path, "--licenses"],
         env=android_sdk.env,
         check=True,
         stream_output=False,
@@ -50,7 +49,7 @@ def test_verify_license_handles_sdkmanager_crash(mock_tools, android_sdk):
         android_sdk.verify_license()
 
     mock_tools.subprocess.run.assert_called_once_with(
-        [os.fsdecode(android_sdk.sdkmanager_path), "--licenses"],
+        [android_sdk.sdkmanager_path, "--licenses"],
         env=android_sdk.env,
         check=True,
         stream_output=False,
@@ -66,7 +65,7 @@ def test_verify_license_insists_on_agreement(mock_tools, android_sdk):
         android_sdk.verify_license()
 
     mock_tools.subprocess.run.assert_called_once_with(
-        [os.fsdecode(android_sdk.sdkmanager_path), "--licenses"],
+        [android_sdk.sdkmanager_path, "--licenses"],
         env=android_sdk.env,
         check=True,
         stream_output=False,

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
@@ -1,4 +1,3 @@
-import os
 import platform
 from subprocess import CalledProcessError
 
@@ -68,7 +67,7 @@ def test_incompatible_abi(mock_tools, android_sdk, capsys):
     # The system image was installed.
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            os.fsdecode(android_sdk.sdkmanager_path),
+            android_sdk.sdkmanager_path,
             "system-images;android-31;default;anything",
         ],
         env=android_sdk.env,
@@ -105,7 +104,7 @@ def test_new_system_image(mock_tools, android_sdk):
     # The system image was installed.
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            os.fsdecode(android_sdk.sdkmanager_path),
+            android_sdk.sdkmanager_path,
             "system-images;android-31;default;x86_64",
         ],
         env=android_sdk.env,
@@ -135,7 +134,7 @@ def test_problem_downloading_system_image(mock_tools, android_sdk):
     # An attempt to install the system image was made
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            os.fsdecode(android_sdk.sdkmanager_path),
+            android_sdk.sdkmanager_path,
             "system-images;android-31;default;x86_64",
         ],
         env=android_sdk.env,


### PR DESCRIPTION
## Changes
- Allows Briefcase to use `ANDROID_USER_HOME` as the location of the `.android` directory and `ANDROID_AVD_HOME` as the location of the AVDs; these were previously hardcorded to their defaults, `$HOME/.android` and `$HOME/.android/avd`
- Closes #1665

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct