### PR TITLE
Pin all deps in tox.ini

### DIFF
--- a/changes/1686.misc.rst
+++ b/changes/1686.misc.rst
@@ -1,0 +1,1 @@
+All dependencies in tox.ini are now pinned to specific versions.

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,9 @@ skip_missing_interpreters = True
 [testenv:pre-commit]
 skip_install = True
 deps =
-    build
-    setuptools
-    wheel
+    build==1.1.1
+    setuptools==69.1.1
+    wheel==0.42.0
 commands_pre = python -m install_requirement pre-commit --extra dev --project-root "{tox_root}"
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
@@ -81,9 +81,9 @@ setenv =
     # disable conditional coverage exclusions for host platform to test entire project
     project: COVERAGE_EXCLUDE_PLATFORM=disable
 deps =
-    build
-    setuptools
-    wheel
+    build==1.1.1
+    setuptools==69.1.1
+    wheel==0.42.0
 commands_pre =
     python --version
     python -m install_requirement coverage coverage-conditional-plugin --extra dev --project-root "{tox_root}"
@@ -95,7 +95,7 @@ commands =
 [testenv:towncrier{,-check}]
 skip_install = True
 deps =
-    towncrier ~= 22.8
+    towncrier==23.11.0
 commands =
     check  : python -m towncrier.check --compare-with origin/main
     !check : python -m towncrier {posargs}


### PR DESCRIPTION
## Changes
- With #1683 live, this pins all dependencies in tox.ini

## Notes
- As it relates to `towncrier`, I confirmed the changes to `docs/background/releases.rst` were the same for this version as the previous.
- Additionally, I noticed that the current use of `towncrier` in `tox` seemingly requires that Briefcase has been installed...otherwise, the version is indeterminable.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct