### PR TITLE
Correct signing order for macOS bundles

### DIFF
--- a/automation/src/automation/bootstraps/pyside6.py
+++ b/automation/src/automation/bootstraps/pyside6.py
@@ -50,3 +50,14 @@ def main():
     main_window = {{{{ cookiecutter.class_name }}}}()
     sys.exit(app.exec())
 """
+
+    def pyproject_table_briefcase_app_extra_content(self):
+        # Include PySide6-Addons, even though it isn't used, as a way to exercise
+        # signing of apps that include nested frameworks and apps. See #1891 for
+        # details.
+        return """
+requires = [
+    "PySide6-Essentials~=6.5",
+    "PySide6-Addons~=6.5",
+]
+"""

--- a/automation/src/automation/bootstraps/pyside6.py
+++ b/automation/src/automation/bootstraps/pyside6.py
@@ -51,13 +51,13 @@ def main():
     sys.exit(app.exec())
 """
 
-    def pyproject_table_briefcase_app_extra_content(self):
-        # Include PySide6-Addons, even though it isn't used, as a way to exercise
-        # signing of apps that include nested frameworks and apps. See #1891 for
-        # details.
-        return """
+    def pyproject_table_macOS(self):
+        # Include PySide6-Addons on macOS, even though it isn't used, as a way to
+        # exercise signing of apps that include nested frameworks and apps. See #1891
+        # for details.
+        return """\
+universal_build = true
 requires = [
-    "PySide6-Essentials~=6.5",
     "PySide6-Addons~=6.5",
 ]
 """

--- a/changes/1891.bugfix.rst
+++ b/changes/1891.bugfix.rst
@@ -1,0 +1,1 @@
+The order in which nested frameworks and apps are signed on macOS was corrected.

--- a/tests/integrations/file/test_File__sorted_depth_first.py
+++ b/tests/integrations/file/test_File__sorted_depth_first.py
@@ -44,6 +44,19 @@ from ...utils import create_file
                 "foo/bar/e.txt",
             ],
         ),
+        # If a folder contains both folders and files, the folders are returned first.
+        (
+            [
+                "foo/bar/a",
+                "foo/bar/b.txt",
+                "foo/bar/c",
+            ],
+            [
+                "foo/bar/a",
+                "foo/bar/c",
+                "foo/bar/b.txt",
+            ],
+        ),
     ],
 )
 def test_sorted_depth_first(files, sorted, tmp_path):
@@ -54,6 +67,8 @@ def test_sorted_depth_first(files, sorted, tmp_path):
     for file_path in paths:
         if file_path.suffix:
             create_file(tmp_path / file_path, content=str(file_path))
+        else:
+            file_path.mkdir(parents=True, exist_ok=True)
 
     assert File.sorted_depth_first(paths) == [
         tmp_path / file_path for file_path in sorted

--- a/tests/integrations/file/test_File__sorted_depth_first.py
+++ b/tests/integrations/file/test_File__sorted_depth_first.py
@@ -1,0 +1,60 @@
+import pytest
+
+from briefcase.integrations.file import File
+
+from ...utils import create_file
+
+
+@pytest.mark.parametrize(
+    "files, sorted",
+    [
+        # Files in a directory are sorted lexically
+        (
+            ["foo/bar/a.txt", "foo/bar/c.txt", "foo/bar/b.txt"],
+            ["foo/bar/a.txt", "foo/bar/b.txt", "foo/bar/c.txt"],
+        ),
+        # Subfolders are sorted before files in that directory; but sorted lexically in themselves
+        (
+            [
+                "foo/bar/b",
+                "foo/bar/b/aaa.txt",
+                "foo/bar/b/zzz.txt",
+                "foo/bar/b/deeper",
+                "foo/bar/b/deeper/deeper_db2.txt",
+                "foo/bar/b/deeper/deeper_db1.txt",
+                "foo/bar/a.txt",
+                "foo/bar/c.txt",
+                "foo/bar/e.txt",
+                "foo/bar/d",
+                "foo/bar/d/deep_d2.txt",
+                "foo/bar/d/deep_d1.txt",
+            ],
+            [
+                "foo/bar/b/deeper/deeper_db1.txt",
+                "foo/bar/b/deeper/deeper_db2.txt",
+                "foo/bar/b/deeper",
+                "foo/bar/b/aaa.txt",
+                "foo/bar/b/zzz.txt",
+                "foo/bar/d/deep_d1.txt",
+                "foo/bar/d/deep_d2.txt",
+                "foo/bar/b",
+                "foo/bar/d",
+                "foo/bar/a.txt",
+                "foo/bar/c.txt",
+                "foo/bar/e.txt",
+            ],
+        ),
+    ],
+)
+def test_sorted_depth_first(files, sorted, tmp_path):
+    # Convert the strings into paths in the temp folder
+    paths = [tmp_path / file_path for file_path in files]
+
+    # Create all the paths that have a suffix
+    for file_path in paths:
+        if file_path.suffix:
+            create_file(tmp_path / file_path, content=str(file_path))
+
+    assert [
+        str(path.relative_to(tmp_path)) for path in File.sorted_depth_first(paths)
+    ] == sorted

--- a/tests/integrations/file/test_File__sorted_depth_first.py
+++ b/tests/integrations/file/test_File__sorted_depth_first.py
@@ -55,6 +55,6 @@ def test_sorted_depth_first(files, sorted, tmp_path):
         if file_path.suffix:
             create_file(tmp_path / file_path, content=str(file_path))
 
-    assert [
-        str(path.relative_to(tmp_path)) for path in File.sorted_depth_first(paths)
-    ] == sorted
+    assert File.sorted_depth_first(paths) == [
+        tmp_path / file_path for file_path in sorted
+    ]

--- a/tests/integrations/file/test_File__sorted_depth_first.py
+++ b/tests/integrations/file/test_File__sorted_depth_first.py
@@ -11,7 +11,7 @@ from ...utils import create_file
         # Files in a directory are sorted lexically
         (
             ["foo/bar/a.txt", "foo/bar/c.txt", "foo/bar/b.txt"],
-            ["foo/bar/a.txt", "foo/bar/b.txt", "foo/bar/c.txt"],
+            ["foo/bar/c.txt", "foo/bar/b.txt", "foo/bar/a.txt"],
         ),
         # Subfolders are sorted before files in that directory; but sorted lexically in themselves
         (
@@ -30,18 +30,18 @@ from ...utils import create_file
                 "foo/bar/d/deep_d1.txt",
             ],
             [
-                "foo/bar/b/deeper/deeper_db1.txt",
-                "foo/bar/b/deeper/deeper_db2.txt",
-                "foo/bar/b/deeper",
-                "foo/bar/b/aaa.txt",
-                "foo/bar/b/zzz.txt",
-                "foo/bar/d/deep_d1.txt",
                 "foo/bar/d/deep_d2.txt",
-                "foo/bar/b",
+                "foo/bar/d/deep_d1.txt",
+                "foo/bar/b/deeper/deeper_db2.txt",
+                "foo/bar/b/deeper/deeper_db1.txt",
+                "foo/bar/b/deeper",
+                "foo/bar/b/zzz.txt",
+                "foo/bar/b/aaa.txt",
                 "foo/bar/d",
-                "foo/bar/a.txt",
-                "foo/bar/c.txt",
+                "foo/bar/b",
                 "foo/bar/e.txt",
+                "foo/bar/c.txt",
+                "foo/bar/a.txt",
             ],
         ),
         # If a folder contains both folders and files, the folders are returned first.
@@ -52,8 +52,8 @@ from ...utils import create_file
                 "foo/bar/c",
             ],
             [
-                "foo/bar/a",
                 "foo/bar/c",
+                "foo/bar/a",
                 "foo/bar/b.txt",
             ],
         ),

--- a/tests/integrations/file/test_File__sorted_depth_first_groups.py
+++ b/tests/integrations/file/test_File__sorted_depth_first_groups.py
@@ -12,7 +12,7 @@ from ...utils import create_file
         (
             ["foo/bar/a.txt", "foo/bar/c.txt", "foo/bar/b.txt"],
             [
-                ["foo/bar/a.txt", "foo/bar/b.txt", "foo/bar/c.txt"],
+                ["foo/bar/c.txt", "foo/bar/b.txt", "foo/bar/a.txt"],
             ],
         ),
         # Subfolders are sorted before files in that directory, and in a different
@@ -33,12 +33,12 @@ from ...utils import create_file
                 "foo/bar/d/deep_d1.txt",
             ],
             [
-                ["foo/bar/b/deeper/deeper_db1.txt", "foo/bar/b/deeper/deeper_db2.txt"],
+                ["foo/bar/d/deep_d2.txt", "foo/bar/d/deep_d1.txt"],
+                ["foo/bar/b/deeper/deeper_db2.txt", "foo/bar/b/deeper/deeper_db1.txt"],
                 ["foo/bar/b/deeper"],
-                ["foo/bar/b/aaa.txt", "foo/bar/b/zzz.txt"],
-                ["foo/bar/d/deep_d1.txt", "foo/bar/d/deep_d2.txt"],
-                ["foo/bar/b", "foo/bar/d"],
-                ["foo/bar/a.txt", "foo/bar/c.txt", "foo/bar/e.txt"],
+                ["foo/bar/b/zzz.txt", "foo/bar/b/aaa.txt"],
+                ["foo/bar/d", "foo/bar/b"],
+                ["foo/bar/e.txt", "foo/bar/c.txt", "foo/bar/a.txt"],
             ],
         ),
         # If a folder contains both folders and files, the folders are in a different
@@ -51,8 +51,8 @@ from ...utils import create_file
             ],
             [
                 [
-                    "foo/bar/a",
                     "foo/bar/c",
+                    "foo/bar/a",
                 ],
                 [
                     "foo/bar/b.txt",

--- a/tests/integrations/file/test_File__sorted_depth_first_groups.py
+++ b/tests/integrations/file/test_File__sorted_depth_first_groups.py
@@ -1,0 +1,78 @@
+import pytest
+
+from briefcase.integrations.file import File
+
+from ...utils import create_file
+
+
+@pytest.mark.parametrize(
+    "files, groups",
+    [
+        # Files in a single directory are sorted lexically into the same group
+        (
+            ["foo/bar/a.txt", "foo/bar/c.txt", "foo/bar/b.txt"],
+            [
+                ["foo/bar/a.txt", "foo/bar/b.txt", "foo/bar/c.txt"],
+            ],
+        ),
+        # Subfolders are sorted before files in that directory, and in a different
+        # group; but sorted lexically in themselves
+        (
+            [
+                "foo/bar/b",
+                "foo/bar/b/aaa.txt",
+                "foo/bar/b/zzz.txt",
+                "foo/bar/b/deeper",
+                "foo/bar/b/deeper/deeper_db2.txt",
+                "foo/bar/b/deeper/deeper_db1.txt",
+                "foo/bar/a.txt",
+                "foo/bar/c.txt",
+                "foo/bar/e.txt",
+                "foo/bar/d",
+                "foo/bar/d/deep_d2.txt",
+                "foo/bar/d/deep_d1.txt",
+            ],
+            [
+                ["foo/bar/b/deeper/deeper_db1.txt", "foo/bar/b/deeper/deeper_db2.txt"],
+                ["foo/bar/b/deeper"],
+                ["foo/bar/b/aaa.txt", "foo/bar/b/zzz.txt"],
+                ["foo/bar/d/deep_d1.txt", "foo/bar/d/deep_d2.txt"],
+                ["foo/bar/b", "foo/bar/d"],
+                ["foo/bar/a.txt", "foo/bar/c.txt", "foo/bar/e.txt"],
+            ],
+        ),
+        # If a folder contains both folders and files, the folders are in a different
+        # group the files, and are returned first.
+        (
+            [
+                "foo/bar/a",
+                "foo/bar/b.txt",
+                "foo/bar/c",
+            ],
+            [
+                [
+                    "foo/bar/a",
+                    "foo/bar/c",
+                ],
+                [
+                    "foo/bar/b.txt",
+                ],
+            ],
+        ),
+    ],
+)
+def test_sorted_depth_first_groups(files, groups, tmp_path):
+    # Convert the strings into paths in the temp folder
+    paths = [tmp_path / file_path for file_path in files]
+
+    # Create files for all paths that have a suffix; otherwise, ensure the folder
+    # exists.
+    for file_path in paths:
+        if file_path.suffix:
+            create_file(tmp_path / file_path, content=str(file_path))
+        else:
+            file_path.mkdir(parents=True, exist_ok=True)
+
+    assert list(list(group) for group in File.sorted_depth_first_groups(paths)) == [
+        [tmp_path / file_path for file_path in group] for group in groups
+    ]

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -713,6 +713,6 @@ def test_sign_app_with_failure(
         # coverage we need to. However, win32 doesn't handle executable permissions
         # the same as linux/unix, `unknown.binary` is identified as a signing target.
         # We ignore this discrepancy for testing purposes.
-        assert len(output.strip("\n").split("\n")) == (7 if verbose else 1)
+        assert len(output.strip("\n").split("\n")) == (11 if verbose else 1)
     else:
-        assert len(output.strip("\n").split("\n")) == (6 if verbose else 1)
+        assert len(output.strip("\n").split("\n")) == (10 if verbose else 1)

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -713,6 +713,6 @@ def test_sign_app_with_failure(
         # coverage we need to. However, win32 doesn't handle executable permissions
         # the same as linux/unix, `unknown.binary` is identified as a signing target.
         # We ignore this discrepancy for testing purposes.
-        assert len(output.strip("\n").split("\n")) == (11 if verbose else 1)
+        assert len(output.strip("\n").split("\n")) == (9 if verbose else 1)
     else:
-        assert len(output.strip("\n").split("\n")) == (10 if verbose else 1)
+        assert len(output.strip("\n").split("\n")) == (8 if verbose else 1)


### PR DESCRIPTION
Fixes #1891.

Corrects the order in which files are signed in a macOS app bundle.

This manifests if you sign an PySide app that includes PySide-Addons. This package contains a number of frameworks; these frameworks contain embedded applications. These applications must be signed *before* the library content of the framework, or the signing of the framework library fails with the error:
```
In subcomponent: .../QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app
```

The previous approach to signing used reverse lexical sorting; this was enough to guarantee that content in a folder would be signed before the folder; but it wouldn't guarantee that a *file* in a folder would be signed before subfolders in the same folder. 

Using the PySide6 example, reverse lexical sorting would result in a sort order of:
```
.../Qt/lib/QtWebEngineCore.framework/Versions/A/QtWebEngineCore
.../Qt/lib/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
.../Qt/lib/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app
.../Qt/lib/QtWebEngineCore.framework/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
.../Qt/lib/QtWebEngineCore.framework/Helpers/QtWebEngineProcess.app
```

Because "QtWebEngineCore" sorts alphabetically after "Helpers", and the sort order is reversed, QtWebEngineCore is signed *before* the QtWebEngineProcess.app, which causes the error.

The new sorting approach results in the signing order:
```
.../Qt/lib/QtWebEngineCore.framework/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
.../Qt/lib/QtWebEngineCore.framework/Helpers/QtWebEngineProcess.app
.../Qt/lib/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
.../Qt/lib/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app
.../Qt/lib/QtWebEngineCore.framework/Versions/A/QtWebEngineCore
```
so QtWebEngineCore is signed *after* the app that uses it. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
