### PR TITLE
Normalize usage of newlines.

### DIFF
--- a/changes/1769.misc.rst
+++ b/changes/1769.misc.rst
@@ -1,0 +1,1 @@
+The usage of newlines in a message was modified to be consistent with line autosplitting.

--- a/changes/1769.misc.rst
+++ b/changes/1769.misc.rst
@@ -1,1 +1,1 @@
-The usage of newlines in a message was modified to be consistent with line autosplitting.
+The usage of newlines in a message was modified to be consistent with line splitting.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -685,11 +685,13 @@ class CreateCommand(BaseCommand):
 
         # Briefcase v0.3.18 - splash screens deprecated.
         if getattr(app, "splash", None):
+            self.logger.warning()
             self.logger.warning(
-                "\nSplash screens are now configured based on the icon. "
-                "The splash configuration will be ignored.\n"
+                "Splash screens are now configured based on the icon. "
+                "The splash configuration will be ignored."
             )
 
+        self.logger.info()
         for extension, doctype in self.document_type_icon_targets(app).items():
             for size, target in doctype.items():
                 self.install_image(

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -691,8 +691,8 @@ class CreateCommand(BaseCommand):
                 "The splash configuration will be ignored."
             )
 
-        self.logger.info()
         for extension, doctype in self.document_type_icon_targets(app).items():
+            self.logger.info()
             for size, target in doctype.items():
                 self.install_image(
                     f"icon for .{extension} documents",


### PR DESCRIPTION
#1766 included a newline cleanup that isn't entirely compatible with the line splitting approach being used.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
