### PR TITLE
Allow test mode for console apps on macOS

### DIFF
--- a/changes/1992.bugfix.rst
+++ b/changes/1992.bugfix.rst
@@ -1,0 +1,1 @@
+The ``--test`` flag now works for console apps for macOS.


### PR DESCRIPTION
## Changes
- Directly run and stream console apps on macOS to allow capturing testing outcome

## Related
- https://github.com/beeware/toga/pull/2822
- https://github.com/beeware/toga/pull/2823

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct