### PR TITLE
Modified arguments passed to xcodebuild when building iOS apps.

### DIFF
--- a/changes/2102.bugfix.rst
+++ b/changes/2102.bugfix.rst
@@ -1,0 +1,1 @@
+The arguments passed to xcodebuild when compiling an iOS app have been modified to avoid a warning about an ignored argument.

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -402,8 +402,6 @@ class iOSXcodeBuildCommand(iOSXcodePassiveMixin, BuildCommand):
                         "build",
                         "-project",
                         self.project_path(app),
-                        "-destination",
-                        'platform="iOS Simulator"',
                         "-configuration",
                         "Debug",
                         "-arch",

--- a/tests/platforms/iOS/xcode/test_build.py
+++ b/tests/platforms/iOS/xcode/test_build.py
@@ -46,8 +46,6 @@ def test_build_app(build_command, first_app_generated, tool_debug_mode, tmp_path
             / "ios"
             / "xcode"
             / "First App.xcodeproj",
-            "-destination",
-            'platform="iOS Simulator"',
             "-configuration",
             "Debug",
             "-arch",
@@ -87,8 +85,6 @@ def test_build_app_test_mode(build_command, first_app_generated, tmp_path):
             / "ios"
             / "xcode"
             / "First App.xcodeproj",
-            "-destination",
-            'platform="iOS Simulator"',
             "-configuration",
             "Debug",
             "-arch",
@@ -133,8 +129,6 @@ def test_build_app_failed(build_command, first_app_generated, tmp_path):
             / "ios"
             / "xcode"
             / "First App.xcodeproj",
-            "-destination",
-            'platform="iOS Simulator"',
             "-configuration",
             "Debug",
             "-arch",


### PR DESCRIPTION
Xcode 16 has introduced a warning about the `-destination` argument passed to `xcodebuild` when building iOS apps:

```
--- xcodebuild: WARNING: Ignoring provided run destination because no scheme was passed.
```

This warning correctly identifies that the `-destination` argument is redundant when performing a build, as there is no run destination. This PR removes the argument, preventing the warning.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
