### PR TITLE
Simplify handling of command line arguments.

### DIFF
--- a/changes/2026.bugfix.rst
+++ b/changes/2026.bugfix.rst
@@ -1,0 +1,1 @@
+Python 3.12.7 introduced an incompatibility with the handling of ``-C``, ``-d`` and other flags that accept values. This incompatibility has been corrected.

--- a/src/briefcase/exceptions.py
+++ b/src/briefcase/exceptions.py
@@ -26,6 +26,17 @@ class NoCommandError(HelpText):
         return self.msg
 
 
+class InvalidPlatformError(BriefcaseError):
+    def __init__(self, requested, choices):
+        super().__init__(error_code=-20, skip_logfile=True)
+        self.requested = requested
+        self.choices = choices
+
+    def __str__(self):
+        choices = ", ".join(sorted(self.choices, key=str.lower))
+        return f"Invalid platform {self.requested!r}; (choose from: {choices})"
+
+
 class InvalidFormatError(BriefcaseError):
     def __init__(self, requested, choices):
         super().__init__(error_code=-21, skip_logfile=True)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -9,6 +9,7 @@ from briefcase.commands import ConvertCommand, DevCommand, NewCommand, UpgradeCo
 from briefcase.console import Console, Log, LogLevel
 from briefcase.exceptions import (
     InvalidFormatError,
+    InvalidPlatformError,
     NoCommandError,
     UnsupportedCommandError,
 )
@@ -456,14 +457,9 @@ def test_command_unknown_platform(monkeypatch, logger, console):
     # Pretend we're on macOS, regardless of where the tests run.
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    with pytest.raises(SystemExit) as excinfo:
+    expected_exc_regex = r"Invalid platform 'foobar'; \(choose from: .*\)"
+    with pytest.raises(InvalidPlatformError, match=expected_exc_regex):
         do_cmdline_parse("create foobar".split(), logger, console)
-
-    assert excinfo.value.code == 2
-    assert excinfo.value.__context__.argument_name == "platform"
-    assert excinfo.value.__context__.message.startswith(
-        "invalid choice: 'foobar' (choose from"
-    )
 
 
 def test_command_explicit_platform(monkeypatch, logger, console):


### PR DESCRIPTION
Python 3.12.7 modified the handling of command line arguments in a way that broke Briefcase's handling of arguments that take values (e.g., `-C <config=value>`, `-d <device>`, etc).

Briefcase's command line handling pushes argparse to its limits, performing 2 partial parsing passes of arguments before all options have been registered, when the full parsing pass can be performed. 

The second pass in particular is a problem, because it involves 2 optional positional arguments; and prior to formally registering options, there's no way to tell the difference between a positional argument, and an option that takes a value. We have been inadvertently relying on a behavior of argparse that stopped processing positional arguments once an option was discovered. That behavior has changed in 3.12.7 (which will also be in 3.13.1), but it's hard to argue that the way we were using argparse was "correct" behaviour. 

Instead of trying to use a partial parser on an incomplete argument set, this PR interrogates the arguments for platform and output format directly. This requires that platform and format, if provided, are the first and second arguments after the command... but that was already a requirement - `briefcase run -d "iPhone 15 Pro" iOS` would be rejected using the old code. 

The only difference in behaviour is that the error raised by `briefcase run foobar` now raises a custom error, rather than an argparse error about the invalid platform. Invalid *format* names were already handled as custom errors.

Fixes #2026

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
