### PR TITLE
Fix error in documentation example for briefcase run

### DIFF
--- a/docs/reference/commands/run.rst
+++ b/docs/reference/commands/run.rst
@@ -108,7 +108,7 @@ Update application support package before running. Equivalent to running:
 
 .. code-block:: console
 
-    $ briefcase update --update-resources
+    $ briefcase update --update-support
     $ briefcase build
     $ briefcase run
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
The documentation for the briefcase run command had an error in the `--update-support` section.
The example showed it being equivalent to `briefcase update --update-resources` instead of `briefcase update --update-support.`
This PR fixes that issue.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
