### PR TITLE
Exclude logging output from emulator list

### DIFF
--- a/changes/1697.bugfix.rst
+++ b/changes/1697.bugfix.rst
@@ -1,0 +1,1 @@
+A spurious Android emulator named ``@INFO`` will no longer be included in the list of available emulators.


### PR DESCRIPTION
## Changes
- Recently, `emulator -list-avds` started including logging output in the list of AVDs...so, it's ignored now

```
>>> Running Command:
>>>     /opt/sdks/Android/sdk/emulator/emulator -list-avds
>>> Working Directory:
>>>     /home/russell/tmp/beeware/helloworld
>>> Command Output:
>>>     INFO    | Storing crashdata in: /tmp/android-russell/emu-crash-34.1.19.db, detection is enabled for process: 2413840
>>>     Pixel_3a_API_31
>>>     Pixel_5_API_31
>>>     Pixel_6a_API_31
>>>     Pixel_7a_API_34
>>>     Pixel_8_Pro_API_31
>>>     beePhone
>>> Return code: 0

Select device:

  1) Unknown device (offline) (emulator-5554)
  2) @INFO    | Storing crashdata in: /tmp/android-russell/emu-crash-34.1.19.db, detection is enabled for process: 2413840 (emulator)
  3) @Pixel_3a_API_31 (emulator)
  4) @Pixel_5_API_31 (emulator)
  5) @Pixel_6a_API_31 (emulator)
  6) @Pixel_7a_API_34 (emulator)
  7) @Pixel_8_Pro_API_31 (emulator)
  8) @beePhone (emulator)
  9) Create a new Android emulator

>
```
Other [mayhem](https://www.google.com/search?q=emulator+list-avds+%22INFO++++%7C+Storing+crashdata+in%22&sca_esv=941af24518045317&sxsrf=ACQVn09ejTmdHe31ARSr4fK7_DdAm8JHHQ%3A1710433939367&source=hp&ei=kybzZZeCFOGsur8P79OjoAs&iflsig=ANes7DEAAAAAZfM0oz8dWdGcNrA2xkBX2HKbd01kBRNB&ved=0ahUKEwjXl_b6lvSEAxVhlu4BHe_pCLQQ4dUDCBc&uact=5&oq=emulator+list-avds+%22INFO++++%7C+Storing+crashdata+in%22&gs_lp=Egdnd3Mtd2l6IjNlbXVsYXRvciBsaXN0LWF2ZHMgIklORk8gICAgfCBTdG9yaW5nIGNyYXNoZGF0YSBpbiIyBxAhGAoYoAEyBxAhGAoYoAEyBxAhGAoYoAEyBxAhGAoYoAFImi1Q0QVY1ytwAXgAkAEAmAGaAaABxA-qAQQxNS42uAEDyAEA-AEB-AECmAIWoAKAEKgCCsICBxAjGOoCGCfCAgoQIxiABBiKBRgnwgIEECMYJ8ICERAuGIAEGLEDGIMBGMcBGNEDwgILEAAYgAQYsQMYgwHCAgsQLhiABBixAxiDAcICDhAuGIAEGLEDGMcBGNEDwgIFEAAYgATCAg4QLhiABBiKBRixAxiDAcICCBAuGIAEGLEDwgIFEC4YgATCAgsQLhiABBixAxjUAsICCBAAGIAEGLEDwgIOEAAYgAQYigUYsQMYgwHCAgsQABiABBiKBRiGA8ICBhAAGBYYHpgDBZIHBDE1LjegB4qEAQ&sclient=gws-wiz) caused by this logging.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct