### PR TITLE
Added documentation describing manual signing requirement for Android packages

### DIFF
--- a/changes/1703.doc.rst
+++ b/changes/1703.doc.rst
@@ -1,0 +1,1 @@
+Added documentation describing manual signing requirement for Android packages.

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -384,6 +384,6 @@ us to support, please visit the `issue tracker
 While it is possible to use `briefcase package android` to produce an APK or AAB
 file for distribution, the file is *not* usable as-is. It must be signed
 regardless of whether you're distributing your app through the Play Store, or
-ad-hoc via sideloading an APK. For details on how to manually sign your code,
+via loading the APK directly. For details on how to manually sign your code,
 see the instructions on `signing an Android App Bundle
 <https://briefcase.readthedocs.io/en/stable/how-to/publishing/android.html#sign-the-android-app-bundle>`__.```

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -382,7 +382,7 @@ us to support, please visit the `issue tracker
 <https://github.com/chaquo/chaquopy/issues>`__ and provide details about that package.
 
 Additionally: while it is possible to use `briefcase package android` to produce an APK or
-AAB file for distribution, the file is not usable as-is. It must be manually signed regardless
+AAB file for distribution, the file is NOT usable as-is. It must be manually signed regardless
 of whether you're distributing your app by means of the Play Store or ad-hoc via APK. For details on
 how to manually sign your code, see `Sign the Android App Bundle <https://briefcase.readthedocs.
 io/en/stable/how-to/publishing/android.html#sign-the-android-app-bundle>`__.

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -381,8 +381,9 @@ can be submitted as pull requests. Or, if you have a particular package that you
 us to support, please visit the `issue tracker
 <https://github.com/chaquo/chaquopy/issues>`__ and provide details about that package.
 
-Additionally: while it is possible to use `briefcase package android` to produce an APK or
-AAB file for distribution, the file is NOT usable as-is. It must be manually signed regardless
-of whether you're distributing your app by means of the Play Store or ad-hoc via APK. For details on
-how to manually sign your code, see `Sign the Android App Bundle <https://briefcase.readthedocs.
-io/en/stable/how-to/publishing/android.html#sign-the-android-app-bundle>`__.
+While it is possible to use `briefcase package android` to produce an APK or AAB
+file for distribution, the file is *not* usable as-is. It must be signed
+regardless of whether you're distributing your app through the Play Store, or
+ad-hoc via sideloading an APK. For details on how to manually sign your code,
+see the instructions on `signing an Android App Bundle
+<https://briefcase.readthedocs.io/en/stable/how-to/publishing/android.html#sign-the-android-app-bundle>`__.```

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -380,3 +380,9 @@ recipes for building the packages that are stored in the `secondary package repo
 can be submitted as pull requests. Or, if you have a particular package that you'd like
 us to support, please visit the `issue tracker
 <https://github.com/chaquo/chaquopy/issues>`__ and provide details about that package.
+
+Additionally: while it is possible to use `briefcase package android` to produce an APK or
+AAB file for distribution, the file is not usable as-is. It must be manually signed regardless
+of whether you're distributing your app by means of the Play Store or ad-hoc via APK. For details on
+how to manually sign your code, see `Sign the Android App Bundle <https://briefcase.readthedocs.
+io/en/stable/how-to/publishing/android.html#sign-the-android-app-bundle>`__.


### PR DESCRIPTION
Wrote documentation under "Platform quirks" describing the need for Android packages to be manually signed regardless of distribution method. Linked to [this page](https://briefcase.readthedocs.io/en/stable/how-to/publishing/android.html#sign-the-android-app-bundle) describing how to sign your app bundle. Previously, the documentation didn't make note of the need to manually sign these bundles. 

Fixes Issue #1703 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
