### PR TITLE
Modify Bootstrap API to provide access to the console, logger, and overrides

### DIFF
--- a/changes/2114.feature.rst
+++ b/changes/2114.feature.rst
@@ -1,0 +1,1 @@
+Project bootstraps now have access to the Briefcase logger, console, and the overrides specified with ``-Q`` options at the command line.

--- a/changes/2114.removal.rst
+++ b/changes/2114.removal.rst
@@ -1,0 +1,1 @@
+The API for project bootstraps has been slightly modified. The constructor for a bootstrap must now accept a logger and console argument; the ``extra_context()`` method must now accept a ``project_overrides`` argument.

--- a/src/briefcase/bootstraps/base.py
+++ b/src/briefcase/bootstraps/base.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC
 from typing import Any, TypedDict
 
+from briefcase.console import Console, Log
+
 
 class AppContext(TypedDict):
     formal_name: str
@@ -51,15 +53,21 @@ class BaseGuiBootstrap(ABC):
     # is presented with the options to create a new project.
     display_name_annotation: str = ""
 
-    def __init__(self, context: AppContext):
+    def __init__(self, logger: Log, input: Console, context: AppContext):
+        self.logger = logger
+        self.input = input
+
         # context contains metadata about the app being created
         self.context = context
 
-    def extra_context(self) -> dict[str, Any] | None:
+    def extra_context(self, project_overrides: dict[str, str]) -> dict[str, Any] | None:
         """Runs prior to other plugin hooks to provide additional context.
 
         This can be used to prompt the user with additional questions or run arbitrary
         logic to supplement the context provided to cookiecutter.
+
+        :param project_overrides: Any overrides provided by the user as -Q options that
+            haven't been consumed by the standard bootstrap wizard questions.
         """
 
     def app_source(self) -> str | None:

--- a/src/briefcase/bootstraps/console.py
+++ b/src/briefcase/bootstraps/console.py
@@ -8,7 +8,7 @@ from briefcase.bootstraps.base import BaseGuiBootstrap
 class ConsoleBootstrap(BaseGuiBootstrap):
     display_name_annotation = "does not support iOS/Android/Web deployment"
 
-    def extra_context(self) -> dict[str, Any] | None:
+    def extra_context(self, project_overrides: dict[str, str]) -> dict[str, Any] | None:
         return {
             "console_app": True,
         }

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -623,14 +623,20 @@ class NewCommand(BaseCommand):
         gui_context = {}
 
         if bootstrap_class is not None:
-            bootstrap: BaseGuiBootstrap = bootstrap_class(context=context)
+            bootstrap: BaseGuiBootstrap = bootstrap_class(
+                logger=self.logger,
+                input=self.input,
+                context=context,
+            )
 
             # Iterate over the Bootstrap interface to build the context.
             # Returning ``None`` is a special case that means the field should not be
             # included in the context and instead deferred to the template default.
 
             if hasattr(bootstrap, "extra_context"):
-                if (additional_context := bootstrap.extra_context()) is not None:
+                if (
+                    additional_context := bootstrap.extra_context(project_overrides)
+                ) is not None:
                     gui_context.update(additional_context)
 
             for context_field in bootstrap.fields:

--- a/tests/commands/new/test_build_context.py
+++ b/tests/commands/new/test_build_context.py
@@ -34,7 +34,7 @@ def test_question_sequence_bootstrap_context(
     class GuiBootstrap:
         fields = []
 
-        def __init__(self, context):
+        def __init__(self, logger, input, context):
             nonlocal passed_context
             passed_context = context.copy()
 
@@ -825,7 +825,7 @@ def test_question_sequence_with_overrides(
     class GuiBootstrap:
         fields = []
 
-        def __init__(self, context):
+        def __init__(self, logger, input, context):
             pass
 
     monkeypatch.setattr(
@@ -886,7 +886,7 @@ def test_question_sequence_with_bad_license_override(
     class GuiBootstrap:
         fields = []
 
-        def __init__(self, context):
+        def __init__(self, logger, input, context):
             pass
 
     monkeypatch.setattr(
@@ -949,7 +949,7 @@ def test_question_sequence_with_bad_bootstrap_override(
         # requires() would cause an error
         fields = ["requires"]
 
-        def __init__(self, context):
+        def __init__(self, logger, input, context):
             pass
 
     monkeypatch.setattr(
@@ -1222,11 +1222,14 @@ def test_question_sequence_custom_bootstrap(
     class GuiBootstrap:
         fields = ["requires", "platform"]
 
-        def __init__(self, context):
+        def __init__(self, logger, input, context):
             pass
 
-        def extra_context(self):
-            return {"custom_context": "value"}
+        def extra_context(self, project_overrides):
+            return {
+                "custom_context": "value",
+                "custom_override": project_overrides.pop("custom_override", None),
+            }
 
         def requires(self):
             return "toga"
@@ -1259,7 +1262,7 @@ def test_question_sequence_custom_bootstrap(
         "5",  # Custom GUI bootstrap
     ]
 
-    context = new_command.build_context(project_overrides={})
+    context = new_command.build_context(project_overrides={"custom_override": "other"})
 
     assert context == dict(
         app_name="myapplication",
@@ -1276,6 +1279,7 @@ def test_question_sequence_custom_bootstrap(
         project_name="My Project",
         url="https://navy.mil/myapplication",
         custom_context="value",
+        custom_override="other",
         requires="toga",
         platform="bsd",
     )
@@ -1291,7 +1295,7 @@ def test_question_sequence_custom_bootstrap_without_additional_context(
     class GuiBootstrap:
         fields = ["requires", "platform"]
 
-        def __init__(self, context):
+        def __init__(self, logger, input, context):
             pass
 
         def requires(self):


### PR DESCRIPTION
Briefcase's Bootstrap interface provides a mechanism for projects to define code and configuration items that describe certain "starting states" for a project. The intention is that GUI frameworks would provide bootstraps for "getting started" apps.

However, in the process of actually trying to use the bootstrap interface to resolve #1288, the interface exposed is not actually as useful as intended. Although the `extra_context()` entry point is documented as "This is where you could ask additional questions", there's no way to access any of Briefcase's console handling or logging, nor is there any way to access overrides that have been specified at the command line.

This PR modifies the API for boostraps to provide access to these tools.

Although this modifies the API for bootstraps in a way that is strictly backwards incompatible, the changes don't impact the  automation bootstraps, or the two known bootstraps that are in the wild:

* [PyGame CE](https://github.com/Starbuck5/pygame-ce/blob/main/src_py/__briefcase/pygame_ce.py)
* [PPB](https://github.com/ppb/pursuedpybear/pull/722/files)

If there are any others, the changes required are very minor.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
