### PR TITLE
Issue-1212: Bundle indentifier doesnt not check reserved words

### DIFF
--- a/changes/1212.bugfix.rst
+++ b/changes/1212.bugfix.rst
@@ -1,0 +1,1 @@
+Validation rules for bundle identifiers have been loosened. App IDs that contain country codes or language reserved words are no longer flagged as invalid.

--- a/changes/1212.misc.rst
+++ b/changes/1212.misc.rst
@@ -1,0 +1,7 @@
+Refactored config.py to accept anything but the following below
+
+- Free text.
+- Only one section.
+- underscore
+- comma
+- exclamation point

--- a/changes/1212.misc.rst
+++ b/changes/1212.misc.rst
@@ -1,7 +1,0 @@
-Refactored config.py to accept anything but the following below
-
-- Free text.
-- Only one section.
-- underscore
-- comma
-- exclamation point

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -87,15 +87,6 @@ def is_valid_bundle_identifier(bundle):
     if not VALID_BUNDLE_RE.match(bundle):
         return False
 
-    for part in bundle.split("."):
-        # *Some* 2-letter country codes are valid identifiers,
-        # even though they're reserved words; see:
-        #    https://www.oracle.com/java/technologies/javase/codeconventions-namingconventions.html
-        # `.do` *should* be on this list, but as of Apr 2022, `.do` breaks
-        # the Android build tooling.
-        if is_reserved_keyword(part) and part not in {"in", "is"}:
-            return False
-
     return True
 
 

--- a/tests/commands/new/test_validate_bundle.py
+++ b/tests/commands/new/test_validate_bundle.py
@@ -8,6 +8,10 @@ import pytest
         "com.example.more",
         "com.example42.more",
         "com.example-42.more",
+        "ca.example.issue1212",
+        "au.example.issue1212",
+        "in.example.issue1212",
+        "im.glyph.and.this.is.1212",
     ],
 )
 def test_valid_bundle(new_command, bundle):

--- a/tests/commands/new/test_validate_bundle.py
+++ b/tests/commands/new/test_validate_bundle.py
@@ -27,7 +27,6 @@ def test_valid_bundle(new_command, bundle):
         "com.hello_world",  # underscore
         "com.hello,world",  # comma
         "com.hello world!",  # exclamation point
-        "com.pass.example",  # Reserved word
     ],
 )
 def test_invalid_bundle(new_command, bundle):

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -170,10 +170,6 @@ def test_valid_bundle(bundle):
         "com.hello_world",  # underscore
         "com.hello,world",  # comma
         "com.hello world!",  # exclamation point
-        "com.pass",  # Python reserved word
-        "com.pass.example",  # Python reserved word
-        "com.switch",  # Java reserved word
-        "com.switch.example",  # Java reserved word
     ],
 )
 def test_invalid_bundle_identifier(bundle):

--- a/tests/config/test_is_valid_bundle_identifier.py
+++ b/tests/config/test_is_valid_bundle_identifier.py
@@ -28,12 +28,6 @@ def test_valid_bundle(bundle):
         "com.hello_world",  # underscore
         "com.hello,world",  # comma
         "com.hello world!",  # exclamation point
-        "com.pass",  # Python reserved word
-        "com.pass.example",  # Python reserved word
-        "com.switch",  # Java reserved word
-        "com.switch.example",  # Java reserved word
-        "int.example",  # Valid identifier with a reserved word as the TLD
-        "do.example",  # This *should* be valid by the Java spec, but Android chokes.
     ],
 )
 def test_invalid_bundle(bundle):


### PR DESCRIPTION
Refactored config.py to accept anything but the following below
 - Free text.
 - Only one section.
 - underscore
 - comma
 - exclamation point
Problem Solved: overly aggressive restriction on bundle identifiers

- Fixes #1212

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
