### PR TITLE
Verify the version of user's installed Git is acceptable

### DIFF
--- a/changes/1915.feature.rst
+++ b/changes/1915.feature.rst
@@ -1,0 +1,1 @@
+When the available version if Git is older than v2.17.0, an error message now prompts the user to upgrade their install of Git to proceed.

--- a/src/briefcase/integrations/git.py
+++ b/src/briefcase/integrations/git.py
@@ -10,6 +10,9 @@ class Git(Tool):
     name = "git"
     full_name = "Git"
 
+    MIN_VERSION = (2, 17, 0)
+    GIT_URL = "https://git-scm.com/"
+
     @classmethod
     def verify_install(cls, tools: ToolCache, **kwargs) -> ModuleType:
         """Verify if git is installed.
@@ -42,14 +45,14 @@ class Git(Tool):
             # for this.
             if tools.host_os == "Darwin":
                 raise BriefcaseCommandError(
-                    """\
+                    f"""\
 Briefcase requires git, but it is not installed. Xcode provides git; you should
 be shown a dialog prompting you to install Xcode and the Command Line Developer
 Tools. Select "Install" to install the Command Line Developer Tools.
 
 Alternatively, you can visit:
 
-    https://git-scm.com/
+    {cls.GIT_URL}
 
 to download and install git manually.
 
@@ -60,10 +63,10 @@ need to restart your terminal session.
 
             else:
                 raise BriefcaseCommandError(
-                    """\
+                    f"""\
 Briefcase requires git, but it is not installed (or is not on your PATH). Visit:
 
-    https://git-scm.com/
+    {cls.GIT_URL}
 
 to download and install git manually.
 
@@ -71,6 +74,16 @@ If you have installed git recently and are still getting this error, you may
 need to restart your terminal session.
 """
                 ) from e
+
+        installed_version = git.cmd.Git().version_info
+        if installed_version < cls.MIN_VERSION:
+            raise BriefcaseCommandError(
+                f"At least Git v{'.'.join(map(str, cls.MIN_VERSION))} is required; "
+                f"however, v{'.'.join(map(str, installed_version))} is installed.\n"
+                "\n"
+                f"Please update Git; downloads are available at {cls.GIT_URL}.",
+                skip_logfile=True,
+            )
 
         tools.logger.configure_stdlib_logging("git")
 


### PR DESCRIPTION
## Changes
- A user in [Discord](https://discord.com/channels/836455665257021440/836455665257021443/1260273576540377223) reported that `briefcase-template` could not be cloned and the issue ultimately stemmed from their dated version of Git.
- The version of Git is now verified to be at least v2.17.0.

## Notes
- Since Git's release notes are impenetrable insofar as what's meaningfully changing for users....I discovered through trial and error that Briefcase works as far back as v2.17.0 and begins failing at v2.16.6.
- Failure log using v2.16.6: [briefcase.2024_07_15-16_25_47.new.log](https://github.com/user-attachments/files/16239976/briefcase.2024_07_15-16_25_47.new.log)
- RE: https://github.com/beeware/briefcase/issues/1907


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
