### PR TITLE
Bump minimuim pip to 23.1.2 for Python 3.12 compatibility

### DIFF
--- a/changes/1681.bugfix.rst
+++ b/changes/1681.bugfix.rst
@@ -1,0 +1,1 @@
+The minimum version of pip was bumped to 23.1.2 to ensure compatibility with Python 3.12.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     # limited to <=3.9 for the `group` argument for `entry_points()`
     "importlib_metadata >= 4.4; python_version <= '3.9'",
     "packaging >= 22.0",
-    "pip >= 23.1.1",
+    "pip >= 23.1.2",
     "setuptools >= 60",
     "wheel >= 0.37",
     "build >= 0.10",


### PR DESCRIPTION
## Changes
- pip <23.1.2 is not compatible with Python 3.12; require at least 23.1.2
  - https://github.com/pypa/pip/pull/11997
  - https://github.com/pypa/pip/issues/11501

```
  File "/home/russell/tmp/testing/venv/lib/python3.12/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2191, in <module>
    register_finder(pkgutil.ImpImporter, find_on_path)
                    ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
```

[briefcase.2024_03_05-11_52_03.dev.log](https://github.com/beeware/briefcase/files/14498745/briefcase.2024_03_05-11_52_03.dev.log)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct