### PR TITLE
Omit old URL for `origin` remote update for Briefcase-managed templates

### DIFF
--- a/changes/2077.bugfix.rst
+++ b/changes/2077.bugfix.rst
@@ -1,0 +1,1 @@
+Briefcase no longer fails to create projects or builds because it cannot update the Git configuration for the relevant template.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -1014,7 +1014,7 @@ Did you run Briefcase in a project directory that contains {filename.name!r}?"""
                 # Ensure the existing repo's origin URL points to the location
                 # being requested. A difference can occur, for instance, if a
                 # fork of the template is used.
-                remote.set_url(new_url=template, old_url=remote.url)
+                remote.set_url(new_url=template)
                 try:
                     # Attempt to update the repository
                     remote.fetch()

--- a/tests/commands/base/test_update_cookiecutter_cache.py
+++ b/tests/commands/base/test_update_cookiecutter_cache.py
@@ -219,7 +219,6 @@ def test_existing_repo_template(base_command, mock_git):
     mock_repo.remote.assert_called_once_with(name="origin")
     mock_remote.set_url.assert_called_once_with(
         new_url="https://example.com/magic/special-template.git",
-        old_url="https://example.com/magic/special-template.git",
     )
     mock_remote.fetch.assert_called_once_with()
 
@@ -307,7 +306,6 @@ def test_existing_repo_template_with_different_url(base_command, mock_git):
     mock_repo.remote.assert_called_once_with(name="origin")
     mock_remote.set_url.assert_called_once_with(
         new_url="https://example.com/magic/special-template.git",
-        old_url="https://example.com/existing/special-template.git",
     )
     mock_remote.fetch.assert_called_once_with()
 
@@ -356,7 +354,6 @@ def test_offline_repo_template(base_command, mock_git, capsys):
     mock_repo.remote.assert_called_once_with(name="origin")
     mock_remote.set_url.assert_called_once_with(
         new_url="https://example.com/magic/special-template.git",
-        old_url="https://example.com/magic/special-template.git",
     )
     mock_remote.fetch.assert_called_once_with()
 
@@ -407,7 +404,6 @@ def test_cached_missing_branch_template(base_command, mock_git):
     mock_repo.remote.assert_called_once_with(name="origin")
     mock_remote.set_url.assert_called_once_with(
         new_url="https://example.com/magic/special-template.git",
-        old_url="https://example.com/magic/special-template.git",
     )
     mock_remote.fetch.assert_called_once_with()
 


### PR DESCRIPTION
## Changes
- See https://github.com/beeware/briefcase/pull/1525 for background on why the `origin` remote is updated at all.
- Specifying the old (i.e. current) URL for the remote when attempting to update the URL is unnecessary in Briefcase's case. Instead, this will just set `origin` to point at what's currently being requested.
- Fixes #2077
- Fixes #2084

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
