### PR TITLE
Eagerly update app requirements for `DevCommand`

### DIFF
--- a/changes/1719.feature.rst
+++ b/changes/1719.feature.rst
@@ -1,0 +1,1 @@
+The transitive requirements for an app are now eagerly updated when an app's requirements are installed for the ``briefcase dev`` command.

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -97,6 +97,7 @@ class DevCommand(RunAppMixin, BaseCommand):
                             "-m",
                             "pip",
                             "install",
+                            "--upgrade-strategy=eager",
                             "--upgrade",
                         ]
                         + (["-vv"] if self.logger.is_deep_debug else [])

--- a/tests/commands/dev/test_install_dev_requirements.py
+++ b/tests/commands/dev/test_install_dev_requirements.py
@@ -26,6 +26,7 @@ def test_install_requirements_no_error(dev_command, first_app, logging_level):
             "-m",
             "pip",
             "install",
+            "--upgrade-strategy=eager",
             "--upgrade",
         ]
         + (["-vv"] if logging_level == LogLevel.DEEP_DEBUG else [])
@@ -58,6 +59,7 @@ def test_install_requirements_error(dev_command, first_app):
             "-m",
             "pip",
             "install",
+            "--upgrade-strategy=eager",
             "--upgrade",
             "package-one",
             "package_two",
@@ -93,6 +95,7 @@ def test_install_requirements_test_mode(dev_command, first_app):
             "-m",
             "pip",
             "install",
+            "--upgrade-strategy=eager",
             "--upgrade",
             "package-one",
             "package_two",
@@ -121,6 +124,7 @@ def test_only_test_requirements(dev_command, first_app):
             "-m",
             "pip",
             "install",
+            "--upgrade-strategy=eager",
             "--upgrade",
             "test-one",
             "test_two",


### PR DESCRIPTION
## Changes
- When requirements are re-installed in to the build for `BuildCommand`, the installation target directory is deleted prior to installing the app's requirements. Effectively, this means the transitive requirements are eagerly updated since the resolver will re-run and determine the latest version to install.
- To align with the behavior of `BuildCommand`, this updates `DevCommand` to eagerly update the app's transitive requirements when installing its direct requirements.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct