### PR TITLE
Pin the python version used on RTD.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.12"
   jobs:
     post_checkout:
       # RTD defaults to a depth of 50 but Briefcase versioning may require

--- a/changes/1940.misc.rst
+++ b/changes/1940.misc.rst
@@ -1,0 +1,1 @@
+The environment for RTD builds was pinned, and protection for Sphinx updates was added.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,10 +110,12 @@ docs = [
     "furo == 2024.7.18",
     "pyenchant == 3.2.2",
     # Sphinx 7.2 deprecated support for Python 3.8
+    # Sphinx 8.0 deprecated support for Python 3.9
     "sphinx == 7.1.2 ; python_version < '3.9'",
+    "sphinx == 7.4.7 ; python_version == '3.9'",
     "sphinx == 7.4.7 ; python_version >= '3.9'",
     "sphinx_tabs == 3.4.5",
-    # Sphinx 2024.2.4 deprecated support for Python 3.8
+    # sphinx-autobuild 2024.2.4 deprecated support for Python 3.8
     "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",
     "sphinx-autobuild == 2024.4.16 ; python_version >= '3.9'",
     "sphinx-copybutton == 0.5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ docs = [
     # Sphinx 8.0 deprecated support for Python 3.9
     "sphinx == 7.1.2 ; python_version < '3.9'",
     "sphinx == 7.4.7 ; python_version == '3.9'",
-    "sphinx == 7.4.7 ; python_version >= '3.9'",
+    "sphinx == 7.4.7 ; python_version >= '3.10'",
     "sphinx_tabs == 3.4.5",
     # sphinx-autobuild 2024.2.4 deprecated support for Python 3.8
     "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",


### PR DESCRIPTION
To ensure a consistent and repeatable build environment, use a hard version pin on the RTD environment.

Also adds a pin to Sphinx on Python 3.9 as, Sphinx 8 deprecates Python 3.9 support.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
