### PR TITLE
Ensure macOS apps pick up new icons after an update

### DIFF
--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -686,8 +686,8 @@ class CreateCommand(BaseCommand):
         # Briefcase v0.3.18 - splash screens deprecated.
         if getattr(app, "splash", None):
             self.logger.warning(
-                "Splash screens are now configured based on the icon. "
-                "The splash configuration will be ignored."
+                "\nSplash screens are now configured based on the icon. "
+                "The splash configuration will be ignored.\n"
             )
 
         for extension, doctype in self.document_type_icon_targets(app).items():

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -717,6 +717,7 @@ To run your application, type:
 
     $ cd {context['app_name']}
     $ briefcase dev
+
 """
         )
 

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -42,6 +42,13 @@ class macOSMixin:
 class macOSCreateMixin(AppPackagesMergeMixin):
     hidden_app_properties = {"permission", "entitlement"}
 
+    def install_app_resources(self, app: AppConfig):
+        super().install_app_resources(app)
+
+        # macOS will cache application icons. Touching the .app folder flushes the icon
+        # cache for the app, ensuring the current icon is loaded.
+        self.binary_path(app).touch(exist_ok=True)
+
     def _install_app_requirements(
         self,
         app: AppConfig,

--- a/tests/platforms/macOS/app/test_create.py
+++ b/tests/platforms/macOS/app/test_create.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from unittest import mock
@@ -283,6 +284,24 @@ def test_permissions_context(
     x_permissions = create_command._x_permissions(first_app)
     # Check that the final platform permissions are rendered as expected.
     assert context == create_command.permissions_context(first_app, x_permissions)
+
+
+def test_install_app_resources(create_command, first_app_templated, tmp_path):
+    """The app bundle's modification time is updated when app resources are
+    installed."""
+    # Get the initial app modification time
+    initial_timestamp = os.path.getmtime(
+        create_command.binary_path(first_app_templated)
+    )
+
+    # Install resources
+    create_command.install_app_resources(first_app_templated)
+
+    # Modification time has been updated, and is newer
+    assert (
+        os.path.getmtime(create_command.binary_path(first_app_templated))
+        > initial_timestamp
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
With the switch to Toga using the binary's icon at runtime, a new bug emerges - macOS caches app icons. When using the app template, and you change the app icon, the app bundle on the filesystem will be updated, but starting the app will show the old icon.

If you re-create the app, the new icon is displayed.

The cache key appears to be the modification time on the .app bundle itself; if you touch the bundle as part of an update, the new icon is loaded.

This didn't affect the Xcode template because every run is a new build, which implicitly touches the .app bundle.

This PR force touches the .app bundle on the macOS backends to ensure that the icon cache is busted.

Includes a coupe of cosmetic whitespace updates for good measure.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
