### PR TITLE
issue1746- fixed the toml escape 

### DIFF
--- a/changes/1746.bugfix.rst
+++ b/changes/1746.bugfix.rst
@@ -1,0 +1,2 @@
+TOMLEscape class was fixed to properly escape doublequotes and backslash and the test files were corrected accordingly.
+Now author creation can include single and double quotes at the time of creation

--- a/changes/1746.bugfix.rst
+++ b/changes/1746.bugfix.rst
@@ -1,2 +1,1 @@
-TOMLEscape class was fixed to properly escape doublequotes and backslash and the test files were corrected accordingly.
-Now author creation can include single and double quotes at the time of creation
+Escaping of quotation marks in TOML templates was corrected.

--- a/src/briefcase/integrations/cookiecutter.py
+++ b/src/briefcase/integrations/cookiecutter.py
@@ -61,9 +61,10 @@ class TOMLEscape(Extension):
         super().__init__(environment)
 
         def escape_toml(obj):
-            """Escapes double quotes and backslashes."""
-            return obj.replace('"', '"').replace("\\", "\\\\")
-
+            """Escapes string to match toml string requirements 
+            https://toml.io/en/         v1.0.0#string."""
+            return obj.replace("\\", "\\\\").replace('"', '\\"')
+            
         def escape_non_ascii(obj):
             """Quotes obj if non ascii characters are present."""
             if obj.isascii():

--- a/src/briefcase/integrations/cookiecutter.py
+++ b/src/briefcase/integrations/cookiecutter.py
@@ -61,8 +61,7 @@ class TOMLEscape(Extension):
         super().__init__(environment)
 
         def escape_toml(obj):
-            """Escapes string to match toml string requirements
-            https://toml.io/en/         v1.0.0#string."""
+            """Escapes double quotes and backslashes."""
             return obj.replace("\\", "\\\\").replace('"', '\\"')
 
         def escape_non_ascii(obj):

--- a/src/briefcase/integrations/cookiecutter.py
+++ b/src/briefcase/integrations/cookiecutter.py
@@ -61,10 +61,10 @@ class TOMLEscape(Extension):
         super().__init__(environment)
 
         def escape_toml(obj):
-            """Escapes string to match toml string requirements 
+            """Escapes string to match toml string requirements
             https://toml.io/en/         v1.0.0#string."""
             return obj.replace("\\", "\\\\").replace('"', '\\"')
-            
+
         def escape_non_ascii(obj):
             """Quotes obj if non ascii characters are present."""
             if obj.isascii():

--- a/tests/integrations/cookiecutter/test_TOMLEscape.py
+++ b/tests/integrations/cookiecutter/test_TOMLEscape.py
@@ -10,7 +10,7 @@ from briefcase.integrations.cookiecutter import TOMLEscape
     [
         # Single digit minor
         ("Hello World", "Hello World"),
-        ('Hello " World', 'Hello " World'),
+        ('Hello " World', 'Hello \\" World'),
         ("Hello \\ World", "Hello \\\\ World"),
     ],
 )


### PR DESCRIPTION
TOMLEscape class was fixed to properly escape doublequotes and backslash and the test files were corrected accordingly.
Now author creation can include single and double quotes at the time of creation
PR relates to an issue,  Fixes #1746 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
