### PR TITLE
Remove DeprecationWarning suppression with python-dateutil==2.9.0 release

### DIFF
--- a/changes/1428.misc.rst
+++ b/changes/1428.misc.rst
@@ -1,0 +1,1 @@
+The error suppression for a deprecated API use from python-dateutil was removed with its release of version 2.9.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,12 +80,12 @@ dependencies = [
     # If the package uses calver, we don't pin the upper version, as the upper version
     # provides no basis for determining API stability.
     #
-    # See beeware/briefcase#1663 to bump <2.6.0 pin
-    "cookiecutter >= 2.3.1, < 2.6.0",
+    "cookiecutter >= 2.3.1, < 2.6.0",  # See beeware/briefcase#1663 to bump <2.6.0 pin
     "dmgbuild >= 1.6, < 2.0; sys_platform == 'darwin'",
     "GitPython >= 3.1, < 4.0",
     "platformdirs >= 2.6, < 5.0",
     "psutil >= 5.9, < 6.0",
+    "python-dateutil >= 2.9.0.post0",  # transitive dependency (beeware/briefcase#1428)
     "requests >= 2.28, < 3.0",
     "rich >= 12.6, < 14.0",
     "tomli >= 2.0, < 3.0; python_version <= '3.10'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,8 +232,6 @@ multi_line_output = 3
 testpaths = ["tests"]
 filterwarnings = [
     "error",
-    # suppress until python-dateutil>2.8.2 is released (https://github.com/dateutil/dateutil/issues/1284)
-    "ignore:.*datetime.utcfromtimestamp\\(\\) is deprecated.*:DeprecationWarning:",
 ]
 
 # need to ensure build directories aren't excluded from recursion


### PR DESCRIPTION
## Changes
- Remove pytest error suppression for `DeprecatedWarning`
- Add `-r` to `tox` calls and update `python-dateutil` manually before using `pytest`
- Closes #1428

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct