### PR TITLE
Support cookiecutter v2.6.0

### DIFF
--- a/changes/1663.bugfix.rst
+++ b/changes/1663.bugfix.rst
@@ -1,0 +1,1 @@
+Creating new projects is now compatible with cookiecutter v2.6.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     # If the package uses calver, we don't pin the upper version, as the upper version
     # provides no basis for determining API stability.
     #
-    "cookiecutter >= 2.3.1, < 2.6.0",  # See beeware/briefcase#1663 to bump <2.6.0 pin
+    "cookiecutter >= 2.6.0, < 3.0",
     "dmgbuild >= 1.6, < 2.0; sys_platform == 'darwin'",
     "GitPython >= 3.1, < 4.0",
     "platformdirs >= 2.6, < 5.0",

--- a/src/briefcase/bootstraps/pursuedpybear.py
+++ b/src/briefcase/bootstraps/pursuedpybear.py
@@ -49,19 +49,18 @@ def main():
 
     def pyproject_table_briefcase_app_extra_content(self):
         return """
-
 requires = [
     "ppb~=3.2.0",
 ]
 test_requires = [
-{%- if cookiecutter.test_framework == "pytest" %}
+{% if cookiecutter.test_framework == "pytest" %}
     "pytest",
-{%- endif %}
+{% endif %}
 ]
 """
 
     def pyproject_table_macOS(self):
-        return """
+        return """\
 universal_build = true
 requires = [
     "std-nslog~=1.0.0",
@@ -69,13 +68,13 @@ requires = [
 """
 
     def pyproject_table_linux(self):
-        return """
+        return """\
 requires = [
 ]
 """
 
     def pyproject_table_linux_system_debian(self):
-        return """
+        return """\
 system_requires = [
 ]
 
@@ -89,7 +88,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_system_rhel(self):
-        return """
+        return """\
 system_requires = [
 ]
 
@@ -104,7 +103,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_system_suse(self):
-        return """
+        return """\
 system_requires = [
 ]
 
@@ -119,7 +118,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_system_arch(self):
-        return """
+        return """\
 system_requires = [
 ]
 
@@ -133,7 +132,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_appimage(self):
-        return """
+        return """\
 manylinux = "manylinux_2_28"
 
 system_requires = [
@@ -144,29 +143,29 @@ linuxdeploy_plugins = [
 """
 
     def pyproject_table_linux_flatpak(self):
-        return """
+        return """\
 flatpak_runtime = "org.freedesktop.Platform"
 flatpak_runtime_version = "23.08"
 flatpak_sdk = "org.freedesktop.Sdk"
 """
 
     def pyproject_table_windows(self):
-        return """
+        return """\
 requires = [
 ]
 """
 
     def pyproject_table_iOS(self):
-        return """
+        return """\
 supported = false
 """
 
     def pyproject_table_android(self):
-        return """
+        return """\
 supported = false
 """
 
     def pyproject_table_web(self):
-        return """
+        return """\
 supported = false
 """

--- a/src/briefcase/bootstraps/pygame.py
+++ b/src/briefcase/bootstraps/pygame.py
@@ -59,19 +59,18 @@ def main():
 
     def pyproject_table_briefcase_app_extra_content(self):
         return """
-
 requires = [
     "pygame~=2.2",
 ]
 test_requires = [
-{%- if cookiecutter.test_framework == "pytest" %}
+{% if cookiecutter.test_framework == "pytest" %}
     "pytest",
-{%- endif %}
+{% endif %}
 ]
 """
 
     def pyproject_table_macOS(self):
-        return """
+        return """\
 universal_build = true
 requires = [
     "std-nslog~=1.0.0",
@@ -79,13 +78,13 @@ requires = [
 """
 
     def pyproject_table_linux(self):
-        return """
+        return """\
 requires = [
 ]
 """
 
     def pyproject_table_linux_system_debian(self):
-        return """
+        return """\
 system_requires = [
 ]
 
@@ -94,7 +93,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_system_rhel(self):
-        return """
+        return """\
 system_requires = [
 ]
 
@@ -103,7 +102,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_system_suse(self):
-        return """
+        return """\
 system_requires = [
 ]
 
@@ -112,7 +111,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_system_arch(self):
-        return """
+        return """\
 system_requires = [
 ]
 
@@ -121,7 +120,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_appimage(self):
-        return """
+        return """\
 manylinux = "manylinux_2_28"
 
 system_requires = [
@@ -132,29 +131,29 @@ linuxdeploy_plugins = [
 """
 
     def pyproject_table_linux_flatpak(self):
-        return """
+        return """\
 flatpak_runtime = "org.freedesktop.Platform"
 flatpak_runtime_version = "23.08"
 flatpak_sdk = "org.freedesktop.Sdk"
 """
 
     def pyproject_table_windows(self):
-        return """
+        return """\
 requires = [
 ]
 """
 
     def pyproject_table_iOS(self):
-        return """
+        return """\
 supported = false
 """
 
     def pyproject_table_android(self):
-        return """
+        return """\
 supported = false
 """
 
     def pyproject_table_web(self):
-        return """
+        return """\
 supported = false
 """

--- a/src/briefcase/bootstraps/pyside6.py
+++ b/src/briefcase/bootstraps/pyside6.py
@@ -46,20 +46,19 @@ def main():
 
     def pyproject_table_briefcase_app_extra_content(self):
         return """
-
 requires = [
     "PySide6-Essentials~=6.5",
     # "PySide6-Addons~=6.5",
 ]
 test_requires = [
-{%- if cookiecutter.test_framework == "pytest" %}
+{% if cookiecutter.test_framework == "pytest" %}
     "pytest",
-{%- endif %}
+{% endif %}
 ]
 """
 
     def pyproject_table_macOS(self):
-        return """
+        return """\
 universal_build = true
 requires = [
     "std-nslog~=1.0.0",
@@ -67,13 +66,13 @@ requires = [
 """
 
     def pyproject_table_linux(self):
-        return """
+        return """\
 requires = [
 ]
 """
 
     def pyproject_table_linux_system_debian(self):
-        return """
+        return """\
 system_requires = [
 ]
 
@@ -102,7 +101,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_system_rhel(self):
-        return """
+        return """\
 system_requires = [
 ]
 
@@ -112,7 +111,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_system_suse(self):
-        return """
+        return """\
 system_requires = [
 ]
 
@@ -123,7 +122,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_system_arch(self):
-        return """
+        return """\
 system_requires = [
 ]
 
@@ -133,7 +132,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_appimage(self):
-        return """
+        return """\
 manylinux = "manylinux_2_28"
 
 system_requires = [
@@ -145,29 +144,29 @@ linuxdeploy_plugins = [
 """
 
     def pyproject_table_linux_flatpak(self):
-        return """
+        return """\
 flatpak_runtime = "org.kde.Platform"
 flatpak_runtime_version = "6.6"
 flatpak_sdk = "org.kde.Sdk"
 """
 
     def pyproject_table_windows(self):
-        return """
+        return """\
 requires = [
 ]
 """
 
     def pyproject_table_iOS(self):
-        return """
+        return """\
 supported = false
 """
 
     def pyproject_table_android(self):
-        return """
+        return """\
 supported = false
 """
 
     def pyproject_table_web(self):
-        return """
+        return """\
 supported = false
 """

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -38,18 +38,17 @@ if __name__ == "__main__":
 
     def pyproject_table_briefcase_app_extra_content(self):
         return """
-
 requires = [
 ]
 test_requires = [
-{%- if cookiecutter.test_framework == "pytest" %}
+{% if cookiecutter.test_framework == "pytest" %}
     "pytest",
-{%- endif %}
+{% endif %}
 ]
 """
 
     def pyproject_table_macOS(self):
-        return """
+        return """\
 universal_build = true
 requires = [
     "toga-cocoa~=0.4.0",
@@ -58,14 +57,14 @@ requires = [
 """
 
     def pyproject_table_linux(self):
-        return """
+        return """\
 requires = [
     "toga-gtk~=0.4.0",
 ]
 """
 
     def pyproject_table_linux_system_debian(self):
-        return """
+        return """\
 system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",
@@ -85,7 +84,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_system_rhel(self):
-        return """
+        return """\
 system_requires = [
     # Needed to compile pycairo wheel
     "cairo-gobject-devel",
@@ -106,7 +105,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_system_suse(self):
-        return """
+        return """\
 system_requires = [
     # Needed to compile pycairo wheel
     "cairo-devel",
@@ -127,7 +126,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_system_arch(self):
-        return """
+        return """\
 system_requires = [
     # Needed to compile pycairo wheel
     "cairo",
@@ -156,7 +155,7 @@ system_runtime_requires = [
 """
 
     def pyproject_table_linux_appimage(self):
-        return """
+        return """\
 manylinux = "manylinux_2_28"
 
 system_requires = [
@@ -179,21 +178,21 @@ linuxdeploy_plugins = [
 """
 
     def pyproject_table_linux_flatpak(self):
-        return """
+        return """\
 flatpak_runtime = "org.gnome.Platform"
 flatpak_runtime_version = "45"
 flatpak_sdk = "org.gnome.Sdk"
 """
 
     def pyproject_table_windows(self):
-        return """
+        return """\
 requires = [
     "toga-winforms~=0.4.0",
 ]
 """
 
     def pyproject_table_iOS(self):
-        return """
+        return """\
 requires = [
     "toga-iOS~=0.4.0",
     "std-nslog~=1.0.0",
@@ -201,7 +200,7 @@ requires = [
 """
 
     def pyproject_table_android(self):
-        return """
+        return """\
 requires = [
     "toga-android~=0.4.0",
 ]
@@ -217,7 +216,7 @@ build_gradle_dependencies = [
 """
 
     def pyproject_table_web(self):
-        return """
+        return """\
 requires = [
     "toga-web~=0.4.0",
 ]

--- a/tests/commands/new/test_build_context.py
+++ b/tests/commands/new/test_build_context.py
@@ -92,28 +92,27 @@ if __name__ == "__main__":
     main().main_loop()
 """,
         pyproject_table_briefcase_app_extra_content="""
-
 requires = [
 ]
 test_requires = [
-{%- if cookiecutter.test_framework == "pytest" %}
+{% if cookiecutter.test_framework == "pytest" %}
     "pytest",
-{%- endif %}
+{% endif %}
 ]
 """,
-        pyproject_table_macOS="""
+        pyproject_table_macOS="""\
 universal_build = true
 requires = [
     "toga-cocoa~=0.4.0",
     "std-nslog~=1.0.0",
 ]
 """,
-        pyproject_table_linux="""
+        pyproject_table_linux="""\
 requires = [
     "toga-gtk~=0.4.0",
 ]
 """,
-        pyproject_table_linux_system_debian="""
+        pyproject_table_linux_system_debian="""\
 system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",
@@ -131,7 +130,7 @@ system_runtime_requires = [
     # "gir1.2-webkit2-4.0",
 ]
 """,
-        pyproject_table_linux_system_rhel="""
+        pyproject_table_linux_system_rhel="""\
 system_requires = [
     # Needed to compile pycairo wheel
     "cairo-gobject-devel",
@@ -150,7 +149,7 @@ system_runtime_requires = [
     # "webkit2gtk3",
 ]
 """,
-        pyproject_table_linux_system_suse="""
+        pyproject_table_linux_system_suse="""\
 system_requires = [
     # Needed to compile pycairo wheel
     "cairo-devel",
@@ -169,7 +168,7 @@ system_runtime_requires = [
     # "libwebkit2gtk3", "typelib(WebKit2)",
 ]
 """,
-        pyproject_table_linux_system_arch="""
+        pyproject_table_linux_system_arch="""\
 system_requires = [
     # Needed to compile pycairo wheel
     "cairo",
@@ -196,7 +195,7 @@ system_runtime_requires = [
     # "webkit2gtk",
 ]
 """,
-        pyproject_table_linux_appimage="""
+        pyproject_table_linux_appimage="""\
 manylinux = "manylinux_2_28"
 
 system_requires = [
@@ -217,23 +216,23 @@ linuxdeploy_plugins = [
     "DEPLOY_GTK_VERSION=3 gtk",
 ]
 """,
-        pyproject_table_linux_flatpak="""
+        pyproject_table_linux_flatpak="""\
 flatpak_runtime = "org.gnome.Platform"
 flatpak_runtime_version = "45"
 flatpak_sdk = "org.gnome.Sdk"
 """,
-        pyproject_table_windows="""
+        pyproject_table_windows="""\
 requires = [
     "toga-winforms~=0.4.0",
 ]
 """,
-        pyproject_table_iOS="""
+        pyproject_table_iOS="""\
 requires = [
     "toga-iOS~=0.4.0",
     "std-nslog~=1.0.0",
 ]
 """,
-        pyproject_table_android="""
+        pyproject_table_android="""\
 requires = [
     "toga-android~=0.4.0",
 ]
@@ -247,7 +246,7 @@ build_gradle_dependencies = [
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]
 """,
-        pyproject_table_web="""
+        pyproject_table_web="""\
 requires = [
     "toga-web~=0.4.0",
 ]
@@ -334,28 +333,27 @@ def main():
     sys.exit(app.exec())
 """,
         pyproject_table_briefcase_app_extra_content="""
-
 requires = [
     "PySide6-Essentials~=6.5",
     # "PySide6-Addons~=6.5",
 ]
 test_requires = [
-{%- if cookiecutter.test_framework == "pytest" %}
+{% if cookiecutter.test_framework == "pytest" %}
     "pytest",
-{%- endif %}
+{% endif %}
 ]
 """,
-        pyproject_table_macOS="""
+        pyproject_table_macOS="""\
 universal_build = true
 requires = [
     "std-nslog~=1.0.0",
 ]
 """,
-        pyproject_table_linux="""
+        pyproject_table_linux="""\
 requires = [
 ]
 """,
-        pyproject_table_linux_system_debian="""
+        pyproject_table_linux_system_debian="""\
 system_requires = [
 ]
 
@@ -382,7 +380,7 @@ system_runtime_requires = [
     "libdbus-1-3",
 ]
 """,
-        pyproject_table_linux_system_rhel="""
+        pyproject_table_linux_system_rhel="""\
 system_requires = [
 ]
 
@@ -390,7 +388,7 @@ system_runtime_requires = [
     "qt6-qtbase-gui",
 ]
 """,
-        pyproject_table_linux_system_suse="""
+        pyproject_table_linux_system_suse="""\
 system_requires = [
 ]
 
@@ -399,7 +397,7 @@ system_runtime_requires = [
     "libQt6Gui6",
 ]
 """,
-        pyproject_table_linux_system_arch="""
+        pyproject_table_linux_system_arch="""\
 system_requires = [
 ]
 
@@ -407,7 +405,7 @@ system_runtime_requires = [
     "qt6-base",
 ]
 """,
-        pyproject_table_linux_appimage="""
+        pyproject_table_linux_appimage="""\
 manylinux = "manylinux_2_28"
 
 system_requires = [
@@ -417,22 +415,22 @@ system_requires = [
 linuxdeploy_plugins = [
 ]
 """,
-        pyproject_table_linux_flatpak="""
+        pyproject_table_linux_flatpak="""\
 flatpak_runtime = "org.kde.Platform"
 flatpak_runtime_version = "6.6"
 flatpak_sdk = "org.kde.Sdk"
 """,
-        pyproject_table_windows="""
+        pyproject_table_windows="""\
 requires = [
 ]
 """,
-        pyproject_table_iOS="""
+        pyproject_table_iOS="""\
 supported = false
 """,
-        pyproject_table_android="""
+        pyproject_table_android="""\
 supported = false
 """,
-        pyproject_table_web="""
+        pyproject_table_web="""\
 supported = false
 """,
     )
@@ -519,27 +517,26 @@ def main():
     )
 """,
         pyproject_table_briefcase_app_extra_content="""
-
 requires = [
     "ppb~=3.2.0",
 ]
 test_requires = [
-{%- if cookiecutter.test_framework == "pytest" %}
+{% if cookiecutter.test_framework == "pytest" %}
     "pytest",
-{%- endif %}
+{% endif %}
 ]
 """,
-        pyproject_table_macOS="""
+        pyproject_table_macOS="""\
 universal_build = true
 requires = [
     "std-nslog~=1.0.0",
 ]
 """,
-        pyproject_table_linux="""
+        pyproject_table_linux="""\
 requires = [
 ]
 """,
-        pyproject_table_linux_system_debian="""
+        pyproject_table_linux_system_debian="""\
 system_requires = [
 ]
 
@@ -551,7 +548,7 @@ system_runtime_requires = [
     "libsdl2-ttf-2.0-0",
 ]
 """,
-        pyproject_table_linux_system_rhel="""
+        pyproject_table_linux_system_rhel="""\
 system_requires = [
 ]
 
@@ -564,7 +561,7 @@ system_runtime_requires = [
     "libmodplug",
 ]
 """,
-        pyproject_table_linux_system_suse="""
+        pyproject_table_linux_system_suse="""\
 system_requires = [
 ]
 
@@ -577,7 +574,7 @@ system_runtime_requires = [
     "libmodplug1",
 ]
 """,
-        pyproject_table_linux_system_arch="""
+        pyproject_table_linux_system_arch="""\
 system_requires = [
 ]
 
@@ -589,7 +586,7 @@ system_runtime_requires = [
     "sdl2_mixer",
 ]
 """,
-        pyproject_table_linux_appimage="""
+        pyproject_table_linux_appimage="""\
 manylinux = "manylinux_2_28"
 
 system_requires = [
@@ -598,22 +595,22 @@ system_requires = [
 linuxdeploy_plugins = [
 ]
 """,
-        pyproject_table_linux_flatpak="""
+        pyproject_table_linux_flatpak="""\
 flatpak_runtime = "org.freedesktop.Platform"
 flatpak_runtime_version = "23.08"
 flatpak_sdk = "org.freedesktop.Sdk"
 """,
-        pyproject_table_windows="""
+        pyproject_table_windows="""\
 requires = [
 ]
 """,
-        pyproject_table_iOS="""
+        pyproject_table_iOS="""\
 supported = false
 """,
-        pyproject_table_android="""
+        pyproject_table_android="""\
 supported = false
 """,
-        pyproject_table_web="""
+        pyproject_table_web="""\
 supported = false
 """,
     )
@@ -710,55 +707,54 @@ def main():
     pygame.quit()
 """,
         pyproject_table_briefcase_app_extra_content="""
-
 requires = [
     "pygame~=2.2",
 ]
 test_requires = [
-{%- if cookiecutter.test_framework == "pytest" %}
+{% if cookiecutter.test_framework == "pytest" %}
     "pytest",
-{%- endif %}
+{% endif %}
 ]
 """,
-        pyproject_table_macOS="""
+        pyproject_table_macOS="""\
 universal_build = true
 requires = [
     "std-nslog~=1.0.0",
 ]
 """,
-        pyproject_table_linux="""
+        pyproject_table_linux="""\
 requires = [
 ]
 """,
-        pyproject_table_linux_system_debian="""
+        pyproject_table_linux_system_debian="""\
 system_requires = [
 ]
 
 system_runtime_requires = [
 ]
 """,
-        pyproject_table_linux_system_rhel="""
+        pyproject_table_linux_system_rhel="""\
 system_requires = [
 ]
 
 system_runtime_requires = [
 ]
 """,
-        pyproject_table_linux_system_suse="""
+        pyproject_table_linux_system_suse="""\
 system_requires = [
 ]
 
 system_runtime_requires = [
 ]
 """,
-        pyproject_table_linux_system_arch="""
+        pyproject_table_linux_system_arch="""\
 system_requires = [
 ]
 
 system_runtime_requires = [
 ]
 """,
-        pyproject_table_linux_appimage="""
+        pyproject_table_linux_appimage="""\
 manylinux = "manylinux_2_28"
 
 system_requires = [
@@ -767,22 +763,22 @@ system_requires = [
 linuxdeploy_plugins = [
 ]
 """,
-        pyproject_table_linux_flatpak="""
+        pyproject_table_linux_flatpak="""\
 flatpak_runtime = "org.freedesktop.Platform"
 flatpak_runtime_version = "23.08"
 flatpak_sdk = "org.freedesktop.Sdk"
 """,
-        pyproject_table_windows="""
+        pyproject_table_windows="""\
 requires = [
 ]
 """,
-        pyproject_table_iOS="""
+        pyproject_table_iOS="""\
 supported = false
 """,
-        pyproject_table_android="""
+        pyproject_table_android="""\
 supported = false
 """,
-        pyproject_table_web="""
+        pyproject_table_web="""\
 supported = false
 """,
     )
@@ -1083,28 +1079,27 @@ if __name__ == "__main__":
     main().main_loop()
 """,
         pyproject_table_briefcase_app_extra_content="""
-
 requires = [
 ]
 test_requires = [
-{%- if cookiecutter.test_framework == "pytest" %}
+{% if cookiecutter.test_framework == "pytest" %}
     "pytest",
-{%- endif %}
+{% endif %}
 ]
 """,
-        pyproject_table_macOS="""
+        pyproject_table_macOS="""\
 universal_build = true
 requires = [
     "toga-cocoa~=0.4.0",
     "std-nslog~=1.0.0",
 ]
 """,
-        pyproject_table_linux="""
+        pyproject_table_linux="""\
 requires = [
     "toga-gtk~=0.4.0",
 ]
 """,
-        pyproject_table_linux_system_debian="""
+        pyproject_table_linux_system_debian="""\
 system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",
@@ -1122,7 +1117,7 @@ system_runtime_requires = [
     # "gir1.2-webkit2-4.0",
 ]
 """,
-        pyproject_table_linux_system_rhel="""
+        pyproject_table_linux_system_rhel="""\
 system_requires = [
     # Needed to compile pycairo wheel
     "cairo-gobject-devel",
@@ -1141,7 +1136,7 @@ system_runtime_requires = [
     # "webkit2gtk3",
 ]
 """,
-        pyproject_table_linux_system_suse="""
+        pyproject_table_linux_system_suse="""\
 system_requires = [
     # Needed to compile pycairo wheel
     "cairo-devel",
@@ -1160,7 +1155,7 @@ system_runtime_requires = [
     # "libwebkit2gtk3", "typelib(WebKit2)",
 ]
 """,
-        pyproject_table_linux_system_arch="""
+        pyproject_table_linux_system_arch="""\
 system_requires = [
     # Needed to compile pycairo wheel
     "cairo",
@@ -1187,7 +1182,7 @@ system_runtime_requires = [
     # "webkit2gtk",
 ]
 """,
-        pyproject_table_linux_appimage="""
+        pyproject_table_linux_appimage="""\
 manylinux = "manylinux_2_28"
 
 system_requires = [
@@ -1208,23 +1203,23 @@ linuxdeploy_plugins = [
     "DEPLOY_GTK_VERSION=3 gtk",
 ]
 """,
-        pyproject_table_linux_flatpak="""
+        pyproject_table_linux_flatpak="""\
 flatpak_runtime = "org.gnome.Platform"
 flatpak_runtime_version = "45"
 flatpak_sdk = "org.gnome.Sdk"
 """,
-        pyproject_table_windows="""
+        pyproject_table_windows="""\
 requires = [
     "toga-winforms~=0.4.0",
 ]
 """,
-        pyproject_table_iOS="""
+        pyproject_table_iOS="""\
 requires = [
     "toga-iOS~=0.4.0",
     "std-nslog~=1.0.0",
 ]
 """,
-        pyproject_table_android="""
+        pyproject_table_android="""\
 requires = [
     "toga-android~=0.4.0",
 ]
@@ -1238,7 +1233,7 @@ build_gradle_dependencies = [
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]
 """,
-        pyproject_table_web="""
+        pyproject_table_web="""\
 requires = [
     "toga-web~=0.4.0",
 ]


### PR DESCRIPTION
## Changes
- Closes #1663
- v2.6.0 changed how jinja2 whitespace control configuration is respected; these changes ensure the rolled out Briefcase template matches the previous syntax.
- Pins v2.6.0 as the lower end for cookiecutter

## Notes
- This should be merged in tandem with https://github.com/beeware/briefcase-template/pull/110

BRIEFCASE_TEMPLATE_REPO: https://github.com/rmartin16/briefcase-template
BRIEFCASE_TEMPLATE_REF: template-whitespace

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct