### PR TITLE
Replace `add_background_task()` in Toga automation bootstrap

### DIFF
--- a/automation/src/automation/bootstraps/toga.py
+++ b/automation/src/automation/bootstraps/toga.py
@@ -26,10 +26,8 @@ class {{{{ cookiecutter.class_name }}}}(toga.App):
         self.main_window.content = main_box
         self.main_window.show()
 
-        self.add_background_task(self.exit_soon)
-
-    async def exit_soon(self, app: toga.App, **kwargs):
-        """Background task that closes the app after a few seconds."""
+    async def on_running(self):
+        """Close the app after a few seconds."""
         await asyncio.sleep(2)
         print("{EXIT_SUCCESS_NOTIFY}")
         print("{BRIEFCASE_EXIT_SUCCESS_SIGNAL}")

--- a/changes/1977.misc.rst
+++ b/changes/1977.misc.rst
@@ -1,0 +1,1 @@
+The deprecated ``add_background_task()`` API was replaced in the Toga automation bootstrap.


### PR DESCRIPTION
## Changes
- Fix CI warnings for deprecated `add_background_task()`
```
2024-08-29T17:16:25.7757238Z [2m[verifyapp][0m Starting app...
2024-08-29T17:16:25.7797688Z ===========================================================================
2024-08-29T17:16:26.3294634Z 
2024-08-29T17:16:26.3310775Z (verifyapp:3766): dbind-WARNING **: 17:16:26.328: AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files
2024-08-29T17:16:26.4161697Z /home/runner/work/briefcase-template/briefcase-template/apps/verifyapp/build/verifyapp/ubuntu/jammy/verifyapp-0.0.1/usr/lib/verifyapp/app/verifyapp/app.py:26: DeprecationWarning: App.add_background_task is deprecated. Use asyncio.create_task(), or set an App.on_running() handler
2024-08-29T17:16:26.4177389Z   self.add_background_task(self.exit_soon)
2024-08-29T17:16:28.4233150Z >>> successfully started...exiting <<<
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
