### PR TITLE
Bump Android SDK Commandline Tools from 9.0 to 12.0

### DIFF
--- a/changes/1778.feature.rst
+++ b/changes/1778.feature.rst
@@ -1,0 +1,1 @@
+Android SDK Commandline Tools 12.0 is now used to build Android apps.

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -37,7 +37,7 @@ If you have an existing install of the Android SDK, it will be used by Briefcase
 if the ``ANDROID_HOME`` environment variable is set. If ``ANDROID_HOME`` is not
 present in the environment, Briefcase will honor the deprecated
 ``ANDROID_SDK_ROOT`` environment variable. Additionally, an existing SDK install
-must have version 9.0 of Command-line Tools installed; this version can be
+must have version 12.0 of Command-line Tools installed; this version can be
 installed in the SDK Manager in Android Studio.
 
 Packaging format

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -48,10 +48,10 @@ class AndroidSDK(ManagedTool):
     name = "android_sdk"
     full_name = "Android SDK"
 
-    # Latest version for Command-Line Tools download as of August 2023
-    # **Be sure the android.rst docs stay in sync with version updates here**
-    SDK_MANAGER_DOWNLOAD_VER = "9477386"
-    SDK_MANAGER_VER = "9.0"
+    # Latest version for Command-Line Tools download as of May 2024
+    # **Be sure the gradle.rst docs stay in sync with version updates here**
+    SDK_MANAGER_DOWNLOAD_VER = "11076708"
+    SDK_MANAGER_VER = "12.0"
 
     def __init__(self, tools: ToolCache, root_path: Path):
         super().__init__(tools=tools)
@@ -1204,7 +1204,13 @@ In future, you can specify this device by running:
                         "--device",
                         device_type,
                     ],
-                    env=self.env,
+                    # Ensure XDG_CONFIG_HOME is not set so avdmanager uses the default
+                    # location (i.e. ~/.android) because the emulator does not respect
+                    # XDG_CONFIG_HOME and will not be able to find the AVD to run it.
+                    env={
+                        **self.env,
+                        **{"XDG_CONFIG_HOME": None},
+                    },
                 )
             except subprocess.CalledProcessError as e:
                 raise BriefcaseCommandError("Unable to create Android emulator") from e

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -302,8 +302,11 @@ class Subprocess(Tool):
         # This is a no-op; the native subprocess environment is ready-to-use.
         yield subprocess_kwargs
 
-    def full_env(self, overrides: dict[str, str]) -> dict[str, str]:
+    def full_env(self, overrides: dict[str, str | None] | None) -> dict[str, str]:
         """Generate the full environment in which the command will run.
+
+        If an env var in `overrides` is set to `None`, then that env var
+        will be altogether absent in the returned environment.
 
         :param overrides: The environment passed to the subprocess call;
             can be `None` if there are no explicit environment changes.
@@ -311,6 +314,7 @@ class Subprocess(Tool):
         env = self.tools.os.environ.copy()
         if overrides:
             env.update(overrides)
+            env = {k: v for k, v in env.items() if v is not None}
         return env
 
     def final_kwargs(self, **kwargs) -> dict[str, str]:

--- a/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
@@ -100,7 +100,10 @@ def test_create_emulator(
             "--device",
             "slab",
         ],
-        env=android_sdk.env,
+        env={
+            **android_sdk.env,
+            **{"XDG_CONFIG_HOME": None},
+        },
     )
 
     # Emulator configuration file has been appended.
@@ -173,7 +176,10 @@ def test_create_emulator_with_defaults(
             "--device",
             "pixel",
         ],
-        env=android_sdk.env,
+        env={
+            **android_sdk.env,
+            **{"XDG_CONFIG_HOME": None},
+        },
     )
 
     # Emulator configuration file has been appended.
@@ -220,7 +226,10 @@ def test_create_failure(mock_tools, android_sdk):
             "--device",
             "pixel",
         ],
-        env=android_sdk.env,
+        env={
+            **android_sdk.env,
+            **{"XDG_CONFIG_HOME": None},
+        },
     )
 
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -115,7 +115,7 @@ def test_supported_os_arch(mock_tools, host_os, host_arch, tmp_path):
 
     # Create `sdkmanager` and the license file.
     android_sdk_root_path = tmp_path / "tools/android_sdk"
-    tools_bin = android_sdk_root_path / "cmdline-tools/9.0/bin"
+    tools_bin = android_sdk_root_path / f"cmdline-tools/{SDK_MGR_VER}/bin"
     tools_bin.mkdir(parents=True, mode=0o755)
     if host_os == "Windows":
         sdk_manager = tools_bin / "sdkmanager.bat"

--- a/tests/integrations/android_sdk/conftest.py
+++ b/tests/integrations/android_sdk/conftest.py
@@ -10,8 +10,8 @@ from briefcase.integrations.java import JDK
 from briefcase.integrations.subprocess import Subprocess
 
 # current versions of Android SDK Manager
-SDK_MGR_VER = "9.0"
-SDK_MGR_DL_VER = "9477386"
+SDK_MGR_VER = "12.0"
+SDK_MGR_DL_VER = "11076708"
 
 
 @pytest.fixture

--- a/tests/integrations/subprocess/test_Subprocess__final_kwargs.py
+++ b/tests/integrations/subprocess/test_Subprocess__final_kwargs.py
@@ -49,6 +49,20 @@ def test_env_overrides(mock_sub):
     }
 
 
+def test_env_overrides_none(mock_sub):
+    """Any overrides set to None are absent in the final kwargs."""
+    assert mock_sub.final_kwargs(env={"NEWVAR": "val", "VAR1": None, "VAR2": None}) == {
+        "env": {
+            "PS1": "\nLine 2\n\nLine 4",
+            "PWD": "/home/user/",
+            "NEWVAR": "val",
+        },
+        "text": True,
+        "encoding": CONSOLE_ENCODING,
+        "errors": "backslashreplace",
+    }
+
+
 def test_cwd_provided(mock_sub):
     """If a cwd is provided, it is reflected in the environment."""
     cwd_override = "/my/current/path"


### PR DESCRIPTION
## Changes
-  Requires Android Commandline Tools 12.0
- Whether using Briefcase's SDK install or a user-managed one, version 12.0 will just be installed if it isn't already

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct