### PR TITLE
Capture network errors when downloading files

### DIFF
--- a/changes/1960.bugfix.rst
+++ b/changes/1960.bugfix.rst
@@ -1,0 +1,1 @@
+Network errors that arise when downloading tools are now more cleanly handled.

--- a/src/briefcase/exceptions.py
+++ b/src/briefcase/exceptions.py
@@ -90,9 +90,12 @@ class BriefcaseCommandError(BriefcaseError):
 
 
 class NetworkFailure(BriefcaseCommandError):
-    def __init__(self, action):
+    DEFAULT_HINT = "is your computer offline?"
+
+    def __init__(self, action, hint=None):
         self.action = action
-        super().__init__(msg=f"Unable to {action}; is your computer offline?")
+        self.hint = hint if hint is not None else self.DEFAULT_HINT
+        super().__init__(msg=f"Unable to {action}; {self.hint}")
 
 
 class MissingNetworkResourceError(BriefcaseCommandError):


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #1960.

I'm not very happy with the error message I've come up with, it's a bit of riffing on pip's "likely not a problem with pip" error. I think the same situation applies here, because either the server didn't send a chunked response, or the response it sent was unintelligible or had an SSL cert issue. With the server not sending a chunked response, perhaps Briefcase could try requesting an un-chunked response, but that's not going to work well for downloads the size of the Android SDK or Visual Studio, I don't think.

Regardless, the logs will contain more detailed information, including the handled requests exception.

Suggestions welcome, of course.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
