### PR TITLE
Bump pre-commit-hooks from v4.6.0 to v5.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-toml
       - id: check-yaml

--- a/changes/2012.misc.rst
+++ b/changes/2012.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``pre-commit-hooks`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `pre-commit-hooks` from v4.6.0 to v5.0.0 and ran the update against the repo.