### PR TITLE
Add timestamp when generating requirements.txt

### DIFF
--- a/changes/1721.bugfix.rst
+++ b/changes/1721.bugfix.rst
@@ -1,0 +1,1 @@
+When using ``-r/--update-requirements`` for building for Android, the app's requirements are always reinstalled now.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -6,7 +6,7 @@ import platform
 import shutil
 import subprocess
 import sys
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 
 import briefcase
@@ -399,6 +399,9 @@ class CreateCommand(BaseCommand):
         with self.input.wait_bar("Writing requirements file..."):
             with requirements_path.open("w", encoding="utf-8") as f:
                 if requires:
+                    # Add timestamp so build systems (such as Gradle) detect a change
+                    # in the file and perform a re-installation of all requirements.
+                    f.write(f"# Generated {datetime.now()}\n")
                     for requirement in requires:
                         # If the requirement is a local path, convert it to
                         # absolute, because Flatpak moves the requirements file


### PR DESCRIPTION
## Changes
- Since Gradle will only reinstall the requirements if the requirements.txt file changes, this ensures the file has a different hash and performs the reinstallation.
- This aligns Android builds with other output formats where `briefcase build -r` always reinstalls all requirements.
- Closes #1721

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct