### PR TITLE
Add mechamism for explicit `requires` package repository references

### DIFF
--- a/changes/1270.feature.rst
+++ b/changes/1270.feature.rst
@@ -1,0 +1,1 @@
+Briefcase now supports package repository configuration options for app requirements.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -366,6 +366,33 @@ Any PEP 508 version specifier is legal. For example:
 
     requires=["fullpath/wheelfile.whl"]
 
+.. _configuration-package-repository:
+
+``package_repository``
+~~~~~~~~~~~~~~~~~~~~~~
+
+A reference to the package repository that should be used for requirement installation.
+
+.. admonition:: Supported installer backends
+
+    The type of reference supported in this option depends on the installer backend. For
+    example, when pip is used to install requirements, the type of references supported in
+    this option depend on pip's `index-url
+    <https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-i>`_ option.
+
+    Pip is the only currently supported backend. Other backends may not support the same
+    references as pip. As such, this option does not have a concrete format, and the variety
+    of references supported by pip may not be supported by other backends.
+
+``extra_package_repositories``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A list of references of the same type and with the same stipulations as
+:ref:`package_repository <configuration-package-repository>`.
+
+When pip is the installer backend, this option maps to `extra-index-url
+<https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-extra-index-url>`__.
+
 ``revision``
 ~~~~~~~~~~~~
 

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -548,7 +548,7 @@ class CreateCommand(BaseCommand):
     def _extra_pip_args(self, app: AppConfig):
         """Any additional arguments that must be passed to pip when installing packages.
 
-        Maps the app config repository_url and extra_repository_urls to pip's
+        Maps the app config package_repository and extra_package_repositories to pip's
         index-url and extra-index-url respectively. For both, do only minimal
         validation to ensure most common use cases function as expected. Namely,
         that means mapping local path references to stable absolute references so
@@ -577,19 +577,19 @@ class CreateCommand(BaseCommand):
         # will give a usable error in that case and the user can adjust their
         # configuration accordingly.
 
-        if repo_url := app.repository_url:
-            if not _has_url(repo_url):
-                index_url = os.path.abspath(self.base_path / repo_url)
+        if repo := app.package_repository:
+            if not _has_url(repo):
+                index_url = os.path.abspath(self.base_path / repo)
             else:
-                index_url = repo_url
+                index_url = repo
 
             extra_args.append(f"--index-url={index_url}")
 
-        for url in app.extra_repository_urls:
-            if not _has_url(url):
-                extra_index_url = os.path.abspath(self.base_path / url)
+        for extra_repo in app.extra_package_repositories:
+            if not _has_url(extra_repo):
+                extra_index_url = os.path.abspath(self.base_path / extra_repo)
             else:
-                extra_index_url = url
+                extra_index_url = extra_repo
 
             extra_args.append(f"--extra-index-url={extra_index_url}")
 

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -266,6 +266,8 @@ class AppConfig(BaseConfig):
         supported=True,
         long_description=None,
         console_app=False,
+        repository_url: str | None = None,
+        extra_repository_urls: list[str] | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -295,6 +297,10 @@ class AppConfig(BaseConfig):
         self.long_description = long_description
         self.license = license
         self.console_app = console_app
+        self.repository_url = repository_url
+        self.extra_repository_urls = (
+            [] if extra_repository_urls is None else extra_repository_urls
+        )
 
         if not is_valid_app_name(self.app_name):
             raise BriefcaseConfigError(
@@ -426,6 +432,7 @@ def merge_config(config, data):
         "sources",
         "test_requires",
         "test_sources",
+        "extra_repository_urls",
     ]:
         value = data.pop(option, [])
 

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -266,8 +266,8 @@ class AppConfig(BaseConfig):
         supported=True,
         long_description=None,
         console_app=False,
-        repository_url: str | None = None,
-        extra_repository_urls: list[str] | None = None,
+        package_repository: str | None = None,
+        extra_package_repositories: list[str] | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -297,9 +297,9 @@ class AppConfig(BaseConfig):
         self.long_description = long_description
         self.license = license
         self.console_app = console_app
-        self.repository_url = repository_url
-        self.extra_repository_urls = (
-            [] if extra_repository_urls is None else extra_repository_urls
+        self.package_repository = package_repository
+        self.extra_package_repositories = (
+            [] if extra_package_repositories is None else extra_package_repositories
         )
 
         if not is_valid_app_name(self.app_name):
@@ -432,7 +432,7 @@ def merge_config(config, data):
         "sources",
         "test_requires",
         "test_sources",
-        "extra_repository_urls",
+        "extra_package_repositories",
     ]:
         value = data.pop(option, [])
 

--- a/tests/commands/create/test_install_app_requirements.py
+++ b/tests/commands/create/test_install_app_requirements.py
@@ -162,15 +162,15 @@ def test_app_packages_valid_requires(
     assert myapp.test_requires is None
 
 
-def test_app_packages_repository_url(
+def test_app_packages_package_repository(
     create_command,
     myapp,
     app_packages_path,
     app_packages_path_index,
 ):
-    """If an app defines a repository_url, it's included in the pip arguments."""
+    """If an app defines a package_repository, it's included in the pip arguments."""
     myapp.requires = ["first"]
-    myapp.repository_url = "https://pypi.org/simple"
+    myapp.package_repository = "https://pypi.org/simple"
 
     create_command.install_app_requirements(myapp, test_mode=False)
 
@@ -196,15 +196,15 @@ def test_app_packages_repository_url(
     )
 
 
-def test_app_packages_repository_url_local_path(
+def test_app_packages_package_repository_local_path(
     create_command,
     myapp,
     app_packages_path,
     app_packages_path_index,
 ):
-    """If an app defines a repository_url, it's included in the pip arguments."""
+    """If an app defines a package_repository, it's included in the pip arguments."""
     myapp.requires = ["first"]
-    myapp.repository_url = "./packages"
+    myapp.package_repository = "./packages"
 
     create_command.install_app_requirements(myapp, test_mode=False)
 
@@ -222,7 +222,7 @@ def test_app_packages_repository_url_local_path(
             "--upgrade",
             "--no-user",
             f"--target={app_packages_path}",
-            f"--index-url={os.path.abspath(create_command.base_path / myapp.repository_url)}",
+            f"--index-url={os.path.abspath(create_command.base_path / myapp.package_repository)}",
             "first",
         ],
         check=True,
@@ -230,16 +230,16 @@ def test_app_packages_repository_url_local_path(
     )
 
 
-def test_app_packages_extra_repository_urls(
+def test_app_packages_extra_package_repositories(
     create_command,
     myapp,
     app_packages_path,
     app_packages_path_index,
 ):
-    """If an app defines a repository_url, it's included in the pip arguments."""
+    """If an app defines extra_package_repositories, they are included in the pip arguments."""
     myapp.requires = ["first"]
     local_extra_repo = "./local-package-repository"
-    myapp.extra_repository_urls = [
+    myapp.extra_package_repositories = [
         "https://example.com/extra",
         local_extra_repo,
     ]

--- a/tests/commands/create/test_install_app_requirements.py
+++ b/tests/commands/create/test_install_app_requirements.py
@@ -162,6 +162,113 @@ def test_app_packages_valid_requires(
     assert myapp.test_requires is None
 
 
+def test_app_packages_repository_url(
+    create_command,
+    myapp,
+    app_packages_path,
+    app_packages_path_index,
+):
+    """If an app defines a repository_url, it's included in the pip arguments."""
+    myapp.requires = ["first"]
+    myapp.repository_url = "https://pypi.org/simple"
+
+    create_command.install_app_requirements(myapp, test_mode=False)
+
+    create_command.tools[myapp].app_context.run.assert_called_with(
+        [
+            sys.executable,
+            "-u",
+            "-X",
+            "utf8",
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--no-python-version-warning",
+            "--upgrade",
+            "--no-user",
+            f"--target={app_packages_path}",
+            "--index-url=https://pypi.org/simple",
+            "first",
+        ],
+        check=True,
+        encoding="UTF-8",
+    )
+
+
+def test_app_packages_repository_url_local_path(
+    create_command,
+    myapp,
+    app_packages_path,
+    app_packages_path_index,
+):
+    """If an app defines a repository_url, it's included in the pip arguments."""
+    myapp.requires = ["first"]
+    myapp.repository_url = "./packages"
+
+    create_command.install_app_requirements(myapp, test_mode=False)
+
+    create_command.tools[myapp].app_context.run.assert_called_with(
+        [
+            sys.executable,
+            "-u",
+            "-X",
+            "utf8",
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--no-python-version-warning",
+            "--upgrade",
+            "--no-user",
+            f"--target={app_packages_path}",
+            f"--index-url={os.path.abspath(create_command.base_path / myapp.repository_url)}",
+            "first",
+        ],
+        check=True,
+        encoding="UTF-8",
+    )
+
+
+def test_app_packages_extra_repository_urls(
+    create_command,
+    myapp,
+    app_packages_path,
+    app_packages_path_index,
+):
+    """If an app defines a repository_url, it's included in the pip arguments."""
+    myapp.requires = ["first"]
+    local_extra_repo = "./local-package-repository"
+    myapp.extra_repository_urls = [
+        "https://example.com/extra",
+        local_extra_repo,
+    ]
+
+    create_command.install_app_requirements(myapp, test_mode=False)
+
+    create_command.tools[myapp].app_context.run.assert_called_with(
+        [
+            sys.executable,
+            "-u",
+            "-X",
+            "utf8",
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--no-python-version-warning",
+            "--upgrade",
+            "--no-user",
+            f"--target={app_packages_path}",
+            "--extra-index-url=https://example.com/extra",
+            f"--extra-index-url={os.path.abspath(create_command.base_path / local_extra_repo)}",
+            "first",
+        ],
+        check=True,
+        encoding="UTF-8",
+    )
+
+
 def test_app_packages_valid_requires_no_support_package(
     create_command,
     myapp,


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Part of #1270.

Does not close out #1270 because @freakboy3742 also requested adding support for pip's `--find-links`. I chose to leave that out of this PR because this PR already has enough edge cases to consider (see the issue for discussion about them), and supporting `--find-links` requires thinking about how to generically describe it.

While this PR is feature complete for `--index-url` and `--extra-index-url`, which were the original concerns of the linked issue, I'm leaving it as a draft in order to propose a very different approach, which might simplify description of the feature, and better anticipate future changes like support/hooks for different package installation backends.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
