### PR TITLE
Bump versions in Toga bootstrap

### DIFF
--- a/changes/2017.misc.rst
+++ b/changes/2017.misc.rst
@@ -1,0 +1,1 @@
+The versions for Toga's dependencies in its bootstrap were bumped to their latest versions.

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -51,7 +51,7 @@ test_requires = [
         return """\
 universal_build = true
 requires = [
-    "toga-cocoa~=0.4.6",
+    "toga-cocoa~=0.4.7",
     "std-nslog~=1.0.3",
 ]
 """
@@ -59,7 +59,7 @@ requires = [
     def pyproject_table_linux(self):
         return """\
 requires = [
-    "toga-gtk~=0.4.6",
+    "toga-gtk~=0.4.7",
 ]
 """
 
@@ -181,21 +181,21 @@ linuxdeploy_plugins = [
     def pyproject_table_linux_flatpak(self):
         return """\
 flatpak_runtime = "org.gnome.Platform"
-flatpak_runtime_version = "46"
+flatpak_runtime_version = "47"
 flatpak_sdk = "org.gnome.Sdk"
 """
 
     def pyproject_table_windows(self):
         return """\
 requires = [
-    "toga-winforms~=0.4.6",
+    "toga-winforms~=0.4.7",
 ]
 """
 
     def pyproject_table_iOS(self):
         return """\
 requires = [
-    "toga-iOS~=0.4.6",
+    "toga-iOS~=0.4.7",
     "std-nslog~=1.0.3",
 ]
 """
@@ -203,24 +203,24 @@ requires = [
     def pyproject_table_android(self):
         return """\
 requires = [
-    "toga-android~=0.4.6",
+    "toga-android~=0.4.7",
 ]
 
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "com.google.android.material:material:1.11.0",
+    "com.google.android.material:material:1.12.0",
     # Needed for DetailedList
     # "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
     # Needed for MapView
-    # "org.osmdroid:osmdroid-android:6.1.0",
+    # "org.osmdroid:osmdroid-android:6.1.20",
 ]
 """
 
     def pyproject_table_web(self):
         return """\
 requires = [
-    "toga-web~=0.4.6",
+    "toga-web~=0.4.7",
 ]
 style_framework = "Shoelace v2.3"
 """

--- a/tests/commands/new/test_build_context.py
+++ b/tests/commands/new/test_build_context.py
@@ -161,13 +161,13 @@ test_requires = [
         pyproject_table_macOS="""\
 universal_build = true
 requires = [
-    "toga-cocoa~=0.4.6",
+    "toga-cocoa~=0.4.7",
     "std-nslog~=1.0.3",
 ]
 """,
         pyproject_table_linux="""\
 requires = [
-    "toga-gtk~=0.4.6",
+    "toga-gtk~=0.4.7",
 ]
 """,
         pyproject_table_linux_system_debian="""\
@@ -277,38 +277,38 @@ linuxdeploy_plugins = [
 """,
         pyproject_table_linux_flatpak="""\
 flatpak_runtime = "org.gnome.Platform"
-flatpak_runtime_version = "46"
+flatpak_runtime_version = "47"
 flatpak_sdk = "org.gnome.Sdk"
 """,
         pyproject_table_windows="""\
 requires = [
-    "toga-winforms~=0.4.6",
+    "toga-winforms~=0.4.7",
 ]
 """,
         pyproject_table_iOS="""\
 requires = [
-    "toga-iOS~=0.4.6",
+    "toga-iOS~=0.4.7",
     "std-nslog~=1.0.3",
 ]
 """,
         pyproject_table_android="""\
 requires = [
-    "toga-android~=0.4.6",
+    "toga-android~=0.4.7",
 ]
 
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "com.google.android.material:material:1.11.0",
+    "com.google.android.material:material:1.12.0",
     # Needed for DetailedList
     # "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
     # Needed for MapView
-    # "org.osmdroid:osmdroid-android:6.1.0",
+    # "org.osmdroid:osmdroid-android:6.1.20",
 ]
 """,
         pyproject_table_web="""\
 requires = [
-    "toga-web~=0.4.6",
+    "toga-web~=0.4.7",
 ]
 style_framework = "Shoelace v2.3"
 """,
@@ -1058,13 +1058,13 @@ test_requires = [
         pyproject_table_macOS="""\
 universal_build = true
 requires = [
-    "toga-cocoa~=0.4.6",
+    "toga-cocoa~=0.4.7",
     "std-nslog~=1.0.3",
 ]
 """,
         pyproject_table_linux="""\
 requires = [
-    "toga-gtk~=0.4.6",
+    "toga-gtk~=0.4.7",
 ]
 """,
         pyproject_table_linux_system_debian="""\
@@ -1174,38 +1174,38 @@ linuxdeploy_plugins = [
 """,
         pyproject_table_linux_flatpak="""\
 flatpak_runtime = "org.gnome.Platform"
-flatpak_runtime_version = "46"
+flatpak_runtime_version = "47"
 flatpak_sdk = "org.gnome.Sdk"
 """,
         pyproject_table_windows="""\
 requires = [
-    "toga-winforms~=0.4.6",
+    "toga-winforms~=0.4.7",
 ]
 """,
         pyproject_table_iOS="""\
 requires = [
-    "toga-iOS~=0.4.6",
+    "toga-iOS~=0.4.7",
     "std-nslog~=1.0.3",
 ]
 """,
         pyproject_table_android="""\
 requires = [
-    "toga-android~=0.4.6",
+    "toga-android~=0.4.7",
 ]
 
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "com.google.android.material:material:1.11.0",
+    "com.google.android.material:material:1.12.0",
     # Needed for DetailedList
     # "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
     # Needed for MapView
-    # "org.osmdroid:osmdroid-android:6.1.0",
+    # "org.osmdroid:osmdroid-android:6.1.20",
 ]
 """,
         pyproject_table_web="""\
 requires = [
-    "toga-web~=0.4.6",
+    "toga-web~=0.4.7",
 ]
 style_framework = "Shoelace v2.3"
 """,


### PR DESCRIPTION
## Changes
- Require at least Toga 0.4.7
- Flatpak GNOME runtime 46 -> 47
- com.google.android.material:material 1.11.0 -> 1.12.0
- org.osmdroid:osmdroid-android 6.1.0 -> 6.1.20

## Notes
- If Toga will have another release for Python 3.13, probably best to wait on this one

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct