### PR TITLE
Bump black-pre-commit-mirror from 24.2.0 to 24.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: docformatter
         args: [--in-place, --black]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.2.0
+    rev: 24.3.0
     hooks:
       - id: black
         language_version: python3

--- a/changes/1701.misc.rst
+++ b/changes/1701.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``black-pre-commit-mirror`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 24.2.0 to 24.3.0 and ran the update against the repo.