### PR TITLE
Add a --clean option to the briefcase build command

### DIFF
--- a/changes/1830.feature.rst
+++ b/changes/1830.feature.rst
@@ -1,0 +1,1 @@
+Add a --clean option to the `briefcase build` command.

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from argparse import ArgumentParser
+
 import shutil
+from argparse import ArgumentParser
 
 from briefcase.config import AppConfig
 from briefcase.exceptions import BriefcaseCommandError
@@ -19,7 +20,7 @@ class BuildCommand(BaseCommand):
         parser.add_argument(
             "--clean",
             action="store_true",
-            help=f"Delete the build directory for this app and platform",
+            help="Delete the build directory for this app and platform",
         )
 
     def build_app(self, app: AppConfig, **options):
@@ -166,9 +167,7 @@ class BuildCommand(BaseCommand):
         )
 
         if not confirm:
-            self.logger.warning(
-                f"Aborting deleting build directory."
-            )
+            self.logger.warning("Aborting build cleaning.")
             return
 
         shutil.rmtree(build_path)

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -157,13 +157,17 @@ class BuildCommand(BaseCommand):
     def _clean_build_dir(self, app: AppConfig) -> None:
         build_path = self.bundle_path(app)
 
+        if not build_path.exists():
+            self.logger.warning(f"Nothing to clean ('{build_path}' doesn't exist)")
+            return
+
         confirm = self.input.boolean_input(
             f"Will delete '{build_path}'; are you sure", default=False
         )
 
         if not confirm:
             self.logger.warning(
-                f"Aborting cleaning build dir for app {app.app_name!r}; files will remain."
+                f"Aborting deleting build directory."
             )
             return
 

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -20,7 +20,7 @@ class BuildCommand(BaseCommand):
         parser.add_argument(
             "--clean",
             action="store_true",
-            help="Delete the build directory for this app and platform",
+            help="Delete the build directory for the specified format",
         )
 
     def build_app(self, app: AppConfig, **options):


### PR DESCRIPTION
I found myself wanting a quick way to wipe all build artifacts so I added a `--clean` option, as in `briefcase build macOS Xcode --clean`. Feel free to request changes or just close if that's not something the team is interested in.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested (but there's no `pytest` test)
- [x] All new features have been documented (appears in the `--help` output)
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

**edit**: just to be clear, i will add unit tests if this is actually a feature people are interested in