### PR TITLE
Fix minor holes in PEP-508 name validation

### DIFF
--- a/changes/1762.bugfix.rst
+++ b/changes/1762.bugfix.rst
@@ -1,0 +1,1 @@
+When creating a new project, the validation for App Name now rejects all non-ASCII values.

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -15,7 +15,11 @@ from briefcase.platforms import get_output_formats, get_platforms
 from .constants import RESERVED_WORDS
 from .exceptions import BriefcaseConfigError
 
-# PEP508 provides a basic restriction on naming
+# PEP 508 restricts the naming of modules. The PEP defines a regex that uses
+# re.IGNORECASE; but in in practice, packaging uses a version that rolls out the lower
+# case, which has very slightly different semantics with non-ASCII characters. This
+# definition is the one from
+# https://github.com/pypa/packaging/blob/24.0/src/packaging/_tokenizer.py#L80
 PEP508_NAME_RE = re.compile(r"^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])$")
 
 

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -16,7 +16,7 @@ from .constants import RESERVED_WORDS
 from .exceptions import BriefcaseConfigError
 
 # PEP508 provides a basic restriction on naming
-PEP508_NAME_RE = re.compile(r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", re.IGNORECASE)
+PEP508_NAME_RE = re.compile(r"^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])$")
 
 
 def is_valid_pep508_name(app_name):

--- a/tests/commands/new/test_validate_app_name.py
+++ b/tests/commands/new/test_validate_app_name.py
@@ -10,7 +10,6 @@ import pytest
         "42helloworld",  # ?? Are we sure this is correct?
         "hello_world",
         "hello-world",
-        "helloworld_ı",
     ],
 )
 def test_valid_app_name(new_command, name):

--- a/tests/config/test_is_valid_app_name.py
+++ b/tests/config/test_is_valid_app_name.py
@@ -34,9 +34,10 @@ def test_is_valid_app_name(name):
         "main",
         "socket",
         "test",
-        # İ and K (i.e. 0x212a) are valid ASCII when made lowercase and as such are
-        # accepted by the PEP-508 regex...but these should be rejected here to ensure
-        # compliance where app name is used downstream and only ASCII is accepted.
+        # ı, İ and K (i.e. 0x212a) are valid ASCII when made lowercase and as such are
+        # accepted by the official PEP 508 regex... but they are rejected here to ensure
+        # compliance with the regex that is used in practice.
+        "helloworld_ı",
         "İstanbul",
         "Kelvin",
     ],

--- a/tests/config/test_is_valid_app_name.py
+++ b/tests/config/test_is_valid_app_name.py
@@ -34,6 +34,11 @@ def test_is_valid_app_name(name):
         "main",
         "socket",
         "test",
+        # İ and K (i.e. 0x212a) are valid ASCII when made lowercase and as such are
+        # accepted by the PEP-508 regex...but these should be rejected here to ensure
+        # compliance where app name is used downstream and only ASCII is accepted.
+        "İstanbul",
+        "Kelvin",
     ],
 )
 def test_is_invalid_app_name(name):


### PR DESCRIPTION
## Changes
- This resolves a hole in the recommended implementation of name validation from [PEP-508](https://peps.python.org/pep-0508/#names) to avoid allowing non-ASCII values.
```
The regex (run with re.IGNORECASE) is:

^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$
```
- The implementation of `re.IGNORECASE` is ostensibly coercing the case of the input because it will match on non-ASCII.
  - This matters for, at least, İ ([0x130](https://everythingfonts.com/unicode/0x0130)) and K ([0x212a](https://everythingfonts.com/unicode/0x212A)).
```pycon
>>> import re
>>> PEP508_NAME_RE = re.compile(r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", re.IGNORECASE)
>>> 
>>> bool(PEP508_NAME_RE.match("helloworld"))
True
>>> bool(PEP508_NAME_RE.match("İstanbul"))
True
>>> bool(PEP508_NAME_RE.match("Kelvin"))
True
>>> bool(PEP508_NAME_RE.match("Æolia"))
False
>>> bool(PEP508_NAME_RE.match("jalapeño"))
False
>>> bool(PEP508_NAME_RE.match("Beyoncé"))
False
>>> bool(PEP508_NAME_RE.match("naïve"))
False
```

## Related
- https://github.com/beeware/briefcase/issues/1011

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct