### PR TITLE
Move logic to determine support revision from templates

### DIFF
--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -104,6 +104,10 @@ class CreateCommand(BaseCommand):
             f"{self.support_package_filename(support_revision)}"
         )
 
+    def default_support_revision(self) -> str:
+        """The default revision for the default support package for a format."""
+        return ""
+
     def stub_binary_filename(self, support_revision: str, is_console_app: bool) -> str:
         """The filename for the stub binary."""
         stub_type = "Console" if is_console_app else "GUI"
@@ -229,6 +233,8 @@ class CreateCommand(BaseCommand):
                 # Properties of the generating environment
                 # The full Python version string, including minor and dev/a/b/c suffixes (e.g., 3.11.0rc2)
                 "python_version": platform.python_version(),
+                # Support package revision for default support package
+                "support_revision": self.default_support_revision(),
                 # The host architecture
                 "host_arch": self.tools.host_arch,
                 # Transformations of explicit properties into useful forms

--- a/src/briefcase/platforms/linux/__init__.py
+++ b/src/briefcase/platforms/linux/__init__.py
@@ -57,30 +57,6 @@ def parse_freedesktop_os_release(content):
 class LinuxMixin:
     platform = "linux"
 
-    def support_package_url(self, support_revision):
-        """The URL of the support package to use for apps of this type.
-
-        Linux builds that use a support package (AppImage, Flatpak) use indygreg's
-        Standalone Python to provide system packages. See
-        `https://github.com/indygreg/python-build-standalone` for details.
-
-        System packages don't use a support package; this is defined by
-        the template, so this method won't be invoked
-        """
-        python_download_arch = self.tools.host_arch
-        # use a 32bit Python if using 32bit Python on 64bit hardware
-        if self.tools.is_32bit_python and self.tools.host_arch == "aarch64":
-            python_download_arch = "armv7"
-        elif self.tools.is_32bit_python and self.tools.host_arch == "x86_64":
-            python_download_arch = "i686"
-
-        version, datestamp = support_revision.split("+")
-        return (
-            "https://github.com/indygreg/python-build-standalone/releases/download/"
-            f"{datestamp}/"
-            f"cpython-{support_revision}-{python_download_arch}-unknown-linux-gnu-install_only_stripped.tar.gz"
-        )
-
     def vendor_details(self, freedesktop_info):
         """Normalize the identity of the target Linux vendor, version, and base.
 
@@ -121,6 +97,42 @@ class LinuxMixin:
             vendor_base = None
 
         return vendor, codename, vendor_base
+
+
+class StandalonePythonSupportMixin:
+    """Linux builds that use a support package (AppImage, Flatpak) use indygreg's
+    Standalone Python to provide system packages.
+
+    See `https://github.com/indygreg/python-build-standalone` for details.
+
+    System packages don't use a support package and instead use the system Python.
+    """
+
+    def default_support_revision(self) -> str:
+        """The default support revision for Standalone Python."""
+        return {
+            "3.8": "3.8.19+20240726",
+            "3.9": "3.9.19+20240726",
+            "3.10": "3.10.14+20240726",
+            "3.11": "3.11.9+20240726",
+            "3.12": "3.12.4+20240726",
+        }[self.python_version_tag]
+
+    def support_package_url(self, support_revision: str):
+        """The URL of the Standalone Python package."""
+        python_download_arch = self.tools.host_arch
+        # use a 32bit Python if using 32bit Python on 64bit hardware
+        if self.tools.is_32bit_python and self.tools.host_arch == "aarch64":
+            python_download_arch = "armv7"
+        elif self.tools.is_32bit_python and self.tools.host_arch == "x86_64":
+            python_download_arch = "i686"
+
+        version, datestamp = support_revision.split("+")
+        return (
+            "https://github.com/indygreg/python-build-standalone/releases/download/"
+            f"{datestamp}/"
+            f"cpython-{support_revision}-{python_download_arch}-unknown-linux-gnu-install_only_stripped.tar.gz"
+        )
 
 
 class LocalRequirementsMixin:  # pragma: no-cover-if-is-windows

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -24,10 +24,11 @@ from briefcase.platforms.linux import (
     DockerOpenCommand,
     LinuxMixin,
     LocalRequirementsMixin,
+    StandalonePythonSupportMixin,
 )
 
 
-class LinuxAppImagePassiveMixin(LinuxMixin):
+class LinuxAppImagePassiveMixin(StandalonePythonSupportMixin, LinuxMixin):
     # The Passive mixin honors the docker options, but doesn't try to verify
     # docker exists. It is used by commands that are "passive" from the
     # perspective of the build system, like open and run.

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -12,10 +12,10 @@ from briefcase.commands import (
 from briefcase.config import AppConfig
 from briefcase.exceptions import BriefcaseConfigError
 from briefcase.integrations.flatpak import Flatpak
-from briefcase.platforms.linux import LinuxMixin
+from briefcase.platforms.linux import LinuxMixin, StandalonePythonSupportMixin
 
 
-class LinuxFlatpakMixin(LinuxMixin):
+class LinuxFlatpakMixin(StandalonePythonSupportMixin, LinuxMixin):
     output_format = "flatpak"
     supported_host_os = {"Linux"}
     supported_host_os_reason = "Flatpaks can only be built on Linux."


### PR DESCRIPTION
## Proposal
- Instead of logic specified in a template to specify the default support revision, this moves that logic in to Briefcase.
- We're currently using three different sources of support packages:
  - macOS: first-party BeeWare packages
  - Windows: third-party python.org packages
  - Linux: third-party Standalone Python packages
- These defaults of where to source a support package from are specified directly within Briefcase
- So, also specifying the default revision to use for these packages makes sense to me
- Also, it'll make it much simpler to bump the revision if we don't have to create a PR for each output format 🙂 
- None of the semantics of overriding these defaults in `pyproject.toml` changes
- What do you tihnk?

## WiP Changes
- The attached changes so how this would work for Flatpak

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct