### PR TITLE
Correct handling of arguments that take values.

### DIFF
--- a/changes/2026.bugfix.rst
+++ b/changes/2026.bugfix.rst
@@ -1,0 +1,1 @@
+Python 3.12.7 introduced an incompatibility with the handling of ``-C``, ``-d`` and other flags that accept values. This incompatibility has been corrected.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -81,7 +81,7 @@ def split_passthrough(args):
     try:
         pos = args.index("--")
     except ValueError:
-        return args, []
+        return args[:], []
     else:
         return args[:pos], args[pos + 1 :]
 


### PR DESCRIPTION
Python 3.12.7 modified the handling of command line arguments in a way that broke Briefcase's handling of arguments that take values (e.g., `-C <config=value>`, `-d <device>`, etc).

Briefcase's command line handling is based on pushing argparse to its limits, performing partial parsing of arguments before all options have been registered. This is needed to allow commands to register their own arguments, and for the help for commands to be responsive to the target platform and output format.

The parser *also* has 2 optional positional arguments for most commands (`platform` and `output_format`). Because they're optional, there's an ambiguity between these positional arguments, and arguments with flags that take values that haven't been registered yet. 

This PR takes a quick-and-dirty approach, removing any argument that looks like it might be passing a value from consideration from the partial parse. It's not pretty, but it works.

Fixes #2026.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
