### PR TITLE
Added option to run ADB in no-streaming mode

### DIFF
--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1493,14 +1493,20 @@ class ADB:
                 raise InvalidDeviceError("device id", self.device) from e
             raise
 
-    def install_apk(self, apk_path: str | Path):
+    def install_apk(self, apk_path: str | Path, no_streaming=False):
         """Install an APK file on an Android device.
 
         :param apk_path: The path of the Android APK file to install.
+        :param no_streaming: Whether to push APK to device and invoke Package Manager as separate steps.
         :returns: `None` on success; raises an exception on failure.
         """
+        command = (
+            ["install", "-r"]
+            + (["--no-streaming"] if no_streaming else [])
+            + [apk_path]
+        )
         try:
-            self.run("install", "-r", apk_path)
+            self.run(*command)
         except subprocess.CalledProcessError as e:
             raise BriefcaseCommandError(
                 f"Unable to install APK {apk_path} on {self.device}"

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -354,6 +354,12 @@ class GradleRunCommand(GradleMixin, RunCommand):
             required=False,
         )
         parser.add_argument(
+            "--no-streaming",
+            action="store_true",
+            help="Push APK to device and invoke Package Manager as separate steps",
+            required=False,
+        )
+        parser.add_argument(
             "--shutdown-on-exit",
             action="store_true",
             help="Shutdown the emulator on exit",
@@ -367,6 +373,7 @@ class GradleRunCommand(GradleMixin, RunCommand):
         passthrough: list[str],
         device_or_avd=None,
         extra_emulator_args=None,
+        no_streaming=False,
         shutdown_on_exit=False,
         **kwargs,
     ):
@@ -378,6 +385,7 @@ class GradleRunCommand(GradleMixin, RunCommand):
         :param device_or_avd: The device to target. If ``None``, the user will
             be asked to re-run the command selecting a specific device.
         :param extra_emulator_args: Any additional arguments to pass to the emulator.
+        :param no_streaming: Whether to push APK to device and invoke Package Manager as separate steps.
         :param shutdown_on_exit: Should the emulator be shut down on exit?
         """
         device, name, avd = self.tools.android_sdk.select_target_device(device_or_avd)
@@ -425,7 +433,7 @@ class GradleRunCommand(GradleMixin, RunCommand):
 
             # Install the latest APK file onto the device.
             with self.input.wait_bar("Installing new app version..."):
-                adb.install_apk(self.binary_path(app))
+                adb.install_apk(self.binary_path(app), no_streaming=no_streaming)
 
             # To start the app, we launch `org.beeware.android.MainActivity`.
             with self.input.wait_bar(f"Launching {label}..."):


### PR DESCRIPTION
ADB can install an app either directly from the host ("streamed install"), or by copying the APK to the device and then running the installation process. The former is the current default, but the latter is still needed for some devices. Added an option allowing streamed install to be disabled.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
