### PR TITLE
Revert "Respect and pass through `ANDROID_USER_HOME` and `ANDROID_AVD_HOME`"

### DIFF
--- a/changes/1665.feature.rst
+++ b/changes/1665.feature.rst
@@ -1,1 +1,0 @@
-The environment variables ``ANDROID_USER_HOME`` and ``ANDROID_AVD_HOME`` are now respected and passed through to Android SDK commands. This allows for storing AVDs for the Android emulator outside of the home directory.

--- a/changes/1689.misc.rst
+++ b/changes/1689.misc.rst
@@ -1,0 +1,1 @@
+Support for ``ANDROID_USER_HOME`` and ``ANDROID_AVD_HOME`` was removed after issues with running AVDs created by non-Briefcase-managed Android SDKs were discovered.

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -12,10 +12,26 @@ Gradle project
 | |f|    | |y|   |     | |f|    |       | |v| | |f|    | |v| | |v|   |
 +--------+-------+-----+--------+-------+-----+--------+-----+-------+
 
-
 When generating an Android project, Briefcase produces a Gradle project.
 
-Gradle requires an install of the Android SDK and a Java 17 JDK.
+Environment
+===========
+
+Gradle requires an install of a Java 17 JDK and the Android SDK.
+
+If the methods below fail to find an Android SDK or Java JDK, Briefcase will
+download and install an isolated copy in its data directory.
+
+Java JDK
+--------
+
+If you have an existing install of a Java 17 JDK, it will be used by Briefcase
+if the ``JAVA_HOME`` environment variable is set. On macOS, if ``JAVA_HOME`` is
+not set, Briefcase will use the ``/usr/libexec/java_home`` tool to find an
+existing JDK install.
+
+Android SDK
+-----------
 
 If you have an existing install of the Android SDK, it will be used by Briefcase
 if the ``ANDROID_HOME`` environment variable is set. If ``ANDROID_HOME`` is not
@@ -24,13 +40,8 @@ present in the environment, Briefcase will honor the deprecated
 must have version 9.0 of Command-line Tools installed; this version can be
 installed in the SDK Manager in Android Studio.
 
-If you have an existing install of a Java 17 JDK, it will be used by Briefcase
-if the ``JAVA_HOME`` environment variable is set. On macOS, if ``JAVA_HOME`` is
-not set, Briefcase will use the ``/usr/libexec/java_home`` tool to find an
-existing JDK install.
-
-If the above methods fail to find an Android SDK or Java JDK, Briefcase will
-download and install an isolated copy in its data directory.
+Packaging format
+================
 
 Briefcase supports three packaging formats for an Android app:
 
@@ -114,6 +125,61 @@ Android allows for some customization of the colors used by your app:
   status bar at the top of the screen.
 * ``splash_background_color`` is the color of the splash background that
   displays while an app is loading.
+
+Additional options
+==================
+
+The following options can be provided at the command line when producing
+Android projects:
+
+run
+---
+
+``-d <device>`` / ``--device <device>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The device or emulator to target. Can be specified as:
+
+* ``@`` followed by an AVD name (e.g., ``@beePhone``); or
+* a device ID (a hexadecimal identifier associated with a specific hardware device);
+  or
+* a JSON dictionary specifying the properties of a device that will be created.
+  This dictionary must have, at a minimum, an AVD name:
+
+.. code-block:: console
+
+     $ briefcase run -d '{"avd":"new-device"}'
+
+  You may also specify:
+
+  - ``device_type`` (e.g., ``pixel``) - the type of device to emulate
+  - ``skin`` (e.g., ``pixel_3a``) - the skin to apply to the emulator
+  - ``system_image`` (e.g., ``system-images;android-31;default;arm64-v8a``) - the Android
+    system image to use in the emulator.
+
+  If any of these attributes are *not* specified, they will fall back
+  to reasonable defaults.
+
+``--Xemulator=<value>``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A configuration argument to be passed to the emulator on startup. For example,
+to start the emulator in "headless" mode (i.e., without a display window),
+specify ``--Xemulator=-no-window``. See `the Android documentation
+<https://developer.android.com/studio/run/emulator-commandline>`__ for details
+on the full list of options that can be provided.
+
+You may specify multiple ``--Xemulator`` arguments; each one specifies a
+single argument to pass to the emulator, in the order they are specified.
+
+``--shutdown-on-exit``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instruct Briefcase to shut down the emulator when the run finishes. This is
+especially useful if you are running in headless mode, as the emulator will
+continue to run in the background, but there will be no visual manifestation
+that it is running. It may also be useful as a cleanup mechanism when running
+in a CI configuration.
 
 Application configuration
 =========================
@@ -234,61 +300,6 @@ significant digits of the final version code:
 If you want to manually specify a version code by defining ``version_code`` in
 your application configuration. If provided, this value will override any
 auto-generated value.
-
-Additional options
-==================
-
-The following options can be provided at the command line when producing
-Android projects:
-
-run
----
-
-``-d <device>`` / ``--device <device>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The device or emulator to target. Can be specified as:
-
-* ``@`` followed by an AVD name (e.g., ``@beePhone``); or
-* a device ID (a hexadecimal identifier associated with a specific hardware device);
-  or
-* a JSON dictionary specifying the properties of a device that will be created.
-  This dictionary must have, at a minimum, an AVD name:
-
-.. code-block:: console
-
-     $ briefcase run -d '{"avd":"new-device"}'
-
-  You may also specify:
-
-  - ``device_type`` (e.g., ``pixel``) - the type of device to emulate
-  - ``skin`` (e.g., ``pixel_3a``) - the skin to apply to the emulator
-  - ``system_image`` (e.g., ``system-images;android-31;default;arm64-v8a``) - the Android
-    system image to use in the emulator.
-
-  If any of these attributes are *not* specified, they will fall back
-  to reasonable defaults.
-
-``--Xemulator=<value>``
-~~~~~~~~~~~~~~~~~~~~~~~
-
-A configuration argument to be passed to the emulator on startup. For example,
-to start the emulator in "headless" mode (i.e., without a display window),
-specify ``--Xemulator=-no-window``. See `the Android documentation
-<https://developer.android.com/studio/run/emulator-commandline>`__ for details
-on the full list of options that can be provided.
-
-You may specify multiple ``--Xemulator`` arguments; each one specifies a
-single argument to pass to the emulator, in the order they are specified.
-
-``--shutdown-on-exit``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Instruct Briefcase to shut down the emulator when the run finishes. This is
-especially useful if you are running in headless mode, as the emulator will
-continue to run in the background, but there will be no visual manifestation
-that it is running. It may also be useful as a cleanup mechanism when running
-in a CI configuration.
 
 .. _android-permissions:
 

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -15,24 +15,7 @@ Gradle project
 
 When generating an Android project, Briefcase produces a Gradle project.
 
-Environment
-===========
-
-Gradle requires an install of a Java 17 JDK and the Android SDK.
-
-If the methods below fail to find an Android SDK or Java JDK, Briefcase will
-download and install an isolated copy in its data directory.
-
-Java JDK
---------
-
-If you have an existing install of a Java 17 JDK, it will be used by Briefcase
-if the ``JAVA_HOME`` environment variable is set. On macOS, if ``JAVA_HOME`` is
-not set, Briefcase will use the ``/usr/libexec/java_home`` tool to find an
-existing JDK install.
-
-Android SDK
------------
+Gradle requires an install of the Android SDK and a Java 17 JDK.
 
 If you have an existing install of the Android SDK, it will be used by Briefcase
 if the ``ANDROID_HOME`` environment variable is set. If ``ANDROID_HOME`` is not
@@ -41,16 +24,13 @@ present in the environment, Briefcase will honor the deprecated
 must have version 9.0 of Command-line Tools installed; this version can be
 installed in the SDK Manager in Android Studio.
 
-Android Emulator
-----------------
+If you have an existing install of a Java 17 JDK, it will be used by Briefcase
+if the ``JAVA_HOME`` environment variable is set. On macOS, if ``JAVA_HOME`` is
+not set, Briefcase will use the ``/usr/libexec/java_home`` tool to find an
+existing JDK install.
 
-By default, the Android emulator creates Android Virtual Devices (AVD) in the
-``.android`` directory in your user's home directory. As the AVDs can consume
-large amounts of disk space, they can be stored in an arbitrary directory via
-the ``ANDROID_USER_HOME`` and ``ANDROID_AVD_HOME`` environment variables.
-
-Packaging format
-================
+If the above methods fail to find an Android SDK or Java JDK, Briefcase will
+download and install an isolated copy in its data directory.
 
 Briefcase supports three packaging formats for an Android app:
 
@@ -134,61 +114,6 @@ Android allows for some customization of the colors used by your app:
   status bar at the top of the screen.
 * ``splash_background_color`` is the color of the splash background that
   displays while an app is loading.
-
-Additional options
-==================
-
-The following options can be provided at the command line when producing
-Android projects:
-
-run
----
-
-``-d <device>`` / ``--device <device>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The device or emulator to target. Can be specified as:
-
-* ``@`` followed by an AVD name (e.g., ``@beePhone``); or
-* a device ID (a hexadecimal identifier associated with a specific hardware device);
-  or
-* a JSON dictionary specifying the properties of a device that will be created.
-  This dictionary must have, at a minimum, an AVD name:
-
-.. code-block:: console
-
-     $ briefcase run -d '{"avd":"new-device"}'
-
-  You may also specify:
-
-  - ``device_type`` (e.g., ``pixel``) - the type of device to emulate
-  - ``skin`` (e.g., ``pixel_3a``) - the skin to apply to the emulator
-  - ``system_image`` (e.g., ``system-images;android-31;default;arm64-v8a``) - the Android
-    system image to use in the emulator.
-
-  If any of these attributes are *not* specified, they will fall back
-  to reasonable defaults.
-
-``--Xemulator=<value>``
-~~~~~~~~~~~~~~~~~~~~~~~
-
-A configuration argument to be passed to the emulator on startup. For example,
-to start the emulator in "headless" mode (i.e., without a display window),
-specify ``--Xemulator=-no-window``. See `the Android documentation
-<https://developer.android.com/studio/run/emulator-commandline>`__ for details
-on the full list of options that can be provided.
-
-You may specify multiple ``--Xemulator`` arguments; each one specifies a
-single argument to pass to the emulator, in the order they are specified.
-
-``--shutdown-on-exit``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Instruct Briefcase to shut down the emulator when the run finishes. This is
-especially useful if you are running in headless mode, as the emulator will
-continue to run in the background, but there will be no visual manifestation
-that it is running. It may also be useful as a cleanup mechanism when running
-in a CI configuration.
 
 Application configuration
 =========================
@@ -309,6 +234,61 @@ significant digits of the final version code:
 If you want to manually specify a version code by defining ``version_code`` in
 your application configuration. If provided, this value will override any
 auto-generated value.
+
+Additional options
+==================
+
+The following options can be provided at the command line when producing
+Android projects:
+
+run
+---
+
+``-d <device>`` / ``--device <device>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The device or emulator to target. Can be specified as:
+
+* ``@`` followed by an AVD name (e.g., ``@beePhone``); or
+* a device ID (a hexadecimal identifier associated with a specific hardware device);
+  or
+* a JSON dictionary specifying the properties of a device that will be created.
+  This dictionary must have, at a minimum, an AVD name:
+
+.. code-block:: console
+
+     $ briefcase run -d '{"avd":"new-device"}'
+
+  You may also specify:
+
+  - ``device_type`` (e.g., ``pixel``) - the type of device to emulate
+  - ``skin`` (e.g., ``pixel_3a``) - the skin to apply to the emulator
+  - ``system_image`` (e.g., ``system-images;android-31;default;arm64-v8a``) - the Android
+    system image to use in the emulator.
+
+  If any of these attributes are *not* specified, they will fall back
+  to reasonable defaults.
+
+``--Xemulator=<value>``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A configuration argument to be passed to the emulator on startup. For example,
+to start the emulator in "headless" mode (i.e., without a display window),
+specify ``--Xemulator=-no-window``. See `the Android documentation
+<https://developer.android.com/studio/run/emulator-commandline>`__ for details
+on the full list of options that can be provided.
+
+You may specify multiple ``--Xemulator`` arguments; each one specifies a
+single argument to pass to the emulator, in the order they are specified.
+
+``--shutdown-on-exit``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instruct Briefcase to shut down the emulator when the run finishes. This is
+especially useful if you are running in headless mode, as the emulator will
+continue to run in the background, but there will be no visual manifestation
+that it is running. It may also be useful as a cleanup mechanism when running
+in a CI configuration.
 
 .. _android-permissions:
 

--- a/docs/reference/platforms/web/static.rst
+++ b/docs/reference/platforms/web/static.rst
@@ -48,6 +48,32 @@ Splash Image format
 
 Web projects do not support splash screens or installer images.
 
+Additional options
+==================
+
+The following options can be provided at the command line when producing
+web projects:
+
+run
+---
+
+``--host <ip or hostname>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The hostname or IP address that the development web server should be bound to.
+Defaults to ``localhost``.
+
+``-p <port>`` / ``--port <port>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The port that the development web server should be bound to. Defaults to ``8080``.
+If port ``8080`` is already in use, an arbitrary available port will be used.
+
+``--no-browser``
+~~~~~~~~~~~~~~~~
+
+Don't open a web browser after starting the development web server.
+
 Application configuration
 =========================
 
@@ -73,28 +99,3 @@ define a custom runtime, and change the default PyScript app name, you could use
     [[runtimes]]
     src = "https://example.com/custom/pyodide.js"
     """
-
-Additional options
-==================
-
-The following options can be provided at the command line when producing
-web projects:
-
-run
----
-
-``--host <ip or hostname>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The hostname or IP address that the development web server should be bound to.
-Defaults to ``localhost``.
-
-``-p <port>`` / ``--port <port>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The port that the development web server should be bound to. Defaults to ``8080``.
-
-``--no-browser``
-~~~~~~~~~~~~~~~~
-
-Don't open a web browser after starting the development web server.

--- a/docs/reference/platforms/web/static.rst
+++ b/docs/reference/platforms/web/static.rst
@@ -48,32 +48,6 @@ Splash Image format
 
 Web projects do not support splash screens or installer images.
 
-Additional options
-==================
-
-The following options can be provided at the command line when producing
-web projects:
-
-run
----
-
-``--host <ip or hostname>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The hostname or IP address that the development web server should be bound to.
-Defaults to ``localhost``.
-
-``-p <port>`` / ``--port <port>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The port that the development web server should be bound to. Defaults to ``8080``.
-If port ``8080`` is already in use, an arbitrary available port will be used.
-
-``--no-browser``
-~~~~~~~~~~~~~~~~
-
-Don't open a web browser after starting the development web server.
-
 Application configuration
 =========================
 
@@ -99,3 +73,28 @@ define a custom runtime, and change the default PyScript app name, you could use
     [[runtimes]]
     src = "https://example.com/custom/pyodide.js"
     """
+
+Additional options
+==================
+
+The following options can be provided at the command line when producing
+web projects:
+
+run
+---
+
+``--host <ip or hostname>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The hostname or IP address that the development web server should be bound to.
+Defaults to ``localhost``.
+
+``-p <port>`` / ``--port <port>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The port that the development web server should be bound to. Defaults to ``8080``.
+
+``--no-browser``
+~~~~~~~~~~~~~~~~
+
+Don't open a web browser after starting the development web server.

--- a/tests/integrations/android_sdk/ADB/test_kill.py
+++ b/tests/integrations/android_sdk/ADB/test_kill.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from unittest.mock import MagicMock
 
@@ -14,13 +15,12 @@ def test_kill(mock_tools, adb):
     # Validate call parameters.
     mock_tools.subprocess.check_output.assert_called_once_with(
         [
-            mock_tools.android_sdk.adb_path,
+            os.fsdecode(mock_tools.android_sdk.adb_path),
             "-s",
             "exampleDevice",
             "emu",
             "kill",
         ],
-        env=mock_tools.android_sdk.env,
         quiet=False,
     )
 

--- a/tests/integrations/android_sdk/ADB/test_logcat.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from unittest import mock
 
@@ -24,7 +25,7 @@ def test_logcat(mock_tools, adb, is_color_enabled, monkeypatch):
     # Validate call parameters.
     mock_tools.subprocess.Popen.assert_called_once_with(
         [
-            mock_tools.android_sdk.adb_path,
+            os.fsdecode(mock_tools.android_sdk.adb_path),
             "-s",
             "exampleDevice",
             "logcat",

--- a/tests/integrations/android_sdk/ADB/test_logcat_tail.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat_tail.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from datetime import datetime
 from unittest.mock import MagicMock, PropertyMock
@@ -23,7 +24,7 @@ def test_logcat_tail(mock_tools, adb, is_color_enabled, monkeypatch):
     # Validate call parameters.
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            mock_tools.android_sdk.adb_path,
+            os.fsdecode(mock_tools.android_sdk.adb_path),
             "-s",
             "exampleDevice",
             "logcat",

--- a/tests/integrations/android_sdk/ADB/test_run.py
+++ b/tests/integrations/android_sdk/ADB/test_run.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -14,14 +15,17 @@ def test_simple_command(mock_tools, adb, tmp_path):
     # Check that adb was invoked with the expected commands
     mock_tools.subprocess.check_output.assert_called_once_with(
         [
-            tmp_path
-            / f"sdk/platform-tools/adb{'.exe' if sys.platform == 'win32' else ''}",
+            os.fsdecode(
+                tmp_path
+                / "sdk"
+                / "platform-tools"
+                / f"adb{'.exe' if sys.platform == 'win32' else ''}"
+            ),
             "-s",
             "exampleDevice",
             "example",
             "command",
         ],
-        env=mock_tools.android_sdk.env,
         quiet=False,
     )
 
@@ -33,14 +37,17 @@ def test_quiet_command(mock_tools, adb, tmp_path):
     # Check that adb was invoked with the expected commands
     mock_tools.subprocess.check_output.assert_called_once_with(
         [
-            tmp_path
-            / f"sdk/platform-tools/adb{'.exe' if sys.platform == 'win32' else ''}",
+            os.fsdecode(
+                tmp_path
+                / "sdk"
+                / "platform-tools"
+                / f"adb{'.exe' if sys.platform == 'win32' else ''}"
+            ),
             "-s",
             "exampleDevice",
             "example",
             "command",
         ],
-        env=mock_tools.android_sdk.env,
         quiet=True,
     )
 
@@ -79,14 +86,17 @@ def test_error_handling(mock_tools, adb, name, exception, tmp_path):
     # Check that adb was invoked as expected
     mock_tools.subprocess.check_output.assert_called_once_with(
         [
-            tmp_path
-            / f"sdk/platform-tools/adb{'.exe' if sys.platform == 'win32' else ''}",
+            os.fsdecode(
+                tmp_path
+                / "sdk"
+                / "platform-tools"
+                / f"adb{'.exe' if sys.platform == 'win32' else ''}"
+            ),
             "-s",
             "exampleDevice",
             "example",
             "command",
         ],
-        env=mock_tools.android_sdk.env,
         quiet=False,
     )
 

--- a/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
@@ -1,5 +1,6 @@
+import os
 import subprocess
-from unittest.mock import ANY, MagicMock, PropertyMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 
@@ -87,7 +88,7 @@ def test_create_emulator(
     # avdmanager was invoked
     mock_tools.subprocess.check_output.assert_called_once_with(
         [
-            android_sdk.avdmanager_path,
+            os.fsdecode(android_sdk.avdmanager_path),
             "--verbose",
             "create",
             "avd",
@@ -160,7 +161,7 @@ def test_create_emulator_with_defaults(
     # avdmanager was invoked
     mock_tools.subprocess.check_output.assert_called_once_with(
         [
-            android_sdk.avdmanager_path,
+            os.fsdecode(android_sdk.avdmanager_path),
             "--verbose",
             "create",
             "avd",
@@ -181,69 +182,6 @@ def test_create_emulator_with_defaults(
         config = f.read().split("\n")
     assert "hw.keyboard=yes" in config
     assert "skin.name=pixel_7_pro" in config
-
-
-def test_create_emulator_with_nonexistent_avd_home(
-    mock_tools,
-    android_sdk,
-    tmp_path,
-    monkeypatch,
-):
-    """Ensure a AVD home directory is created for a new emulator."""
-    # Mock the hardware and operating system to specific values
-    mock_tools.host_os = "Darwin"
-    mock_tools.host_arch = "x86_64"
-
-    # Mock system image and skin verification
-    android_sdk.verify_system_image = MagicMock()
-    android_sdk.verify_emulator_skin = MagicMock()
-
-    # Mock a custom location for the AVDs
-    android_sdk.update_emulator_config = MagicMock()
-    avd_home_path = tmp_path / "my-avds"
-    monkeypatch.setattr(
-        type(android_sdk),
-        "avd_home_path",
-        PropertyMock(return_value=avd_home_path),
-    )
-    assert avd_home_path.is_dir() is False
-
-    # Create the emulator
-    android_sdk._create_emulator(
-        avd="new-emulator",
-        device_type="slab",
-        skin="slab_skin",
-        system_image="system-images;android-42;default;gothic",
-    )
-
-    # The system image was verified
-    android_sdk.verify_system_image.assert_called_once_with(
-        "system-images;android-42;default;gothic"
-    )
-
-    # The emulator skin was verified
-    android_sdk.verify_emulator_skin.assert_called_once_with("slab_skin")
-
-    # avdmanager was invoked
-    mock_tools.subprocess.check_output.assert_called_once_with(
-        [
-            android_sdk.avdmanager_path,
-            "--verbose",
-            "create",
-            "avd",
-            "--name",
-            "new-emulator",
-            "--abi",
-            "x86_64",
-            "--package",
-            "system-images;android-42;default;gothic",
-            "--device",
-            "slab",
-        ],
-        env=android_sdk.env,
-    )
-
-    assert avd_home_path.is_dir()
 
 
 def test_create_failure(mock_tools, android_sdk):
@@ -270,7 +208,7 @@ def test_create_failure(mock_tools, android_sdk):
     # avdmanager was invoked
     mock_tools.subprocess.check_output.assert_called_once_with(
         [
-            android_sdk.avdmanager_path,
+            os.fsdecode(android_sdk.avdmanager_path),
             "--verbose",
             "create",
             "avd",

--- a/tests/integrations/android_sdk/AndroidSDK/test_emulators.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_emulators.py
@@ -5,15 +5,8 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError
 
 
-def test_no_avd_home(mock_tools, android_sdk):
-    """If the AVD home directory doesn't exist, an empty list is returned."""
-    assert not android_sdk.avd_home_path.is_dir()
-    assert android_sdk.emulators() == []
-
-
 def test_no_emulators(mock_tools, android_sdk):
     """If there are no emulators, an empty list is returned."""
-    android_sdk.avd_home_path.mkdir(parents=True, exist_ok=True)
     mock_tools.subprocess.check_output.return_value = ""
 
     assert android_sdk.emulators() == []
@@ -21,7 +14,6 @@ def test_no_emulators(mock_tools, android_sdk):
 
 def test_one_emulator(mock_tools, android_sdk):
     """If there is a single emulator, it is returned."""
-    android_sdk.avd_home_path.mkdir(parents=True, exist_ok=True)
     mock_tools.subprocess.check_output.return_value = "first\n"
 
     assert android_sdk.emulators() == ["first"]
@@ -29,7 +21,6 @@ def test_one_emulator(mock_tools, android_sdk):
 
 def test_multiple_emulators(mock_tools, android_sdk):
     """If there are multiple emulators, they are all returned."""
-    android_sdk.avd_home_path.mkdir(parents=True, exist_ok=True)
     mock_tools.subprocess.check_output.return_value = "first\nsecond\nthird\n"
 
     assert android_sdk.emulators() == ["first", "second", "third"]
@@ -37,9 +28,8 @@ def test_multiple_emulators(mock_tools, android_sdk):
 
 def test_adb_error(mock_tools, android_sdk):
     """If there is a problem invoking adb, an error is returned."""
-    android_sdk.avd_home_path.mkdir(parents=True, exist_ok=True)
     mock_tools.subprocess.check_output.side_effect = subprocess.CalledProcessError(
-        returncode=69, cmd="avdmanager list avd --compact"
+        returncode=69, cmd="adb devices -l"
     )
 
     with pytest.raises(BriefcaseCommandError):

--- a/tests/integrations/android_sdk/AndroidSDK/test_list_packages.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_list_packages.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 import pytest
@@ -10,7 +11,7 @@ def test_list_packages(mock_tools, android_sdk):
     android_sdk.list_packages()
 
     mock_tools.subprocess.check_output.assert_called_once_with(
-        [android_sdk.sdkmanager_path, "--list_installed"],
+        [os.fsdecode(android_sdk.sdkmanager_path), "--list_installed"],
         env=android_sdk.env,
     )
 
@@ -24,6 +25,6 @@ def test_list_packages_failure(mock_tools, android_sdk):
         android_sdk.list_packages()
 
     mock_tools.subprocess.check_output.assert_called_once_with(
-        [android_sdk.sdkmanager_path, "--list_installed"],
+        [os.fsdecode(android_sdk.sdkmanager_path), "--list_installed"],
         env=android_sdk.env,
     )

--- a/tests/integrations/android_sdk/AndroidSDK/test_properties.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_properties.py
@@ -86,55 +86,8 @@ def test_emulator_path(mock_tools, android_sdk, host_os, emulator_name):
     )
 
 
-def test_dot_android_path(mock_tools, android_sdk, tmp_path):
-    """Default user android path is $HOME/.android/avd."""
-    assert android_sdk.dot_android_path == tmp_path / "home/.android"
-
-
-def test_dot_android_path_env_var(mock_tools, android_sdk, monkeypatch):
-    """ANDROID_AVD_HOME is respected as AVD path."""
-    mock_tools.os.environ = {"ANDROID_USER_HOME": "/my/android"}
-    assert android_sdk.dot_android_path == Path("/my/android")
-
-
-def test_avd_home_path(mock_tools, android_sdk, tmp_path):
-    """Default AVD path is $HOME/.android/avd."""
-    assert android_sdk.avd_home_path == tmp_path / "home/.android/avd"
-
-
-def test_avd_home_path_env_var(mock_tools, android_sdk, monkeypatch):
-    """ANDROID_AVD_HOME is respected as AVD path."""
-    mock_tools.os.environ = {"ANDROID_AVD_HOME": "/my/avds"}
-    assert android_sdk.avd_home_path == Path("/my/avds")
-
-
 def test_avd_path(mock_tools, android_sdk, tmp_path):
-    """Default path for AVD is correct."""
-    assert (
-        android_sdk.avd_path(avd="my-avd") == tmp_path / "home/.android/avd/my-avd.avd"
-    )
-
-
-def test_avd_path_env_var(mock_tools, android_sdk, tmp_path, monkeypatch):
-    """ANDROID_AVD_HOME is respected for AVD path."""
-    mock_tools.os.environ = {"ANDROID_AVD_HOME": "/my/avds"}
-    assert android_sdk.avd_path(avd="my-avd") == Path("/my/avds/my-avd.avd")
-
-
-def test_avd_config_filepath(mock_tools, android_sdk, tmp_path):
-    """Default AVD config file is correct."""
-    assert (
-        android_sdk.avd_config_filepath(avd="my-avd")
-        == tmp_path / "home/.android/avd/my-avd.avd/config.ini"
-    )
-
-
-def test_avd_config_filepath_env_var(mock_tools, android_sdk, tmp_path, monkeypatch):
-    """ANDROID_AVD_HOME is respected for AVD config filepath."""
-    mock_tools.os.environ = {"ANDROID_AVD_HOME": "/my/avds"}
-    assert android_sdk.avd_config_filepath(avd="my-avd") == Path(
-        "/my/avds/my-avd.avd/config.ini"
-    )
+    assert android_sdk.avd_path == tmp_path / "home/.android/avd"
 
 
 def test_simple_env(mock_tools, android_sdk, tmp_path):
@@ -143,8 +96,6 @@ def test_simple_env(mock_tools, android_sdk, tmp_path):
         "JAVA_HOME": os.fsdecode(Path("/path/to/jdk")),
         "ANDROID_HOME": os.fsdecode(tmp_path / "sdk"),
         "ANDROID_SDK_ROOT": os.fsdecode(tmp_path / "sdk"),
-        "ANDROID_USER_HOME": os.fsdecode(tmp_path / "home/.android"),
-        "ANDROID_AVD_HOME": os.fsdecode(tmp_path / "home/.android/avd"),
     }
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from unittest.mock import MagicMock, call
 
@@ -108,7 +109,7 @@ def test_start_emulator(mock_tools, android_sdk):
     # The process was started.
     mock_tools.subprocess.Popen.assert_called_with(
         [
-            android_sdk.emulator_path,
+            os.fsdecode(android_sdk.emulator_path),
             "@idleEmulator",
             "-dns-server",
             "8.8.8.8",
@@ -189,7 +190,7 @@ def test_start_emulator_fast_start(mock_tools, android_sdk):
     # The process was started.
     mock_tools.subprocess.Popen.assert_called_with(
         [
-            android_sdk.emulator_path,
+            os.fsdecode(android_sdk.emulator_path),
             "@idleEmulator",
             "-dns-server",
             "8.8.8.8",
@@ -284,7 +285,7 @@ def test_emulator_fail_to_start(mock_tools, android_sdk):
     # The process was started.
     mock_tools.subprocess.Popen.assert_called_with(
         [
-            android_sdk.emulator_path,
+            os.fsdecode(android_sdk.emulator_path),
             "@idleEmulator",
             "-dns-server",
             "8.8.8.8",
@@ -388,7 +389,7 @@ def test_emulator_fail_to_boot(mock_tools, android_sdk):
     # The process was started.
     mock_tools.subprocess.Popen.assert_called_with(
         [
-            android_sdk.emulator_path,
+            os.fsdecode(android_sdk.emulator_path),
             "@idleEmulator",
             "-dns-server",
             "8.8.8.8",
@@ -457,7 +458,7 @@ def test_emulator_ctrl_c(mock_tools, android_sdk, emulator_comm, expected_log, c
     # The process was started.
     mock_tools.subprocess.Popen.assert_called_with(
         [
-            android_sdk.emulator_path,
+            os.fsdecode(android_sdk.emulator_path),
             "@idleEmulator",
             "-dns-server",
             "8.8.8.8",
@@ -523,7 +524,7 @@ def test_start_emulator_extra_args(mock_tools, android_sdk):
     # The process was started with the headless test options.
     mock_tools.subprocess.Popen.assert_called_with(
         [
-            android_sdk.emulator_path,
+            os.fsdecode(android_sdk.emulator_path),
             "@idleEmulator",
             "-dns-server",
             "8.8.8.8",

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -1,7 +1,6 @@
 import os
 import platform
 import shutil
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -321,7 +320,7 @@ def test_user_provided_sdk_wrong_cmdline_tools_ver(
     # Create `sdkmanager` and the license file
     # for the *briefcase* managed version of the SDK.
     android_sdk_root_path = tmp_path / "tools/android_sdk"
-    tools_bin = android_sdk_root_path / f"cmdline-tools/{SDK_MGR_VER}/bin"
+    tools_bin = android_sdk_root_path / "cmdline-tools" / SDK_MGR_VER / "bin"
     tools_bin.mkdir(parents=True, mode=0o755)
     (tools_bin / SDKMANAGER_FILENAME).touch(mode=0o755)
 
@@ -344,16 +343,14 @@ def test_user_provided_sdk_wrong_cmdline_tools_ver(
     # Required Command-line Tools installed
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            tmp_path / f"other_sdk/cmdline-tools/latest/bin/{SDKMANAGER_FILENAME}",
+            tmp_path
+            / "other_sdk"
+            / "cmdline-tools"
+            / "latest"
+            / "bin"
+            / SDKMANAGER_FILENAME,
             f"cmdline-tools;{SDK_MGR_VER}",
         ],
-        env={
-            "ANDROID_HOME": f"{tmp_path / 'other_sdk'}",
-            "ANDROID_SDK_ROOT": f"{tmp_path / 'other_sdk'}",
-            "ANDROID_USER_HOME": f"{tmp_path / 'home/.android'}",
-            "ANDROID_AVD_HOME": f"{tmp_path / 'home/.android/avd'}",
-            "JAVA_HOME": str(Path("/path/to/jdk")),
-        },
         check=True,
         stream_output=False,
     )
@@ -398,10 +395,14 @@ def test_user_provided_sdk_with_latest_cmdline_tools(
     # Required Command-line Tools installed
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            tmp_path / f"other_sdk/cmdline-tools/latest/bin/{SDKMANAGER_FILENAME}",
+            tmp_path
+            / "other_sdk"
+            / "cmdline-tools"
+            / "latest"
+            / "bin"
+            / SDKMANAGER_FILENAME,
             f"cmdline-tools;{SDK_MGR_VER}",
         ],
-        env=sdk.env,
         check=True,
         stream_output=False,
     )

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_emulator.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -61,7 +62,7 @@ def test_installs_android_emulator(mock_tools, android_sdk):
 
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            android_sdk.sdkmanager_path,
+            os.fsdecode(android_sdk.sdkmanager_path),
             "platform-tools",
             "emulator",
         ],
@@ -83,7 +84,7 @@ def test_partial_android_emulator_install(mock_tools, android_sdk):
 
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            android_sdk.sdkmanager_path,
+            os.fsdecode(android_sdk.sdkmanager_path),
             "platform-tools",
             "emulator",
         ],

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_license.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_license.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 import pytest
@@ -34,7 +35,7 @@ def test_verify_license_prompts_for_licenses_and_exits_if_you_agree(
     mock_tools.subprocess.run.side_effect = accept_license
     android_sdk.verify_license()
     mock_tools.subprocess.run.assert_called_once_with(
-        [android_sdk.sdkmanager_path, "--licenses"],
+        [os.fsdecode(android_sdk.sdkmanager_path), "--licenses"],
         env=android_sdk.env,
         check=True,
         stream_output=False,
@@ -49,7 +50,7 @@ def test_verify_license_handles_sdkmanager_crash(mock_tools, android_sdk):
         android_sdk.verify_license()
 
     mock_tools.subprocess.run.assert_called_once_with(
-        [android_sdk.sdkmanager_path, "--licenses"],
+        [os.fsdecode(android_sdk.sdkmanager_path), "--licenses"],
         env=android_sdk.env,
         check=True,
         stream_output=False,
@@ -65,7 +66,7 @@ def test_verify_license_insists_on_agreement(mock_tools, android_sdk):
         android_sdk.verify_license()
 
     mock_tools.subprocess.run.assert_called_once_with(
-        [android_sdk.sdkmanager_path, "--licenses"],
+        [os.fsdecode(android_sdk.sdkmanager_path), "--licenses"],
         env=android_sdk.env,
         check=True,
         stream_output=False,

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
@@ -1,3 +1,4 @@
+import os
 import platform
 from subprocess import CalledProcessError
 
@@ -67,7 +68,7 @@ def test_incompatible_abi(mock_tools, android_sdk, capsys):
     # The system image was installed.
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            android_sdk.sdkmanager_path,
+            os.fsdecode(android_sdk.sdkmanager_path),
             "system-images;android-31;default;anything",
         ],
         env=android_sdk.env,
@@ -104,7 +105,7 @@ def test_new_system_image(mock_tools, android_sdk):
     # The system image was installed.
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            android_sdk.sdkmanager_path,
+            os.fsdecode(android_sdk.sdkmanager_path),
             "system-images;android-31;default;x86_64",
         ],
         env=android_sdk.env,
@@ -134,7 +135,7 @@ def test_problem_downloading_system_image(mock_tools, android_sdk):
     # An attempt to install the system image was made
     mock_tools.subprocess.run.assert_called_once_with(
         [
-            android_sdk.sdkmanager_path,
+            os.fsdecode(android_sdk.sdkmanager_path),
             "system-images;android-31;default;x86_64",
         ],
         env=android_sdk.env,

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -3,6 +3,7 @@ import os
 import platform
 import sys
 import time
+from os.path import normpath
 from pathlib import Path
 from unittest import mock
 
@@ -52,7 +53,6 @@ def run_command(tmp_path, first_app_config, jdk):
     command.tools.requests = mock.MagicMock(spec_set=requests)
     command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
     command.tools.sys = mock.MagicMock(spec_set=sys)
-    command.tools.home_path = tmp_path / "home"
 
     command._stream_app_logs = mock.MagicMock()
 
@@ -524,7 +524,7 @@ def test_run_idle_device(run_command, first_app_config):
     )
 
 
-def test_log_file_extra(run_command, tmp_path, monkeypatch):
+def test_log_file_extra(run_command, monkeypatch):
     """Android commands register a log file extra to list SDK packages."""
     mock_android_sdk_verify = mock.MagicMock(return_value=run_command.tools.android_sdk)
     monkeypatch.setattr(AndroidSDK, "verify", mock_android_sdk_verify)
@@ -545,17 +545,14 @@ def test_log_file_extra(run_command, tmp_path, monkeypatch):
     run_command.tools.logger.save_log = True
     run_command.tools.logger.save_log_to_file(run_command)
 
-    sdk_manager = Path(
-        f"/path/to/android_sdk/cmdline-tools/{AndroidSDK.SDK_MANAGER_VER}"
-        f"/bin/sdkmanager{'.bat' if platform.system() == 'Windows' else ''}"
-    )
+    sdk_manager = f"/path/to/android_sdk/cmdline-tools/{AndroidSDK.SDK_MANAGER_VER}/bin/sdkmanager"
+    if platform.system() == "Windows":
+        sdk_manager += ".bat"
     run_command.tools.subprocess.check_output.assert_called_once_with(
-        [sdk_manager, "--list_installed"],
+        [normpath(sdk_manager), "--list_installed"],
         env={
             "ANDROID_HOME": str(run_command.tools.android_sdk.root_path),
             "ANDROID_SDK_ROOT": str(run_command.tools.android_sdk.root_path),
-            "ANDROID_USER_HOME": f"{tmp_path / 'home/.android'}",
-            "ANDROID_AVD_HOME": f"{tmp_path / 'home/.android/avd'}",
             "JAVA_HOME": str(run_command.tools.java.java_home),
         },
     )


### PR DESCRIPTION
## Changes
- Reverts beeware/briefcase#1673
- Closes #1688
- Reopens https://github.com/beeware/briefcase/issues/1665

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct