### PR TITLE
Update a reference to old-style bundle paths.

### DIFF
--- a/changes/1860.misc.rst
+++ b/changes/1860.misc.rst
@@ -1,0 +1,1 @@
+A reference to old-style app bundle paths was updated.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -207,8 +207,8 @@ to identify a specific compiled version of an application.
 
 A list of strings describing paths that will be *removed* from the project after
 the installation of the support package and app code. The paths provided will be
-interpreted relative to the app bundle folder (e.g., the ``macOS/app/My App``
-folder in the case of a macOS app).
+interpreted relative to the platform-specific build folder generated for the app
+(e.g., the ``build/my-app/macOS/app`` folder in the case of a macOS app).
 
 Paths can be:
  * An explicit reference to a single file


### PR DESCRIPTION
Fixes #1860.

The docs for `cleanup_paths` used the format for app bundle paths used before the introduction of the `build` and `dist` folders. The name "app bundle" has also proven ambiguous; Briefcase refers to the folder generated by template for a specific platform as the "bundle", but this terminology is also used by macOS to refer to the `.app` folder for an app.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
