### PR TITLE
Ensure app bootstrap `AppContext` is correct

### DIFF
--- a/changes/1988.bugfix.rst
+++ b/changes/1988.bugfix.rst
@@ -1,0 +1,1 @@
+The typings for ``AppContext`` passed to GUI Toolkit bootstraps for creating new projects is now correct.

--- a/src/briefcase/bootstraps/base.py
+++ b/src/briefcase/bootstraps/base.py
@@ -9,6 +9,8 @@ class AppContext(TypedDict):
     app_name: str
     class_name: str
     module_name: str
+    source_dir: str
+    test_source_dir: str
     project_name: str
     description: str
     author: str
@@ -16,9 +18,6 @@ class AppContext(TypedDict):
     bundle: str
     url: str
     license: str
-    briefcase_version: str
-    template_source: str
-    template_branch: str
 
 
 class BaseGuiBootstrap(ABC):


### PR DESCRIPTION
## Changes
- Noticed `AppContext` didn't actually match reality; this helps avoid that going forward

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct