### PR TITLE
Only upload the briefcase assets to the release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           name: ${{ env.VERSION }}
           draft: true
-          artifacts: dist/*
+          artifacts: dist/${{ github.event.repository.name }}*
           artifactErrorsFailBuild: true
 
       - name: Publish release to Test PyPI

--- a/changes/1777.misc.rst
+++ b/changes/1777.misc.rst
@@ -1,0 +1,1 @@
+The release workflow was modified to exclude non-releasable artefacts.


### PR DESCRIPTION

The [release workflow for v0.3.18](https://github.com/beeware/briefcase/actions/runs/8964252321/job/24616241803) technically failed because the TestPyPI publication didn't complete. It did [successfully create the release](https://test.pypi.org/project/briefcase/0.3.18), but it attempted (and was unable) to upload the x-briefcase wheels that are used for testing purposes.

This PR filters the release asset list to only include the "true" briefcase assets.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
