### PR TITLE
Use verbose logging for Linux file perms updating

### DIFF
--- a/changes/1720.feature.rst
+++ b/changes/1720.feature.rst
@@ -1,0 +1,1 @@
+The listing of filenames for updating permissions for building native Linux packages is now only shown when verbose logging is enabled via ``-v``.

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -761,7 +761,7 @@ with details about the release.
                     f"Template does not provide a manpage source file `{app.app_name}.1`"
                 )
 
-        self.logger.info("Update file permissions...")
+        self.logger.verbose("Update file permissions...")
         with self.input.wait_bar("Updating file permissions..."):
             for path in self.project_path(app).glob("**/*"):
                 old_perms = self.tools.os.stat(path).st_mode & 0o777
@@ -775,7 +775,7 @@ with details about the release.
 
                 # If there's been any change in permissions, apply them
                 if new_perms != old_perms:  # pragma: no-cover-if-is-windows
-                    self.logger.info(
+                    self.logger.verbose(
                         "Updating file permissions on "
                         f"{path.relative_to(self.bundle_path(app))} "
                         f"from {oct(old_perms)[2:]} to {oct(new_perms)[2:]}"


### PR DESCRIPTION
## Changes
- Instead of individually listing all files whose permissions are updated for Linux packaging by default, this logging is now verbose so it only appears in the log or when `-v` is used.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct