### PR TITLE
Modify pip handling to use platform tag for iOS.

### DIFF
--- a/changes/2101.feature.rst
+++ b/changes/2101.feature.rst
@@ -1,0 +1,1 @@
+Briefcase now uses native pip handling for cross-platform installs, rather than the site-based shim.

--- a/docs/reference/platforms/iOS/xcode.rst
+++ b/docs/reference/platforms/iOS/xcode.rst
@@ -133,13 +133,12 @@ PyPI to provide those wheels. Briefcase uses a `secondary repository
 
 This repository is maintained by the BeeWare project, and as a result, it does not have
 binary wheels for *every* package that is available on PyPI, or even every *version* of
-every package that is on PyPI. If you see any of the following messages when building an
-app for a mobile platform, then the package (or this version of it) probably isn't
-supported yet:
+every package that is on PyPI. If you see the message::
 
-* The error "Cannot compile native modules"
-* A reference to downloading a ``.tar.gz`` version of the package
-* A reference to ``Building wheels for collected packages: <package>``
+    ERROR: Could not find a version that satisfies the requirement <package name> (from versions: none)
+    ERROR: No matching distribution found for <package name>
+
+then the package (or the version that you've specified) probably isn't supported yet.
 
 It is *usually* possible to compile any binary package wheels for iOS, depending on the
 requirements of the package itself. If the package has a dependency on other binary
@@ -157,3 +156,27 @@ Contributions of new package recipes are welcome, and can be submitted as pull r
 Or, if you have a particular package that you'd like us to support, please visit the
 `issue tracker <https://github.com/beeware/mobile-forge/issues>`__ and provide details
 about that package.
+
+Requirements cannot be provided as source tarballs
+--------------------------------------------------
+
+Briefcase *cannot* install packages published as source tarballs into an iOS app, even
+if the package is a pure Python package that would produce a ``py3-none-any`` wheel.
+This is an inherent limitation in the use of source tarballs as a distribution format.
+
+If you need to install a package in an iOS app that is only published as a source
+tarball, you'll need to compile that package into a wheel first. If the package is pure
+Python, you can generate a ``py3-none-any`` wheel using ``pip wheel <package name>``. If
+the project has a binary component, you'll need to use `Mobile Forge
+<https://github.com/beeware/mobile-forge>`__ (or similar tooling) to compile compatible
+wheels.
+
+You can then directly add the wheel file to the ``requires`` definition for your app, or
+put the wheel in a folder and add:
+
+.. code-block:: TOML
+
+    requirement_installer_args = ["--find-links", "<path-to-wheel-folder>"]
+
+to your ``pyproject.toml``. This will instruct Briefcase to search that folder for
+compatible wheels during the installation process.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,8 @@ dependencies = [
     #
     # limited to <=3.9 for the `group` argument for `entry_points()`
     "importlib_metadata >= 4.4; python_version <= '3.9'",
-    "packaging >= 22.0",
-    "pip >= 23.1.2",
+    "packaging >= 24.2",
+    "pip >= 24.3",
     "setuptools >= 60",
     "wheel >= 0.37",
     "build >= 0.10",

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -622,6 +622,7 @@ class CreateCommand(BaseCommand):
         requires: list[str],
         app_packages_path: Path,
         progress_message: str = "Installing app requirements...",
+        pip_args: list[str] | None = None,
         pip_kwargs: dict[str, str] | None = None,
     ):
         """Install requirements for the app with pip.
@@ -631,6 +632,7 @@ class CreateCommand(BaseCommand):
         :param app_packages_path: The full path of the app_packages folder into which
             requirements should be installed.
         :param progress_message: The waitbar progress message to display to the user.
+        :param pip_args: Any additional command line arguments to use when invoking pip.
         :param pip_kwargs: Any additional keyword arguments to pass to the subprocess
             when invoking pip.
         """
@@ -645,7 +647,10 @@ class CreateCommand(BaseCommand):
                 self._pip_install(
                     app,
                     app_packages_path=app_packages_path,
-                    pip_args=self._pip_requires(app, requires),
+                    pip_args=(
+                        ([] if pip_args is None else pip_args)
+                        + self._pip_requires(app, requires)
+                    ),
                     **(pip_kwargs if pip_kwargs else {}),
                 )
         else:

--- a/tests/platforms/iOS/xcode/conftest.py
+++ b/tests/platforms/iOS/xcode/conftest.py
@@ -14,12 +14,15 @@ def first_app_generated(first_app_config, tmp_path):
         / "ios"
         / "xcode"
         / "briefcase.toml",
-        """
-[paths]
-app_packages_path="app_packages"
-support_path="support"
-info_plist_path="Info.plist"
-""",
+        "\n".join(
+            [
+                "[paths]",
+                'app_packages_path="app_packages"',
+                'support_path="Support"',
+                'info_plist_path="Info.plist"',
+                "",
+            ],
+        ),
     )
 
     create_plist_file(
@@ -27,5 +30,24 @@ info_plist_path="Info.plist"
         {
             "MainModule": "first_app",
         },
+    )
+
+    # Create the support package VERSIONS file
+    # with a deliberately weird min iOS version
+    create_file(
+        tmp_path / "base_path/build/first-app/ios/xcode/Support/VERSIONS",
+        "\n".join(
+            [
+                "Python version: 3.10.15",
+                "Build: b11",
+                "Min iOS version: 14.2",
+                "---------------------",
+                "BZip2: 1.0.8-1",
+                "libFFI: 3.4.6-1",
+                "OpenSSL: 3.0.15-1",
+                "XZ: 5.6.2-1",
+                "",
+            ]
+        ),
     )
     return first_app_config

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -61,27 +61,15 @@ def test_extra_pip_args(create_command, first_app_generated, tmp_path):
                 "--upgrade",
                 "--no-user",
                 f"--target={bundle_path / 'app_packages.iphoneos'}",
-                "--prefer-binary",
+                "--only-binary=:all:",
                 "--extra-index-url",
                 "https://pypi.anaconda.org/beeware/simple",
+                "--platform=ios_14_2_arm64_iphoneos",
                 "something==1.2.3",
                 "other>=2.3.4",
             ],
             check=True,
             encoding="UTF-8",
-            env={
-                "PYTHONPATH": str(
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "support"
-                    / "platform-site"
-                    / "iphoneos.arm64"
-                )
-            },
         ),
         call(
             [
@@ -97,27 +85,15 @@ def test_extra_pip_args(create_command, first_app_generated, tmp_path):
                 "--upgrade",
                 "--no-user",
                 f"--target={bundle_path / 'app_packages.iphonesimulator'}",
-                "--prefer-binary",
+                "--only-binary=:all:",
                 "--extra-index-url",
                 "https://pypi.anaconda.org/beeware/simple",
+                "--platform=ios_14_2_wonky_iphonesimulator",
                 "something==1.2.3",
                 "other>=2.3.4",
             ],
             check=True,
             encoding="UTF-8",
-            env={
-                "PYTHONPATH": str(
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "support"
-                    / "platform-site"
-                    / "iphonesimulator.wonky"
-                )
-            },
         ),
     ]
 

--- a/tests/platforms/iOS/xcode/test_update.py
+++ b/tests/platforms/iOS/xcode/test_update.py
@@ -48,27 +48,15 @@ def test_extra_pip_args(update_command, first_app_generated, tmp_path):
                 "--upgrade",
                 "--no-user",
                 f"--target={bundle_path / 'app_packages.iphoneos'}",
-                "--prefer-binary",
+                "--only-binary=:all:",
                 "--extra-index-url",
                 "https://pypi.anaconda.org/beeware/simple",
+                "--platform=ios_14_2_arm64_iphoneos",
                 "something==1.2.3",
                 "other>=2.3.4",
             ],
             check=True,
             encoding="UTF-8",
-            env={
-                "PYTHONPATH": str(
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "support"
-                    / "platform-site"
-                    / "iphoneos.arm64"
-                )
-            },
         ),
         call(
             [
@@ -84,26 +72,14 @@ def test_extra_pip_args(update_command, first_app_generated, tmp_path):
                 "--upgrade",
                 "--no-user",
                 f"--target={bundle_path / 'app_packages.iphonesimulator'}",
-                "--prefer-binary",
+                "--only-binary=:all:",
                 "--extra-index-url",
                 "https://pypi.anaconda.org/beeware/simple",
+                "--platform=ios_14_2_wonky_iphonesimulator",
                 "something==1.2.3",
                 "other>=2.3.4",
             ],
             check=True,
             encoding="UTF-8",
-            env={
-                "PYTHONPATH": str(
-                    tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "support"
-                    / "platform-site"
-                    / "iphonesimulator.wonky"
-                )
-            },
         ),
     ]


### PR DESCRIPTION
With the release of pip 24.3, we're now in a position to use explicit `--platform` tags when installing wheels for iOS.

This removes the need for the platform-site shim to "fake" pip installation; we can instead rely on default pip/Python platform handling. 

As part of this change, the use of wheels is now *required*, through use of the `--only-binary=:all:`. This is required as part of using `--platform`, as pip can't install from source when installing onto a foreign target platform, even if the wheel being installed is pure Python. There is a small minority of packages that are only packaged as source tarballs; but the broader Python ecosystem is firmly promoting the use of wheels, so this seems like a good opportunity to force the issue.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
