### PR TITLE
Fix error on first run after iOS simulator update

### DIFF
--- a/changes/708.bugfix.rst
+++ b/changes/708.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed error on first run after iOS simulator update.

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -44,7 +44,7 @@ def json_parser(json_output: str) -> JsonT:
     :param json_output: command output to parse as JSON
     """
     try:
-        return json.loads(json_output)
+        return json.loads(json_output[json_output.index("{") :])
     except json.JSONDecodeError as e:
         raise ParseError(f"Failed to parse output as JSON: {e}") from e
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Added logic to the `JSON` parser in `subprocess.py` to grab everything from the first `{` forward. This makes sure that it's only parsing- for lack of better phrasing- _parseable_ stuff instead of just trying to parse the entire output, which contains "Install started, 1%... " on the first run after an iOS simulator update. Fixes #780.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
