### PR TITLE
Update docs to reflect AppImages no longer depend on ``libcrypt.so.1``

### DIFF
--- a/changes/1383.feature.rst
+++ b/changes/1383.feature.rst
@@ -1,0 +1,1 @@
+Apps packaged as AppImages are no longer dependent on ``libcrypt.so.1``.

--- a/docs/reference/platforms/linux/appimage.rst
+++ b/docs/reference/platforms/linux/appimage.rst
@@ -239,17 +239,6 @@ Packaging on Linux is a difficult problem - especially when it comes to binary
 libraries. The following are some common problems you may see, and ways that
 they can be mitigated.
 
-Missing ``libcrypt.so.1``
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The support package used by Briefcase has a `number of runtime requirements
-<https://gregoryszorc.com/docs/python-build-standalone/main/running.html#runtime-requirements>`__.
-One of those requirements is ``libcrypt.so.1``, which *should* be provided by
-most modern Linux distributions, as it is mandated as part of the Linux Standard
-Base Core Specification. However, some Red Hat maintained distributions don't
-include ``libcrypt.so.1`` as part of the base OS configuration. This can usually
-be fixed by installing the ``libxcrypt-compat`` package.
-
 Failure to load ``libpango-1.0-so.0``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Changes
- Closes https://github.com/beeware/briefcase/issues/1383

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct