### PR TITLE
Clarify where to package Android from

### DIFF
--- a/changes/1819.misc.rst
+++ b/changes/1819.misc.rst
@@ -1,0 +1,1 @@
+Android packaging documentation was clarified to describe the working directory.

--- a/changes/tbd.doc.rst
+++ b/changes/tbd.doc.rst
@@ -1,0 +1,1 @@
+Updated Android packaging documentation to clarify to run commands from the directory containing the toml file.

--- a/changes/tbd.doc.rst
+++ b/changes/tbd.doc.rst
@@ -1,1 +1,0 @@
-Updated Android packaging documentation to clarify to run commands from the directory containing the toml file.

--- a/docs/how-to/publishing/android.rst
+++ b/docs/how-to/publishing/android.rst
@@ -15,6 +15,7 @@ focuses on how to distribute a BeeWare app on the Google Play Store.
 Build the app in release mode
 -----------------------------
 
+To build the app, you must start from the directory containing the `pyproject.toml` file.
 Use Briefcase to build a release bundle for your application:
 
 .. tabs::


### PR DESCRIPTION
Added a sentence to the Android packaging documentation to clarify that you should run these commands from within the directory that has the `pyproject.toml` file.

While working on #1212, @mas192 ran into some trouble testing Android builds because the docs didn't say whether there was a way to run the build commands from another directory (like by specifying where the pyproject.toml is). It seems like there's not! This PR does not actually resolve #1212 , which will be addressed separately, but does address the confusion we encountered during testing.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ N/A ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
