### PR TITLE
Ensure all files are unique for check-wheel-contents

### DIFF
--- a/changes/1839.misc.rst
+++ b/changes/1839.misc.rst
@@ -1,0 +1,1 @@
+Files with non-unique content were made unique so the packaged wheel passes ``check-wheel-contents``.

--- a/src/briefcase/platforms/linux/snap.py
+++ b/src/briefcase/platforms/linux/snap.py
@@ -1,1 +1,1 @@
-# An implementation would go here!
+# A Snap implementation would go here!

--- a/src/briefcase/platforms/tvOS/xcode.py
+++ b/src/briefcase/platforms/tvOS/xcode.py
@@ -1,1 +1,1 @@
-# An implementation would go here!
+# A tvOS implementation would go here!

--- a/src/briefcase/platforms/watchOS/xcode.py
+++ b/src/briefcase/platforms/watchOS/xcode.py
@@ -1,1 +1,1 @@
-# An implementation would go here!
+# A watchOS implementation would go here!

--- a/src/briefcase/platforms/wearos/gradle.py
+++ b/src/briefcase/platforms/wearos/gradle.py
@@ -1,1 +1,1 @@
-# An implementation would go here!
+# A Wear OS implementation would go here!


### PR DESCRIPTION
## Changes
- [hynek/build-and-inspect-python-package](https://github.com/hynek/build-and-inspect-python-package) runs [`check-wheel-contents`](https://pypi.org/project/check-wheel-contents/) and it requires the wheel contains zero duplicated files
- RE: https://github.com/beeware/.github/pull/137

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct