### PR TITLE
Update URL provided when a project doesn't include it's own gradle config

### DIFF
--- a/changes/1905.bugfix.rst
+++ b/changes/1905.bugfix.rst
@@ -1,0 +1,1 @@
+Corrected link to ``build_gradle_dependencies`` documentation in warning message.

--- a/changes/1905.doc.rst
+++ b/changes/1905.doc.rst
@@ -1,2 +1,0 @@
-Changed android/gradle URL to https://briefcase.readthedocs.io/en/stable/reference/platforms/android/gradle.html#build-gradle-dependencies
-because the previous location no longer existed

--- a/changes/1905.doc.rst
+++ b/changes/1905.doc.rst
@@ -1,0 +1,2 @@
+Changed android/gradle URL to https://briefcase.readthedocs.io/en/stable/reference/platforms/android/gradle.html#build-gradle-dependencies
+because the previous location no longer existed

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -200,7 +200,7 @@ class GradleCreateCommand(GradleMixin, CreateCommand):
     You should add this definition to the Android configuration
     of your project's pyproject.toml file. See:
 
-        https://briefcase.readthedocs.io/en/stable/reference/platforms/android.html#build_gradle-dependencies
+        https://briefcase.readthedocs.io/en/stable/reference/platforms/android/gradle.html#build-gradle-dependencies
 
     for more information.
 


### PR DESCRIPTION
I was trying to experiment with pygame-ce builds on android, but I ran into a docs 404 error when I tried. This PR just points it to what I suspect is where it's meant to go

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] All new features have been tested
- [ ] All new features have been documented
- [ x ] I have read the **CONTRIBUTING.md** file
- [ x ] I will abide by the code of conduct
