### PR TITLE
Correct permissions for iOS Geolocation APIs

### DIFF
--- a/changes/1713.bugfix.rst
+++ b/changes/1713.bugfix.rst
@@ -1,0 +1,1 @@
+The configuration generated for iOS apps declaring geolocation permissions has been corrected.

--- a/docs/reference/platforms/iOS/xcode.rst
+++ b/docs/reference/platforms/iOS/xcode.rst
@@ -92,12 +92,16 @@ Briefcase cross platform permissions map to the following ``info`` keys:
 
 * ``camera``: ``NSCameraUsageDescription``
 * ``microphone``: ``NSMicrophoneUsageDescription``
-* ``coarse_location``: ``NSLocationDefaultAccuracyReduced=True`` if ``fine_location`` is
-  not defined, plus ``NSLocationWhenInUseUsageDescription`` if ``background_location``
-  is not defined
-* ``fine_location``: ``NSLocationDefaultAccuracyReduced=False``, plus
-  ``NSLocationWhenInUseUsageDescription`` if ``background_location`` is not defined
-* ``background_location``: ``NSLocationAlwaysAndWhenInUseUsageDescription``
+* ``coarse_location``
+  - ``NSLocationDefaultAccuracyReduced=True``
+  - ``NSLocationWhenInUseUsageDescription`` if ``fine_location`` is not defined
+* ``fine_location``
+  - ``NSLocationDefaultAccuracyReduced=False``
+  - ``NSLocationWhenInUseUsageDescription``
+* ``background_location``:
+  - ``NSLocationAlwaysAndWhenInUseUsageDescription``
+  - ``NSLocationWhenInUseUsageDescription`` if neither ``fine_location`` or ``coarse_location`` is set
+  - ``UIBackgroundModes`` will include ``location`` and ``processing``
 * ``photo_library``: ``NSPhotoLibraryAddUsageDescription``
 
 Platform quirks

--- a/src/briefcase/integrations/cookiecutter.py
+++ b/src/briefcase/integrations/cookiecutter.py
@@ -89,6 +89,15 @@ class PListExtension(Extension):
                     return "<true/>"
                 else:
                     return "<false/>"
+            elif isinstance(obj, list):
+                children = "\n        ".join(plist_value(value) for value in obj)
+                return f"<array>\n        {children}\n    </array>"
+            elif isinstance(obj, dict):
+                children = "\n        ".join(
+                    f"<key>{key}</key>\n        {plist_value(value)}"
+                    for key, value in obj.items()
+                )
+                return f"<dict>\n        {children}\n    </dict>"
             else:
                 return f"<string>{obj}</string>"
 

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -271,20 +271,23 @@ class iOSXcodeCreateCommand(iOSXcodePassiveMixin, CreateCommand):
             info["NSMicrophoneUsageDescription"] = x_permissions["microphone"]
 
         if x_permissions["fine_location"]:
-            info["NSLocationDefaultAccuracyReduced"] = False
-        elif x_permissions["coarse_location"]:
-            info["NSLocationDefaultAccuracyReduced"] = True
-
-        if x_permissions["background_location"]:
-            info["NSLocationAlwaysAndWhenInUseUsageDescription"] = x_permissions[
-                "background_location"
-            ]
-        elif x_permissions["fine_location"]:
             info["NSLocationWhenInUseUsageDescription"] = x_permissions["fine_location"]
+            info["NSLocationDefaultAccuracyReduced"] = False
         elif x_permissions["coarse_location"]:
             info["NSLocationWhenInUseUsageDescription"] = x_permissions[
                 "coarse_location"
             ]
+            info["NSLocationDefaultAccuracyReduced"] = True
+
+        if x_permissions["background_location"]:
+            if "NSLocationWhenInUseUsageDescription" not in info:
+                info["NSLocationWhenInUseUsageDescription"] = x_permissions[
+                    "background_location"
+                ]
+            info["NSLocationAlwaysAndWhenInUseUsageDescription"] = x_permissions[
+                "background_location"
+            ]
+            info["UIBackgroundModes"] = ["processing", "location"]
 
         if x_permissions["photo_library"]:
             info["NSPhotoLibraryAddUsageDescription"] = x_permissions["photo_library"]

--- a/tests/integrations/cookiecutter/test_PListExtension.py
+++ b/tests/integrations/cookiecutter/test_PListExtension.py
@@ -11,6 +11,23 @@ from briefcase.integrations.cookiecutter import PListExtension
         (True, "<true/>"),
         (False, "<false/>"),
         ("Hello world", "<string>Hello world</string>"),
+        (
+            ["hello", "world", True],
+            "<array>\n"
+            "        <string>hello</string>\n"
+            "        <string>world</string>\n"
+            "        <true/>\n"
+            "    </array>",
+        ),
+        (
+            {"hello": "world", "goodbye": False},
+            "<dict>\n"
+            "        <key>hello</key>\n"
+            "        <string>world</string>\n"
+            "        <key>goodbye</key>\n"
+            "        <false/>\n"
+            "    </dict>",
+        ),
     ],
 )
 def test_plist_value(value, expected):

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -203,7 +203,9 @@ def test_extra_pip_args(create_command, first_app_generated, tmp_path):
             {},
             {
                 "info": {
+                    "NSLocationWhenInUseUsageDescription": "I always need to know where you are",
                     "NSLocationAlwaysAndWhenInUseUsageDescription": "I always need to know where you are",
+                    "UIBackgroundModes": ["processing", "location"],
                 }
             },
         ),
@@ -217,7 +219,9 @@ def test_extra_pip_args(create_command, first_app_generated, tmp_path):
             {
                 "info": {
                     "NSLocationDefaultAccuracyReduced": True,
+                    "NSLocationWhenInUseUsageDescription": "I need to know roughly where you are",
                     "NSLocationAlwaysAndWhenInUseUsageDescription": "I always need to know where you are",
+                    "UIBackgroundModes": ["processing", "location"],
                 }
             },
         ),
@@ -231,7 +235,9 @@ def test_extra_pip_args(create_command, first_app_generated, tmp_path):
             {
                 "info": {
                     "NSLocationDefaultAccuracyReduced": False,
+                    "NSLocationWhenInUseUsageDescription": "I need to know exactly where you are",
                     "NSLocationAlwaysAndWhenInUseUsageDescription": "I always need to know where you are",
+                    "UIBackgroundModes": ["processing", "location"],
                 }
             },
         ),
@@ -260,7 +266,9 @@ def test_extra_pip_args(create_command, first_app_generated, tmp_path):
             {
                 "info": {
                     "NSLocationDefaultAccuracyReduced": False,
+                    "NSLocationWhenInUseUsageDescription": "I need to know exactly where you are",
                     "NSLocationAlwaysAndWhenInUseUsageDescription": "I always need to know where you are",
+                    "UIBackgroundModes": ["processing", "location"],
                 }
             },
         ),


### PR DESCRIPTION
Corrects the permissions required for geolocation on iOS:

* `NSLocationWhenInUseUsageDescription` must be specified in addition to `NSLocationAlwaysAndWhenInUseUsageDescription` if the user wants background processing.
* If the user requests `background_location`, but doesn't specify `coarse_location` or `fine_location`, the background description is now used for `NSLocationWhenInUseUsageDescription`
* `UIBackgroundModes` must also be specified to allow background processing to occur.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
