### PR TITLE
ISSUE-1472: Added xcrun debugging tips to error message for failed signing attempts

### DIFF
--- a/changes/1472.misc.rst
+++ b/changes/1472.misc.rst
@@ -1,0 +1,1 @@
+Added xcrun debugging tips to error message for failed signing attempts

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -686,10 +686,18 @@ password:
                         store_credentials = True
                     else:
                         raise BriefcaseCommandError(
-                            f"""Unable to submit {filename.relative_to(self.base_path)} for notarization.
-                                To examine this failure use `xcrun notarytool history` to find the submission-id,
-                                then use `xcrun notarytool log <submission-id>` for a log of the error.
-                            """
+                            f"""\
+Unable to submit {filename.relative_to(self.base_path)} for notarization.
+To find the cause of this failure, get the submission ID by running:
+
+    xcrun notarytool history
+    
+Then run: 
+
+    xcrun notarytool log <submission-id>
+    
+to generate a full log of the error.
+"""
                         ) from e
         finally:
             # Clean up house; we don't need the archive anymore.

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -686,7 +686,10 @@ password:
                         store_credentials = True
                     else:
                         raise BriefcaseCommandError(
-                            f"Unable to submit {filename.relative_to(self.base_path)} for notarization."
+                            f"""Unable to submit {filename.relative_to(self.base_path)} for notarization.
+                                To examine this failure use `xcrun notarytool history` to find the submission-id,
+                                then use `xcrun notarytool log <submission-id>` for a log of the error.
+                            """
                         ) from e
         finally:
             # Clean up house; we don't need the archive anymore.

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -691,11 +691,11 @@ Unable to submit {filename.relative_to(self.base_path)} for notarization.
 To find the cause of this failure, get the submission ID by running:
 
     xcrun notarytool history
-    
-Then run: 
+
+Then run:
 
     xcrun notarytool log <submission-id>
-    
+
 to generate a full log of the error.
 """
                         ) from e


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
This implements a bit of guidance for failed signing attempts on MacOS to smooth the issue described in #1472. Considering that we would need to run `xcrun notarytool history` to first find the `submission-id` of the failed signing attempt before running `xcrun notarytool log <submission-id>` to get the logs, all within the except of a try/except, it seems most sensible to just inform the user of how they could track down the error themselves.

Refs #1472 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
