### PR TITLE
Add a UUID cookiecutter extension.

### DIFF
--- a/changes/1850.misc.rst
+++ b/changes/1850.misc.rst
@@ -1,0 +1,1 @@
+A UUID cookiecutter extension was added to support Windows MSI templating.

--- a/src/briefcase/integrations/cookiecutter.py
+++ b/src/briefcase/integrations/cookiecutter.py
@@ -1,5 +1,7 @@
 """Jinja2 extensions."""
 
+import uuid
+
 from jinja2.ext import Extension
 
 
@@ -116,3 +118,17 @@ class XMLExtension(Extension):
             return "true" if obj else "false"
 
         environment.filters["bool_attr"] = bool_attr
+
+
+class UUIDExtension(Extension):
+    """Extensions for generating UUIDs."""
+
+    def __init__(self, environment):
+        """Initialize the extension with the given environment."""
+        super().__init__(environment)
+
+        def dns_uuid5(obj):
+            """A DNS-based UUID5 object generated from the provided content."""
+            return str(uuid.uuid5(uuid.NAMESPACE_DNS, obj))
+
+        environment.filters["dns_uuid5"] = dns_uuid5

--- a/tests/integrations/cookiecutter/test_UUIDExtension.py
+++ b/tests/integrations/cookiecutter/test_UUIDExtension.py
@@ -1,0 +1,19 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from briefcase.integrations.cookiecutter import UUIDExtension
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("example.com", "cfbff0d1-9375-5685-968c-48ce8b15ae17"),
+        ("foobar.example.com", "941bbcd9-03e1-568a-a728-8434055bc338"),
+    ],
+)
+def test_dns_uuid5_value(value, expected):
+    env = MagicMock()
+    env.filters = {}
+    UUIDExtension(env)
+    assert env.filters["dns_uuid5"](value) == expected


### PR DESCRIPTION
Refs #1781 

Supporting console apps requires a UUID extension; to avoid a chicken-and-egg problem with landing the templates, this PR adds the UUID extension to Briefcase so that it can be landed; the templates can use it; and we can then land the templates; and then we can land #1781.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
