### PR TITLE
Replace dead reST reference with a more authoritative source.

### DIFF
--- a/changes/1695.doc.rst
+++ b/changes/1695.doc.rst
@@ -1,0 +1,1 @@
+The documentation contribution guide was updated to use a more authoritative reStructuredText reference.

--- a/docs/how-to/contribute-docs.rst
+++ b/docs/how-to/contribute-docs.rst
@@ -4,9 +4,9 @@ Contributing to the documentation
 Here are some tips for working on this documentation. You're welcome to add
 more and help us out!
 
-First of all, you should check the `Restructured Text (reST) and Sphinx
-CheatSheet <https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html>`_ to
-learn how to write your .rst file.
+First of all, you should check the `reStructuredText (reST) Primer
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_ to learn how
+to write your .rst file.
 
 Create a .rst file
 ---------------------


### PR DESCRIPTION
It appears that https://thomas-cokelaer.info, which we're using as a reST reference is down. It's unclear if this is temporary or permanent, but either way, there are better and more authoritative sources of reST tutorials.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
