### PR TITLE
Bump pytest from 8.1.2 to 8.2.1

### DIFF
--- a/changes/1815.misc.rst
+++ b/changes/1815.misc.rst
@@ -1,0 +1,1 @@
+Pytest was bumped from version 8.1.2 to 8.2.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ dev = [
     # Pre-commit 3.6.0 deprecated support for Python 3.8
     "pre-commit == 3.5.0 ; python_version < '3.9'",
     "pre-commit == 3.7.1 ; python_version >= '3.9'",
-    "pytest == 8.1.2",
+    "pytest == 8.2.1",
     "pytest-xdist == 3.6.1",
     "setuptools_scm == 8.0.4",
     "tox == 4.15.0",


### PR DESCRIPTION
## Changes
- Pytest 8.2.0 had [issues](https://github.com/beeware/briefcase/pull/1755)....so, what about 8.2.1?

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct