### PR TITLE
M1 to Apple Silicon

### DIFF
--- a/docs/background/releases.rst
+++ b/docs/background/releases.rst
@@ -466,12 +466,12 @@ Features
 --------
 
 * Apps can be updated as part of a call to package. (#473)
-* The Android emulator can now be used on Apple M1 hardware. (#616)
+* The Android emulator can now be used on Apple Silicon hardware. (#616)
 * Names that are reserved words in Python (or other common programming languages) are now prevented when creating apps. (#617)
 * Names that are invalid on Windows as filenames (such as CON and LPT0) are now invalid as app names. (#685)
 * Verbose logging via ``-v`` and ``-vv`` now includes the return code, output, and environment variables for shell commands (#704)
 * When the output of a wrapped command cannot be parsed, full command output, and failure reason is now logged. (#728)
-* The iOS emulator will now run apps natively on M1 hardware, rather than through Rosetta emulation. (#739)
+* The iOS emulator will now run apps natively on Apple Silicon hardware, rather than through Rosetta emulation. (#739)
 
 
 Bugfixes
@@ -481,7 +481,7 @@ Bugfixes
 * The error reporting when the user is on an unsupported platform or Python version has been improved. (#541)
 * When the formal name uses non-Latin characters, the suggested Class and App names are now valid. (#612)
 * The code signing process for macOS apps has been made more robust. (#652)
-* macOS app binaries are now adhoc signed by default, ensuring they can run on M1 hardware. (#664)
+* macOS app binaries are now adhoc signed by default, ensuring they can run on Apple Silicon hardware. (#664)
 * Xcode version checks are now more robust. (#668)
 * Android projects that have punctuation in their formal names can now build without error. (#696)
 * Bundle name validation no longer excludes valid country identifiers (like ``in.example``). (#709)

--- a/docs/how-to/contribute-docs.rst
+++ b/docs/how-to/contribute-docs.rst
@@ -34,7 +34,7 @@ You'll also need to install the Enchant spell checking library.
 
       (venv) $ brew install enchant
 
-    If you're on an M1 machine, you'll also need to manually set the location
+    If you're on an Apple Silicon machine, you'll also need to manually set the location
     of the Enchant library:
 
     .. code-block:: console

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -93,7 +93,7 @@ class macOSAppBuildCommand(macOSAppMixin, macOSSigningMixin, BuildCommand):
         :param app: The application to build
         """
         # macOS apps don't have anything to compile, but they do need to be
-        # signed to be able to execute on M1 hardware - even if it's only an
+        # signed to be able to execute on Apple Silicon hardware - even if it's only an
         # ad-hoc signing identity. Apply an ad-hoc signing identity to the
         # app bundle.
         self.logger.info("Ad-hoc signing app...", prefix=app.app_name)

--- a/tox.ini
+++ b/tox.ini
@@ -118,7 +118,7 @@ package = wheel
 wheel_build_env = .pkg
 extras = docs
 passenv =
-    # On macOS M1, you need to manually set the location of the PyEnchant
+    # On macOS Apple Silicon, you need to manually set the location of the PyEnchant
     # library:
     #     export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.2.dylib
     PYENCHANT_LIBRARY_PATH


### PR DESCRIPTION
Changed instances of `M1` to `Apple Silicon` to accommodate for newer versions of Apple Silicon chips

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
