### PR TITLE
Ignore vendored .dist-info folders.

### DIFF
--- a/changes/1970.bugfix.rst
+++ b/changes/1970.bugfix.rst
@@ -1,1 +1,1 @@
-Packages that include ``.dist-info`` content in vendored dependencies are now ignored as part of the binary widening process on macOS. If a binary package has vendored subpackages, it is assumed that the top-level package includes the vendored package's files in it's wheel manifest.
+Packages that include ``.dist-info`` content in vendored dependencies are now ignored as part of the binary widening process on macOS. If a binary package has vendored subpackages, it is assumed that the top-level package includes the vendored packages' files in its wheel manifest.

--- a/changes/1970.bugfix.rst
+++ b/changes/1970.bugfix.rst
@@ -1,0 +1,1 @@
+Packages that include ``.dist-info`` content in vendored dependencies are now ignored as part of the binary widening process on macOS. If a binary package has vendored subpackages, it is assumed that the top-level package includes the vendored package's files in it's wheel manifest.

--- a/src/briefcase/platforms/macOS/utils.py
+++ b/src/briefcase/platforms/macOS/utils.py
@@ -41,7 +41,7 @@ class AppPackagesMergeMixin:
             are in the install path that are non-universal and non-pure.
         """
         binary_packages = []
-        for distinfo in install_path.glob("**/*.dist-info"):
+        for distinfo in install_path.glob("*.dist-info"):
             # Read the WHEEL file in the dist-info folder.
             # Use this to determine if the wheel is "pure", and the tag
             # for the wheel.

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__find_binary_packages.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__find_binary_packages.py
@@ -37,6 +37,17 @@ def test_find_binary_packages(dummy_command, tmp_path):
         "binary-package-2",
         version="3.4.6",
         tag="macOS_13_arm64",
+        extra_content=[
+            # A vendored, but incomplete .dist-info folder. See #1970
+            ("vendored/nested-incomplete.dist-info/LICENSE", "Nested License", 0o644),
+        ],
+    )
+    # A vendored .dist-info folder. This *isn't* found and processed.
+    create_installed_package(
+        tmp_path / "app-packages/binary-package-2/vendored",
+        "nested-package",
+        version="9.9.9",
+        tag="macOS_13_arm64",
     )
 
     binary_packages = dummy_command.find_binary_packages(


### PR DESCRIPTION
Fixes #1970.

setuptools has always included vendored downstream libraries; however, as of 73.0, they started including a vendored copy of the `.dist-info` folder as well. This breaks Briefcase's binary package search mechanism.

This PR modifies binary package search to do a shallow search, rather than a deep search.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
