### PR TITLE
Cleanups identified while adding Tutorial 10

### DIFF
--- a/changes/1725.feature.rst
+++ b/changes/1725.feature.rst
@@ -1,0 +1,1 @@
+Android apps now support ``xxdpi`` sizes for splash screens.

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -58,19 +58,19 @@ application must provide the icons in the following sizes, for 2 variants:
 
 * ``round``:
 
-  * 48px
-  * 72px
-  * 96px
-  * 144px
-  * 192px
+  * 48px (``mdpi``; baseline resolution)
+  * 72px (``hdpi``; 1.5x scale)
+  * 96px (``xhdpi``; 2x scale)
+  * 144px (``xxhdpi``; 3x scale)
+  * 192px (``xxxhdpi``; 4x scale)
 
 * ``square``:
 
-  * 48px
-  * 72px
-  * 96px
-  * 144px
-  * 192px
+  * 48px (``mdpi``; baseline resolution)
+  * 72px (``hdpi``; 1.5x scale)
+  * 96px (``xhdpi``; 2x scale)
+  * 144px (``xxhdpi``; 3x scale)
+  * 192px (``xxxhdpi``; 4x scale)
 
 Splash Image format
 ===================
@@ -82,25 +82,28 @@ and device display densities:
 
 * ``normal`` (typical phones; up to 480 density-independent pixels):
 
-  * 320px
-  * 480px (``hdpi``)
-  * 640px (``xhdpi``)
-  * 1280px (``xxxhdpi``)
+  * 320px (``mdpi``; baseline resolution)
+  * 480px (``hdpi``; 1.5x scale)
+  * 640px (``xhdpi``; 2x scale)
+  * 960px (``xxhdpi``; 3x scale)
+  * 1280px (``xxxhdpi``; 4x scale)
 
 * ``large`` (large format phones, or phone-tablet "phablet" hybrids; up to
   720 density-independent pixels):
 
-  * 480px
-  * 720px (``hdpi``)
-  * 960px (``xhdpi``)
-  * 1920px (``xxxhdpi``)
+  * 480px (``mdpi``; baseline resolution)
+  * 720px (``hdpi``; 1.5x scale)
+  * 960px (``xhdpi``; 2x scale)
+  * 1440px (``xxhdpi``; 3x scale)
+  * 1920px (``xxxhdpi``; 4x scale)
 
 * ``xlarge`` (tablets; larger than 720 density-independent pixels)
 
-  * 720px
-  * 1080px (``hdpi``)
-  * 1440px (``xhdpi``)
-  * 2880px (``xxxhdpi``)
+  * 720px (``mdpi``; baseline resolution)
+  * 1080px (``hdpi``; 1.5x scale)
+  * 1440px (``xhdpi``; 2x scale)
+  * 2160px (``xxhdpi``; 3x scale)
+  * 2880px (``xxxhdpi``; 4x scale)
 
 Consult `the Android documentation
 <https://developer.android.com/guide/topics/large-screens/support-different-screen-sizes>`__

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -728,6 +728,7 @@ password:
         :param adhoc_sign: If ``True``, code will be signed with ad-hoc identity
             of "-", and the resulting app will not be re-distributable.
         """
+        self.logger.info("Signing app...", prefix=app.app_name)
         if adhoc_sign:
             identity = "-"
             identity_name = ADHOC_IDENTITY_NAME
@@ -739,21 +740,33 @@ password:
                 raise BriefcaseCommandError(
                     "Can't notarize an app with an ad-hoc signing identity"
                 )
-            self.logger.info("Signing app with ad-hoc identity...", prefix=app.app_name)
             self.logger.warning(
-                "Because you are signing with the ad-hoc identity, this "
-                "app will run, but cannot be re-distributed."
+                """
+*************************************************************************
+** WARNING: Signing with an ad-hoc identity                            **
+*************************************************************************
+
+    This app is being signed with an ad-hoc identity. The resulting
+    app will run on this computer, but will not run on anyone else's
+    computer.
+
+    To generate an app that can be distributed to others, you must
+    obtain an application distribution certificate from Apple, and
+    select the developer identity associated with that certificate
+    when running 'briefcase package'.
+
+*************************************************************************
+
+"""
             )
+            self.logger.info("Signing app with ad-hoc identity...")
         else:
             # If we're signing, and notarization isn't explicitly disabled,
             # notarize by default.
             if notarize_app is None:
                 notarize_app = True
 
-            self.logger.info(
-                f"Signing app with identity {identity_name}...",
-                prefix=app.app_name,
-            )
+            self.logger.info(f"Signing app with identity {identity_name}...")
 
             if notarize_app:
                 team_id = self.team_id_from_identity(identity_name)


### PR DESCRIPTION
In the process of adding Tutorial 10, some cleanups and fixes were identified:

* Make the warning about ad-hoc signing more prominent when signing an macOS package. This matches the warning on Windows.
* Documents the xxhdpi option for Android splash screens 
* Adds descriptions of what the various DPI settings mean in terms of scale.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
