### PR TITLE
Modifications to support Python 3.13 support packages

### DIFF
--- a/changes/1933.bugfix.1.rst
+++ b/changes/1933.bugfix.1.rst
@@ -1,0 +1,1 @@
+Briefcase will no longer attempt to sign symlinks in macOS apps.

--- a/changes/1933.bugfix.2.rst
+++ b/changes/1933.bugfix.2.rst
@@ -1,0 +1,1 @@
+Briefcase is now able to remove symlinks to directories as part of the template cleanup.

--- a/changes/1933.bugfix.3.rst
+++ b/changes/1933.bugfix.3.rst
@@ -1,0 +1,1 @@
+If a macOS support package contains symlinks, those symlinks will be preserved when the support package is copied into the app bundle.

--- a/changes/1933.bugfix.4.rst
+++ b/changes/1933.bugfix.4.rst
@@ -1,0 +1,1 @@
+The log filter for iOS has been modified to capture logs generated when using PEP 730-style binary modules.

--- a/changes/1933.feature.rst
+++ b/changes/1933.feature.rst
@@ -1,0 +1,1 @@
+macOS app templates can now specify what part of the support package should be copied into the final application bundle.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -851,7 +851,7 @@ class CreateCommand(BaseCommand):
                 # on the file system.
                 for path in self.bundle_path(app).glob(glob):
                     relative_path = path.relative_to(self.bundle_path(app))
-                    if path.is_dir():
+                    if path.is_dir() and not path.is_symlink():
                         self.logger.verbose(f"Removing directory {relative_path}")
                         self.tools.shutil.rmtree(path)
                     else:

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -570,7 +570,8 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
                 f'senderImagePath ENDSWITH "/{app.formal_name}"'
                 f' OR (processImagePath ENDSWITH "/{app.formal_name}"'
                 ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-                ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"'
+                ' OR senderImagePath ENDSWITH "_ctypes.framework/_ctypes"))',
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -588,7 +588,9 @@ or
             sign_targets.extend(
                 path
                 for path in folder.rglob("*")
-                if not path.is_dir() and is_mach_o_binary(path)
+                if not path.is_dir()
+                and not path.is_symlink()
+                and is_mach_o_binary(path)
             )
 
             # Sign all embedded frameworks

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -419,7 +419,7 @@ class macOSSigningMixin:
         # These are abstracted to enable testing without patching.
         self.get_identities = get_identities
 
-    def entitlements_path(self, app: AppConfig):
+    def entitlements_path(self, app: AppConfig):  # pragma: no-cover-if-is-windows
         return self.bundle_path(app) / self.path_index(app, "entitlements_path")
 
     def select_identity(
@@ -571,7 +571,11 @@ or
             else:
                 raise BriefcaseCommandError(f"Unable to code sign {path}.")
 
-    def sign_app(self, app: AppConfig, identity: SigningIdentity):
+    def sign_app(
+        self,
+        app: AppConfig,
+        identity: SigningIdentity,
+    ):  # pragma: no-cover-if-is-windows
         """Sign an entire app with a specific identity.
 
         :param app: The app to sign

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -47,6 +47,12 @@ class macOSAppCreateCommand(macOSAppMixin, macOSCreateMixin, CreateCommand):
         else:
             return self.bundle_path(app) / "support"
 
+    def runtime_path(self, app: AppConfig) -> Path:
+        try:
+            return self.path_index(app, "runtime_path")
+        except KeyError:
+            return "python-stdlib"
+
     def install_app_support_package(self, app: AppConfig):
         """Install the application support package.
 
@@ -61,9 +67,15 @@ class macOSAppCreateCommand(macOSAppMixin, macOSCreateMixin, CreateCommand):
                 self.tools.shutil.rmtree(runtime_support_path)
             runtime_support_path.mkdir()
 
+            # The support package will contain a lot more content than is
+            # actually needed at runtime. Only copy the runtime_path into
+            # the support location nominated by the template. Also ensure
+            # that symlinks are preserved.
+            runtime_path = self.runtime_path(app)
             self.tools.shutil.copytree(
-                self.support_path(app) / "python-stdlib",
-                runtime_support_path / "python-stdlib",
+                self.support_path(app) / runtime_path,
+                runtime_support_path / Path(runtime_path).name,
+                # symlinks=True,
             )
 
     def install_app_resources(self, app: AppConfig):

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -75,7 +75,7 @@ class macOSAppCreateCommand(macOSAppMixin, macOSCreateMixin, CreateCommand):
             self.tools.shutil.copytree(
                 self.support_path(app) / runtime_path,
                 runtime_support_path / Path(runtime_path).name,
-                # symlinks=True,
+                symlinks=True,
             )
 
     def install_app_resources(self, app: AppConfig):

--- a/src/briefcase/platforms/macOS/filters.py
+++ b/src/briefcase/platforms/macOS/filters.py
@@ -4,7 +4,7 @@ import re
 
 MACOS_LOG_PREFIX_REGEX = re.compile(
     r"\d{4}-\d{2}-\d{2} (?P<timestamp>\d{2}:\d{2}:\d{2}.\d{3}) Df (.*?)\[.*?:.*?\]"
-    r"(?P<subsystem>( \(libffi\.dylib\))|( \(_ctypes\.cpython-3\d{1,2}-.*?\.(so|dylib)\)))? (?P<content>.*)"
+    r"(?P<subsystem>( \(libffi\.dylib\))|( \(_ctypes(\.cpython-3\d{1,2}-.*?\.(so|dylib))?\)))? (?P<content>.*)"
 )
 
 

--- a/tests/commands/create/test_cleanup_app_content.py
+++ b/tests/commands/create/test_cleanup_app_content.py
@@ -46,11 +46,7 @@ def test_no_cleanup(create_command, myapp_unrolled, support_path, debug, capsys)
 
     # Symlinks still exist
     assert (support_path / "dir1/symlink.txt").is_symlink()
-    assert (support_path / "dir1/symlink.txt").readlink() == (
-        support_path / "dir2/b_file.txt"
-    )
     assert (support_path / "mirror").is_symlink()
-    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -78,7 +74,6 @@ def test_dir_cleanup(create_command, myapp_unrolled, support_path, debug, capsys
     # Directory symlinks still exists, but the file symlink doesn't
     assert not (support_path / "dir1/symlink.txt").exists()
     assert (support_path / "mirror").is_symlink()
-    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -108,11 +103,7 @@ def test_file_cleanup(create_command, myapp_unrolled, support_path, debug, capsy
 
     # Symlinks still exist
     assert (support_path / "dir1/symlink.txt").is_symlink()
-    assert (support_path / "dir1/symlink.txt").readlink() == (
-        support_path / "dir2/b_file.txt"
-    )
     assert (support_path / "mirror").is_symlink()
-    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -147,7 +138,6 @@ def test_all_files_in_dir_cleanup(
     # Directory symlinks still exist; file symlink doesn't
     assert not (support_path / "dir1/symlink.txt").exists()
     assert (support_path / "mirror").is_symlink()
-    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -175,7 +165,6 @@ def test_dir_glob_cleanup(create_command, myapp_unrolled, support_path, debug, c
     # Directory symlinks still exist; file symlink doesn't
     assert not (support_path / "dir1/symlink.txt").exists()
     assert (support_path / "mirror").is_symlink()
-    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -206,7 +195,6 @@ def test_file_glob_cleanup(create_command, myapp_unrolled, support_path, debug, 
     # Directory symlinks still exist; file symlink doesn't
     assert not (support_path / "dir1/symlink.txt").exists()
     assert (support_path / "mirror").is_symlink()
-    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -237,11 +225,7 @@ def test_deep_glob_cleanup(create_command, myapp_unrolled, support_path, debug, 
 
     # Symlinks still exist
     assert (support_path / "dir1/symlink.txt").is_symlink()
-    assert (support_path / "dir1/symlink.txt").readlink() == (
-        support_path / "dir2/b_file.txt"
-    )
     assert (support_path / "mirror").is_symlink()
-    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -313,11 +297,7 @@ def test_template_glob_cleanup(
 
     # Symlinks still exist
     assert (support_path / "dir1/symlink.txt").is_symlink()
-    assert (support_path / "dir1/symlink.txt").readlink() == (
-        support_path / "dir2/b_file.txt"
-    )
     assert (support_path / "mirror").is_symlink()
-    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -361,11 +341,7 @@ def test_non_existent_cleanup(
 
     # Symlinks still exist
     assert (support_path / "dir1/symlink.txt").is_symlink()
-    assert (support_path / "dir1/symlink.txt").readlink() == (
-        support_path / "dir2/b_file.txt"
-    )
     assert (support_path / "mirror").is_symlink()
-    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.

--- a/tests/commands/create/test_cleanup_app_content.py
+++ b/tests/commands/create/test_cleanup_app_content.py
@@ -17,6 +17,12 @@ def myapp_unrolled(myapp, support_path, app_packages_path_index):
     create_file(support_path / "other/deep/b_file.doc", "wigs")
     create_file(support_path / "other/deep/other.doc", "wigs")
 
+    # Create a symlink to a file
+    (support_path / "dir1/symlink.txt").symlink_to(support_path / "dir2/b_file.txt")
+
+    # Create a symlink to a directory
+    (support_path / "mirror").symlink_to(support_path / "dir1")
+
     return myapp
 
 
@@ -37,6 +43,14 @@ def test_no_cleanup(create_command, myapp_unrolled, support_path, debug, capsys)
     assert not (support_path / "dir1/__pycache__").exists()
     assert (support_path / "dir2/b_file.txt").exists()
     assert (support_path / "other/deep/b_file.doc").exists()
+
+    # Symlinks still exist
+    assert (support_path / "dir1/symlink.txt").is_symlink()
+    assert (support_path / "dir1/symlink.txt").readlink() == (
+        support_path / "dir2/b_file.txt"
+    )
+    assert (support_path / "mirror").is_symlink()
+    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -60,6 +74,11 @@ def test_dir_cleanup(create_command, myapp_unrolled, support_path, debug, capsys
     assert not (support_path / "dir1").exists()
     assert (support_path / "dir2/b_file.txt").exists()
     assert (support_path / "other/deep/b_file.doc").exists()
+
+    # Directory symlinks still exists, but the file symlink doesn't
+    assert not (support_path / "dir1/symlink.txt").exists()
+    assert (support_path / "mirror").is_symlink()
+    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -86,6 +105,14 @@ def test_file_cleanup(create_command, myapp_unrolled, support_path, debug, capsy
     assert (support_path / "dir2/b_file.txt").exists()
     assert not (support_path / "dir1/__pycache__").exists()
     assert (support_path / "other/deep/b_file.doc").exists()
+
+    # Symlinks still exist
+    assert (support_path / "dir1/symlink.txt").is_symlink()
+    assert (support_path / "dir1/symlink.txt").readlink() == (
+        support_path / "dir2/b_file.txt"
+    )
+    assert (support_path / "mirror").is_symlink()
+    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -117,11 +144,16 @@ def test_all_files_in_dir_cleanup(
     assert (support_path / "dir2/b_file.txt").exists()
     assert (support_path / "other/deep/b_file.doc").exists()
 
+    # Directory symlinks still exist; file symlink doesn't
+    assert not (support_path / "dir1/symlink.txt").exists()
+    assert (support_path / "mirror").is_symlink()
+    assert (support_path / "mirror").readlink() == (support_path / "dir1")
+
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
     output = capsys.readouterr().out.split("\n")
     assert output[-3] == "Removing unneeded app bundle content... done"
-    assert len(output) == (8 if debug else 4)
+    assert len(output) == (9 if debug else 4)
 
 
 @pytest.mark.parametrize("debug", [True, False])
@@ -139,6 +171,11 @@ def test_dir_glob_cleanup(create_command, myapp_unrolled, support_path, debug, c
     assert not (support_path / "dir1").exists()
     assert not (support_path / "dir2").exists()
     assert (support_path / "other/deep/b_file.doc").exists()
+
+    # Directory symlinks still exist; file symlink doesn't
+    assert not (support_path / "dir1/symlink.txt").exists()
+    assert (support_path / "mirror").is_symlink()
+    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -166,11 +203,16 @@ def test_file_glob_cleanup(create_command, myapp_unrolled, support_path, debug, 
     assert (support_path / "dir2/b_file.txt").exists()
     assert (support_path / "other/deep/b_file.doc").exists()
 
+    # Directory symlinks still exist; file symlink doesn't
+    assert not (support_path / "dir1/symlink.txt").exists()
+    assert (support_path / "mirror").is_symlink()
+    assert (support_path / "mirror").readlink() == (support_path / "dir1")
+
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
     output = capsys.readouterr().out.split("\n")
     assert output[-3] == "Removing unneeded app bundle content... done"
-    assert len(output) == (7 if debug else 4)
+    assert len(output) == (8 if debug else 4)
 
 
 @pytest.mark.parametrize("debug", [True, False])
@@ -193,11 +235,52 @@ def test_deep_glob_cleanup(create_command, myapp_unrolled, support_path, debug, 
     assert not (support_path / "other/deep/b_file.doc").exists()
     assert (support_path / "other/deep/other.doc").exists()
 
+    # Symlinks still exist
+    assert (support_path / "dir1/symlink.txt").is_symlink()
+    assert (support_path / "dir1/symlink.txt").readlink() == (
+        support_path / "dir2/b_file.txt"
+    )
+    assert (support_path / "mirror").is_symlink()
+    assert (support_path / "mirror").readlink() == (support_path / "dir1")
+
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
     output = capsys.readouterr().out.split("\n")
     assert output[-3] == "Removing unneeded app bundle content... done"
     assert len(output) == (8 if debug else 4)
+
+
+@pytest.mark.parametrize("debug", [True, False])
+def test_symlink_cleanup(create_command, myapp_unrolled, support_path, debug, capsys):
+    """Symlinks can be cleaned up."""
+    if debug:
+        create_command.logger.verbosity = LogLevel.DEBUG
+
+    myapp_unrolled.cleanup_paths = [
+        "path/to/support/dir1/symlink.txt",
+        "path/to/support/mirror",
+    ]
+
+    # Cleanup app content
+    create_command.cleanup_app_content(myapp_unrolled)
+
+    # Confirm none of the files (except __pycache__) have been removed
+    assert (support_path / "dir1/a_file1.txt").exists()
+    assert (support_path / "dir1/a_file2.doc").exists()
+    assert (support_path / "dir1/b_file.txt").exists()
+    assert not (support_path / "dir1/__pycache__").exists()
+    assert (support_path / "dir2/b_file.txt").exists()
+    assert (support_path / "other/deep/b_file.doc").exists()
+
+    # Directory symlinks still exist; file symlink doesn't
+    assert not (support_path / "dir1/symlink.txt").exists()
+    assert not (support_path / "mirror").is_symlink()
+
+    # Console output ends with the done message; the number of other messages depends on
+    # whether debug is enabled.
+    output = capsys.readouterr().out.split("\n")
+    assert output[-3] == "Removing unneeded app bundle content... done"
+    assert len(output) == (7 if debug else 4)
 
 
 @pytest.mark.parametrize("debug", [True, False])
@@ -227,6 +310,14 @@ def test_template_glob_cleanup(
     assert not (support_path / "dir1/__pycache__").exists()
     assert (support_path / "dir2/b_file.txt").exists()
     assert not (support_path / "other/deep/b_file.doc").exists()
+
+    # Symlinks still exist
+    assert (support_path / "dir1/symlink.txt").is_symlink()
+    assert (support_path / "dir1/symlink.txt").readlink() == (
+        support_path / "dir2/b_file.txt"
+    )
+    assert (support_path / "mirror").is_symlink()
+    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.
@@ -267,6 +358,14 @@ def test_non_existent_cleanup(
     assert not (support_path / "dir1/__pycache__").exists()
     assert (support_path / "dir2/b_file.txt").exists()
     assert (support_path / "other/deep/b_file.doc").exists()
+
+    # Symlinks still exist
+    assert (support_path / "dir1/symlink.txt").is_symlink()
+    assert (support_path / "dir1/symlink.txt").readlink() == (
+        support_path / "dir2/b_file.txt"
+    )
+    assert (support_path / "mirror").is_symlink()
+    assert (support_path / "mirror").readlink() == (support_path / "dir1")
 
     # Console output ends with the done message; the number of other messages depends on
     # whether debug is enabled.

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -178,7 +178,8 @@ def test_run_app_simulator_booted(run_command, first_app_config, tmp_path):
                     'senderImagePath ENDSWITH "/First App"'
                     ' OR (processImagePath ENDSWITH "/First App"'
                     ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"'
+                    ' OR senderImagePath ENDSWITH "_ctypes.framework/_ctypes"))',
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -309,7 +310,8 @@ def test_run_app_simulator_booted_underscore(
                     'senderImagePath ENDSWITH "/First App"'
                     ' OR (processImagePath ENDSWITH "/First App"'
                     ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"'
+                    ' OR senderImagePath ENDSWITH "_ctypes.framework/_ctypes"))',
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -438,7 +440,8 @@ def test_run_app_with_passthrough(run_command, first_app_config, tmp_path):
                     'senderImagePath ENDSWITH "/First App"'
                     ' OR (processImagePath ENDSWITH "/First App"'
                     ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"'
+                    ' OR senderImagePath ENDSWITH "_ctypes.framework/_ctypes"))',
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -573,7 +576,8 @@ def test_run_app_simulator_shut_down(
                     'senderImagePath ENDSWITH "/First App"'
                     ' OR (processImagePath ENDSWITH "/First App"'
                     ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"'
+                    ' OR senderImagePath ENDSWITH "_ctypes.framework/_ctypes"))',
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -714,7 +718,8 @@ def test_run_app_simulator_shutting_down(run_command, first_app_config, tmp_path
                     'senderImagePath ENDSWITH "/First App"'
                     ' OR (processImagePath ENDSWITH "/First App"'
                     ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"'
+                    ' OR senderImagePath ENDSWITH "_ctypes.framework/_ctypes"))',
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -1090,7 +1095,8 @@ def test_run_app_simulator_launch_failure(run_command, first_app_config, tmp_pat
                     'senderImagePath ENDSWITH "/First App"'
                     ' OR (processImagePath ENDSWITH "/First App"'
                     ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"'
+                    ' OR senderImagePath ENDSWITH "_ctypes.framework/_ctypes"))',
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -1210,7 +1216,8 @@ def test_run_app_simulator_no_pid(run_command, first_app_config, tmp_path):
                     'senderImagePath ENDSWITH "/First App"'
                     ' OR (processImagePath ENDSWITH "/First App"'
                     ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"'
+                    ' OR senderImagePath ENDSWITH "_ctypes.framework/_ctypes"))',
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -1332,7 +1339,8 @@ def test_run_app_simulator_non_integer_pid(run_command, first_app_config, tmp_pa
                     'senderImagePath ENDSWITH "/First App"'
                     ' OR (processImagePath ENDSWITH "/First App"'
                     ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"'
+                    ' OR senderImagePath ENDSWITH "_ctypes.framework/_ctypes"))',
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -1433,7 +1441,8 @@ def test_run_app_test_mode(run_command, first_app_config, tmp_path):
                     'senderImagePath ENDSWITH "/First App"'
                     ' OR (processImagePath ENDSWITH "/First App"'
                     ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"'
+                    ' OR senderImagePath ENDSWITH "_ctypes.framework/_ctypes"))',
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -1548,7 +1557,8 @@ def test_run_app_test_mode_with_passthrough(run_command, first_app_config, tmp_p
                     'senderImagePath ENDSWITH "/First App"'
                     ' OR (processImagePath ENDSWITH "/First App"'
                     ' AND (senderImagePath ENDSWITH "-iphonesimulator.so"'
-                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"))',
+                    ' OR senderImagePath ENDSWITH "-iphonesimulator.dylib"'
+                    ' OR senderImagePath ENDSWITH "_ctypes.framework/_ctypes"))',
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,

--- a/tests/platforms/macOS/app/conftest.py
+++ b/tests/platforms/macOS/app/conftest.py
@@ -33,7 +33,8 @@ def first_app_templated(first_app_config, tmp_path):
         """
 [paths]
 app_packages_path="First App.app/Contents/Resources/app_packages"
-support_path="First App.app/Contents/Resources/support"
+support_path="First App.app/Contents/Frameworks"
+stdlib_path="Python.xcframework/macos-arm64_x86_64/Python.framework"
 info_plist_path="First App.app/Contents/Info.plist"
 entitlements_path="Entitlements.plist"
 """,

--- a/tests/platforms/macOS/app/conftest.py
+++ b/tests/platforms/macOS/app/conftest.py
@@ -34,7 +34,7 @@ def first_app_templated(first_app_config, tmp_path):
 [paths]
 app_packages_path="First App.app/Contents/Resources/app_packages"
 support_path="First App.app/Contents/Frameworks"
-stdlib_path="Python.xcframework/macos-arm64_x86_64/Python.framework"
+runtime_path="Python.xcframework/macos-arm64_x86_64/Python.framework"
 info_plist_path="First App.app/Contents/Info.plist"
 entitlements_path="Entitlements.plist"
 """,

--- a/tests/platforms/macOS/app/conftest.py
+++ b/tests/platforms/macOS/app/conftest.py
@@ -119,4 +119,7 @@ def first_app_with_binaries(first_app_templated, first_app_config, tmp_path):
     with (lib_path / "unknown.binary").open("wb") as f:
         f.write(b"\xCA\xFE\xBA\xBEother")
 
+    # A symlink to a Mach-O executable binary file
+    (lib_path / "first_symlink.so").symlink_to(lib_path / "first_so.so")
+
     return first_app_config

--- a/tests/platforms/macOS/app/package/test_notarize.py
+++ b/tests/platforms/macOS/app/package/test_notarize.py
@@ -92,6 +92,7 @@ def test_notarize_app(
             "First App.app/Contents/Resources/app_packages/first.other",
             "First App.app/Contents/Resources/app_packages/first_dylib.dylib",
             "First App.app/Contents/Resources/app_packages/first_so.so",
+            "First App.app/Contents/Resources/app_packages/first_symlink.so",
             "First App.app/Contents/Resources/app_packages/other_binary",
             "First App.app/Contents/Resources/app_packages/second.other",
             "First App.app/Contents/Resources/app_packages/special.binary",

--- a/tests/platforms/macOS/app/package/test_package_zip.py
+++ b/tests/platforms/macOS/app/package/test_package_zip.py
@@ -67,6 +67,7 @@ def test_package_zip(
             "First App.app/Contents/Resources/app_packages/first.other",
             "First App.app/Contents/Resources/app_packages/first_dylib.dylib",
             "First App.app/Contents/Resources/app_packages/first_so.so",
+            "First App.app/Contents/Resources/app_packages/first_symlink.so",
             "First App.app/Contents/Resources/app_packages/other_binary",
             "First App.app/Contents/Resources/app_packages/second.other",
             "First App.app/Contents/Resources/app_packages/special.binary",

--- a/tests/platforms/macOS/app/test_create.py
+++ b/tests/platforms/macOS/app/test_create.py
@@ -814,7 +814,7 @@ def test_install_support_package(
     create_command.tools.file.download = mock.MagicMock(
         side_effect=mock_tgz_download(
             f"Python-3.{sys.version_info.minor}-macOS-support.b37.tar.gz",
-            [
+            content=[
                 ("VERSIONS", "Version tracking info"),
                 (
                     "platform-site/macosx.arm64/sitecustomize.py",
@@ -826,8 +826,14 @@ def test_install_support_package(
                 ),
                 ("Python.xcframework/Info.plist", "this is the xcframework"),
                 (
-                    "Python.xcframework/macos-arm64_x86_64/Python.framework/Python",
+                    "Python.xcframework/macos-arm64_x86_64/Python.framework/Versions/Current/Python",
                     "this is the library",
+                ),
+            ],
+            links=[
+                (
+                    "Python.xcframework/macos-arm64_x86_64/Python.framework/Python",
+                    "Versions/Current/Python",
                 ),
             ],
         )
@@ -847,11 +853,16 @@ def test_install_support_package(
     assert (bundle_path / "support/Python.xcframework/Info.plist").exists()
     assert (
         bundle_path
+        / "support/Python.xcframework/macos-arm64_x86_64/Python.framework/Versions/Current/Python"
+    ).is_file()
+    assert (
+        bundle_path
         / "support/Python.xcframework/macos-arm64_x86_64/Python.framework/Python"
-    ).exists()
+    ).is_symlink()
 
     # The standard library has been copied to the app...
-    assert (runtime_support_path / "Python.framework/Python").exists()
+    assert (runtime_support_path / "Python.framework/Versions/Current/Python").is_file()
+    assert (runtime_support_path / "Python.framework/Python").is_symlink()
     # ... but the other support files have not.
     assert not (
         runtime_support_path / "platform-site/macosx.arm64/sitecustomize.py"

--- a/tests/platforms/macOS/app/test_create.py
+++ b/tests/platforms/macOS/app/test_create.py
@@ -710,15 +710,29 @@ def test_install_app_packages_non_universal(
 
 
 @pytest.mark.parametrize("pre_existing", [True, False])
-def test_install_support_package(
+def test_install_legacy_support_package(
     create_command,
     first_app_templated,
     tmp_path,
     pre_existing,
 ):
-    """The standard library is copied out of the support package into the app bundle."""
+    """The legacy location for the standard library is used by default when installing
+    the support package."""
     # Hard code the support revision
     first_app_templated.support_revision = "37"
+
+    # Rewrite the app's briefcase.toml to use the legacy paths (i.e.,
+    # a support path of Resources/support, and no stdlib_path)
+    create_file(
+        tmp_path / "base_path/build/first-app/macos/app/briefcase.toml",
+        """
+[paths]
+app_packages_path="First App.app/Contents/Resources/app_packages"
+support_path="First App.app/Contents/Resources/support"
+info_plist_path="First App.app/Contents/Info.plist"
+entitlements_path="Entitlements.plist"
+""",
+    )
 
     bundle_path = tmp_path / "base_path/build/first-app/macos/app"
     runtime_support_path = bundle_path / "First App.app/Contents/Resources/support"
@@ -726,7 +740,7 @@ def test_install_support_package(
     if pre_existing:
         create_file(
             runtime_support_path / "python-stdlib/old-stdlib",
-            "Legacy stdlib file",
+            "old stdlib file",
         )
 
     # Mock download.file to return a support package
@@ -774,3 +788,78 @@ def test_install_support_package(
 
     # The legacy content has been purged
     assert not (runtime_support_path / "python-stdlib/old-stdlib").exists()
+
+
+@pytest.mark.parametrize("pre_existing", [True, False])
+def test_install_support_package(
+    create_command,
+    first_app_templated,
+    tmp_path,
+    pre_existing,
+):
+    """The Python framework is copied out of the support package into the app bundle."""
+    # Hard code the support revision
+    first_app_templated.support_revision = "37"
+
+    bundle_path = tmp_path / "base_path/build/first-app/macos/app"
+    runtime_support_path = bundle_path / "First App.app/Contents/Frameworks"
+
+    if pre_existing:
+        create_file(
+            runtime_support_path / "Python.framework/old-Python",
+            "Old library",
+        )
+
+    # Mock download.file to return a support package
+    create_command.tools.file.download = mock.MagicMock(
+        side_effect=mock_tgz_download(
+            f"Python-3.{sys.version_info.minor}-macOS-support.b37.tar.gz",
+            [
+                ("VERSIONS", "Version tracking info"),
+                (
+                    "platform-site/macosx.arm64/sitecustomize.py",
+                    "this is the arm64 platform site",
+                ),
+                (
+                    "platform-site/macosx.x86_64/sitecustomize.py",
+                    "this is the x86_64 platform site",
+                ),
+                ("Python.xcframework/Info.plist", "this is the xcframework"),
+                (
+                    "Python.xcframework/macos-arm64_x86_64/Python.framework/Python",
+                    "this is the library",
+                ),
+            ],
+        )
+    )
+
+    # Install the support package
+    create_command.install_app_support_package(first_app_templated)
+
+    # Confirm that the support files have been unpacked into the bundle location
+    assert (bundle_path / "support/VERSIONS").exists()
+    assert (
+        bundle_path / "support/platform-site/macosx.arm64/sitecustomize.py"
+    ).exists()
+    assert (
+        bundle_path / "support/platform-site/macosx.x86_64/sitecustomize.py"
+    ).exists()
+    assert (bundle_path / "support/Python.xcframework/Info.plist").exists()
+    assert (
+        bundle_path
+        / "support/Python.xcframework/macos-arm64_x86_64/Python.framework/Python"
+    ).exists()
+
+    # The standard library has been copied to the app...
+    assert (runtime_support_path / "Python.framework/Python").exists()
+    # ... but the other support files have not.
+    assert not (
+        runtime_support_path / "platform-site/macosx.arm64/sitecustomize.py"
+    ).exists()
+    assert not (
+        runtime_support_path / "platform-site/macosx.x86_64/sitecustomize.py"
+    ).exists()
+    assert not (runtime_support_path / "VERSIONS").exists()
+
+    # The legacy content has been purged
+    assert not (runtime_support_path / "python-stdlib/old-Python").exists()

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -663,14 +663,7 @@ def test_sign_app(
 
     # Output only happens if in debug mode.
     output = capsys.readouterr().out
-    if sys.platform == "win32":
-        # In practice, we won't ever actually run signing on win32; but to ensure test
-        # coverage we need to. However, win32 doesn't handle executable permissions
-        # the same as linux/unix, `unknown.binary` is identified as a signing target.
-        # We ignore this discrepancy for testing purposes.
-        assert len(output.strip("\n").split("\n")) == (12 if verbose else 1)
-    else:
-        assert len(output.strip("\n").split("\n")) == (11 if verbose else 1)
+    assert len(output.strip("\n").split("\n")) == (11 if verbose else 1)
 
 
 @pytest.mark.parametrize("verbose", [True, False])

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -667,14 +667,7 @@ def test_sign_app(
 
     # Output only happens if in debug mode.
     output = capsys.readouterr().out
-    if sys.platform == "win32":
-        # In practice, we won't ever actually run signing on win32; but to ensure test
-        # coverage we need to. However, win32 doesn't handle executable permissions
-        # the same as linux/unix, `unknown.binary` is identified as a signing target.
-        # We ignore this discrepancy for testing purposes.
-        assert len(output.strip("\n").split("\n")) == (12 if verbose else 1)
-    else:
-        assert len(output.strip("\n").split("\n")) == (11 if verbose else 1)
+    assert len(output.strip("\n").split("\n")) == (11 if verbose else 1)
 
 
 @pytest.mark.skipif(
@@ -718,11 +711,4 @@ def test_sign_app_with_failure(
 
     # Output only happens if in debug mode.
     output = capsys.readouterr().out
-    if sys.platform == "win32":
-        # In practice, we won't ever actually run signing on win32; but to ensure test
-        # coverage we need to. However, win32 doesn't handle executable permissions
-        # the same as linux/unix, `unknown.binary` is identified as a signing target.
-        # We ignore this discrepancy for testing purposes.
-        assert len(output.strip("\n").split("\n")) == (9 if verbose else 1)
-    else:
-        assert len(output.strip("\n").split("\n")) == (8 if verbose else 1)
+    assert len(output.strip("\n").split("\n")) == (8 if verbose else 1)

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -584,6 +584,8 @@ def test_sign_app(
     )
     lib_path = app_path / "Contents/Resources/app_packages"
     frameworks_path = app_path / "Contents/Frameworks"
+
+    assert len(dummy_command.tools.subprocess.run.mock_calls) == 11
     dummy_command.tools.subprocess.run.assert_has_calls(
         [
             sign_call(

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -546,6 +546,10 @@ def test_sign_file_unknown_error(
     assert len(output.strip("\n").split("\n")) == 1
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Can't test macOS codesigning on Windows",
+)
 @pytest.mark.parametrize("verbose", [True, False])
 def test_sign_app(
     dummy_command,
@@ -673,6 +677,10 @@ def test_sign_app(
         assert len(output.strip("\n").split("\n")) == (11 if verbose else 1)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Can't test macOS codesigning on Windows",
+)
 @pytest.mark.parametrize("verbose", [True, False])
 def test_sign_app_with_failure(
     dummy_command,

--- a/tests/platforms/macOS/app/test_signing.py
+++ b/tests/platforms/macOS/app/test_signing.py
@@ -663,7 +663,14 @@ def test_sign_app(
 
     # Output only happens if in debug mode.
     output = capsys.readouterr().out
-    assert len(output.strip("\n").split("\n")) == (11 if verbose else 1)
+    if sys.platform == "win32":
+        # In practice, we won't ever actually run signing on win32; but to ensure test
+        # coverage we need to. However, win32 doesn't handle executable permissions
+        # the same as linux/unix, `unknown.binary` is identified as a signing target.
+        # We ignore this discrepancy for testing purposes.
+        assert len(output.strip("\n").split("\n")) == (12 if verbose else 1)
+    else:
+        assert len(output.strip("\n").split("\n")) == (11 if verbose else 1)
 
 
 @pytest.mark.parametrize("verbose", [True, False])

--- a/tests/platforms/macOS/test_macOS_log_clean_filter.py
+++ b/tests/platforms/macOS/test_macOS_log_clean_filter.py
@@ -59,13 +59,18 @@ from briefcase.platforms.macOS.filters import macOS_log_clean_filter
             "2022-11-14 13:21:15.341 Df My App[59972:780a15] (_ctypes.cpython-38-iphonesimulator.so) Hello World!",
             ("Hello World!", True),
         ),
-        # iOS App log
+        # iOS App log (old style .dylib libraries)
         (
             "2022-11-14 13:21:15.341 Df My App[59972:780a15] (_ctypes.cpython-312-iphonesimulator.dylib) Hello World!",
             ("Hello World!", True),
         ),
         (
             "2022-11-14 13:21:15.341 Df My App[59972:780a15] (_ctypes.cpython-38-iphonesimulator.dylib) Hello World!",
+            ("Hello World!", True),
+        ),
+        # iOS App log
+        (
+            "2022-11-14 13:21:15.341 Df My App[59972:780a15] (_ctypes) Hello World!",
             ("Hello World!", True),
         ),
         # Empty iOS App log (old style .so binaries)
@@ -77,13 +82,18 @@ from briefcase.platforms.macOS.filters import macOS_log_clean_filter
             "2022-11-14 13:21:15.341 Df My App[59972:780a15] (_ctypes.cpython-38-iphonesimulator.so) ",
             ("", True),
         ),
-        # Empty iOS App log
+        # Empty iOS App log (old style .dylib binaries)
         (
             "2022-11-14 13:21:15.341 Df My App[59972:780a15] (_ctypes.cpython-312-iphonesimulator.dylib) ",
             ("", True),
         ),
         (
             "2022-11-14 13:21:15.341 Df My App[59972:780a15] (_ctypes.cpython-38-iphonesimulator.dylib) ",
+            ("", True),
+        ),
+        # Empty iOS App log
+        (
+            "2022-11-14 13:21:15.341 Df My App[59972:780a15] (_ctypes) ",
             ("", True),
         ),
         # Unknown content


### PR DESCRIPTION
Python 3.13 will introduce official iOS and Android support; supporting this new format requires some small changes to how Briefcase deals with iOS apps.

As a side effect of these changes, we're also in a position to use a dynamically loaded macOS framework based on the official distributable, rather than compiling it ourselves. This is an interim measure until an official "embeddable" or XCFramework-based macOS distribution is available; but it also requires some minor changes to how Briefcase handles macOS support packages.

* Modifies the filtering pattern for iOS logs. When redirecting to NSLog, stdout appears to come from the `_ctypes` library. In the official 3.13 packaging arrangement, the binary no longer has a `.cpython-313-iphonesimulator.dylib` extension - it is just `_ctypes`.
* Frameworks often include symlinks, so there's a need to copy those symlinks correctly, protect against cleaning up symlinks, and not attempt to sign symlinks.
* The new framework-based macOS template doesn't include a standalone `python-stdlib`; instead, a framework can be copied from the XCFramework. The `briefcase.toml` can now include a `runtime_path` definition that declares what subfolder of the support package should be copied to the `support_path` location.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
