### PR TITLE
Limit automatic version updates to once a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,14 @@
-
 version: 2
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates on Sunday, 8PM UTC
-      interval: "weekly"
-      day: "sunday"
-      time: "20:00"
+      interval: "monthly"
+      time: "00:00"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      # Check for updates on Sunday, 8PM UTC
-      interval: "weekly"
-      day: "sunday"
-      time: "20:00"
+      interval: "monthly"
+      time: "00:00"

--- a/.github/workflows/config-file-deps-bump.yml
+++ b/.github/workflows/config-file-deps-bump.yml
@@ -2,7 +2,7 @@ name: Bump Config File Dependencies
 
 on:
   schedule:
-    - cron: "0 20 * * SUN"  # Sunday @ 2000 UTC
+    - cron: "0 0 1 * *"  # first of the month @ 0000 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -2,7 +2,7 @@ name: Update pre-commit
 
 on:
   schedule:
-    - cron: "0 20 * * SUN"  # Sunday @ 2000 UTC
+    - cron: "0 0 1 * *"  # first of the month @ 0000 UTC
   workflow_dispatch:
 
 jobs:

--- a/changes/1797.misc.rst
+++ b/changes/1797.misc.rst
@@ -1,0 +1,1 @@
+Automation to bump the version for dependencies only runs the first of the month now.


### PR DESCRIPTION
## Changes
- Dependabot, pre-commit, and config file version updates only run on the first of the month now
- The cuts down on the chore load to merge all these PRs and may help avoid some of the occasional broken minor releases for dependencies

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct