### PR TITLE
Forward git error message when template repo clone fails

### DIFF
--- a/changes/1118.feature.rst
+++ b/changes/1118.feature.rst
@@ -1,0 +1,1 @@
+Briefcase will now surface git's error messages if an error occurs when cloning a template repository.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -981,15 +981,12 @@ Did you run Briefcase in a project directory that contains {filename.name!r}?"""
                     git_fatal_message = re.findall(r"(?<=fatal: ).*?$", e.stderr, re.S)
                     if git_fatal_message:
                         # GitError captures stderr with single quotes. Because the regex above
-                        # takes everything after git's "fatal" message, we need to strip that final single quote
-                        hint = git_fatal_message[0].rstrip("'")
+                        # takes everything after git's "fatal" message, we need to strip that final single quote.
+                        hint = git_fatal_message[0].rstrip("'").strip()
 
                         # git is inconsistent with capitalisation of the first word of the message
-                        # and about periods at the end of the message. Normalise those here to ensure
-                        # a clean and uniform presentation
-                        # Also strip the string of any trailing whitespace before applying the period fix.
-                        hint = f"{hint[0].upper()}{hint[1:]}".strip()
-                        hint += "." if hint[-1] != "." else ""
+                        # and about periods at the end of the message.
+                        hint = f"{hint[0].upper()}{hint[1:]}{'' if hint[-1] == '.' else '.'}"
                     else:
                         hint = (
                             "This may be because your computer is offline, or "

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -32,10 +32,10 @@ from briefcase.console import MAX_TEXT_WIDTH, Console, Log
 from briefcase.exceptions import (
     BriefcaseCommandError,
     BriefcaseConfigError,
+    InvalidTemplateBranch,
     InvalidTemplateRepository,
     MissingAppMetadata,
     NetworkFailure,
-    TemplateUnsupportedVersion,
     UnsupportedHostError,
     UnsupportedPythonVersion,
 )
@@ -1037,7 +1037,7 @@ Did you run Briefcase in a project directory that contains {filename.name!r}?"""
                     head.checkout()
                 except IndexError as e:
                     # No branch exists for the requested version.
-                    raise TemplateUnsupportedVersion(branch) from e
+                    raise InvalidTemplateBranch(template, branch) from e
             except (ValueError, self.tools.git.exc.GitError) as e:
                 raise BriefcaseCommandError(
                     "Unable to check out template branch.\n"
@@ -1094,7 +1094,7 @@ Did you run Briefcase in a project directory that contains {filename.name!r}?"""
             raise InvalidTemplateRepository(template) from e
         except cookiecutter_exceptions.RepositoryCloneFailed as e:
             # Branch does not exist.
-            raise TemplateUnsupportedVersion(branch) from e
+            raise InvalidTemplateBranch(template, branch) from e
         except cookiecutter_exceptions.UndefinedVariableInTemplate as e:
             raise BriefcaseConfigError(e.message) from e
 
@@ -1135,7 +1135,7 @@ Did you run Briefcase in a project directory that contains {filename.name!r}?"""
                 output_path=output_path,
                 extra_context=extra_context,
             )
-        except TemplateUnsupportedVersion:
+        except InvalidTemplateBranch:
             # Only use the main template if we're on a development branch of briefcase
             # and the user didn't explicitly specify which branch to use.
             if version.dev is None or branch is not None:

--- a/src/briefcase/exceptions.py
+++ b/src/briefcase/exceptions.py
@@ -137,11 +137,10 @@ class UpgradeToolError(BriefcaseCommandError):
         super().__init__(msg=error_msg, skip_logfile=True)
 
 
-class TemplateUnsupportedVersion(BriefcaseCommandError):
-    def __init__(self, briefcase_version):
-        self.briefcase_version = briefcase_version
+class InvalidTemplateBranch(BriefcaseCommandError):
+    def __init__(self, template_repo, branch):
         super().__init__(
-            f"Could not find a template branch for Briefcase {briefcase_version}."
+            f"{branch} did not match any branches in template repository {template_repo}."
         )
 
 

--- a/src/briefcase/exceptions.py
+++ b/src/briefcase/exceptions.py
@@ -139,8 +139,10 @@ class UpgradeToolError(BriefcaseCommandError):
 
 class InvalidTemplateBranch(BriefcaseCommandError):
     def __init__(self, template_repo, branch):
+        self.template_repo = template_repo
+        self.branch = branch
         super().__init__(
-            f"{branch} did not match any branches in template repository {template_repo}."
+            f"Could not find a branch named {branch!r} in template repository {template_repo!r}."
         )
 
 

--- a/tests/commands/base/test_update_cookiecutter_cache.py
+++ b/tests/commands/base/test_update_cookiecutter_cache.py
@@ -185,13 +185,6 @@ def test_repo_clone_error(stderr_string, error_message, base_command, mock_git):
             branch="briefcase-template",
         )
 
-    base_command.tools.git.Repo.clone_from.assert_called_once_with(
-        url="https://example.com",
-        to_path=base_command.data_path / "templates" / "example.com",
-        filter=["blob:none"],
-        no_checkout=True,
-    )
-
 
 def test_existing_repo_template(base_command, mock_git):
     """If a previously known URL template is specified it is used."""

--- a/tests/commands/base/test_update_cookiecutter_cache.py
+++ b/tests/commands/base/test_update_cookiecutter_cache.py
@@ -1,3 +1,4 @@
+import re
 import shutil
 from unittest import mock
 
@@ -124,6 +125,72 @@ def test_new_repo_invalid_template_url(base_command, mock_git):
 
     # The template directory should be cleaned up
     assert not (base_command.data_path / "templates" / "special-template").exists()
+
+
+@pytest.mark.parametrize(
+    ("stderr_string", "error_message"),
+    (
+        pytest.param(
+            "\n    stderr: '\nfatal: could not clone repository 'https://example.com' \n'",
+            "Could not clone repository 'https://example.com'.",
+            id="tailing-whitespace-no-caps-no-period",
+        ),
+        pytest.param(
+            (
+                "\n    stderr: '\nfatal: Could not read from remote repository.\n\n"
+                "Please make sure you have the correct access rights\nand the repository exists. \n'"
+            ),
+            (
+                "Could not read from remote repository.\n\nPlease make sure "
+                "you have the correct access rights\nand the repository exists."
+            ),
+            id="tailing-whitespace-has-caps-has-period",
+        ),
+        pytest.param(
+            (
+                "\n    stderr: '\nfatal: unable to access 'https://example.com/': "
+                "OpenSSL/3.2.2: error:0A000438:SSL routines::tlsv1 alert internal error'"
+            ),
+            (
+                "Unable to access 'https://example.com/': OpenSSL/3.2.2: "
+                "error:0A000438:SSL routines::tlsv1 alert internal error."
+            ),
+            id="no-tailing-whitespace-no-caps-no-period",
+        ),
+        pytest.param(
+            "\n stderr: 'Mysterious git clone edge case with no fatal error.",
+            "This may be because your computer is offline",
+            id="fallback-hint",
+        ),
+    ),
+)
+def test_repo_clone_error(stderr_string, error_message, base_command, mock_git):
+    """If git emits error information when cloning, Briefcase provides that to the user.
+    If git does not emit a 'fatal' error, then fallback to a generic hint."""
+    base_command.tools.git = mock_git
+
+    base_command.tools.git.Repo.clone_from.side_effect = git_exceptions.GitCommandError(
+        "git", 128, stderr_string
+    )
+
+    repository = "https://example.com"
+
+    with pytest.raises(
+        BriefcaseCommandError,
+        # The error message should not retain the "fatal:" prefix; it isn't useful information to the user.
+        match=f"Unable to clone repository '{re.escape(repository)}'.\n\n?(?<!fatal: ){re.escape(error_message)}",
+    ):
+        base_command.update_cookiecutter_cache(
+            template=repository,
+            branch="briefcase-template",
+        )
+
+    base_command.tools.git.Repo.clone_from.assert_called_once_with(
+        url="https://example.com",
+        to_path=base_command.data_path / "templates" / "example.com",
+        filter=["blob:none"],
+        no_checkout=True,
+    )
 
 
 def test_existing_repo_template(base_command, mock_git):

--- a/tests/commands/base/test_update_cookiecutter_cache.py
+++ b/tests/commands/base/test_update_cookiecutter_cache.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 from git import exc as git_exceptions
 
-from briefcase.exceptions import BriefcaseCommandError, TemplateUnsupportedVersion
+from briefcase.exceptions import BriefcaseCommandError, InvalidTemplateBranch
 
 from ...utils import create_file
 
@@ -394,7 +394,7 @@ def test_cached_missing_branch_template(base_command, mock_git):
     cached_path.mkdir(parents=True)
 
     # Generating the template under there conditions raises an error
-    with pytest.raises(TemplateUnsupportedVersion):
+    with pytest.raises(InvalidTemplateBranch):
         base_command.update_cookiecutter_cache(
             template="https://example.com/magic/special-template.git",
             branch="invalid",

--- a/tests/commands/create/test_generate_app_template.py
+++ b/tests/commands/create/test_generate_app_template.py
@@ -12,8 +12,8 @@ import briefcase
 from briefcase.exceptions import (
     BriefcaseCommandError,
     BriefcaseConfigError,
+    InvalidTemplateBranch,
     NetworkFailure,
-    TemplateUnsupportedVersion,
 )
 
 
@@ -243,7 +243,7 @@ def test_default_template_dev_explicit_invalid_branch(
     )
 
     # Generate the template.
-    with pytest.raises(TemplateUnsupportedVersion):
+    with pytest.raises(InvalidTemplateBranch):
         create_command.generate_app_template(myapp)
 
     # Cookiecutter was invoked (once) with the expected template name and context.
@@ -651,7 +651,7 @@ def test_cached_missing_branch_template(monkeypatch, create_command, myapp):
     mock_remote.refs.__getitem__.side_effect = IndexError
 
     # Generating the template under there conditions raises an error
-    with pytest.raises(TemplateUnsupportedVersion):
+    with pytest.raises(InvalidTemplateBranch):
         create_command.generate_app_template(myapp)
 
 

--- a/tests/commands/new/test_new_app.py
+++ b/tests/commands/new/test_new_app.py
@@ -10,8 +10,8 @@ from briefcase.commands import NewCommand
 from briefcase.console import Console, Log
 from briefcase.exceptions import (
     BriefcaseCommandError,
+    InvalidTemplateBranch,
     InvalidTemplateRepository,
-    TemplateUnsupportedVersion,
 )
 
 
@@ -123,7 +123,7 @@ def test_new_app_missing_template(monkeypatch, new_command, tmp_path):
     )
 
     # Create the new app, using the default template. This raises an error.
-    with pytest.raises(TemplateUnsupportedVersion):
+    with pytest.raises(InvalidTemplateBranch):
         new_command.new_app()
 
     # App context is constructed
@@ -397,7 +397,7 @@ def test_new_app_with_invalid_template_branch(monkeypatch, new_command, tmp_path
     )
 
     # Create a new app, with a specific template; this raises an error
-    with pytest.raises(TemplateUnsupportedVersion):
+    with pytest.raises(InvalidTemplateBranch):
         new_command.new_app(template="https://example.com/other.git")
 
     # App context is constructed


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #1118.

When cloning goes wrong, git usually provides a useful message. Examples of these are listed in the linked issue, and as far as I can tell, they always include a `fatal:` before the message details. Git sometimes also outputs information _before_ the `fatal:` sigil, but the exact content of that message varies, and appears to do so based on the server responding. From what I've seen, doesn't offer more information than Briefcase's "Unable to clone ..." message. For example, GitHub and Sourcehut say almost, but not quite the same things when you try to clone a repository that doesn't exist.

- GitHub: `ERROR: Repository not found.` with only a single trailing newline
- Sourcehut: `Repository not found.` with two trailing newlines and no `ERROR:` preamble

That message is then followed by identical `fatal: ...` messages. Git already introduces enough variability in the formatting of its `fatal` messages (see the normalisation part of this PR), so trying to account for the variations introduced by any given git server would be futile, and with dubious value. So far as I can tell, git's `fatal` message provides the context that would be useful to a user, so that's what I've chosen to surface to the Briefcase user.

The messages used in the test cases are based on the handful of real messages discussed in the issue, but have manufactured aspects documented in the `pytest.param` `id`, meant to test the particular cases of the hint normalisation. I have not tried to find every error git can emit when cloning, and have not verified that any of them don't include the `fatal:` sigil. It could be that the fallback hint will never be used in real life.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
