### PR TITLE
Run `pip` verbosely in deep debug mode

### DIFF
--- a/changes/1708.feature.rst
+++ b/changes/1708.feature.rst
@@ -1,0 +1,1 @@
+When deep debug is activated via ``-vv``, ``pip`` now installs requirements for the app with verbose logging.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -524,6 +524,7 @@ class CreateCommand(BaseCommand):
                     "--no-user",
                     f"--target={app_packages_path}",
                 ]
+                + (["-vv"] if self.logger.is_deep_debug else [])
                 + self._extra_pip_args(app)
                 + pip_args,
                 check=True,

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -99,6 +99,7 @@ class DevCommand(RunAppMixin, BaseCommand):
                             "install",
                             "--upgrade",
                         ]
+                        + (["-vv"] if self.logger.is_deep_debug else [])
                         + requires,
                         check=True,
                         encoding="UTF-8",

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -169,7 +169,8 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
                         self.wheel_path(app),
                         "-r",
                         self.bundle_path(app) / "requirements.txt",
-                    ],
+                    ]
+                    + (["-vv"] if self.logger.is_deep_debug else []),
                     check=True,
                     encoding="UTF-8",
                 )

--- a/tests/commands/create/test_install_app_requirements.py
+++ b/tests/commands/create/test_install_app_requirements.py
@@ -7,6 +7,7 @@ import pytest
 import tomli_w
 
 from briefcase.commands.create import _is_local_requirement
+from briefcase.console import LogLevel
 from briefcase.exceptions import BriefcaseCommandError, RequirementsInstallError
 from briefcase.integrations.subprocess import Subprocess
 
@@ -285,13 +286,17 @@ def test_app_packages_offline(
     assert myapp.test_requires is None
 
 
+@pytest.mark.parametrize("logging_level", [LogLevel.INFO, LogLevel.DEEP_DEBUG])
 def test_app_packages_install_requirements(
     create_command,
     myapp,
     app_packages_path,
     app_packages_path_index,
+    logging_level,
 ):
     """Requirements can be installed."""
+    # Configure logging level
+    create_command.logger.verbosity = logging_level
 
     # Set up the app requirements
     myapp.requires = ["first", "second", "third"]
@@ -319,10 +324,9 @@ def test_app_packages_install_requirements(
             "--upgrade",
             "--no-user",
             f"--target={app_packages_path}",
-            "first",
-            "second",
-            "third",
-        ],
+        ]
+        + (["-vv"] if logging_level == LogLevel.DEEP_DEBUG else [])
+        + ["first", "second", "third"],
         check=True,
         encoding="UTF-8",
     )

--- a/tests/commands/dev/test_install_dev_requirements.py
+++ b/tests/commands/dev/test_install_dev_requirements.py
@@ -3,11 +3,16 @@ from subprocess import CalledProcessError
 
 import pytest
 
+from briefcase.console import LogLevel
 from briefcase.exceptions import RequirementsInstallError
 
 
-def test_install_requirements_no_error(dev_command, first_app):
+@pytest.mark.parametrize("logging_level", [LogLevel.INFO, LogLevel.DEEP_DEBUG])
+def test_install_requirements_no_error(dev_command, first_app, logging_level):
     """Ensure run is executed properly to install requirements."""
+    # Configure logging level
+    dev_command.logger.verbosity = logging_level
+
     first_app.requires = ["package-one", "package_two", "packagethree"]
 
     dev_command.install_dev_requirements(app=first_app)
@@ -22,10 +27,9 @@ def test_install_requirements_no_error(dev_command, first_app):
             "pip",
             "install",
             "--upgrade",
-            "package-one",
-            "package_two",
-            "packagethree",
-        ],
+        ]
+        + (["-vv"] if logging_level == LogLevel.DEEP_DEBUG else [])
+        + ["package-one", "package_two", "packagethree"],
         check=True,
         encoding="UTF-8",
     )

--- a/tests/platforms/web/static/test_build.py
+++ b/tests/platforms/web/static/test_build.py
@@ -10,7 +10,7 @@ else:  # pragma: no-cover-if-gte-py311
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import BriefcaseCommandError, BriefcaseConfigError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.web.static import StaticWebBuildCommand
@@ -32,8 +32,12 @@ def build_command(tmp_path):
     return command
 
 
-def test_build_app(build_command, first_app_generated, tmp_path):
+@pytest.mark.parametrize("logging_level", [LogLevel.INFO, LogLevel.DEEP_DEBUG])
+def test_build_app(build_command, first_app_generated, logging_level, tmp_path):
     """An app can be built."""
+    # Configure logging level
+    build_command.logger.verbosity = logging_level
+
     bundle_path = tmp_path / "base_path/build/first-app/web/static"
 
     # Invoking build will create wheels as a side effect.
@@ -110,7 +114,8 @@ def test_build_app(build_command, first_app_generated, tmp_path):
                 bundle_path / "www/static/wheels",
                 "-r",
                 bundle_path / "requirements.txt",
-            ],
+            ]
+            + (["-vv"] if logging_level == LogLevel.DEEP_DEBUG else []),
             check=True,
             encoding="UTF-8",
         ),


### PR DESCRIPTION
## Changes
- Run `pip install` with `-vv` flags when Briefcase is running in deep debug (i.e. `-vvv`) mode

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct