### PR TITLE
Remove custom splash screen configuration.

### DIFF
--- a/automation/src/automation/bootstraps/pursuedpybear.py
+++ b/automation/src/automation/bootstraps/pursuedpybear.py
@@ -17,12 +17,6 @@ class {{{{ cookiecutter.class_name }}}}(ppb.Scene):
         super().__init__(**props)
         self.updates: int = 0
 
-        self.add(
-            ppb.Sprite(
-                image=ppb.Image("{{{{ cookiecutter.module_name }}}}/resources/{{{{ cookiecutter.app_name }}}}.png"),
-            )
-        )
-
     def on_update(self, event, signal):
         self.updates += 1
         # quit after 2 seconds since on_update is run 60 times/second

--- a/automation/src/automation/bootstraps/pygame.py
+++ b/automation/src/automation/bootstraps/pygame.py
@@ -34,11 +34,6 @@ def main():
 
     os.environ["SDL_VIDEO_X11_WMCLASS"] = metadata["Formal-Name"]
 
-    # Set the app's runtime icon
-    pygame.display.set_icon(
-        pygame.image.load(Path(__file__).parent / "resources/{{{{ cookiecutter.app_name }}}}.png")
-    )
-
     pygame.init()
     pygame.display.set_caption(metadata["Formal-Name"])
     screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))

--- a/changes/1737.feature.rst
+++ b/changes/1737.feature.rst
@@ -1,0 +1,1 @@
+When a platform supports a splash screen, that splash screen will be generated automatically based on the app icon, rather than requiring additional configuration.

--- a/changes/1737.removal.1.rst
+++ b/changes/1737.removal.1.rst
@@ -1,1 +1,1 @@
-iOS apps now require 640px, 1280px and 1920px icon image.
+The ``splash`` configuration option will no longer be honored. Splash screens are now generated based on the icon image.

--- a/changes/1737.removal.1.rst
+++ b/changes/1737.removal.1.rst
@@ -1,0 +1,1 @@
+iOS apps now require 640px, 1280px and 1920px icon image.

--- a/changes/1737.removal.2.rst
+++ b/changes/1737.removal.2.rst
@@ -1,0 +1,1 @@
+Android apps now require an ``adaptive`` variant for icons. This requires 108px, 162px, 216px, 324px and 432px images with a transparent background. The Android ``square`` icon variant requires additional 320px, 480px, 640px, 960px and 1280px images.

--- a/changes/1737.removal.3.rst
+++ b/changes/1737.removal.3.rst
@@ -1,0 +1,1 @@
+iOS apps now require 640px, 1280px and 1920px icon image.

--- a/docs/reference/commands/build.rst
+++ b/docs/reference/commands/build.rst
@@ -66,8 +66,8 @@ Update application requirements before building. Equivalent to running:
 ``--update-resources``
 ----------------------
 
-Update application resources (e.g., icons and splash screens) before building.
-Equivalent to running:
+Update application resources such as icons before running. Equivalent to
+running:
 
 .. code-block:: console
 

--- a/docs/reference/commands/build.rst
+++ b/docs/reference/commands/build.rst
@@ -66,7 +66,7 @@ Update application requirements before building. Equivalent to running:
 ``--update-resources``
 ----------------------
 
-Update application resources such as icons before running. Equivalent to
+Update application resources such as icons before building. Equivalent to
 running:
 
 .. code-block:: console

--- a/docs/reference/commands/run.rst
+++ b/docs/reference/commands/run.rst
@@ -92,8 +92,8 @@ Update application requirements before running. Equivalent to running:
 ``--update-resources``
 ----------------------
 
-Update application resources (e.g., icons and splash screens) before running.
-Equivalent to running:
+Update application resources such as icons before running. Equivalent to
+running:
 
 .. code-block:: console
 

--- a/docs/reference/commands/update.rst
+++ b/docs/reference/commands/update.rst
@@ -44,7 +44,7 @@ Update application requirements.
 ``--update-resources``
 ----------------------
 
-Update application resources such as icons before running.
+Update application resources such as icons.
 
 ``--update-support``
 ----------------------

--- a/docs/reference/commands/update.rst
+++ b/docs/reference/commands/update.rst
@@ -44,7 +44,7 @@ Update application requirements.
 ``--update-resources``
 ----------------------
 
-Update application resources (e.g., icons and splash screens).
+Update application resources such as icons before running.
 
 ``--update-support``
 ----------------------

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -287,9 +287,9 @@ be appended when the application is built.
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 A path, relative to the directory where the ``pyproject.toml`` file is located,
-to an image to use as the background for the installer. As with ``splash``, the
-path should *exclude* the extension, and a platform-appropriate extension will
-be appended when the application is built.
+to an image to use as the background for the installer. The path should
+*exclude* the extension, and a platform-appropriate extension will be appended
+when the application is built.
 
 ``long_description``
 ~~~~~~~~~~~~~~~~~~~~
@@ -329,42 +329,6 @@ most specific.
 
 An identifier used to differentiate specific builds of the same version of an
 app. Defaults to ``1`` if not provided.
-
-``splash``
-~~~~~~~~~~
-
-A path, relative to the directory where the ``pyproject.toml`` file is located,
-to an image to use as the splash screen for the application. The path should
-*exclude* the extension; Briefcase will append a platform appropriate extension
-when configuring the application.
-
-Some platforms require multiple splash images, at different sizes; these will
-be handled by appending the required size to the provided icon name. For
-example, iOS requires multiple splash images, (1024px, 2048px and 3072px);
-with a ``splash`` setting of ``resources/my_splash``, Briefcase will look for
-``resources/my_splash-1024.png``, ``resources/my_splash-2045.png``, and
-``resources/my_splash-3072.png``. The sizes that are required are determined
-by the platform template.
-
-Some platforms also require different *variants*. For example, Android requires
-splash screens for ``normal``, ``large`` and ``xlarge`` devices. These variants
-can be specified by qualifying the splash specification::
-
-    splash.normal = "resource/normal-splash"
-    splash.large = "resource/large-splash"
-    splash.xlarge = "resource/xlarge-splash"
-
-These settings can, if you wish, all use the same prefix.
-
-If the platform requires different sizes for each variant (as Android does),
-those size will be appended to path provided by the variant specifier. For
-example, using the previous example, Android would look for
-``resource/normal-splash-320.png``,  ``resource/normal-splash-480.png``,
-``resource/large-splash.480.png``, ``resource/xlarge-splash-720.png``, amongst
-others.
-
-If the platform output format does not use a splash screen, the ``splash``
-setting is ignored.
 
 ``splash_background_color``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -72,44 +72,9 @@ application must provide the icons in the following sizes, for 2 variants:
   * 144px (``xxhdpi``; 3x scale)
   * 192px (``xxxhdpi``; 4x scale)
 
-Splash Image format
-===================
-
-Android projects use ``.png`` format splash screen images. A splash screen
-should be a square image with a transparent background. It must be specified
-in a range of sizes and variants, to suit different possible device sizes
-and device display densities:
-
-* ``normal`` (typical phones; up to 480 density-independent pixels):
-
-  * 320px (``mdpi``; baseline resolution)
-  * 480px (``hdpi``; 1.5x scale)
-  * 640px (``xhdpi``; 2x scale)
-  * 960px (``xxhdpi``; 3x scale)
-  * 1280px (``xxxhdpi``; 4x scale)
-
-* ``large`` (large format phones, or phone-tablet "phablet" hybrids; up to
-  720 density-independent pixels):
-
-  * 480px (``mdpi``; baseline resolution)
-  * 720px (``hdpi``; 1.5x scale)
-  * 960px (``xhdpi``; 2x scale)
-  * 1440px (``xxhdpi``; 3x scale)
-  * 1920px (``xxxhdpi``; 4x scale)
-
-* ``xlarge`` (tablets; larger than 720 density-independent pixels)
-
-  * 720px (``mdpi``; baseline resolution)
-  * 1080px (``hdpi``; 1.5x scale)
-  * 1440px (``xhdpi``; 2x scale)
-  * 2160px (``xxhdpi``; 3x scale)
-  * 2880px (``xxxhdpi``; 4x scale)
-
-Consult `the Android documentation
-<https://developer.android.com/guide/topics/large-screens/support-different-screen-sizes>`__
-for more details on devices, sizes, and display densities. `This list of common
-devices with their sizes and DPI <https://m2.material.io/resources/devices/>`__
-may also be helpful.
+The icon will also be used to populate the splash screen. You can specify a
+background color for the splash screen using the ``splash_background_color``
+configuration setting.
 
 Android projects do not support installer images.
 

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -85,11 +85,10 @@ application must provide the icons in the following sizes, for 3 variants:
   * 324px (``xxhdpi``; 3x scale; 198px drawable area)
   * 432px (``xxxhdpi``; 4x scale; 264px drawable area)
 
-The ``round`` and ``square`` icons should include their background color in
-the image. The ``adaptive`` icons should have a transparent background; the
-image should be centered in the overall image, and be no larger than the itself
-should not exceed the drawable area. The background color of the adaptive icon
-will be the value specified as the ``splash_background_color``.
+The ``round`` and ``square`` icons should include their background color in the image.
+The ``adaptive`` icons should have a transparent background; the icon image should be
+centered in the overall image, and should not exceed the drawable area. The background
+color of the adaptive icon will be the value specified with ``splash_background_color``.
 
 The icon will also be used to populate the splash screen. You can specify a
 background color for the splash screen using the ``splash_background_color``

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -53,8 +53,8 @@ Briefcase supports three packaging formats for an Android app:
 Icon format
 ===========
 
-Android projects use ``.png`` format icons, in round and square variants. An
-application must provide the icons in the following sizes, for 2 variants:
+Android projects use ``.png`` format icons, in round, square and adaptive variants. An
+application must provide the icons in the following sizes, for 3 variants:
 
 * ``round``:
 
@@ -71,6 +71,25 @@ application must provide the icons in the following sizes, for 2 variants:
   * 96px (``xhdpi``; 2x scale)
   * 144px (``xxhdpi``; 3x scale)
   * 192px (``xxxhdpi``; 4x scale)
+  * 320px (``mdpi``; baseline resolution for splash screen)
+  * 480px (``hdpi``; 1.5x scale for splash screen)
+  * 640px (``xhdpi``; 2x scale for splash screen)
+  * 960px (``xxhdpi``; 3x scale for splash screen)
+  * 1280px (``xxxhdpi``; 4x scale for splash screen)
+
+* ``adaptive``:
+
+  * 108px (``mdpi``; baseline resolution; 66px drawable area)
+  * 162px (``hdpi``; 1.5x scale; 99px drawable area)
+  * 216px (``xhdpi``; 2x scale; 132px drawable area)
+  * 324px (``xxhdpi``; 3x scale; 198px drawable area)
+  * 432px (``xxxhdpi``; 4x scale; 264px drawable area)
+
+The ``round`` and ``square`` icons should include their background color in
+the image. The ``adaptive`` icons should have a transparent background; the
+image should be centered in the overall image, and be no larger than the itself
+should not exceed the drawable area. The background color of the adaptive icon
+will be the value specified as the ``splash_background_color``.
 
 The icon will also be used to populate the splash screen. You can specify a
 background color for the splash screen using the ``splash_background_color``

--- a/docs/reference/platforms/iOS/xcode.rst
+++ b/docs/reference/platforms/iOS/xcode.rst
@@ -32,20 +32,14 @@ the following sizes:
 * 152px
 * 167px
 * 180px
+* 640px
 * 1024px
+* 1280px
+* 1920px
 
-Splash Image format
-===================
-
-iOS projects use ``.png`` format splash screen images. A splash screen should
-be a square, transparent image, provided in the following sizes:
-
-* 800px
-* 1600px
-* 2400px
-
-You can specify a background color for the splash screen using the
-``splash_background_color`` configuration setting.
+The icon will also be used to populate the splash screen. You can specify a
+background color for the splash screen using the ``splash_background_color``
+configuration setting.
 
 iOS projects do not support installer images.
 

--- a/docs/reference/platforms/iOS/xcode.rst
+++ b/docs/reference/platforms/iOS/xcode.rst
@@ -43,6 +43,14 @@ configuration setting.
 
 iOS projects do not support installer images.
 
+Colors
+======
+
+iOS allows for some customization of the colors used by your app:
+
+* ``splash_background_color`` is the color of the splash background that
+  displays while an app is loading.
+
 Additional options
 ==================
 

--- a/docs/reference/platforms/linux/appimage.rst
+++ b/docs/reference/platforms/linux/appimage.rst
@@ -81,9 +81,6 @@ the following sizes:
 * 256px
 * 512px
 
-Splash Image format
-===================
-
 AppImages do not support splash screens or installer images.
 
 Additional options

--- a/docs/reference/platforms/linux/flatpak.rst
+++ b/docs/reference/platforms/linux/flatpak.rst
@@ -65,9 +65,6 @@ the following sizes:
 * 256px
 * 512px
 
-Splash Image format
-===================
-
 Flatpaks do not support splash screens or installer images.
 
 Application configuration

--- a/docs/reference/platforms/linux/system.rst
+++ b/docs/reference/platforms/linux/system.rst
@@ -69,9 +69,6 @@ the following sizes:
 * 256px
 * 512px
 
-Splash Image format
-===================
-
 Linux System packages do not support splash screens or installer images.
 
 Additional files

--- a/docs/reference/platforms/macOS/app.rst
+++ b/docs/reference/platforms/macOS/app.rst
@@ -35,9 +35,6 @@ Icon format
 
 macOS ``.app`` bundles use ``.icns`` format icons.
 
-Splash Image format
-===================
-
 macOS ``.app`` bundles do not support splash screens or installer images.
 
 Additional options

--- a/docs/reference/platforms/macOS/xcode.rst
+++ b/docs/reference/platforms/macOS/xcode.rst
@@ -41,9 +41,6 @@ the following sizes:
 * 512px
 * 1024px
 
-Splash Image format
-===================
-
 macOS Xcode projects do not support splash screens.
 
 Additional options

--- a/docs/reference/platforms/web/static.rst
+++ b/docs/reference/platforms/web/static.rst
@@ -43,9 +43,6 @@ Icon format
 
 Web projects use a single 32px ``.png`` format icon as the site icon.
 
-Splash Image format
-===================
-
 Web projects do not support splash screens or installer images.
 
 Additional options

--- a/docs/reference/platforms/windows/app.rst
+++ b/docs/reference/platforms/windows/app.rst
@@ -46,9 +46,6 @@ contain images in the following sizes:
 * 64px
 * 256px
 
-Splash Image format
-===================
-
 Windows Apps do not support splash screens or installer images.
 
 Additional options

--- a/docs/reference/platforms/windows/visualstudio.rst
+++ b/docs/reference/platforms/windows/visualstudio.rst
@@ -69,9 +69,6 @@ contain images in the following sizes:
 * 64px
 * 256px
 
-Splash Image format
-===================
-
 Windows Apps do not support splash screens or installer images.
 
 Additional options

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -24,6 +24,7 @@ Django
 dmg
 Dockerfile
 dr
+drawable
 embeddable
 executables
 Flathub

--- a/src/briefcase/bootstraps/pursuedpybear.py
+++ b/src/briefcase/bootstraps/pursuedpybear.py
@@ -17,11 +17,7 @@ class {{ cookiecutter.class_name }}(ppb.Scene):
     def __init__(self, **props):
         super().__init__(**props)
 
-        self.add(
-            ppb.Sprite(
-                image=ppb.Image("{{ cookiecutter.module_name }}/resources/{{ cookiecutter.app_name }}.png"),
-            )
-        )
+        # Add sprites and details to your scene here
 
 
 def main():

--- a/src/briefcase/bootstraps/pygame.py
+++ b/src/briefcase/bootstraps/pygame.py
@@ -35,11 +35,6 @@ def main():
 
     os.environ["SDL_VIDEO_X11_WMCLASS"] = metadata["Formal-Name"]
 
-    # Set the app's runtime icon
-    pygame.display.set_icon(
-        pygame.image.load(Path(__file__).parent / "resources/{{ cookiecutter.app_name }}.png")
-    )
-
     pygame.init()
     pygame.display.set_caption(metadata["Formal-Name"])
     screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -121,27 +121,6 @@ class CreateCommand(BaseCommand):
 
         return icon_targets
 
-    def splash_image_targets(self, app: AppConfig):
-        """Obtain the dictionary of splash image targets that the template requires.
-
-        :param app: The config object for the app
-        :return: A dictionary of splash images that the template supports. The keys of
-            the dictionary are the size of the splash images.
-        """
-        # If the template specifies no splash images, return an empty dictionary.
-        # If the template specifies a single splash image without a size specification,
-        #   return a dictionary with a single ``None`` key.
-        # Otherwise, return the full size-keyed dictionary.
-        try:
-            splash_targets = self.path_index(app, "splash")
-            # Convert string-specified splash images into an "unknown size" icon form
-            if isinstance(splash_targets, str):
-                splash_targets = {None: splash_targets}
-        except KeyError:
-            splash_targets = {}
-
-        return splash_targets
-
     def document_type_icon_targets(self, app: AppConfig):
         """Obtain the dictionary of document type icon targets that the template
         requires.
@@ -704,27 +683,12 @@ class CreateCommand(BaseCommand):
                     target=self.bundle_path(app) / targets,
                 )
 
-        for variant_or_size, targets in self.splash_image_targets(app).items():
-            try:
-                # Treat the targets as a dictionary of sizes;
-                # if there's no `items`, then it's a splash without variants
-                for size, target in targets.items():
-                    self.install_image(
-                        "splash image",
-                        source=app.splash,
-                        variant=variant_or_size,
-                        size=size,
-                        target=self.bundle_path(app) / target,
-                    )
-            except AttributeError:
-                # Either a single variant, or a single size.
-                self.install_image(
-                    "splash image",
-                    source=app.splash,
-                    variant=None,
-                    size=variant_or_size,
-                    target=self.bundle_path(app) / targets,
-                )
+        # Briefcase v0.3.18 - splash screens deprecated.
+        if getattr(app, "splash", None):
+            self.logger.warning(
+                "Splash screens are now configured based on the icon. "
+                "The splash configuration will be ignored."
+            )
 
         for extension, doctype in self.document_type_icon_targets(app).items():
             for size, target in doctype.items():

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -189,7 +189,6 @@ class AppConfig(BaseConfig):
         author_email=None,
         requires=None,
         icon=None,
-        splash=None,
         document_type=None,
         permission=None,
         template=None,
@@ -217,7 +216,6 @@ class AppConfig(BaseConfig):
         self.author_email = author_email
         self.requires = requires
         self.icon = icon
-        self.splash = splash
         self.document_types = {} if document_type is None else document_type
         self.permission = {} if permission is None else permission
         self.template = template

--- a/tests/commands/create/test_generate_app_template.py
+++ b/tests/commands/create/test_generate_app_template.py
@@ -36,7 +36,6 @@ def full_context():
         "author_email": "first@example.com",
         "requires": None,
         "icon": None,
-        "splash": None,
         "supported": True,
         "permissions": {},
         "custom_permissions": {},

--- a/tests/commands/create/test_install_app_resources.py
+++ b/tests/commands/create/test_install_app_resources.py
@@ -23,7 +23,7 @@ def test_no_resources(create_command):
     # Install app resources
     create_command.install_app_resources(myapp)
 
-    # No icons, splash image or document types, so no calls to install images
+    # No icons or document types, so no calls to install images
     install_image.assert_not_called()
 
 
@@ -180,8 +180,8 @@ def test_icon_variant_target(create_command, tmp_path):
     )
 
 
-def test_splash_target(create_command, tmp_path):
-    """If the template defines a splash target, it will be installed."""
+def test_splash_target(create_command, capsys):
+    """If the template defines a splash target, a warning will be raised."""
     myapp = AppConfig(
         app_name="my-app",
         formal_name="My App",
@@ -192,15 +192,8 @@ def test_splash_target(create_command, tmp_path):
         splash="images/splash",
     )
 
-    # Prime the path index with 2 splash targets
-    create_command._briefcase_toml[myapp] = {
-        "paths": {
-            "splash": {
-                "10x20": "path/to/splash-10x20.png",
-                "20x30": "path/to/splash-20x30.png",
-            }
-        }
-    }
+    # Prime an empty path index
+    create_command._briefcase_toml[myapp] = {"paths": {}}
 
     install_image = mock.MagicMock()
     create_command.install_image = install_image
@@ -208,46 +201,15 @@ def test_splash_target(create_command, tmp_path):
     # Install app resources
     create_command.install_app_resources(myapp)
 
-    # 2 calls to install splash images will be made
-    install_image.assert_has_calls(
-        [
-            mock.call(
-                "splash image",
-                source="images/splash",
-                variant=None,
-                size="10x20",
-                target=tmp_path
-                / "base_path"
-                / "build"
-                / "my-app"
-                / "tester"
-                / "dummy"
-                / "path"
-                / "to"
-                / "splash-10x20.png",
-            ),
-            mock.call(
-                "splash image",
-                source="images/splash",
-                variant=None,
-                size="20x30",
-                target=tmp_path
-                / "base_path"
-                / "build"
-                / "my-app"
-                / "tester"
-                / "dummy"
-                / "path"
-                / "to"
-                / "splash-20x30.png",
-            ),
-        ],
-        any_order=True,
-    )
+    # No calls to install splashes are made
+    install_image.assert_not_called()
+
+    # A warning about the splash configuration was raised.
+    assert "The splash configuration will be ignored." in capsys.readouterr().out
 
 
-def test_splash_variant_target(create_command, tmp_path):
-    """If the template defines a splash target with variants, they will be installed."""
+def test_splash_variant_target(create_command, capsys):
+    """If the template defines a splash target with variants, a warning is raised."""
     myapp = AppConfig(
         app_name="my-app",
         formal_name="My App",
@@ -261,18 +223,8 @@ def test_splash_variant_target(create_command, tmp_path):
         },
     )
 
-    # Prime the path index with 2 splash targets
-    create_command._briefcase_toml[myapp] = {
-        "paths": {
-            "splash": {
-                "portrait": "path/to/portrait.png",
-                "landscape": {
-                    "10x20": "path/to/landscape-10x20.png",
-                    "20x30": "path/to/landscape-20x30.png",
-                },
-            }
-        }
-    }
+    # Prime an empty path index
+    create_command._briefcase_toml[myapp] = {"paths": {}}
 
     install_image = mock.MagicMock()
     create_command.install_image = install_image
@@ -280,57 +232,11 @@ def test_splash_variant_target(create_command, tmp_path):
     # Install app resources
     create_command.install_app_resources(myapp)
 
-    # 3 calls to install splashes will be made
-    install_image.assert_has_calls(
-        [
-            mock.call(
-                "splash image",
-                source={"portrait": "images/portrait", "landscape": "images/landscape"},
-                variant=None,
-                size="portrait",  # This is expected for unsized variants
-                target=tmp_path
-                / "base_path"
-                / "build"
-                / "my-app"
-                / "tester"
-                / "dummy"
-                / "path"
-                / "to"
-                / "portrait.png",
-            ),
-            mock.call(
-                "splash image",
-                source={"portrait": "images/portrait", "landscape": "images/landscape"},
-                variant="landscape",
-                size="10x20",
-                target=tmp_path
-                / "base_path"
-                / "build"
-                / "my-app"
-                / "tester"
-                / "dummy"
-                / "path"
-                / "to"
-                / "landscape-10x20.png",
-            ),
-            mock.call(
-                "splash image",
-                source={"portrait": "images/portrait", "landscape": "images/landscape"},
-                variant="landscape",
-                size="20x30",
-                target=tmp_path
-                / "base_path"
-                / "build"
-                / "my-app"
-                / "tester"
-                / "dummy"
-                / "path"
-                / "to"
-                / "landscape-20x30.png",
-            ),
-        ],
-        any_order=True,
-    )
+    # No calls to install splashes are made
+    install_image.assert_not_called()
+
+    # A warning about the splash configuration was raised.
+    assert "The splash configuration will be ignored." in capsys.readouterr().out
 
 
 def test_doctype_icon_target(create_command, tmp_path):

--- a/tests/commands/create/test_properties.py
+++ b/tests/commands/create/test_properties.py
@@ -219,60 +219,6 @@ def test_icon_variants(create_command, myapp):
     }
 
 
-def test_no_splash(create_command, myapp):
-    """If no splash target is specified, the splash list is empty."""
-    bundle_path = create_command.bundle_path(myapp)
-    bundle_path.mkdir(parents=True)
-    with (bundle_path / "briefcase.toml").open("wb") as f:
-        index = {
-            "paths": {
-                "app_path": "path/to/app",
-            }
-        }
-        tomli_w.dump(index, f)
-
-    assert create_command.splash_image_targets(myapp) == {}
-
-
-def test_single_splash(create_command, myapp):
-    """If the splash target is specified as a single string, the splash list has one
-    unsized entry."""
-    bundle_path = create_command.bundle_path(myapp)
-    bundle_path.mkdir(parents=True)
-    with (bundle_path / "briefcase.toml").open("wb") as f:
-        index = {
-            "paths": {
-                "app_path": "path/to/app",
-                "splash": "path/to/splash.png",
-            }
-        }
-        tomli_w.dump(index, f)
-
-    assert create_command.splash_image_targets(myapp) == {None: "path/to/splash.png"}
-
-
-def test_multiple_splash(create_command, myapp):
-    """If there are multiple splash targets, they're all in the target list."""
-    bundle_path = create_command.bundle_path(myapp)
-    bundle_path.mkdir(parents=True)
-    with (bundle_path / "briefcase.toml").open("wb") as f:
-        index = {
-            "paths": {
-                "app_path": "path/to/app",
-                "splash": {
-                    "10x20": "path/to/splash-10.png",
-                    "20x30": "path/to/splash-20.png",
-                },
-            }
-        }
-        tomli_w.dump(index, f)
-
-    assert create_command.splash_image_targets(myapp) == {
-        "10x20": "path/to/splash-10.png",
-        "20x30": "path/to/splash-20.png",
-    }
-
-
 def test_no_document_types(create_command, myapp):
     """If no document type targets are specified, the document_type_icons list is
     empty."""

--- a/tests/commands/new/test_build_context.py
+++ b/tests/commands/new/test_build_context.py
@@ -475,11 +475,7 @@ class {{ cookiecutter.class_name }}(ppb.Scene):
     def __init__(self, **props):
         super().__init__(**props)
 
-        self.add(
-            ppb.Sprite(
-                image=ppb.Image("{{ cookiecutter.module_name }}/resources/{{ cookiecutter.app_name }}.png"),
-            )
-        )
+        # Add sprites and details to your scene here
 
 
 def main():
@@ -668,11 +664,6 @@ def main():
     metadata = importlib.metadata.metadata(app_module)
 
     os.environ["SDL_VIDEO_X11_WMCLASS"] = metadata["Formal-Name"]
-
-    # Set the app's runtime icon
-    pygame.display.set_icon(
-        pygame.image.load(Path(__file__).parent / "resources/{{ cookiecutter.app_name }}.png")
-    )
 
     pygame.init()
     pygame.display.set_caption(metadata["Formal-Name"])

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -28,9 +28,8 @@ def test_minimal_AppConfig():
     assert config.class_name == "myapp"
     assert config.document_types == {}
 
-    # There is no icon or splash of any kind
+    # There is no icon of any kind
     assert config.icon is None
-    assert config.splash is None
 
     # The PYTHONPATH is derived correctly
     assert config.PYTHONPATH(False) == ["src", "somewhere/else", ""]


### PR DESCRIPTION
Android has modified the handling of splash screens; custom splash screens are now ignored, in favor of an automatic splash screen based on the app icon. This leaves iOS as the only platform that still uses splash screens.

This PR removes the `splash` configuration option (raising a warning if it is specified).

Also modifies the PyGame and PPB bootstrap to remove icon customisation, as the default template will no longer include a bundled icon.

Fixes #1737.

Requires the template modifications from beeware/briefcase-iOS-Xcode-template#35 and beeware/briefcase-android-gradle-template#89.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
