### PR TITLE
OpenSUSE packages depend on `libcanberra-gtk3-module`, not `libcanberra-gtk3-0`

### DIFF
--- a/changes/1774.bugfix.rst
+++ b/changes/1774.bugfix.rst
@@ -1,0 +1,1 @@
+Packages created for OpenSUSE now depend on ``libcanberra-gtk3-module`` instead of ``libcanberra-gtk3-0``.

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -120,7 +120,7 @@ system_runtime_requires = [
     # Needed to support Python bindings to GTK
     "gobject-introspection", "typelib(Gtk) = 3.0",
     # Dependencies that GTK looks for at runtime
-    "libcanberra-gtk3-0",
+    "libcanberra-gtk3-module",
     # Needed to provide WebKit2 at runtime
     # "libwebkit2gtk3", "typelib(WebKit2)",
 ]

--- a/tests/commands/new/test_build_context.py
+++ b/tests/commands/new/test_build_context.py
@@ -159,7 +159,7 @@ system_runtime_requires = [
     # Needed to support Python bindings to GTK
     "gobject-introspection", "typelib(Gtk) = 3.0",
     # Dependencies that GTK looks for at runtime
-    "libcanberra-gtk3-0",
+    "libcanberra-gtk3-module",
     # Needed to provide WebKit2 at runtime
     # "libwebkit2gtk3", "typelib(WebKit2)",
 ]
@@ -1104,7 +1104,7 @@ system_runtime_requires = [
     # Needed to support Python bindings to GTK
     "gobject-introspection", "typelib(Gtk) = 3.0",
     # Dependencies that GTK looks for at runtime
-    "libcanberra-gtk3-0",
+    "libcanberra-gtk3-module",
     # Needed to provide WebKit2 at runtime
     # "libwebkit2gtk3", "typelib(WebKit2)",
 ]


### PR DESCRIPTION
## Changes
- OpenSUSE packaging now depends on the correct canberra module package

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct