### PR TITLE
Ensure consistent spacing for prompts for New Project wizard

### DIFF
--- a/changes/1896.bugfix.rst
+++ b/changes/1896.bugfix.rst
@@ -1,0 +1,1 @@
+The spacing after the New Project wizard prompts are now consistent.

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -417,7 +417,7 @@ class NewCommand(BaseCommand):
 
         self.prompt_intro(intro=intro)
         return _select_option(
-            prompt=f"{variable} [{default}]:",
+            prompt=f"{variable} [{default}]: ",
             input=self.input,
             default=default,
             options=list(zip(options, options)),

--- a/tests/commands/new/test_select_option.py
+++ b/tests/commands/new/test_select_option.py
@@ -42,7 +42,7 @@ def test_override_validation(new_command, mock_select_option, capsys):
         in capsys.readouterr().out
     )
     mock_select_option.assert_called_once_with(
-        prompt="Variable [1]:",
+        prompt="Variable [1]: ",
         input=new_command.input,
         default="1",
         options=[
@@ -63,7 +63,7 @@ def test_default_value_has_correct_index(new_command, mock_select_option):
         override_value=None,
     )
     mock_select_option.assert_called_once_with(
-        prompt="Variable [2]:",
+        prompt="Variable [2]: ",
         input=new_command.input,
         default="2",
         options=[
@@ -84,7 +84,7 @@ def test_default_default_is_one(new_command, mock_select_option):
         override_value=None,
     )
     mock_select_option.assert_called_once_with(
-        prompt="Variable [1]:",
+        prompt="Variable [1]: ",
         input=new_command.input,
         default="1",
         options=[


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct