### PR TITLE
Fix documentation of macOS entitlements configuration to make it clear that lists and dictionaries are also valid.

### DIFF
--- a/changes/1863.doc.rst
+++ b/changes/1863.doc.rst
@@ -1,1 +1,0 @@
-Fix documentation of macOS entitlements configuration to make it clear that lists and dictionaries are also valid.

--- a/changes/1863.doc.rst
+++ b/changes/1863.doc.rst
@@ -1,0 +1,1 @@
+Fix documentation of macOS entitlements configuration to make it clear that lists and dictionaries are also valid.

--- a/changes/1863.misc.rst
+++ b/changes/1863.misc.rst
@@ -1,0 +1,1 @@
+Documentation of valid plist types was corrected.

--- a/docs/reference/platforms/macOS/app.rst
+++ b/docs/reference/platforms/macOS/app.rst
@@ -72,7 +72,7 @@ will result in an ``Entitlements.plist`` declaration of::
 
     <key>com.apple.vm.networking</key><true/>
 
-Any Boolean or string value can be used for an entitlement value.
+Any Boolean, string, or list value can be used for an entitlement value.
 
 All macOS apps are automatically granted the following entitlements:
 

--- a/docs/reference/platforms/macOS/app.rst
+++ b/docs/reference/platforms/macOS/app.rst
@@ -72,9 +72,9 @@ will result in an ``Entitlements.plist`` declaration of::
 
     <key>com.apple.vm.networking</key><true/>
 
-Any Boolean, string, or list value can be used for an entitlement value.
+Any Boolean, string, list, or dictionary value can be used as an entitlement value.
 
-All macOS apps are automatically granted the following entitlements:
+All macOS apps are automatically granted the following entitlements by default:
 
 * ``com.apple.security.cs.allow-unsigned-executable-memory``
 * ``com.apple.security.cs.disable-library-validation``


### PR DESCRIPTION
Tested this out personally after @freakboy3742 told me the documentation was wrong.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
