### PR TITLE
Update to PyScript 2024.11.1

### DIFF
--- a/changes/2080.feature.rst
+++ b/changes/2080.feature.rst
@@ -1,0 +1,1 @@
+The web template now targets PyScript version 2024.11.1.

--- a/changes/2080.feature.rst
+++ b/changes/2080.feature.rst
@@ -1,1 +1,1 @@
-The web template now targets PyScript version 2024.11.1.
+The web template now targets PyScript version 2024.11.1. In addition, the web template can provide a base ``pyscript.toml`` that Briefcase will update as required during the build process.

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -32,6 +32,7 @@ from briefcase.exceptions import BriefcaseCommandError, BriefcaseConfigError
 class StaticWebMixin:
     output_format = "static"
     platform = "web"
+    platform_target_version = "0.3.21"
 
     def project_path(self, app):
         return self.bundle_path(app) / "www"
@@ -182,11 +183,6 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
         with self.input.wait_bar("Writing Pyscript configuration file..."):
             with (self.project_path(app) / "pyscript.toml").open("wb") as f:
                 config = {
-                    "name": app.formal_name,
-                    "description": app.description,
-                    "version": app.version,
-                    "splashscreen": {"autoclose": True},
-                    "terminal": False,
                     # Ensure that we're using Unix path separators, as the content
                     # will be parsed by pyscript in the browser.
                     "packages": [

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -181,28 +181,40 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
                 ) from e
 
         with self.input.wait_bar("Writing Pyscript configuration file..."):
-            with (self.project_path(app) / "pyscript.toml").open("wb") as f:
-                config = {
-                    # Ensure that we're using Unix path separators, as the content
-                    # will be parsed by pyscript in the browser.
-                    "packages": [
-                        f'/{"/".join(wheel.relative_to(self.project_path(app)).parts)}'
-                        for wheel in sorted(self.wheel_path(app).glob("*.whl"))
-                    ],
-                }
-                # Parse any additional pyscript.toml content, and merge it into
-                # the overall content
-                try:
-                    extra = tomllib.loads(app.extra_pyscript_toml_content)
-                    config.update(extra)
-                except tomllib.TOMLDecodeError as e:
-                    raise BriefcaseConfigError(
-                        f"Extra pyscript.toml content isn't valid TOML: {e}"
-                    ) from e
-                except AttributeError:
-                    pass
+            # Load any pre-existing pyscript.toml provided by the template. If the file
+            # doesn't exist, assume an empty pyscript.toml as a starting point.
+            try:
+                with (self.project_path(app) / "pyscript.toml").open("rb") as f:
+                    config = tomllib.load(f)
+            except tomllib.TOMLDecodeError as e:
+                raise BriefcaseConfigError(
+                    f"pyscript.toml content isn't valid TOML: {e}"
+                ) from e
+            except FileNotFoundError:
+                config = {}
 
-                # Write the final configuration.
+            # Add the packages declaration to the existing pyscript.toml.
+            # Ensure that we're using Unix path separators, as the content
+            # will be parsed by pyscript in the browser.
+            config["packages"] = [
+                f'/{"/".join(wheel.relative_to(self.project_path(app)).parts)}'
+                for wheel in sorted(self.wheel_path(app).glob("*.whl"))
+            ]
+
+            # Parse any additional pyscript.toml content, and merge it into
+            # the overall content
+            try:
+                extra = tomllib.loads(app.extra_pyscript_toml_content)
+                config.update(extra)
+            except tomllib.TOMLDecodeError as e:
+                raise BriefcaseConfigError(
+                    f"Extra pyscript.toml content isn't valid TOML: {e}"
+                ) from e
+            except AttributeError:
+                pass
+
+            # Write the final configuration.
+            with (self.project_path(app) / "pyscript.toml").open("wb") as f:
                 tomli_w.dump(config, f)
 
         self.logger.info("Compile static web content from wheels")

--- a/tests/platforms/web/static/conftest.py
+++ b/tests/platforms/web/static/conftest.py
@@ -19,6 +19,15 @@ app_requirements_path="requirements.txt"
     # Create index.html
     create_file(bundle_path / "www/index.html", "<html></html>")
 
+    # Create the initial pyscript.toml
+    create_file(
+        bundle_path / "www/pyscript.toml",
+        """
+existing-key-1 = "value-1"
+existing-key-2 = 2
+""",
+    )
+
     # Create the initial briefcase.css
     create_file(
         bundle_path / "www/static/css/briefcase.css",


### PR DESCRIPTION
Removed all obsolete PyScript settings. Since these settings were required by the old template, also added a `platform_target_version`.

The corresponding template PR should be merged first:
* https://github.com/beeware/briefcase-web-static-template/pull/16

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
