### PR TITLE
Bump JDK to 17.0.11+9

### DIFF
--- a/changes/1736.feature.rst
+++ b/changes/1736.feature.rst
@@ -1,0 +1,1 @@
+Java JDK 17.0.11+9 is now used to package Android apps. Use ``briefcase upgrade java`` to update your Briefcase-installed JDK instance to this version.

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -17,10 +17,10 @@ class JDK(ManagedTool):
     name = "java"
     full_name = "Java JDK"
 
-    # Latest OpenJDK as of September 2023: https://adoptium.net/temurin/releases/
+    # Latest OpenJDK as of April 2024: https://adoptium.net/temurin/releases/
     JDK_MAJOR_VER = "17"
-    JDK_RELEASE = "17.0.10"
-    JDK_BUILD = "7"
+    JDK_RELEASE = "17.0.11"
+    JDK_BUILD = "9"
     JDK_INSTALL_DIR_NAME = f"java{JDK_MAJOR_VER}"
 
     def __init__(self, tools: ToolCache, java_home: Path):

--- a/tests/integrations/java/conftest.py
+++ b/tests/integrations/java/conftest.py
@@ -6,8 +6,8 @@ from briefcase.integrations.base import ToolCache
 from briefcase.integrations.download import Download
 from briefcase.integrations.subprocess import Subprocess
 
-JDK_RELEASE = "17.0.10"
-JDK_BUILD = "7"
+JDK_RELEASE = "17.0.11"
+JDK_BUILD = "9"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Changes
- Use latest JDK: https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.11%2B9

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct