### PR TITLE
Unify Printer, Logger and Console classes

### DIFF
--- a/changes/2114.feature.rst
+++ b/changes/2114.feature.rst
@@ -1,1 +1,1 @@
-Project bootstraps now have access to the Briefcase logger, console, and the overrides specified with ``-Q`` options at the command line.
+Project bootstraps now have access to the Briefcase console, and the overrides specified with ``-Q`` options at the command line.

--- a/changes/2114.feature.rst
+++ b/changes/2114.feature.rst
@@ -1,1 +1,1 @@
-Project bootstraps now have access to the Briefcase console, and the overrides specified with ``-Q`` options at the command line.
+Project bootstraps now have access to the Briefcase console and the overrides specified with ``-Q`` options at the command line.

--- a/changes/2114.removal.rst
+++ b/changes/2114.removal.rst
@@ -1,1 +1,1 @@
-The API for project bootstraps has been slightly modified. The constructor for a bootstrap must now accept a logger and console argument; the ``extra_context()`` method must now accept a ``project_overrides`` argument.
+The API for project bootstraps has been slightly modified. The constructor for a bootstrap must now accept a console argument; the ``extra_context()`` method must now accept a ``project_overrides`` argument.

--- a/changes/2124.misc.rst
+++ b/changes/2124.misc.rst
@@ -1,0 +1,1 @@
+The Printer, Logger and Console classes have been unified into a single Console class.

--- a/src/briefcase/__main__.py
+++ b/src/briefcase/__main__.py
@@ -3,7 +3,7 @@ from contextlib import suppress
 from pathlib import Path
 
 from briefcase.cmdline import parse_cmdline
-from briefcase.console import Console, Log, Printer
+from briefcase.console import Console
 from briefcase.exceptions import (
     BriefcaseError,
     BriefcaseTestSuiteFailure,
@@ -15,12 +15,10 @@ from briefcase.exceptions import (
 def main():
     result = 0
     command = None
-    printer = Printer()
-    console = Console(printer=printer)
-    logger = Log(printer=printer)
+    console = Console()
     try:
         Command, extra_cmdline = parse_cmdline(sys.argv[1:], console=console)
-        command = Command(logger=logger, console=console)
+        command = Command(console=console)
         options, overrides = command.parse_options(extra=extra_cmdline)
         command.parse_config(
             Path.cwd() / "pyproject.toml",
@@ -28,36 +26,36 @@ def main():
         )
         command(**options)
     except HelpText as e:
-        logger.info()
-        logger.info(str(e))
+        console.info()
+        console.info(str(e))
         result = e.error_code
     except BriefcaseWarning as w:
         # The case of something that hasn't gone right, but in an
         # acceptable way.
-        logger.warning(str(w))
+        console.warning(str(w))
         result = w.error_code
     except BriefcaseTestSuiteFailure as e:
         # Test suite status is logged when the test is executed.
         # Set the return code, but don't log anything else.
         result = e.error_code
     except BriefcaseError as e:
-        logger.error()
-        logger.error(str(e))
+        console.error()
+        console.error(str(e))
         result = e.error_code
-        logger.capture_stacktrace()
+        console.capture_stacktrace()
     except Exception:
-        logger.capture_stacktrace()
+        console.capture_stacktrace()
         raise
     except KeyboardInterrupt:
-        logger.warning()
-        logger.warning("Aborted by user.")
-        logger.warning()
+        console.warning()
+        console.warning("Aborted by user.")
+        console.warning()
         result = -42
-        if logger.save_log:
-            logger.capture_stacktrace()
+        if console.save_log:
+            console.capture_stacktrace()
     finally:
         with suppress(KeyboardInterrupt):
-            logger.save_log_to_file(command)
+            console.save_log_to_file(command)
 
     return result
 

--- a/src/briefcase/bootstraps/base.py
+++ b/src/briefcase/bootstraps/base.py
@@ -4,7 +4,7 @@ from abc import ABC
 from pathlib import Path
 from typing import Any, TypedDict
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 
 
 class AppContext(TypedDict):
@@ -54,9 +54,8 @@ class BaseGuiBootstrap(ABC):
     # is presented with the options to create a new project.
     display_name_annotation: str = ""
 
-    def __init__(self, logger: Log, input: Console, context: AppContext):
-        self.logger = logger
-        self.input = input
+    def __init__(self, console: Console, context: AppContext):
+        self.console = console
 
         # context contains metadata about the app being created
         self.context = context

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -77,7 +77,7 @@ class BuildCommand(BaseCommand):
         state = self.build_app(app, test_mode=test_mode, **full_options(state, options))
 
         qualifier = " (test mode)" if test_mode else ""
-        self.logger.info(
+        self.console.info(
             f"Built {self.binary_path(app).relative_to(self.base_path)}{qualifier}",
             prefix=app.app_name,
         )

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -119,9 +119,9 @@ class ConvertCommand(NewCommand):
             and override_value is None
         ):
             app_name = canonicalize_name(self.pep621_data["name"])
-            self.input.divider(title="App name")
-            self.input.prompt()
-            self.input.prompt(
+            self.console.divider(title="App name")
+            self.console.prompt()
+            self.console.prompt(
                 f"Using value from PEP621 formatted pyproject.toml {app_name!r}"
             )
             return app_name
@@ -134,7 +134,7 @@ class ConvertCommand(NewCommand):
                 f"app name of '{default}', but you can use another name if you want."
             )
 
-        return self.input.text_question(
+        return self.console.text_question(
             intro=intro,
             description="App Name",
             default=default,
@@ -148,7 +148,7 @@ class ConvertCommand(NewCommand):
         :returns: The source directory
         """
         default = (" ".join(re.split("[-_]", app_name))).title()
-        return self.input.text_question(
+        return self.console.text_question(
             intro=(
                 "We need a formal name for your application. This is the name that "
                 "will be displayed to humans whenever the name of the application is "
@@ -215,7 +215,7 @@ class ConvertCommand(NewCommand):
         :returns: The source directory
         """
         default, intro = self.get_source_dir_hint(app_name, module_name)
-        return self.input.text_question(
+        return self.console.text_question(
             intro=intro,
             description="Source Directory",
             default=default,
@@ -250,7 +250,7 @@ class ConvertCommand(NewCommand):
         else:
             default = "tests"
 
-        return self.input.text_question(
+        return self.console.text_question(
             intro=intro,
             description="Test Source Directory",
             default=default,
@@ -270,14 +270,14 @@ class ConvertCommand(NewCommand):
         if "description" in self.pep621_data and override_value is None:
             description = self.pep621_data["description"]
 
-            self.input.divider(title="Description")
-            self.input.prompt()
-            self.input.prompt(
+            self.console.divider(title="Description")
+            self.console.prompt()
+            self.console.prompt(
                 f"Using value from PEP621 formatted pyproject.toml {description!r}"
             )
             return description
 
-        return self.input.text_question(
+        return self.console.text_question(
             intro="Now, we need a one line description for your application.",
             description="Description",
             default="My first application",
@@ -293,7 +293,7 @@ class ConvertCommand(NewCommand):
 
         if not options or override_value:
             default = self.make_project_url("com.example", app_name)
-            return self.input.text_question(
+            return self.console.text_question(
                 intro=(
                     "What website URL do you want to use for this application? Based "
                     f"on your existing 'pyproject.toml', this might be {default}"
@@ -305,7 +305,7 @@ class ConvertCommand(NewCommand):
             )
 
         options.append("Other")
-        url = self.input.selection_question(
+        url = self.console.selection_question(
             intro=(
                 "What website URL do you want to use for this application? The "
                 "following URLs are defined in your existing 'pyproject.toml'; "
@@ -318,7 +318,7 @@ class ConvertCommand(NewCommand):
         )
 
         if url == "Other":
-            url = self.input.text_question(
+            url = self.console.text_question(
                 intro="What website URL do you want to use for the application?",
                 description="Application URL",
                 default=self.make_project_url("com.example", app_name),
@@ -337,7 +337,7 @@ class ConvertCommand(NewCommand):
             "console": "Console",
         }
         return (
-            self.input.selection_question(
+            self.console.selection_question(
                 intro="Is this a GUI application or a console application?",
                 description="Interface Style",
                 default="gui",
@@ -349,7 +349,7 @@ class ConvertCommand(NewCommand):
 
     def input_bundle(self, url, app_name, override_value: str | None) -> str:
         default = ".".join(reversed(urlparse(url).netloc.split(".")))
-        return self.input.text_question(
+        return self.console.text_question(
             intro=(
                 "Now we need a bundle identifier for your application.\n"
                 "\n"
@@ -388,7 +388,7 @@ class ConvertCommand(NewCommand):
         ]
 
         if not options or override_value is not None:
-            return self.input.text_question(
+            return self.console.text_question(
                 intro=intro,
                 description="Author",
                 default="Jane Developer",
@@ -405,7 +405,7 @@ class ConvertCommand(NewCommand):
         # author is "Other". However, since we don't want the selection_question prompt
         # if an override value is provided, we need to initialise the author variable
         # here.
-        author = self.input.selection_question(
+        author = self.console.selection_question(
             intro=(
                 f"{intro}\n\n"
                 + "We found these author names in the PEP621 formatted "
@@ -418,7 +418,7 @@ class ConvertCommand(NewCommand):
             override_value=None,
         )
         if author == "Other":
-            author = self.input.text_question(
+            author = self.console.text_question(
                 intro="Who do you want to be credited as the author of this application?",
                 description="Author",
                 default="Jane Developer",
@@ -447,7 +447,7 @@ class ConvertCommand(NewCommand):
             f"we believe it could be '{default}'."
         )
 
-        author_email = self.input.text_question(
+        author_email = self.console.text_question(
             intro=intro,
             description="Author's Email",
             default=default,
@@ -551,7 +551,7 @@ class ConvertCommand(NewCommand):
             "Other",
         ]
 
-        return self.input.selection_question(
+        return self.console.selection_question(
             intro=intro,
             description="Project License",
             options=options,
@@ -663,7 +663,7 @@ class ConvertCommand(NewCommand):
         license_file = self.pep621_data.get("license", {}).get("file")
 
         if license_file is None and not (self.base_path / "LICENSE").exists():
-            self.logger.warning(
+            self.console.warning(
                 f"\nLicense file not found in '{self.base_path}'. "
                 "Briefcase will create a template 'LICENSE' file."
             )
@@ -672,7 +672,7 @@ class ConvertCommand(NewCommand):
         # Copy changelog file
         changelog_file = self.base_path / "CHANGELOG"
         if not changelog_file.is_file():
-            self.logger.warning(
+            self.console.warning(
                 f"\nChangelog file not found in '{self.base_path}'. You should either "
                 f"create a new '{self.base_path / 'CHANGELOG'}' file, or rename an "
                 "already existing changelog file to 'CHANGELOG'."
@@ -705,22 +705,22 @@ class ConvertCommand(NewCommand):
         :param template: The cookiecutter template to use.
         :param template_branch: The git branch that the template should use.
         """
-        self.input.prompt()
-        self.input.prompt("Let's setup an existing project as a Briefcase app!")
+        self.console.prompt()
+        self.console.prompt("Let's setup an existing project as a Briefcase app!")
 
         context = self.build_app_context(project_overrides)
         # The convert wizard uses the new project template - but the user already has
         # project code, and we don't want to add additional GUI dependencies (as the
         # existing app should already be defining them), so we use the Empty bootstrap.
-        bootstrap = EmptyBootstrap(self.logger, self.input, context)
+        bootstrap = EmptyBootstrap(self.console, context)
         context.update(self.build_gui_context(bootstrap, project_overrides))
 
-        self.input.divider()  # close the prompting section of output
+        self.console.debug()  # close the prompting section of output
 
         self.warn_unused_overrides(project_overrides)
 
-        self.logger.info()
-        self.logger.info(
+        self.console.info()
+        self.console.info(
             f"Generating required files to set up '{context['formal_name']}' with Briefcase",
             prefix=context["app_name"],
         )
@@ -742,11 +742,11 @@ class ConvertCommand(NewCommand):
             project_dir, context["test_source_dir"], context["module_name"]
         )
 
-        self.logger.info(
+        self.console.info(
             f"Converted existing application '{context['formal_name']}'",
             prefix=context["app_name"],
         )
-        self.logger.info(
+        self.console.info(
             """
 To run your application, type:
 

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -715,7 +715,7 @@ class ConvertCommand(NewCommand):
         bootstrap = EmptyBootstrap(self.console, context)
         context.update(self.build_gui_context(bootstrap, project_overrides))
 
-        self.console.debug()  # close the prompting section of output
+        self.console.divider()  # close the prompting section of output
 
         self.warn_unused_overrides(project_overrides)
 

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -86,7 +86,7 @@ class DevCommand(RunAppMixin, BaseCommand):
             requires.extend(app.test_requires)
 
         if requires:
-            with self.input.wait_bar("Installing dev requirements..."):
+            with self.console.wait_bar("Installing dev requirements..."):
                 try:
                     self.tools.subprocess.run(
                         [
@@ -99,7 +99,7 @@ class DevCommand(RunAppMixin, BaseCommand):
                             "install",
                             "--upgrade",
                         ]
-                        + (["-vv"] if self.logger.is_deep_debug else [])
+                        + (["-vv"] if self.console.is_deep_debug else [])
                         + requires
                         + app.requirement_installer_args,
                         check=True,
@@ -108,7 +108,7 @@ class DevCommand(RunAppMixin, BaseCommand):
                 except subprocess.CalledProcessError as e:
                     raise RequirementsInstallError() from e
         else:
-            self.logger.info("No application requirements.")
+            self.console.info("No application requirements.")
 
     def run_dev_app(
         self,
@@ -146,7 +146,7 @@ class DevCommand(RunAppMixin, BaseCommand):
         # be handled correctly. However, if we're in test mode, we *must* stream so
         # that we can see the test exit sentinel
         if app.console_app and not test_mode:
-            self.logger.info("=" * 75)
+            self.console.info("=" * 75)
             self.tools.subprocess.run(
                 cmdline,
                 env=env,
@@ -190,7 +190,7 @@ class DevCommand(RunAppMixin, BaseCommand):
             env["PYTHONMALLOC"] = "default"  # pragma: no-cover-if-not-windows
 
         # If we're in verbose mode, put BRIEFCASE_DEBUG into the environment
-        if self.logger.is_debug:
+        if self.console.is_debug:
             env["BRIEFCASE_DEBUG"] = "1"
 
         return env
@@ -238,17 +238,17 @@ class DevCommand(RunAppMixin, BaseCommand):
             # If we are not running the app, it means we should update requirements.
             update_requirements = True
         if update_requirements or not dist_info_path.exists():
-            self.logger.info("Installing requirements...", prefix=app.app_name)
+            self.console.info("Installing requirements...", prefix=app.app_name)
             self.install_dev_requirements(app, **options)
             write_dist_info(app, dist_info_path)
 
         if run_app:
             if test_mode:
-                self.logger.info(
+                self.console.info(
                     "Running test suite in dev environment...", prefix=app.app_name
                 )
             else:
-                self.logger.info("Starting in dev mode...", prefix=app.app_name)
+                self.console.info("Starting in dev mode...", prefix=app.app_name)
             env = self.get_environment(app, test_mode=test_mode)
             return self.run_dev_app(
                 app,

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -528,7 +528,7 @@ class NewCommand(BaseCommand):
         bootstrap = self.create_bootstrap(context, project_overrides)
         context.update(self.build_gui_context(bootstrap, project_overrides))
 
-        self.console.debug()  # close the prompting section of output
+        self.console.divider()  # close the prompting section of output
 
         self.warn_unused_overrides(project_overrides)
 

--- a/src/briefcase/commands/open.py
+++ b/src/briefcase/commands/open.py
@@ -36,7 +36,7 @@ class OpenCommand(BaseCommand):
 
         self.verify_app(app)
 
-        self.logger.info(
+        self.console.info(
             f"Opening {self.project_path(app).relative_to(self.base_path)}...",
             prefix=app.app_name,
         )

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -114,7 +114,7 @@ class PackageCommand(BaseCommand):
         state = self.package_app(app, **full_options(state, options))
 
         filename = self.distribution_path(app).relative_to(self.base_path)
-        self.logger.info(f"Packaged {filename}", prefix=app.app_name)
+        self.console.info(f"Packaged {filename}", prefix=app.app_name)
         return state
 
     def add_options(self, parser):

--- a/src/briefcase/commands/publish.py
+++ b/src/briefcase/commands/publish.py
@@ -36,7 +36,7 @@ class PublishCommand(BaseCommand):
         :param app: The application to publish
         :param channel: The publication channel to use
         """
-        self.logger.info(
+        self.console.info(
             f"TODO: Publish {app.app_name} to {channel}"
         )  # pragma: no cover
 

--- a/src/briefcase/commands/run.py
+++ b/src/briefcase/commands/run.py
@@ -168,7 +168,7 @@ class RunAppMixin:
             )
 
             # Start streaming logs for the app.
-            self.logger.info("=" * 75)
+            self.console.info("=" * 75)
             with popen:
                 self.tools.subprocess.stream_output(
                     label="log stream" if log_stream else app.app_name,
@@ -181,14 +181,14 @@ class RunAppMixin:
             # check for the status of the test suite.
             if test_mode:
                 if log_filter.returncode == 0:
-                    self.logger.info("Test suite passed!", prefix=app.app_name)
+                    self.console.info("Test suite passed!", prefix=app.app_name)
                 else:
                     if log_filter.returncode is None:
                         raise BriefcaseCommandError(
                             "Test suite didn't report a result."
                         )
                     else:
-                        self.logger.error("Test suite failed!", prefix=app.app_name)
+                        self.console.error("Test suite failed!", prefix=app.app_name)
                         raise BriefcaseTestSuiteFailure()
             elif log_stream:
                 # If we're monitoring a log stream, and the log stream reported a
@@ -234,16 +234,16 @@ class RunCommand(RunAppMixin, BaseCommand):
         env = {}
 
         # If we're in debug mode, put BRIEFCASE_DEBUG into the environment
-        if self.logger.is_debug:
+        if self.console.is_debug:
             env["BRIEFCASE_DEBUG"] = "1"
 
         if test_mode:
             # In test mode, set a BRIEFCASE_MAIN_MODULE environment variable
             # to override the module at startup
             env["BRIEFCASE_MAIN_MODULE"] = app.main_module(test_mode)
-            self.logger.info("Starting test_suite...", prefix=app.app_name)
+            self.console.info("Starting test_suite...", prefix=app.app_name)
         else:
-            self.logger.info("Starting app...", prefix=app.app_name)
+            self.console.info("Starting app...", prefix=app.app_name)
 
         # If we need any environment variables, add them to the arguments.
         if env:

--- a/src/briefcase/commands/update.py
+++ b/src/briefcase/commands/update.py
@@ -35,26 +35,26 @@ class UpdateCommand(CreateCommand):
         """
 
         if not self.bundle_path(app).exists():
-            self.logger.error(
+            self.console.error(
                 "Application does not exist; call create first!", prefix=app.app_name
             )
             return
 
         self.verify_app(app)
 
-        self.logger.info("Updating application code...", prefix=app.app_name)
+        self.console.info("Updating application code...", prefix=app.app_name)
         self.install_app_code(app=app, test_mode=test_mode)
 
         if update_requirements:
-            self.logger.info("Updating requirements...", prefix=app.app_name)
+            self.console.info("Updating requirements...", prefix=app.app_name)
             self.install_app_requirements(app=app, test_mode=test_mode)
 
         if update_resources:
-            self.logger.info("Updating application resources...", prefix=app.app_name)
+            self.console.info("Updating application resources...", prefix=app.app_name)
             self.install_app_resources(app=app)
 
         if update_support:
-            self.logger.info("Updating application support...", prefix=app.app_name)
+            self.console.info("Updating application support...", prefix=app.app_name)
             self.cleanup_app_support_package(app=app)
             self.install_app_support_package(app=app)
 
@@ -67,14 +67,14 @@ class UpdateCommand(CreateCommand):
             except KeyError:
                 pass
             else:
-                self.logger.info("Updating stub binary...", prefix=app.app_name)
+                self.console.info("Updating stub binary...", prefix=app.app_name)
                 self.cleanup_stub_binary(app=app)
                 self.install_stub_binary(app=app)
 
-        self.logger.info("Removing unneeded app content...", prefix=app.app_name)
+        self.console.info("Removing unneeded app content...", prefix=app.app_name)
         self.cleanup_app_content(app=app)
 
-        self.logger.info("Application updated.", prefix=app.app_name)
+        self.console.info("Application updated.", prefix=app.app_name)
 
     def __call__(
         self,

--- a/src/briefcase/commands/upgrade.py
+++ b/src/briefcase/commands/upgrade.py
@@ -91,7 +91,7 @@ class UpgradeCommand(BaseCommand):
                 if not tools_to_upgrade:
                     raise UpgradeToolError(error_msg)
                 else:
-                    self.logger.warning(error_msg)
+                    self.console.warning(error_msg)
 
         return sorted(list(tools_to_upgrade), key=attrgetter("name"))
 
@@ -102,16 +102,18 @@ class UpgradeCommand(BaseCommand):
         :param list_tools: Boolean to only list upgradeable tools (default False).
         """
         if tools_to_upgrade := self.get_tools_to_upgrade(set(tool_list)):
-            self.logger.info(
+            self.console.info(
                 f"Briefcase {'is managing' if list_tools else 'will upgrade'} the following tools:",
                 prefix=self.command,
             )
             for tool in tools_to_upgrade:
-                self.logger.info(f" - {tool.full_name} ({tool.name})")
+                self.console.info(f" - {tool.full_name} ({tool.name})")
 
             if not list_tools:
                 for tool in tools_to_upgrade:
-                    self.logger.info(f"Upgrading {tool.full_name}...", prefix=tool.name)
+                    self.console.info(
+                        f"Upgrading {tool.full_name}...", prefix=tool.name
+                    )
                     tool.upgrade()
         else:
-            self.logger.info("Briefcase is not managing any tools.")
+            self.console.info("Briefcase is not managing any tools.")

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -503,7 +503,7 @@ def merge_pep621_config(global_config, pep621_config):
         pass
 
 
-def parse_config(config_file, platform, output_format, logger):
+def parse_config(config_file, platform, output_format, console):
     """Parse the briefcase section of the pyproject.toml configuration file.
 
     This method only does basic structural parsing of the TOML, looking for,
@@ -526,6 +526,7 @@ def parse_config(config_file, platform, output_format, logger):
     :param config_file: A file-like object containing TOML to be parsed.
     :param platform: The platform being targeted
     :param output_format: The output format
+    :param console: The console to use for any output or logging.
     :returns: A dictionary of configuration data. The top level dictionary is
         keyed by the names of the apps that are declared; each value is
         itself the configuration data merged from global, app, platform and
@@ -559,7 +560,7 @@ def parse_config(config_file, platform, output_format, logger):
     for name, config in [("project", global_config)] + list(all_apps.items()):
         if isinstance(config.get("license"), str):
             section_name = "the Project" if name == "project" else f"{name!r}"
-            logger.warning(
+            console.warning(
                 f"""
 *************************************************************************
 ** {f"WARNING: License Definition for {section_name} is Deprecated":67} **

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -203,6 +203,10 @@ class Console:
     def __del__(self):
         self._dev_null.close()
 
+    #################################################################
+    # Console primitives
+    #################################################################
+
     def print(self, *messages, stack_offset=5, show=True, **kwargs):
         """Entry point for all printing to the console and the log.
 
@@ -661,6 +665,10 @@ class Console:
             # Restore previous console state
             if is_wait_bar_running:
                 self._wait_bar.start()
+
+    #################################################################
+    # User Input/Output controls
+    #################################################################
 
     def textwrap(self, text: str, width: int = MAX_TEXT_WIDTH) -> str:
         """Wrap text to the console width, a default max width, or a specified width."""

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -751,9 +751,9 @@ class Console:
             if result in choices:
                 return result
 
-            self.prompt()
-            self.prompt(error_message, style="bold yellow")
-            self.prompt()
+            self.warning()
+            self.warning(error_message)
+            self.warning()
 
     def input_text(self, prompt: str, default: str | None = None) -> str:
         """Prompt the user for text input.

--- a/src/briefcase/integrations/base.py
+++ b/src/briefcase/integrations/base.py
@@ -16,7 +16,7 @@ import httpx
 from cookiecutter.main import cookiecutter
 
 from briefcase.config import AppConfig
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import (
     MissingToolError,
     NonManagedToolError,
@@ -173,7 +173,6 @@ class ToolCache(Mapping):
 
     def __init__(
         self,
-        logger: Log,
         console: Console,
         base_path: Path,
         home_path: Path | None = None,
@@ -185,13 +184,11 @@ class ToolCache(Mapping):
         App-specific tools are available via dictionary access:
             e.g.: tools[app].app_context
 
-        :param logger: Logger for console and logfile.
         :param console: Facilitates console interaction and input solicitation.
         :param base_path: Base directory for tools (e.g. ~/.cache/briefcase/tools).
         :param home_path: Home directory for current user.
         """
-        self.logger = logger
-        self.input = console
+        self.console = console
         self.base_path = Path(base_path)
         self.home_path = Path(
             os.path.expanduser(home_path if home_path else Path.home())
@@ -204,8 +201,7 @@ class ToolCache(Mapping):
 
         self.app_tools: DefaultDict[AppConfig, ToolCache] = defaultdict(
             lambda: ToolCache(
-                logger=self.logger,
-                console=self.input,
+                console=self.console,
                 base_path=self.base_path,
                 home_path=self.home_path,
             )

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -186,9 +186,9 @@ See https://docs.docker.com/go/buildx/ to install the buildx plugin.
                     )
                 )
         except (InvalidVersion, IndexError):
-            tools.logger.warning(cls.UNKNOWN_DOCKER_VERSION_WARNING)
+            tools.console.warning(cls.UNKNOWN_DOCKER_VERSION_WARNING)
         except subprocess.CalledProcessError:
-            tools.logger.warning(cls.DOCKER_INSTALLATION_STATUS_UNKNOWN_WARNING)
+            tools.console.warning(cls.DOCKER_INSTALLATION_STATUS_UNKNOWN_WARNING)
         except OSError as e:
             # Docker executable doesn't exist
             raise BriefcaseCommandError(
@@ -362,7 +362,7 @@ Delete this file and run Briefcase again.
         ).strip()
 
         if not image_id:
-            self.tools.logger.info(
+            self.tools.console.info(
                 f"Downloading Docker base image for {image_tag}...",
                 prefix=self.full_name,
             )
@@ -550,7 +550,7 @@ Delete this file and run Briefcase again.
             try:
                 self._x11_write_xauth_file(DISPLAY, xauth_file_path, proxy_display_num)
             except XauthDatabaseCreationFailure:
-                self.tools.logger.warning(
+                self.tools.console.warning(
                     """\
 An X11 authentication database could not be created for the display.
 
@@ -893,17 +893,17 @@ class DockerAppContext(Tool):
         self.image_tag = image_tag
         self.python_version = python_version
 
-        self.tools.logger.info(
+        self.tools.console.info(
             "Building Docker container image...",
             prefix=self.app.app_name,
         )
-        with self.tools.input.wait_bar("Building Docker image..."):
+        with self.tools.console.wait_bar("Building Docker image..."):
             # Install requirements for both building *and* running the app
             # (ensure a copy of system_requires is used to avoid modification)
             system_requires = getattr(self.app, "system_requires", []).copy()
             system_requires.extend(getattr(self.app, "system_runtime_requires", []))
 
-            with self.tools.logger.context("Docker"):
+            with self.tools.console.context("Docker"):
                 try:
                     self.tools.subprocess.run(
                         [
@@ -953,7 +953,7 @@ class DockerAppContext(Tool):
         if kwargs.get("interactive"):
             kwargs["stream_output"] = False
 
-        with self.tools.logger.context("Docker"):
+        with self.tools.console.context("Docker"):
             self.tools.subprocess.run(**self._dockerize_args(args, **kwargs))
 
     def check_output(self, args: SubprocessArgsT, **kwargs) -> str:

--- a/src/briefcase/integrations/file.py
+++ b/src/briefcase/integrations/file.py
@@ -205,9 +205,9 @@ class File(Tool):
                 filename = download_path / cache_name
 
                 if filename.exists():
-                    self.tools.logger.info(f"{cache_name} already downloaded")
+                    self.tools.console.info(f"{cache_name} already downloaded")
                 else:
-                    self.tools.logger.info(f"Downloading {cache_name}...")
+                    self.tools.console.info(f"Downloading {cache_name}...")
                     self._fetch_and_write_content(response, filename)
         except httpx.RequestError as e:
             if role:
@@ -259,7 +259,7 @@ class File(Tool):
                     response.read()
                     temp_file.write(response.content)
                 else:
-                    progress_bar = self.tools.input.progress_bar()
+                    progress_bar = self.tools.console.progress_bar()
                     task_id = progress_bar.add_task("Downloader", total=int(total))
                     with progress_bar:
                         for data in response.iter_bytes(chunk_size=1024 * 1024):

--- a/src/briefcase/integrations/flatpak.py
+++ b/src/briefcase/integrations/flatpak.py
@@ -41,7 +41,7 @@ class Flatpak(Tool):
                 else:
                     raise ValueError(f"Unexpected tool name {parts[0]}")
             except (ValueError, IndexError):
-                tools.logger.warning(
+                tools.console.warning(
                     """\
 *************************************************************************
 ** WARNING: Unable to determine the version of Flatpak                 **
@@ -99,7 +99,7 @@ You must install both flatpak and flatpak-builder.
                 else:
                     raise ValueError(f"Unexpected tool name {parts[0]}")
             except (ValueError, IndexError):
-                tools.logger.warning(
+                tools.console.warning(
                     """\
 *************************************************************************
 ** WARNING: Unable to determine the version of flatpak-builder         **
@@ -158,7 +158,7 @@ You must install both flatpak and flatpak-builder.
                     repo_alias,
                     url,
                 ]
-                + (["--verbose"] if self.tools.logger.is_deep_debug else []),
+                + (["--verbose"] if self.tools.console.is_deep_debug else []),
                 check=True,
             )
         except subprocess.CalledProcessError as e:
@@ -191,7 +191,7 @@ You must install both flatpak and flatpak-builder.
                     f"{runtime}/{self.tools.host_arch}/{runtime_version}",
                     f"{sdk}/{self.tools.host_arch}/{runtime_version}",
                 ]
-                + (["--verbose"] if self.tools.logger.is_deep_debug else []),
+                + (["--verbose"] if self.tools.console.is_deep_debug else []),
                 check=True,
                 # flatpak install uses many animations that cannot be disabled
                 stream_output=False,
@@ -228,7 +228,7 @@ You must install both flatpak and flatpak-builder.
                     "build",
                     "manifest.yml",
                 ]
-                + (["--verbose"] if self.tools.logger.is_deep_debug else []),
+                + (["--verbose"] if self.tools.console.is_deep_debug else []),
                 check=True,
                 cwd=path,
             )
@@ -281,10 +281,10 @@ flatpak run {bundle_identifier}
         flatpak_run_cmd = ["flatpak", "run", bundle_identifier]
         flatpak_run_cmd.extend([] if args is None else args)
 
-        if self.tools.logger.is_debug:
+        if self.tools.console.is_debug:
             kwargs.setdefault("env", {})["BRIEFCASE_DEBUG"] = "1"
 
-        if self.tools.logger.is_deep_debug:
+        if self.tools.console.is_deep_debug:
             # Must come before bundle identifier; otherwise, it's passed as an arg to app
             flatpak_run_cmd.insert(2, "--verbose")
 
@@ -342,7 +342,7 @@ flatpak run {bundle_identifier}
                     bundle_identifier,
                     version,
                 ]
-                + (["--verbose"] if self.tools.logger.is_deep_debug else []),
+                + (["--verbose"] if self.tools.console.is_deep_debug else []),
                 check=True,
                 cwd=build_path,
             )

--- a/src/briefcase/integrations/git.py
+++ b/src/briefcase/integrations/git.py
@@ -85,7 +85,7 @@ need to restart your terminal session.
                 skip_logfile=True,
             )
 
-        tools.logger.configure_stdlib_logging("git")
+        tools.console.configure_stdlib_logging("git")
 
         tools.git = git
         return git

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -108,8 +108,8 @@ class JDK(ManagedTool):
         install_message = None
 
         if java_home := tools.os.environ.get("JAVA_HOME", ""):
-            tools.logger.debug("Evaluating JAVA_HOME...", prefix=cls.full_name)
-            tools.logger.debug(f"JAVA_HOME={java_home}")
+            tools.console.debug("Evaluating JAVA_HOME...", prefix=cls.full_name)
+            tools.console.debug(f"JAVA_HOME={java_home}")
             try:
                 version_str = cls.version_from_path(tools, java_home)
                 if version_str.split(".")[0] == cls.JDK_MAJOR_VER:
@@ -206,7 +206,7 @@ class JDK(ManagedTool):
 
         # macOS has a helpful system utility to determine JAVA_HOME. Try it.
         elif tools.host_os == "Darwin":
-            tools.logger.debug(
+            tools.console.debug(
                 "Evaluating /usr/libexec/java_home...", prefix=cls.full_name
             )
             try:
@@ -216,7 +216,7 @@ class JDK(ManagedTool):
                     ["/usr/libexec/java_home"],
                 ).strip("\n")
             except (OSError, subprocess.CalledProcessError):
-                tools.logger.debug("An existing JDK/JRE was not returned")
+                tools.console.debug("An existing JDK/JRE was not returned")
             else:
                 try:
                     version_str = cls.version_from_path(tools, java_home)
@@ -228,7 +228,7 @@ class JDK(ManagedTool):
         if java is None:
             # Inform the user if the user-specified JDK wasn't valid
             if install_message:
-                tools.logger.warning(install_message)
+                tools.console.warning(install_message)
 
             # Use the Briefcase JDK install
             java_home = tools.base_path / cls.JDK_INSTALL_DIR_NAME
@@ -242,20 +242,20 @@ class JDK(ManagedTool):
 
             if not java.exists():
                 if install:
-                    tools.logger.info(
+                    tools.console.info(
                         f"A Java {cls.JDK_MAJOR_VER} JDK was not found; downloading and installing...",
                         prefix=cls.name,
                     )
-                    tools.logger.info(
+                    tools.console.info(
                         f"To use an existing JDK {cls.JDK_MAJOR_VER} instance, "
                         f"specify its root directory path in the JAVA_HOME environment variable."
                     )
-                    tools.logger.info()
+                    tools.console.info()
                     java.install()
                 else:
                     raise MissingToolError("Java")
 
-        tools.logger.debug(f"Using JDK at {java.java_home}")
+        tools.console.debug(f"Using JDK at {java.java_home}")
         tools.java = java
         return java
 
@@ -281,7 +281,7 @@ class JDK(ManagedTool):
             role=f"Java {self.JDK_MAJOR_VER} JDK",
         )
 
-        with self.tools.input.wait_bar("Installing OpenJDK..."):
+        with self.tools.console.wait_bar("Installing OpenJDK..."):
             try:
                 self.tools.file.unpack_archive(
                     os.fsdecode(jdk_zip_path),
@@ -309,7 +309,7 @@ Delete {jdk_zip_path} and run briefcase again.
 
     def uninstall(self):
         """Uninstall a JDK."""
-        with self.tools.input.wait_bar("Removing old JDK install..."):
+        with self.tools.console.wait_bar("Removing old JDK install..."):
             if self.tools.host_os == "Darwin":
                 self.tools.shutil.rmtree(self.java_home.parent.parent)
             else:

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -97,7 +97,7 @@ class LinuxDeployBase(ABC):
         plugins while building the AppImage. ELF files need special "magic" bytes zeroed
         to run properly in Docker.
         """
-        with self.tools.input.wait_bar(f"Installing {self.file_name}..."):
+        with self.tools.console.wait_bar(f"Installing {self.file_name}..."):
             self.tools.os.chmod(self.file_path / self.file_name, 0o755)
             if self.is_elf_file():
                 self.patch_elf_header()
@@ -127,7 +127,7 @@ class LinuxDeployBase(ABC):
         tool: LinuxDeployT = cls(tools=tools, **kwargs)
         if not tool.exists():
             if install:
-                tools.logger.info(
+                tools.console.info(
                     cls.install_msg.format(full_name=cls.full_name),
                     prefix="linuxdeploy",
                 )
@@ -142,7 +142,7 @@ class LinuxDeployBase(ABC):
 
     def uninstall(self):
         """Uninstall tool."""
-        with self.tools.input.wait_bar(f"Removing old {self.full_name} install..."):
+        with self.tools.console.wait_bar(f"Removing old {self.full_name} install..."):
             (self.file_path / self.file_name).unlink()
 
     def is_elf_file(self) -> bool:
@@ -180,12 +180,12 @@ class LinuxDeployBase(ABC):
                 appimage.write(ELF_PATCH_PATCHED_BYTES)
                 appimage.flush()
                 appimage.seek(0)
-                self.tools.logger.info(f"Patched ELF header for {self.file_name}.")
+                self.tools.console.info(f"Patched ELF header for {self.file_name}.")
             # Else if the header is the patched value, do nothing.
             elif (
                 appimage.read(len(ELF_PATCH_ORIGINAL_BYTES)) == ELF_PATCH_PATCHED_BYTES
             ):
-                self.tools.logger.info(
+                self.tools.console.info(
                     f"ELF header for {self.file_name} is already patched."
                 )
             else:
@@ -400,14 +400,14 @@ class LinuxDeploy(LinuxDeployBase, ManagedTool):
 
             try:
                 plugin_klass = self.plugins[plugin_name]
-                self.tools.logger.info(f"Using default {plugin_name} plugin")
+                self.tools.console.info(f"Using default {plugin_name} plugin")
                 plugin = plugin_klass.verify(self.tools)
             except KeyError:
                 if plugin_name.startswith(("https://", "http://")):
-                    self.tools.logger.info(f"Using URL plugin {plugin_name}")
+                    self.tools.console.info(f"Using URL plugin {plugin_name}")
                     plugin = LinuxDeployURLPlugin.verify(self.tools, url=plugin_name)
                 else:  # pragma: no-cover-if-is-windows
-                    self.tools.logger.info(f"Using local file plugin {plugin_name}")
+                    self.tools.console.info(f"Using local file plugin {plugin_name}")
                     plugin = LinuxDeployLocalFilePlugin.verify(
                         self.tools,
                         plugin_path=Path(plugin_name),

--- a/src/briefcase/integrations/rcedit.py
+++ b/src/briefcase/integrations/rcedit.py
@@ -38,7 +38,7 @@ class RCEdit(ManagedTool):
 
         if not rcedit.exists():
             if install:
-                tools.logger.info(
+                tools.console.info(
                     "RCEdit was not found; downloading and installing...",
                     prefix=cls.name,
                 )
@@ -62,5 +62,5 @@ class RCEdit(ManagedTool):
 
     def uninstall(self):
         """Uninstall RCEdit."""
-        with self.tools.input.wait_bar("Removing old RCEdit install..."):
+        with self.tools.console.wait_bar("Removing old RCEdit install..."):
             self.rcedit_path.unlink()

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -120,7 +120,7 @@ def ensure_console_is_safe(sub_method):
         :returns: the return value for the Subprocess method
         """
         # Just run the command if no dynamic elements are active
-        if not sub.tools.input.is_console_controlled:
+        if not sub.tools.console.is_console_controlled:
             return sub_method(sub, args, *wrapped_args, **wrapped_kwargs)
 
         remove_dynamic_elements = False
@@ -138,7 +138,7 @@ def ensure_console_is_safe(sub_method):
 
         # Run subprocess command with or without console control
         if remove_dynamic_elements:
-            with sub.tools.input.release_console_control():
+            with sub.tools.console.release_console_control():
                 return sub_method(sub, args, *wrapped_args, **wrapped_kwargs)
         else:
             return sub_method(sub, args, *wrapped_args, **wrapped_kwargs)

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -19,7 +19,7 @@ from typing import TypeVar, Union
 import psutil
 
 from briefcase.config import AppConfig
-from briefcase.console import Log
+from briefcase.console import Console
 from briefcase.exceptions import CommandOutputParseError, ParseError
 from briefcase.integrations.base import Tool, ToolCache
 
@@ -65,7 +65,7 @@ def is_process_dead(pid: int) -> bool:
 def get_process_id_by_command(
     command_list: list[str] | None = None,
     command: str = "",
-    logger: Log | None = None,
+    console: Console | None = None,
 ) -> int | None:
     """Find a Process ID (PID) a by its command. If multiple processes are found, then
     the most recently created process ID is returned.
@@ -75,7 +75,7 @@ def get_process_id_by_command(
         This is primarily intended for use on macOS where the `open` command
         takes a filepath to a directory for an application; therefore, the actual
         running process will be running a command within that directory.
-    :param logger: optional Log to show messages about process matching to users
+    :param console: optional console to show messages about process matching to users
     :returns: PID if found else None
     """
     matching_procs = []
@@ -94,8 +94,8 @@ def get_process_id_by_command(
     elif len(matching_procs) > 1:
         # return the ID of the most recently created matching process
         pid = sorted(matching_procs, key=operator.itemgetter("create_time"))[-1]["pid"]
-        if logger:
-            logger.info(
+        if console:
+            console.info(
                 f"Multiple running instances of app found. Using most recently created app process {pid}."
             )
         return pid
@@ -151,7 +151,7 @@ class PopenOutputStreamer(threading.Thread):
         self,
         label: str,
         popen_process: subprocess.Popen,
-        logger: Log,
+        console: Console,
         capture_output: bool = False,
         filter_func: Callable[[str], Iterator[str]] | None = None,
     ):
@@ -159,7 +159,7 @@ class PopenOutputStreamer(threading.Thread):
 
         :param label: Descriptive name for process being streamed
         :param popen_process: Popen process with stdout to stream
-        :param logger: logger for printing to console
+        :param console: console for printing to console
         :param capture_output: Retain process output in ``output_queue`` via a
             ``queue.Queue`` instead of printing to console
         :param filter_func: a callable that will be invoked on every line of output
@@ -168,7 +168,7 @@ class PopenOutputStreamer(threading.Thread):
         super().__init__(name=f"{label} output streamer", daemon=True)
 
         self.popen_process = popen_process
-        self.logger = logger
+        self.console = console
         self.capture_output = capture_output
         self.filter_func = filter_func
 
@@ -192,7 +192,7 @@ class PopenOutputStreamer(threading.Thread):
                         if self.capture_output:
                             self.output_queue.put_nowait(filtered_line)
                         else:
-                            self.logger.info(filtered_line)
+                            self.console.info(filtered_line)
 
                     if stop_streaming:
                         self.stop_flag.set()
@@ -200,8 +200,8 @@ class PopenOutputStreamer(threading.Thread):
                 if self.stop_flag.is_set():
                     break
         except Exception as e:
-            self.logger.error(f"Error while streaming output: {type(e).__name__}: {e}")
-            self.logger.capture_stacktrace("Output thread")
+            self.console.error(f"Error while streaming output: {type(e).__name__}: {e}")
+            self.console.capture_stacktrace("Output thread")
 
     def request_stop(self):
         """Set the stop flag to cause the streamer to exit.
@@ -237,7 +237,7 @@ class PopenOutputStreamer(threading.Thread):
             # Catch ValueError if stdout is unexpectedly closed; this can
             # happen, for instance, if the user starts spamming CTRL+C.
             if "I/O operation on closed file" in str(e):
-                self.logger.warning(
+                self.console.warning(
                     "WARNING: stdout was unexpectedly closed while streaming output"
                 )
                 return ""
@@ -571,7 +571,7 @@ class Subprocess(Tool):
         be captured for logging.
 
         When dynamic screen content like a Wait Bar is active, output can
-        only be printed to the screen via Log or Console to avoid interfering
+        only be printed to the screen via Console to avoid interfering
         with and likely corrupting the updates to the dynamic screen elements.
 
         stdout will always be piped so it can be printed to the screen;
@@ -689,16 +689,16 @@ class Subprocess(Tool):
                 str(e)
                 or f"Failed to parse command output using '{output_parser.__name__}'"
             )
-            self.tools.logger.error()
-            self.tools.logger.error("Command Output Parsing Error:")
-            self.tools.logger.error(f"    {error_reason}")
-            self.tools.logger.error("Command:")
-            self.tools.logger.error(
+            self.tools.console.error()
+            self.tools.console.error("Command Output Parsing Error:")
+            self.tools.console.error(f"    {error_reason}")
+            self.tools.console.error("Command:")
+            self.tools.console.error(
                 f"    {' '.join(shlex.quote(str(arg)) for arg in args)}"
             )
-            self.tools.logger.error("Command Output:")
+            self.tools.console.error("Command Output:")
             for line in ensure_str(cmd_output).splitlines():
-                self.tools.logger.error(f"    {line}")
+                self.tools.console.error(f"    {line}")
             raise CommandOutputParseError(error_reason) from e
 
     def Popen(self, args: SubprocessArgsT, **kwargs) -> subprocess.Popen:
@@ -748,7 +748,7 @@ class Subprocess(Tool):
         output_streamer = PopenOutputStreamer(
             label=label,
             popen_process=popen_process,
-            logger=self.tools.logger,
+            console=self.tools.console,
             filter_func=filter_func,
         )
         try:
@@ -758,7 +758,7 @@ class Subprocess(Tool):
             while not stop_func() and output_streamer.is_alive():
                 time.sleep(0.1)
         except KeyboardInterrupt:
-            self.tools.logger.info("Stopping...")
+            self.tools.console.info("Stopping...")
             # allow time for CTRL+C to propagate to the child process
             time.sleep(0.25)
             # re-raise to exit as "Aborted by user"
@@ -769,7 +769,7 @@ class Subprocess(Tool):
             while output_streamer.is_alive() and time.time() < streamer_deadline:
                 time.sleep(0.1)
             if output_streamer.is_alive():
-                self.tools.logger.error(
+                self.tools.console.error(
                     "Log stream hasn't terminated; log output may be corrupted."
                 )
 
@@ -800,7 +800,7 @@ class Subprocess(Tool):
         output_streamer = PopenOutputStreamer(
             label=label,
             popen_process=popen_process,
-            logger=self.tools.logger,
+            console=self.tools.console,
             capture_output=capture_output,
             filter_func=filter_func,
         )
@@ -819,12 +819,12 @@ class Subprocess(Tool):
         try:
             popen_process.wait(timeout=3)
         except subprocess.TimeoutExpired:
-            self.tools.logger.warning(f"Forcibly killing {label}...")
+            self.tools.console.warning(f"Forcibly killing {label}...")
             popen_process.kill()
 
     def _log(self, msg: str = ""):
         """Funnel for all subprocess details logging."""
-        self.tools.logger.debug(msg, preface=">>> " if msg else "")
+        self.tools.console.debug(msg, preface=">>> " if msg else "")
 
     def _log_command(self, args: SubprocessArgsT):
         """Log the entire console command being executed."""

--- a/src/briefcase/integrations/windows_sdk.py
+++ b/src/briefcase/integrations/windows_sdk.py
@@ -79,7 +79,7 @@ class WindowsSDK(Tool):
         enforced by the SDK installer. Certain subdirectories, such as `include` and
         `bin`, will contain subdirectories for versions that may be installed.
         """
-        tools.logger.debug("Finding Suitable Installation...", prefix=cls.full_name)
+        tools.console.debug("Finding Suitable Installation...", prefix=cls.full_name)
 
         # Return user-specified SDK
         if (environ_sdk_dir := tools.os.environ.get("WindowsSDKDir")) and (
@@ -130,7 +130,7 @@ WindowsSDKVersion: {environ_sdk_version}
                     if reg_version := winreg.QueryValueEx(key, cls.SDK_VERSION_KEY)[0]:
                         # Append missing "servicing" revision to registry version
                         reg_version = f"{reg_version}.0"
-                        tools.logger.debug(
+                        tools.console.debug(
                             f"Evaluating Registry SDK version '{reg_version}' at {sdk_dir}"
                         )
                         yield sdk_dir, reg_version
@@ -138,7 +138,7 @@ WindowsSDKVersion: {environ_sdk_version}
                     # Return other versions of the SDK installed in sdk_dir
                     for sdk_version in cls._sdk_versions_from_bin(sdk_dir):
                         if sdk_version != reg_version:
-                            tools.logger.debug(
+                            tools.console.debug(
                                 f"Evaluating Registry SDK Bin version '{sdk_version}' at {sdk_dir}"
                             )
                             yield sdk_dir, sdk_version
@@ -148,7 +148,7 @@ WindowsSDKVersion: {environ_sdk_version}
         for sdk_dir in cls.DEFAULT_SDK_DIRS:
             if sdk_dir.is_dir():
                 for sdk_version in cls._sdk_versions_from_bin(sdk_dir):
-                    tools.logger.debug(
+                    tools.console.debug(
                         f"Evaluating Default Bin SDK version '{sdk_version}' at {sdk_dir}"
                     )
                     yield sdk_dir, sdk_version
@@ -224,6 +224,6 @@ See https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/ to inst
 """
             )
 
-        tools.logger.debug(f"Using Windows SDK v{sdk.version} at {sdk.root_path}")
+        tools.console.debug(f"Using Windows SDK v{sdk.version} at {sdk.root_path}")
         tools.windows_sdk = sdk
         return sdk

--- a/src/briefcase/integrations/wix.py
+++ b/src/briefcase/integrations/wix.py
@@ -79,8 +79,8 @@ class WiX(ManagedTool):
 
         # Look for the WIX environment variable
         if wix_env := tools.os.environ.get("WIX"):
-            tools.logger.debug("Evaluating WIX...", prefix=cls.full_name)
-            tools.logger.debug(f"WIX={wix_env}")
+            tools.console.debug("Evaluating WIX...", prefix=cls.full_name)
+            tools.console.debug(f"WIX={wix_env}")
             wix_home = Path(wix_env)
 
             # Set up the paths for the WiX executables we will use.
@@ -102,7 +102,7 @@ does not point to an install of the WiX Toolset.
 
             if not wix.exists():
                 if install:
-                    tools.logger.info(
+                    tools.console.info(
                         "The WiX toolset was not found; downloading and installing...",
                         prefix=cls.name,
                     )
@@ -110,7 +110,7 @@ does not point to an install of the WiX Toolset.
                 else:
                     raise MissingToolError("WiX")
 
-        tools.logger.debug(f"Using WiX at {wix.wix_home}")
+        tools.console.debug(f"Using WiX at {wix.wix_home}")
         tools.wix = wix
         return wix
 
@@ -141,7 +141,7 @@ does not point to an install of the WiX Toolset.
         )
 
         try:
-            with self.tools.input.wait_bar("Installing WiX..."):
+            with self.tools.console.wait_bar("Installing WiX..."):
                 self.tools.file.unpack_archive(
                     os.fsdecode(wix_zip_path),
                     extract_dir=os.fsdecode(self.wix_home),
@@ -161,5 +161,5 @@ Delete {wix_zip_path} and run briefcase again.
 
     def uninstall(self):
         """Uninstall WiX."""
-        with self.tools.input.wait_bar("Removing old WiX install..."):
+        with self.tools.console.wait_bar("Removing old WiX install..."):
             self.tools.shutil.rmtree(self.wix_home)

--- a/src/briefcase/integrations/xcode.py
+++ b/src/briefcase/integrations/xcode.py
@@ -133,7 +133,7 @@ you can re-run Briefcase.
                         # Version number is acceptable
                         return
 
-                tools.logger.warning(
+                tools.console.warning(
                     """
 *************************************************************************
 ** WARNING: Unable to determine the version of Xcode that is installed **
@@ -261,7 +261,7 @@ to continue, and re-run Briefcase once that installation is complete.
             )
         except subprocess.CalledProcessError as e:
             if e.returncode != 1:
-                tools.logger.warning(
+                tools.console.warning(
                     """
 *************************************************************************
 ** WARNING: Unable to determine if Xcode is installed                  **
@@ -297,7 +297,7 @@ to continue, and re-run Briefcase once that installation is complete.
             tools.subprocess.check_output(["/usr/bin/clang", "--version"])
         except subprocess.CalledProcessError as e:
             if e.returncode == 69:
-                tools.logger.info(
+                tools.console.info(
                     """
 Use of Xcode and the iOS developer tools are covered by a license that must be
 accepted before you can use those tools.
@@ -339,7 +339,7 @@ You need to accept the Xcode license before Briefcase can package your app.
 """
                         )
                     else:
-                        tools.logger.warning(
+                        tools.console.warning(
                             """
 *************************************************************************
 ** WARNING: Unable to determine if the Xcode license has been accepted **
@@ -362,7 +362,7 @@ You need to accept the Xcode license before Briefcase can package your app.
 """
                         )
             else:
-                tools.logger.warning(
+                tools.console.warning(
                     """
 *************************************************************************
 ** WARNING: Unable to determine if the Xcode license has been accepted **
@@ -407,7 +407,7 @@ def get_simulators(
     # If the simulator frameworks don't exist, they will be downloaded
     # and installed. This should only occur on first execution.
     if not Path(simulator_location).exists():
-        tools.input.prompt(
+        tools.console.prompt(
             f"""
 It looks like the {os_name} Simulator is not installed. The {os_name} Simulator
 must be installed with administrator privileges.
@@ -416,7 +416,7 @@ xcodebuild will prompt you for your admin password so that it can download
 and install the simulator.
 """
         )
-        tools.input("Press Return to continue: ")
+        tools.console("Press Return to continue: ")
 
     try:
         simctl_data = tools.subprocess.parse_output(

--- a/src/briefcase/platforms/linux/__init__.py
+++ b/src/briefcase/platforms/linux/__init__.py
@@ -160,7 +160,7 @@ class LocalRequirementsMixin:  # pragma: no-cover-if-is-windows
                 if Path(requirement).is_dir():
                     # Requirement is a filesystem reference
                     # Build an sdist for the local requirement
-                    with self.input.wait_bar(f"Building sdist for {requirement}..."):
+                    with self.console.wait_bar(f"Building sdist for {requirement}..."):
                         try:
                             self.tools.subprocess.check_output(
                                 [

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -93,7 +93,7 @@ class LinuxAppImagePassiveMixin(LinuxMixin):
     def finalize_app_config(self, app: AppConfig):
         """If we're *not* using Docker, warn the user about portability."""
         if not self.use_docker:
-            self.logger.warning(
+            self.console.warning(
                 """\
 *************************************************************************
 ** WARNING: Building a Local AppImage!                                 **
@@ -107,7 +107,7 @@ class LinuxAppImagePassiveMixin(LinuxMixin):
 """
             )
 
-        self.logger.warning(
+        self.console.warning(
             """\
 *************************************************************************
 ** WARNING: Use of AppImage is not recommended!                        **
@@ -195,7 +195,7 @@ class LinuxAppImageCreateCommand(
             }[LinuxDeploy.arch(self.tools)]
         except KeyError:
             manylinux_arch = LinuxDeploy.arch(self.tools)
-            self.logger.warning(
+            self.console.warning(
                 f"There is no manylinux base image for {manylinux_arch}"
             )
 
@@ -226,7 +226,7 @@ class LinuxAppImageCreateCommand(
         # On Windows, the support path is co-mingled with app content.
         # This means updating the support package is imperfect.
         # Warn the user that there could be problems.
-        self.logger.warning(
+        self.console.warning(
             """
 *************************************************************************
 ** WARNING: Support package update may be imperfect                    **
@@ -267,14 +267,14 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
         # Build a dictionary of environment definitions that are required
         env = {}
 
-        self.logger.info("Checking for Linuxdeploy plugins...", prefix=app.app_name)
+        self.console.info("Checking for Linuxdeploy plugins...", prefix=app.app_name)
         try:
             plugins = self.tools.linuxdeploy.verify_plugins(
                 app.linuxdeploy_plugins,
                 bundle_path=self.bundle_path(app),
             )
 
-            self.logger.info("Configuring Linuxdeploy plugins...", prefix=app.app_name)
+            self.console.info("Configuring Linuxdeploy plugins...", prefix=app.app_name)
             # We need to add the location of the linuxdeploy plugins to the PATH.
             # However, if we are running inside Docker, we need to know the
             # environment *inside* the Docker container.
@@ -291,11 +291,11 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
                 + [base_path]
             )
         except AttributeError:
-            self.logger.info("No linuxdeploy plugins configured.")
+            self.console.info("No linuxdeploy plugins configured.")
             plugins = {}
 
-        self.logger.info("Building AppImage...", prefix=app.app_name)
-        with self.input.wait_bar("Building..."):
+        self.console.info("Building AppImage...", prefix=app.app_name)
+        with self.console.wait_bar("Building..."):
             try:
                 # For some reason, the version has to be passed in as an
                 # environment variable, *not* in the configuration.
@@ -316,7 +316,7 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
                 env["ARCH"] = self.tools.host_arch
 
                 # Enable debug logging for linuxdeploy GTK and Qt plugins
-                if self.logger.is_deep_debug:
+                if self.console.is_deep_debug:
                     env["DEBUG"] = "1"
 
                 # Find all the .so files in app and app_packages,
@@ -345,7 +345,7 @@ class LinuxAppImageBuildCommand(LinuxAppImageMixin, BuildCommand):
                         self.appdir_path(app) / f"{app.bundle_identifier}.desktop",
                         "--output",
                         "appimage",
-                        "-v0" if self.logger.is_deep_debug else "-v1",
+                        "-v0" if self.console.is_deep_debug else "-v1",
                     ]
                     + additional_args,
                     env=env,
@@ -386,7 +386,7 @@ class LinuxAppImageRunCommand(LinuxAppImagePassiveMixin, RunCommand):
         # be handled correctly. However, if we're in test mode, we *must* stream so
         # that we can see the test exit sentinel
         if app.console_app and not test_mode:
-            self.logger.info("=" * 75)
+            self.console.info("=" * 75)
             self.tools.subprocess.run(
                 [self.binary_path(app)] + passthrough,
                 cwd=self.tools.home_path,

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -164,13 +164,13 @@ class LinuxFlatpakBuildCommand(LinuxFlatpakMixin, BuildCommand):
 
         :param app: The application to build
         """
-        self.logger.info(
+        self.console.info(
             "Ensuring Flatpak runtime for the app is available...",
             prefix=app.app_name,
         )
         flatpak_repo_alias, flatpak_repo_url = self.flatpak_runtime_repo(app)
 
-        with self.input.wait_bar("Ensuring Flatpak runtime repo is registered..."):
+        with self.console.wait_bar("Ensuring Flatpak runtime repo is registered..."):
             self.tools.flatpak.verify_repo(
                 repo_alias=flatpak_repo_alias,
                 url=flatpak_repo_url,
@@ -186,8 +186,8 @@ class LinuxFlatpakBuildCommand(LinuxFlatpakMixin, BuildCommand):
             sdk=self.flatpak_sdk(app),
         )
 
-        self.logger.info("Building Flatpak...", prefix=app.app_name)
-        with self.input.wait_bar("Building..."):
+        self.console.info("Building Flatpak...", prefix=app.app_name)
+        with self.console.wait_bar("Building..."):
             self.tools.flatpak.build(
                 bundle_identifier=app.bundle_identifier,
                 app_name=app.app_name,
@@ -226,7 +226,7 @@ class LinuxFlatpakRunCommand(LinuxFlatpakMixin, RunCommand):
         # be handled correctly. However, if we're in test mode, we *must* stream so
         # that we can see the test exit sentinel
         if app.console_app and not test_mode:
-            self.logger.info("=" * 75)
+            self.console.info("=" * 75)
             self.tools.flatpak.run(
                 bundle_identifier=app.bundle_identifier,
                 args=passthrough,
@@ -259,8 +259,8 @@ class LinuxFlatpakPackageCommand(LinuxFlatpakMixin, PackageCommand):
 
         :param app: The config object for the app
         """
-        self.logger.info("Building bundle...", prefix=app.app_name)
-        with self.input.wait_bar("Bundling..."):
+        self.console.info("Building bundle...", prefix=app.app_name)
+        with self.console.wait_bar("Bundling..."):
             _, flatpak_repo_url = self.flatpak_runtime_repo(app)
             self.tools.flatpak.bundle(
                 repo_url=flatpak_repo_url,

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -61,7 +61,7 @@ class macOSAppCreateCommand(macOSAppMixin, macOSCreateMixin, CreateCommand):
         super().install_app_support_package(app)
 
         # Copy the stdlib into its final location
-        with self.input.wait_bar("Copying standard library into app bundle..."):
+        with self.console.wait_bar("Copying standard library into app bundle..."):
             runtime_support_path = self.support_path(app, runtime=True)
             if runtime_support_path.is_dir():
                 self.tools.shutil.rmtree(runtime_support_path)
@@ -107,16 +107,16 @@ class macOSAppBuildCommand(
 
         :param app: The application to build
         """
-        self.logger.info("Building App...", prefix=app.app_name)
+        self.console.info("Building App...", prefix=app.app_name)
 
         # Move the unbuilt binary in to the final executable location
         unbuilt_path = self.unbuilt_executable_path(app)
         if unbuilt_path.exists():
-            with self.input.wait_bar("Renaming stub binary..."):
+            with self.console.wait_bar("Renaming stub binary..."):
                 unbuilt_path.rename(self.binary_executable_path(app))
 
         if not getattr(app, "universal_build", True):
-            with self.input.wait_bar("Ensuring stub binary is thin..."):
+            with self.console.wait_bar("Ensuring stub binary is thin..."):
                 # The stub binary is universal by default. If we're building a non-universal app,
                 # we can strip the binary to remove the unused slice. This occurs before the
                 self.ensure_thin_binary(
@@ -128,7 +128,7 @@ class macOSAppBuildCommand(
         # signed to be able to execute on Apple Silicon hardware - even if it's only an
         # ad-hoc signing identity. Apply an ad-hoc signing identity to the
         # app bundle.
-        self.logger.info("Ad-hoc signing app...", prefix=app.app_name)
+        self.console.info("Ad-hoc signing app...", prefix=app.app_name)
         self.sign_app(app=app, identity=SigningIdentity())
 
 

--- a/src/briefcase/platforms/macOS/xcode.py
+++ b/src/briefcase/platforms/macOS/xcode.py
@@ -64,25 +64,25 @@ class macOSXcodeBuildCommand(macOSXcodeMixin, BuildCommand):
 
         :param app: The application to build
         """
-        self.logger.info("Building Xcode project...", prefix=app.app_name)
-        with self.input.wait_bar("Building..."):
+        self.console.info("Building Xcode project...", prefix=app.app_name)
+        with self.console.wait_bar("Building..."):
             try:
                 self.tools.subprocess.run(
                     [
                         "xcodebuild",
                         "-project",
                         self.project_path(app),
-                        "-verbose" if self.tools.logger.is_deep_debug else "-quiet",
+                        "-verbose" if self.tools.console.is_deep_debug else "-quiet",
                         "-configuration",
                         "Release",
                         "build",
                     ],
                     check=True,
                     filter_func=(
-                        None if self.tools.logger.is_deep_debug else XcodeBuildFilter()
+                        None if self.tools.console.is_deep_debug else XcodeBuildFilter()
                     ),
                 )
-                self.logger.info("Build succeeded.")
+                self.console.info("Build succeeded.")
             except subprocess.CalledProcessError as e:
                 raise BriefcaseCommandError(
                     f"Unable to build app {app.app_name}."

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -87,7 +87,7 @@ class WindowsCreateCommand(CreateCommand):
             # Create a DNS domain by reversing the bundle identifier
             domain = ".".join(app.bundle_identifier.split(".")[::-1])
             guid = uuid.uuid5(uuid.NAMESPACE_DNS, domain)
-            self.logger.info(f"Assigning {app.app_name} an application GUID of {guid}")
+            self.console.info(f"Assigning {app.app_name} an application GUID of {guid}")
 
         try:
             install_scope = "perMachine" if app.system_installer else "perUser"
@@ -105,7 +105,7 @@ class WindowsCreateCommand(CreateCommand):
         # On Windows, the support path is co-mingled with app content.
         # This means updating the support package is imperfect.
         # Warn the user that there could be problems.
-        self.logger.warning(
+        self.console.warning(
             """
 *************************************************************************
 ** WARNING: Support package update may be imperfect                    **
@@ -146,7 +146,7 @@ class WindowsRunCommand(RunCommand):
         # be handled correctly. However, if we're in test mode, we *must* stream so
         # that we can see the test exit sentinel
         if app.console_app and not test_mode:
-            self.logger.info("=" * 75)
+            self.console.info("=" * 75)
             self.tools.subprocess.run(
                 [self.binary_path(app)] + passthrough,
                 cwd=self.tools.home_path,
@@ -334,7 +334,7 @@ class WindowsPackageCommand(PackageCommand):
             sign_app = True
         else:
             sign_app = False
-            self.logger.warning(
+            self.console.warning(
                 """
 *************************************************************************
 ** WARNING: No signing identity provided                               **
@@ -349,7 +349,7 @@ class WindowsPackageCommand(PackageCommand):
             )
 
         if sign_app:
-            self.logger.info("Signing App...", prefix=app.app_name)
+            self.console.info("Signing App...", prefix=app.app_name)
             sign_options = dict(
                 identity=identity,
                 file_digest=file_digest,
@@ -366,7 +366,7 @@ class WindowsPackageCommand(PackageCommand):
             self._package_msi(app)
 
             if sign_app:
-                self.logger.info("Signing MSI...", prefix=app.app_name)
+                self.console.info("Signing MSI...", prefix=app.app_name)
                 self.sign_file(
                     app=app,
                     filepath=self.distribution_path(app),
@@ -376,10 +376,10 @@ class WindowsPackageCommand(PackageCommand):
     def _package_msi(self, app):
         """Build the msi installer."""
 
-        self.logger.info("Building MSI...", prefix=app.app_name)
+        self.console.info("Building MSI...", prefix=app.app_name)
         try:
-            self.logger.info("Compiling application manifest...")
-            with self.input.wait_bar("Compiling..."):
+            self.console.info("Compiling application manifest...")
+            with self.console.wait_bar("Compiling..."):
                 self.tools.subprocess.run(
                     [
                         self.tools.wix.heat_exe,
@@ -409,8 +409,8 @@ class WindowsPackageCommand(PackageCommand):
             ) from e
 
         try:
-            self.logger.info("Compiling application installer...")
-            with self.input.wait_bar("Compiling..."):
+            self.console.info("Compiling application installer...")
+            with self.console.wait_bar("Compiling..."):
                 self.tools.subprocess.run(
                     [
                         self.tools.wix.candle_exe,
@@ -432,8 +432,8 @@ class WindowsPackageCommand(PackageCommand):
             raise BriefcaseCommandError(f"Unable to compile app {app.app_name}.") from e
 
         try:
-            self.logger.info("Linking application installer...")
-            with self.input.wait_bar("Linking..."):
+            self.console.info("Linking application installer...")
+            with self.console.wait_bar("Linking..."):
                 self.tools.subprocess.run(
                     [
                         self.tools.wix.light_exe,
@@ -458,8 +458,8 @@ class WindowsPackageCommand(PackageCommand):
     def _package_zip(self, app):
         """Package the app as simple zip file."""
 
-        self.logger.info("Building zip file...", prefix=app.app_name)
-        with self.input.wait_bar("Packing..."):
+        self.console.info("Building zip file...", prefix=app.app_name)
+        with self.console.wait_bar("Packing..."):
             source = self.bundle_path(app) / self.packaging_root  # /src
             zip_root = f"{app.formal_name}-{app.version}"
 

--- a/src/briefcase/platforms/windows/app.py
+++ b/src/briefcase/platforms/windows/app.py
@@ -52,19 +52,19 @@ class WindowsAppBuildCommand(WindowsAppMixin, BuildCommand):
 
         :param app: The config object for the app
         """
-        self.logger.info("Building App...", prefix=app.app_name)
+        self.console.info("Building App...", prefix=app.app_name)
 
         # Move the stub binary in to the final executable location
         unbuilt_binary_path = self.unbuilt_executable_path(app)
         if unbuilt_binary_path.exists():
-            with self.input.wait_bar("Renaming stub binary..."):
+            with self.console.wait_bar("Renaming stub binary..."):
                 unbuilt_binary_path.rename(self.binary_executable_path(app))
 
         if hasattr(self.tools, "windows_sdk"):
             # If an app has been packaged and code signed previously, then the digital
             # signature on the app binary needs to be removed before re-building the app.
             # It is not safe to use RCEdit on signed binaries since it corrupts them.
-            with self.input.wait_bar(
+            with self.console.wait_bar(
                 "Removing any digital signatures from stub app..."
             ):
                 try:
@@ -92,7 +92,7 @@ Recreating the app layout may also help resolve this issue:
 """
                         ) from e
 
-        with self.input.wait_bar("Setting stub app details..."):
+        with self.console.wait_bar("Setting stub app details..."):
             try:
                 self.tools.subprocess.run(
                     [

--- a/src/briefcase/platforms/windows/visualstudio.py
+++ b/src/briefcase/platforms/windows/visualstudio.py
@@ -45,9 +45,9 @@ class WindowsVisualStudioBuildCommand(WindowsVisualStudioMixin, BuildCommand):
 
         :param app: The config object for the app
         """
-        self.logger.info("Building VisualStudio project...", prefix=app.app_name)
+        self.console.info("Building VisualStudio project...", prefix=app.app_name)
 
-        with self.input.wait_bar("Building solution..."):
+        with self.console.wait_bar("Building solution..."):
             try:
                 self.tools.subprocess.run(
                     [
@@ -59,7 +59,7 @@ class WindowsVisualStudioBuildCommand(WindowsVisualStudioMixin, BuildCommand):
                         "-property:Configuration=Release",
                         (
                             "-verbosity:detailed"
-                            if self.logger.is_deep_debug
+                            if self.console.is_deep_debug
                             else "-verbosity:normal"
                         ),
                     ],

--- a/tests/commands/base/conftest.py
+++ b/tests/commands/base/conftest.py
@@ -2,7 +2,8 @@ import pytest
 
 from briefcase.commands.base import BaseCommand
 from briefcase.config import AppConfig
-from briefcase.console import Console, Log
+
+from ...utils import DummyConsole
 
 
 class DummyCommand(BaseCommand):
@@ -15,8 +16,7 @@ class DummyCommand(BaseCommand):
     description = "Dummy base command"
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("logger", Log())
-        kwargs.setdefault("console", Console())
+        kwargs.setdefault("console", DummyConsole())
         super().__init__(*args, **kwargs)
 
         self.actions = []
@@ -105,7 +105,7 @@ class OtherDummyCommand(BaseCommand):
 
 @pytest.fixture
 def other_command(tmp_path):
-    return OtherDummyCommand(base_path=tmp_path, logger=Log(), console=Console())
+    return OtherDummyCommand(base_path=tmp_path, console=DummyConsole())
 
 
 @pytest.fixture

--- a/tests/commands/base/test_cookiecutter_logging.py
+++ b/tests/commands/base/test_cookiecutter_logging.py
@@ -26,7 +26,7 @@ def base_command(base_command):
 )
 def test_git_stdlib_logging(base_command, logging_level, handler_expected):
     """A logging handler is configured for GitPython when DEEP_DEBUG is enabled."""
-    base_command.logger.verbosity = logging_level
+    base_command.console.verbosity = logging_level
 
     base_command.generate_template(
         template="",

--- a/tests/commands/base/test_parse_options.py
+++ b/tests/commands/base/test_parse_options.py
@@ -20,8 +20,8 @@ def test_parse_options_no_overrides(base_command):
         "required": "important",
     }
     assert overrides == {}
-    assert base_command.input.enabled
-    assert base_command.logger.verbosity == LogLevel.INFO
+    assert base_command.console.input_enabled
+    assert base_command.console.verbosity == LogLevel.INFO
 
 
 def test_parse_options_with_overrides(base_command):
@@ -48,8 +48,8 @@ def test_parse_options_with_overrides(base_command):
         "width": 10,
         "height": 20,
     }
-    assert base_command.input.enabled
-    assert base_command.logger.verbosity == LogLevel.INFO
+    assert base_command.console.input_enabled
+    assert base_command.console.verbosity == LogLevel.INFO
 
 
 @pytest.mark.parametrize(
@@ -67,7 +67,7 @@ def test_verbosity(base_command, verbosity, log_level):
     """The logging level is set correctly for the verbosity."""
     base_command.parse_options(extra=filter(None, ("-r", "default", verbosity)))
 
-    assert base_command.logger.verbosity == log_level
+    assert base_command.console.verbosity == log_level
 
 
 def test_missing_option(base_command, capsys):

--- a/tests/commands/base/test_properties.py
+++ b/tests/commands/base/test_properties.py
@@ -44,41 +44,35 @@ def test_publish_command(base_command):
 def test_command_state_transferred(tmp_path):
     """Command state is transferred to created subcommands."""
     command = DummyCommand(base_path=tmp_path)
-    command.tools.input.enabled = False
+    command.tools.console.input_enabled = False
 
     # Check the enabled state of subcommands
-    assert not command.create_command.input.enabled
-    assert command.create_command.logger is command.tools.logger
-    assert command.create_command.input is command.tools.input
+    assert not command.create_command.console.input_enabled
+    assert command.create_command.console is command.tools.console
     assert command.create_command.tools is command.tools
     assert command.create_command.is_clone is True
 
-    assert not command.update_command.input.enabled
-    assert command.update_command.logger is command.tools.logger
-    assert command.update_command.input is command.tools.input
+    assert not command.update_command.console.input_enabled
+    assert command.update_command.console is command.tools.console
     assert command.update_command.tools is command.tools
     assert command.update_command.is_clone is True
 
-    assert not command.build_command.input.enabled
-    assert command.build_command.logger is command.tools.logger
-    assert command.build_command.input is command.tools.input
+    assert not command.build_command.console.input_enabled
+    assert command.build_command.console is command.tools.console
     assert command.build_command.tools is command.tools
     assert command.build_command.is_clone is True
 
-    assert not command.run_command.input.enabled
-    assert command.run_command.logger is command.tools.logger
-    assert command.run_command.input is command.tools.input
+    assert not command.run_command.console.input_enabled
+    assert command.run_command.console is command.tools.console
     assert command.run_command.tools is command.tools
     assert command.run_command.is_clone is True
 
-    assert not command.package_command.input.enabled
-    assert command.package_command.logger is command.tools.logger
-    assert command.package_command.input is command.tools.input
+    assert not command.package_command.console.input_enabled
+    assert command.package_command.console is command.tools.console
     assert command.package_command.tools is command.tools
     assert command.package_command.is_clone is True
 
-    assert not command.publish_command.input.enabled
-    assert command.publish_command.logger is command.tools.logger
-    assert command.publish_command.input is command.tools.input
+    assert not command.publish_command.console.input_enabled
+    assert command.publish_command.console is command.tools.console
     assert command.publish_command.tools is command.tools
     assert command.publish_command.is_clone is True

--- a/tests/commands/build/conftest.py
+++ b/tests/commands/build/conftest.py
@@ -3,8 +3,7 @@ import pytest
 from briefcase.commands import BuildCommand
 from briefcase.commands.base import full_options
 from briefcase.config import AppConfig
-from briefcase.console import Console, Log
-from ...utils import create_file
+from ...utils import create_file, DummyConsole
 
 
 class DummyBuildCommand(BuildCommand):
@@ -19,8 +18,7 @@ class DummyBuildCommand(BuildCommand):
     description = "Dummy build command"
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("logger", Log())
-        kwargs.setdefault("console", Console())
+        kwargs.setdefault("console", DummyConsole())
         super().__init__(*args, apps={}, **kwargs)
 
         self.actions = []

--- a/tests/commands/convert/conftest.py
+++ b/tests/commands/convert/conftest.py
@@ -5,7 +5,6 @@ import pytest
 import briefcase.commands.convert
 from briefcase.commands import ConvertCommand
 from briefcase.commands.base import full_options
-from briefcase.console import Console, Log
 from tests.utils import DummyConsole
 
 
@@ -18,12 +17,10 @@ class DummyConvertCommand(ConvertCommand):
     description = "Dummy convert command"
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("logger", Log())
-        kwargs.setdefault("console", Console())
+        kwargs.setdefault("console", DummyConsole())
         super().__init__(*args, apps={}, **kwargs)
 
         self.actions = []
-        self.tools.input = DummyConsole()
 
     def verify_host(self):
         super().verify_host()

--- a/tests/commands/convert/test_convert_app.py
+++ b/tests/commands/convert/test_convert_app.py
@@ -6,7 +6,7 @@ from cookiecutter.main import cookiecutter
 
 import briefcase
 from briefcase.commands import ConvertCommand
-from briefcase.console import Console, Log
+from briefcase.console import Console
 
 
 @pytest.fixture
@@ -14,7 +14,6 @@ def convert_command(tmp_path):
     return ConvertCommand(
         base_path=tmp_path / "project",
         data_path=tmp_path / "data",
-        logger=Log(),
         console=Console(),
     )
 

--- a/tests/commands/convert/test_input_app_name.py
+++ b/tests/commands/convert/test_input_app_name.py
@@ -14,7 +14,7 @@ def test_override_is_used(convert_command):
 def test_no_pep621_data(convert_command, monkeypatch):
     """The app directory is used if there is no PEP621-name."""
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
     convert_command.base_path /= "test-app-name"
     convert_command.input_app_name(None)
 
@@ -48,7 +48,7 @@ def test_invalid_hint_app_name(convert_command, monkeypatch):
     """A placeholder is used if there's no PEP621 name and the app directory is an
     invalid name."""
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
     convert_command.base_path /= "!app_name"
     convert_command.input_app_name(None)
 
@@ -66,7 +66,7 @@ def test_invalid_hint_app_name(convert_command, monkeypatch):
 def test_hint_is_canonicalized(convert_command, monkeypatch):
     """The app directory name is canonicalized when used as a hint."""
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
     convert_command.base_path /= "test-app_name"
     convert_command.input_app_name(None)
 

--- a/tests/commands/convert/test_input_app_type.py
+++ b/tests/commands/convert/test_input_app_type.py
@@ -16,7 +16,7 @@ import pytest
 )
 def test_app_type(convert_command, input, result):
     """The user can be asked for the app type."""
-    convert_command.input.values = input
+    convert_command.console.values = input
     out = convert_command.input_app_type(None)
     assert out == result
 

--- a/tests/commands/convert/test_input_author.py
+++ b/tests/commands/convert/test_input_author.py
@@ -10,7 +10,7 @@ def test_multiple_pep621_authors(convert_command, monkeypatch):
     mock_selection_question = MagicMock()
     mock_selection_question.return_value = "Firstname Firstauthor"
     monkeypatch.setattr(
-        convert_command.input, "selection_question", mock_selection_question
+        convert_command.console, "selection_question", mock_selection_question
     )
 
     (convert_command.base_path / "pyproject.toml").write_text(
@@ -47,7 +47,7 @@ def test_single_pep621_author(convert_command, monkeypatch):
     mock_selection_question = MagicMock()
     mock_selection_question.return_value = "Firstname Firstauthor"
     monkeypatch.setattr(
-        convert_command.input, "selection_question", mock_selection_question
+        convert_command.console, "selection_question", mock_selection_question
     )
 
     (convert_command.base_path / "pyproject.toml").write_text(
@@ -78,11 +78,11 @@ def test_multiple_pep621_authors_select_other(convert_command, monkeypatch):
     mock_selection_question = MagicMock()
     mock_selection_question.return_value = "Other"
     monkeypatch.setattr(
-        convert_command.input, "selection_question", mock_selection_question
+        convert_command.console, "selection_question", mock_selection_question
     )
     mock_text_question = MagicMock()
     mock_text_question.return_value = "Some Name"
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
 
     (convert_command.base_path / "pyproject.toml").write_text(
         "[project]\n"
@@ -123,7 +123,7 @@ def test_no_pep621_author(convert_command, monkeypatch, write_empty_pyproject):
     """If there is no author names in the pyproject.toml, then you're asked to write the
     name."""
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
 
     if write_empty_pyproject:
         (convert_command.base_path / "pyproject.toml").write_text(
@@ -157,7 +157,7 @@ def test_override(convert_command):
 
 def test_prompted_author_without_pyproject(convert_command):
     """The user is prompted for an author."""
-    convert_command.input.values = ["Some author"]
+    convert_command.console.values = ["Some author"]
     assert convert_command.input_author(None) == "Some author"
 
 
@@ -172,7 +172,7 @@ def test_prompted_author_with_pyproject(convert_command):
         "]",
         encoding="utf-8",
     )
-    convert_command.input.values = ["2"]
+    convert_command.console.values = ["2"]
     assert convert_command.input_author(None) == "Name Thirdauthor"
 
 
@@ -188,7 +188,7 @@ def test_prompted_author_with_pyproject_joined_author(convert_command):
         "]",
         encoding="utf-8",
     )
-    convert_command.input.values = ["4"]
+    convert_command.console.values = ["4"]
     assert (
         convert_command.input_author(None)
         == "Firstname Firstauthor, Name Thirdauthor & Firstname Fourthauthor"
@@ -207,5 +207,5 @@ def test_prompted_author_with_pyproject_other(convert_command):
         "]",
         encoding="utf-8",
     )
-    convert_command.input.values = ["5", "Some Author"]
+    convert_command.console.values = ["5", "Some Author"]
     assert convert_command.input_author(None) == "Some Author"

--- a/tests/commands/convert/test_input_bundle.py
+++ b/tests/commands/convert/test_input_bundle.py
@@ -5,7 +5,7 @@ from ...utils import PartialMatchString
 
 def test_default_without_http_protocol(convert_command, monkeypatch):
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
 
     convert_command.input_bundle("http://www.some_url.no", "test-app-name", None)
     mock_text_question.assert_called_once_with(
@@ -19,7 +19,7 @@ def test_default_without_http_protocol(convert_command, monkeypatch):
 
 def test_default_without_https_protocol(convert_command, monkeypatch):
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
 
     convert_command.input_bundle("https://www.some_url.no", "test-app-name", None)
     mock_text_question.assert_called_once_with(
@@ -40,5 +40,5 @@ def test_override_is_used(convert_command):
 
 def test_prompted_bundle(convert_command):
     """You can type in the bundle name."""
-    convert_command.input.values = ["com.some.project"]
+    convert_command.console.values = ["com.some.project"]
     assert convert_command.input_bundle("", "test-app-name", None) == "com.some.project"

--- a/tests/commands/convert/test_input_description.py
+++ b/tests/commands/convert/test_input_description.py
@@ -17,5 +17,5 @@ def test_override_is_used(convert_command):
 def test_prompted_description(convert_command):
     """The user is prompted for a description if there is no description in the
     pyproject.toml file."""
-    convert_command.input.values = ["A very descriptive description"]
+    convert_command.console.values = ["A very descriptive description"]
     assert convert_command.input_description(None) == "A very descriptive description"

--- a/tests/commands/convert/test_input_email.py
+++ b/tests/commands/convert/test_input_email.py
@@ -6,7 +6,7 @@ from ...utils import PartialMatchString
 def test_pep621_author(convert_command, monkeypatch):
     mock_text_question = MagicMock()
     mock_text_question.return_value = "Some Name"
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
     (convert_command.base_path / "pyproject.toml").write_text(
         "[project]\n"
         "authors = [\n"
@@ -31,7 +31,7 @@ def test_pep621_author(convert_command, monkeypatch):
 def test_pep621_wrong_author(convert_command, monkeypatch):
     mock_text_question = MagicMock()
     mock_text_question.return_value = "Some Name"
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
     (convert_command.base_path / "pyproject.toml").write_text(
         "[project]\n"
         "authors = [\n"
@@ -56,7 +56,7 @@ def test_pep621_wrong_author(convert_command, monkeypatch):
 def test_no_pep621_author(convert_command, monkeypatch):
     mock_text_question = MagicMock()
     mock_text_question.return_value = "Some Name"
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
 
     convert_command.input_email("Noname Thirdauthor", "some.bundle", None)
     mock_text_question.assert_called_once_with(
@@ -89,7 +89,7 @@ def test_override(convert_command):
 
 def test_prompted_email(convert_command):
     """You can type in the e-mail address."""
-    convert_command.input.values = ["my@email.com"]
+    convert_command.console.values = ["my@email.com"]
     assert (
         convert_command.input_email("Some name", "com.some.bundle", None)
         == "my@email.com"

--- a/tests/commands/convert/test_input_formal_name.py
+++ b/tests/commands/convert/test_input_formal_name.py
@@ -5,7 +5,7 @@ from ...utils import PartialMatchString
 
 def test_app_name_is_formatted(convert_command, monkeypatch):
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
     convert_command.input_formal_name("test-app-name", None)
 
     mock_text_question.assert_called_once_with(
@@ -27,5 +27,5 @@ def test_override_is_used(convert_command):
 
 def test_prompted_formal_name(convert_command):
     """You can type in the formal name."""
-    convert_command.input.values = ["My Formal Name"]
+    convert_command.console.values = ["My Formal Name"]
     assert convert_command.input_formal_name("app-name", None) == "My Formal Name"

--- a/tests/commands/convert/test_input_license.py
+++ b/tests/commands/convert/test_input_license.py
@@ -49,7 +49,7 @@ def test_get_license_from_file(
 ):
     mock_selection_question = MagicMock()
     monkeypatch.setattr(
-        convert_command.input, "selection_question", mock_selection_question
+        convert_command.console, "selection_question", mock_selection_question
     )
 
     dummy_license_text = (
@@ -125,7 +125,7 @@ def test_get_license_from_pep621_license_file(
 ):
     mock_selection_question = MagicMock()
     monkeypatch.setattr(
-        convert_command.input, "selection_question", mock_selection_question
+        convert_command.console, "selection_question", mock_selection_question
     )
 
     dummy_license_text = (
@@ -181,7 +181,7 @@ def test_get_license_from_pyproject(
 ):
     mock_selection_question = MagicMock()
     monkeypatch.setattr(
-        convert_command.input, "selection_question", mock_selection_question
+        convert_command.console, "selection_question", mock_selection_question
     )
     (convert_command.base_path / "pyproject.toml").write_text(
         "[project]\n" f'license = {{text = "{license_text}"}}', encoding="utf-8"
@@ -210,7 +210,7 @@ def test_get_license_from_pyproject(
 def test_no_license_hint(convert_command, monkeypatch):
     mock_selection_question = MagicMock()
     monkeypatch.setattr(
-        convert_command.input, "selection_question", mock_selection_question
+        convert_command.console, "selection_question", mock_selection_question
     )
 
     convert_command.input_license(None)

--- a/tests/commands/convert/test_input_source_dir.py
+++ b/tests/commands/convert/test_input_source_dir.py
@@ -3,7 +3,7 @@ from unittest.mock import ANY, MagicMock
 
 def test_default_and_intro_is_used(convert_command, monkeypatch):
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
 
     def get_source_dir_hint(*args, **kwargs):
         return "SOME_DIRECTORY", "SOME_DESCRIPTION"
@@ -43,7 +43,7 @@ def test_prompted_source_dir(convert_command):
     (convert_command.base_path / "src/app_name" / "__main__.py").write_text(
         "", encoding="utf-8"
     )
-    convert_command.input.values = ["src/app_name"]
+    convert_command.console.values = ["src/app_name"]
 
     assert (
         convert_command.input_source_dir("app-name", "app_name", None) == "src/app_name"

--- a/tests/commands/convert/test_input_test_source_dir.py
+++ b/tests/commands/convert/test_input_test_source_dir.py
@@ -5,7 +5,7 @@ from ...utils import NoMatchString, PartialMatchString
 
 def test_no_test_dir(convert_command, monkeypatch):
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
 
     convert_command.input_test_source_dir("app_name", None)
     intro_content = "\n\nBased on your project's folder structure, we believe 'test' might be your test directory"
@@ -20,7 +20,7 @@ def test_no_test_dir(convert_command, monkeypatch):
 
 def test_test_dir(convert_command, monkeypatch):
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
 
     (convert_command.base_path / "test").mkdir()
     convert_command.input_test_source_dir("app_name", None)
@@ -37,7 +37,7 @@ def test_test_dir(convert_command, monkeypatch):
 
 def test_tests_dir(convert_command, monkeypatch):
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
 
     (convert_command.base_path / "tests").mkdir()
     convert_command.input_test_source_dir("app_name", None)
@@ -54,7 +54,7 @@ def test_tests_dir(convert_command, monkeypatch):
 
 def test_tests_dir_is_prefered_over_test_dir(convert_command, monkeypatch):
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
 
     (convert_command.base_path / "tests").mkdir()
     (convert_command.base_path / "test").mkdir()
@@ -78,6 +78,6 @@ def test_override_is_used(convert_command):
 def test_prompted_test_source_dir(convert_command):
     """You can type in the test source dir."""
     (convert_command.base_path / "mytest").mkdir(parents=True)
-    convert_command.input.values = ["mytest"]
+    convert_command.console.values = ["mytest"]
 
     assert convert_command.input_test_source_dir("app_name", None) == "mytest"

--- a/tests/commands/convert/test_input_url.py
+++ b/tests/commands/convert/test_input_url.py
@@ -7,7 +7,7 @@ def test_multiple_pep621_options(convert_command, monkeypatch):
     mock_selection_question = MagicMock()
     mock_selection_question.return_value = "https://some_other_url.com/"
     monkeypatch.setattr(
-        convert_command.input, "selection_question", mock_selection_question
+        convert_command.console, "selection_question", mock_selection_question
     )
 
     (convert_command.base_path / "pyproject.toml").write_text(
@@ -38,11 +38,11 @@ def test_multiple_pep621_options_select_other(convert_command, monkeypatch):
     mock_selection_question = MagicMock()
     mock_selection_question.return_value = "Other"
     monkeypatch.setattr(
-        convert_command.input, "selection_question", mock_selection_question
+        convert_command.console, "selection_question", mock_selection_question
     )
 
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
 
     (convert_command.base_path / "pyproject.toml").write_text(
         "[project.urls]\n"
@@ -76,7 +76,7 @@ def test_multiple_pep621_options_select_other(convert_command, monkeypatch):
 
 def test_no_pep621_options(convert_command, monkeypatch):
     mock_text_question = MagicMock()
-    monkeypatch.setattr(convert_command.input, "text_question", mock_text_question)
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
 
     convert_command.input_url("some-name", None)
     default = "https://example.com/some-name"
@@ -101,7 +101,7 @@ def test_override(convert_command):
 
 def test_prompted_url(convert_command):
     """You can type in the URL."""
-    convert_command.input.values = ["https://example.com/some-name"]
+    convert_command.console.values = ["https://example.com/some-name"]
     assert (
         convert_command.input_url("some-name", None) == "https://example.com/some-name"
     )

--- a/tests/commands/convert/test_migrate_necessary_files.py
+++ b/tests/commands/convert/test_migrate_necessary_files.py
@@ -86,7 +86,7 @@ def test_warning_without_license_file(
     test_source_dir,
 ):
     """A single warning is raised if changelog file is present but not license file."""
-    convert_command.logger.warning = mock.MagicMock()
+    convert_command.console.warning = mock.MagicMock()
 
     create_file(convert_command.base_path / "CHANGELOG", "")
     convert_command.migrate_necessary_files(
@@ -95,7 +95,7 @@ def test_warning_without_license_file(
         dummy_app_name,
     )
 
-    convert_command.logger.warning.assert_called_once_with(
+    convert_command.console.warning.assert_called_once_with(
         f"\nLicense file not found in '{convert_command.base_path}'. "
         "Briefcase will create a template 'LICENSE' file."
     )
@@ -127,7 +127,7 @@ def test_pep621_specified_license_filename(
     test_source_dir,
 ):
     """No license file is copied if a license file is specified in pyproject.toml."""
-    convert_command.logger.warning = mock.MagicMock()
+    convert_command.console.warning = mock.MagicMock()
     license_name = "LICENSE.txt"
     create_file(convert_command.base_path / license_name, "")
     create_file(
@@ -152,7 +152,7 @@ def test_pep621_specified_license_text(
 ):
     """A license file is copied if the license is specified as text and no LICENSE file
     exists."""
-    convert_command.logger.warning = mock.MagicMock()
+    convert_command.console.warning = mock.MagicMock()
     create_file(
         convert_command.base_path / "pyproject.toml",
         '[project]\nlicense = { text = "New BSD" }',
@@ -165,7 +165,7 @@ def test_pep621_specified_license_text(
     )
     assert (convert_command.base_path / "LICENSE").exists()
 
-    convert_command.logger.warning.assert_called_once_with(
+    convert_command.console.warning.assert_called_once_with(
         f"\nLicense file not found in '{convert_command.base_path}'. "
         "Briefcase will create a template 'LICENSE' file."
     )
@@ -179,7 +179,7 @@ def test_warning_without_changelog_file(
     test_source_dir,
 ):
     """A single warning is raised if license file is present but not changelog file."""
-    convert_command.logger.warning = mock.MagicMock()
+    convert_command.console.warning = mock.MagicMock()
 
     create_file(convert_command.base_path / "LICENSE", "")
     convert_command.migrate_necessary_files(
@@ -188,7 +188,7 @@ def test_warning_without_changelog_file(
         dummy_app_name,
     )
 
-    convert_command.logger.warning.assert_called_once_with(
+    convert_command.console.warning.assert_called_once_with(
         f"\nChangelog file not found in '{convert_command.base_path}'. You should either "
         f"create a new '{convert_command.base_path / 'CHANGELOG'}' file, or rename an "
         "already existing changelog file to 'CHANGELOG'."
@@ -203,7 +203,7 @@ def test_no_warning_with_license_and_changelog_file(
     test_source_dir,
 ):
     """No warning is raised if both license file and changelog file is present."""
-    convert_command.logger.warning = mock.MagicMock()
+    convert_command.console.warning = mock.MagicMock()
 
     create_file(
         convert_command.base_path / "pyproject.toml",
@@ -217,7 +217,7 @@ def test_no_warning_with_license_and_changelog_file(
         dummy_app_name,
     )
 
-    convert_command.logger.warning.assert_not_called()
+    convert_command.console.warning.assert_not_called()
 
 
 @pytest.mark.parametrize("test_source_dir", ["tests"])
@@ -228,7 +228,7 @@ def test_two_warnings_without_license_and_changelog_file(
     test_source_dir,
 ):
     """Two warnings are raised if both license file and changelog file are missing."""
-    convert_command.logger.warning = mock.MagicMock()
+    convert_command.console.warning = mock.MagicMock()
 
     convert_command.migrate_necessary_files(
         project_dir_with_files,
@@ -244,7 +244,7 @@ def test_two_warnings_without_license_and_changelog_file(
         f"create a new '{convert_command.base_path / 'CHANGELOG'}' file, or rename an "
         "already existing changelog file to 'CHANGELOG'."
     )
-    assert convert_command.logger.warning.mock_calls == [
+    assert convert_command.console.warning.mock_calls == [
         mock.call(license_warning),
         mock.call(changelog_warning),
     ]

--- a/tests/commands/create/conftest.py
+++ b/tests/commands/create/conftest.py
@@ -8,7 +8,6 @@ from cookiecutter.main import cookiecutter
 
 from briefcase.commands import CreateCommand
 from briefcase.config import AppConfig
-from briefcase.console import Console, Log
 from briefcase.integrations.base import Tool
 from briefcase.integrations.subprocess import Subprocess
 
@@ -36,7 +35,7 @@ class DefaultCreateCommand(CreateCommand):
 
 @pytest.fixture
 def default_create_command(tmp_path):
-    return DefaultCreateCommand(base_path=tmp_path, logger=Log(), console=Console())
+    return DefaultCreateCommand(base_path=tmp_path, console=DummyConsole())
 
 
 class DummyCreateCommand(CreateCommand):
@@ -51,8 +50,7 @@ class DummyCreateCommand(CreateCommand):
     hidden_app_properties = {"permission", "request"}
 
     def __init__(self, *args, support_file=None, git=None, home_path=None, **kwargs):
-        kwargs.setdefault("logger", Log())
-        kwargs.setdefault("console", Console())
+        kwargs.setdefault("console", DummyConsole())
         super().__init__(*args, **kwargs)
 
         # Override the host properties
@@ -68,7 +66,6 @@ class DummyCreateCommand(CreateCommand):
         self.tools.git = git
         self.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
         self.support_file = support_file
-        self.tools.input = DummyConsole()
         self.tools.cookiecutter = mock.MagicMock(spec_set=cookiecutter)
 
     @property

--- a/tests/commands/create/test_cleanup_app_content.py
+++ b/tests/commands/create/test_cleanup_app_content.py
@@ -31,7 +31,7 @@ def test_no_cleanup(create_command, myapp_unrolled, support_path, debug, capsys)
     """If there are no cleanup directives, bundle content isn't touched; but __pycache__
     is cleaned."""
     if debug:
-        create_command.logger.verbosity = LogLevel.DEBUG
+        create_command.console.verbosity = LogLevel.DEBUG
 
     # Cleanup app content
     create_command.cleanup_app_content(myapp_unrolled)
@@ -59,7 +59,7 @@ def test_no_cleanup(create_command, myapp_unrolled, support_path, debug, capsys)
 def test_dir_cleanup(create_command, myapp_unrolled, support_path, debug, capsys):
     """A directory can be cleaned up."""
     if debug:
-        create_command.logger.verbosity = LogLevel.DEBUG
+        create_command.console.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = ["path/to/support/dir1"]
 
@@ -86,7 +86,7 @@ def test_dir_cleanup(create_command, myapp_unrolled, support_path, debug, capsys
 def test_file_cleanup(create_command, myapp_unrolled, support_path, debug, capsys):
     """A single file can be cleaned up."""
     if debug:
-        create_command.logger.verbosity = LogLevel.DEBUG
+        create_command.console.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = ["path/to/support/dir1/a_file1.txt"]
 
@@ -118,7 +118,7 @@ def test_all_files_in_dir_cleanup(
 ):
     """All files in a directory can be cleaned up."""
     if debug:
-        create_command.logger.verbosity = LogLevel.DEBUG
+        create_command.console.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = ["path/to/support/dir1/*"]
 
@@ -150,7 +150,7 @@ def test_all_files_in_dir_cleanup(
 def test_dir_glob_cleanup(create_command, myapp_unrolled, support_path, debug, capsys):
     """A glob of directories can be cleaned up."""
     if debug:
-        create_command.logger.verbosity = LogLevel.DEBUG
+        create_command.console.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = ["path/to/support/dir*"]
 
@@ -177,7 +177,7 @@ def test_dir_glob_cleanup(create_command, myapp_unrolled, support_path, debug, c
 def test_file_glob_cleanup(create_command, myapp_unrolled, support_path, debug, capsys):
     """A glob of files can be cleaned up."""
     if debug:
-        create_command.logger.verbosity = LogLevel.DEBUG
+        create_command.console.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = ["path/to/support/dir1/*.txt"]
 
@@ -207,7 +207,7 @@ def test_file_glob_cleanup(create_command, myapp_unrolled, support_path, debug, 
 def test_deep_glob_cleanup(create_command, myapp_unrolled, support_path, debug, capsys):
     """A glob that matches all directories will be added to the cleanup list."""
     if debug:
-        create_command.logger.verbosity = LogLevel.DEBUG
+        create_command.console.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = ["path/to/support/**/b_file.*"]
 
@@ -238,7 +238,7 @@ def test_deep_glob_cleanup(create_command, myapp_unrolled, support_path, debug, 
 def test_symlink_cleanup(create_command, myapp_unrolled, support_path, debug, capsys):
     """Symlinks can be cleaned up."""
     if debug:
-        create_command.logger.verbosity = LogLevel.DEBUG
+        create_command.console.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = [
         "path/to/support/dir1/symlink.txt",
@@ -273,7 +273,7 @@ def test_template_glob_cleanup(
 ):
     """A glob of files specified in the template will be added to the cleanup list."""
     if debug:
-        create_command.logger.verbosity = LogLevel.DEBUG
+        create_command.console.verbosity = LogLevel.DEBUG
 
     # Define a cleanup_paths in the template *and* on the app
     create_command._briefcase_toml[myapp_unrolled] = {
@@ -316,7 +316,7 @@ def test_non_existent_cleanup(
 ):
     """Referencing a specific file that doesn't exist doesn't cause a problem."""
     if debug:
-        create_command.logger.verbosity = LogLevel.DEBUG
+        create_command.console.verbosity = LogLevel.DEBUG
 
     myapp_unrolled.cleanup_paths = [
         # This file exists

--- a/tests/commands/create/test_create_app.py
+++ b/tests/commands/create/test_create_app.py
@@ -9,7 +9,7 @@ def test_create_app(tracking_create_command, tmp_path):
     tracking_create_command.create_app(tracking_create_command.apps["first"])
 
     # Input wasn't required by the user
-    assert tracking_create_command.input.prompts == []
+    assert tracking_create_command.console.prompts == []
 
     # The right sequence of things will be done
     assert tracking_create_command.actions == [
@@ -32,7 +32,7 @@ def test_create_app(tracking_create_command, tmp_path):
 def test_create_existing_app_overwrite(tracking_create_command, tmp_path):
     """An existing app can be overwritten if requested."""
     # Answer yes when asked
-    tracking_create_command.input.values = ["y"]
+    tracking_create_command.console.values = ["y"]
 
     # Generate an app in the location.
     bundle_path = tmp_path / "base_path/build/first/tester/dummy"
@@ -43,7 +43,7 @@ def test_create_existing_app_overwrite(tracking_create_command, tmp_path):
     tracking_create_command.create_app(tracking_create_command.apps["first"])
 
     # Input was required by the user
-    assert tracking_create_command.input.prompts == [
+    assert tracking_create_command.console.prompts == [
         "Application 'first' already exists; overwrite [y/N]? "
     ]
 
@@ -69,7 +69,7 @@ def test_create_existing_app_overwrite(tracking_create_command, tmp_path):
 def test_create_existing_app_no_overwrite(tracking_create_command, tmp_path):
     """If you say no, the existing app won't be overwritten."""
     # Answer no when asked
-    tracking_create_command.input.values = ["n"]
+    tracking_create_command.console.values = ["n"]
 
     bundle_path = tmp_path / "base_path/build/first/tester/dummy"
     bundle_path.mkdir(parents=True)
@@ -78,7 +78,7 @@ def test_create_existing_app_no_overwrite(tracking_create_command, tmp_path):
     tracking_create_command.create_app(tracking_create_command.apps["first"])
 
     # Input was required by the user
-    assert tracking_create_command.input.prompts == [
+    assert tracking_create_command.console.prompts == [
         "Application 'first' already exists; overwrite [y/N]? "
     ]
 
@@ -95,7 +95,7 @@ def test_create_existing_app_no_overwrite(tracking_create_command, tmp_path):
 def test_create_existing_app_no_overwrite_default(tracking_create_command, tmp_path):
     """By default, the existing app won't be overwritten."""
     # Answer '' (i.e., just press return) when asked
-    tracking_create_command.input.values = [""]
+    tracking_create_command.console.values = [""]
 
     bundle_path = tmp_path / "base_path/build/first/tester/dummy"
     bundle_path.mkdir(parents=True)
@@ -105,7 +105,7 @@ def test_create_existing_app_no_overwrite_default(tracking_create_command, tmp_p
     tracking_create_command.create_app(tracking_create_command.apps["first"])
 
     # Input was required by the user
-    assert tracking_create_command.input.prompts == [
+    assert tracking_create_command.console.prompts == [
         "Application 'first' already exists; overwrite [y/N]? "
     ]
 
@@ -122,7 +122,7 @@ def test_create_existing_app_no_overwrite_default(tracking_create_command, tmp_p
 def test_create_existing_app_input_disabled(tracking_create_command, tmp_path):
     """If input is disabled, fallback to default without get input from user."""
     # Answer '' (i.e., just press return) when asked
-    tracking_create_command.input.enabled = False
+    tracking_create_command.console.input_enabled = False
 
     bundle_path = tmp_path / "base_path/build/first/tester/dummy"
     bundle_path.mkdir(parents=True)
@@ -132,7 +132,7 @@ def test_create_existing_app_input_disabled(tracking_create_command, tmp_path):
     tracking_create_command.create_app(tracking_create_command.apps["first"])
 
     # Input wasn't required by the user
-    assert tracking_create_command.input.prompts == []
+    assert tracking_create_command.console.prompts == []
 
     # And no actions were necessary
     assert tracking_create_command.actions == []
@@ -175,7 +175,7 @@ def test_create_app_with_stub(tracking_create_command, tmp_path):
     tracking_create_command.create_app(tracking_create_command.apps["first"])
 
     # Input wasn't required by the user
-    assert tracking_create_command.input.prompts == []
+    assert tracking_create_command.console.prompts == []
 
     # The right sequence of things will be done
     assert tracking_create_command.actions == [

--- a/tests/commands/create/test_install_app_requirements.py
+++ b/tests/commands/create/test_install_app_requirements.py
@@ -504,7 +504,7 @@ def test_app_packages_install_requirements(
 ):
     """Requirements can be installed."""
     # Configure logging level
-    create_command.logger.verbosity = logging_level
+    create_command.console.verbosity = logging_level
 
     # Set up the app requirements
     myapp.requires = ["first", "second", "third"]

--- a/tests/commands/dev/conftest.py
+++ b/tests/commands/dev/conftest.py
@@ -4,13 +4,14 @@ import pytest
 
 from briefcase.commands import DevCommand
 from briefcase.config import AppConfig
-from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
+
+from ...utils import DummyConsole
 
 
 @pytest.fixture
 def dev_command(tmp_path):
-    command = DevCommand(logger=Log(), console=Console(), base_path=tmp_path)
+    command = DevCommand(console=DummyConsole(), base_path=tmp_path)
     command.tools.subprocess = mock.MagicMock(spec_set=Subprocess)
     return command
 

--- a/tests/commands/dev/test_call.py
+++ b/tests/commands/dev/test_call.py
@@ -2,7 +2,7 @@ import pytest
 
 from briefcase.commands import DevCommand
 from briefcase.commands.base import full_options
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 
 
@@ -18,7 +18,6 @@ class DummyDevCommand(DevCommand):
     description = "Dummy dev command"
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("logger", Log())
         kwargs.setdefault("console", Console())
         super().__init__(*args, apps={}, **kwargs)
 

--- a/tests/commands/dev/test_get_environment.py
+++ b/tests/commands/dev/test_get_environment.py
@@ -82,13 +82,13 @@ def test_pythonpath_with_two_sources_and_tests_in_linux(dev_command, third_app):
 
 def test_non_verbose_mode(dev_command, first_app):
     """Non-verbose mode doesn't include BRIEFCASE_DEBUG in the dev environment."""
-    dev_command.logger.verbosity = LogLevel.INFO
+    dev_command.console.verbosity = LogLevel.INFO
     env = dev_command.get_environment(first_app, test_mode=False)
     assert "BRIEFCASE_DEBUG" not in env
 
 
 def test_verbose_mode(dev_command, first_app):
     """Verbose mode adds BRIEFCASE_DEBUG to the dev environment."""
-    dev_command.logger.verbosity = LogLevel.DEBUG
+    dev_command.console.verbosity = LogLevel.DEBUG
     env = dev_command.get_environment(first_app, test_mode=False)
     assert env["BRIEFCASE_DEBUG"] == "1"

--- a/tests/commands/dev/test_install_dev_requirements.py
+++ b/tests/commands/dev/test_install_dev_requirements.py
@@ -11,7 +11,7 @@ from briefcase.exceptions import RequirementsInstallError
 def test_install_requirements_no_error(dev_command, first_app, logging_level):
     """Ensure run is executed properly to install requirements."""
     # Configure logging level
-    dev_command.logger.verbosity = logging_level
+    dev_command.console.verbosity = logging_level
 
     first_app.requires = ["package-one", "package_two", "packagethree"]
 

--- a/tests/commands/new/conftest.py
+++ b/tests/commands/new/conftest.py
@@ -2,7 +2,6 @@ import pytest
 
 from briefcase.commands import NewCommand
 from briefcase.commands.base import full_options
-from briefcase.console import Console, Log
 from tests.utils import DummyConsole
 
 
@@ -15,12 +14,10 @@ class DummyNewCommand(NewCommand):
     description = "Dummy new command"
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("logger", Log())
-        kwargs.setdefault("console", Console())
+        kwargs.setdefault("console", DummyConsole())
         super().__init__(*args, apps={}, **kwargs)
 
         self.actions = []
-        self.tools.input = DummyConsole()
 
     def verify_host(self):
         super().verify_host()

--- a/tests/commands/new/test_build_app_context.py
+++ b/tests/commands/new/test_build_app_context.py
@@ -2,7 +2,7 @@ def test_question_sequence(new_command):
     """Questions are asked, a context is constructed."""
 
     # Prime answers for all the questions.
-    new_command.input.values = [
+    new_command.console.values = [
         "My Application",  # formal name
         "",  # app name - accept the default
         "org.beeware",  # bundle ID
@@ -39,7 +39,7 @@ def test_question_sequence_with_overrides(new_command):
     """Overrides can be used to set the answers for questions."""
 
     # Prime answers for none of the questions.
-    new_command.input.values = []
+    new_command.console.values = []
 
     context = new_command.build_app_context(
         project_overrides=dict(
@@ -76,7 +76,7 @@ def test_question_sequence_with_bad_license_override(new_command):
     """A bad override for license uses user input instead."""
 
     # Prime answers for all the questions.
-    new_command.input.values = [
+    new_command.console.values = [
         "4",  # license
     ]
 
@@ -114,7 +114,7 @@ def test_question_sequence_with_bad_license_override(new_command):
 def test_question_sequence_with_no_user_input(new_command):
     """If no user input is provided, all user inputs are taken as default."""
 
-    new_command.input.enabled = False
+    new_command.console.input_enabled = False
 
     context = new_command.build_app_context(project_overrides={})
 

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -27,8 +27,7 @@ def test_toga_bootstrap(new_command):
 
     context = new_command.build_gui_context(
         TogaGuiBootstrap(
-            new_command.logger,
-            new_command.input,
+            new_command.console,
             {
                 "app_name": "myapplication",
                 "author": "Grace Hopper",
@@ -239,8 +238,7 @@ def test_console_bootstrap(new_command):
 
     context = new_command.build_gui_context(
         ConsoleBootstrap(
-            new_command.logger,
-            new_command.input,
+            new_command.console,
             {
                 "app_name": "myapplication",
                 "author": "Grace Hopper",
@@ -347,8 +345,7 @@ def test_pyside6_bootstrap(new_command):
 
     context = new_command.build_gui_context(
         PySide6GuiBootstrap(
-            new_command.logger,
-            new_command.input,
+            new_command.console,
             {
                 "app_name": "myapplication",
                 "author": "Grace Hopper",
@@ -505,8 +502,7 @@ def test_pygame_bootstrap(new_command):
 
     context = new_command.build_gui_context(
         PygameGuiBootstrap(
-            new_command.logger,
-            new_command.input,
+            new_command.console,
             {
                 "app_name": "myapplication",
                 "author": "Grace Hopper",
@@ -645,8 +641,7 @@ def test_no_bootstrap(new_command):
 
     context = new_command.build_gui_context(
         EmptyBootstrap(
-            new_command.logger,
-            new_command.input,
+            new_command.console,
             {
                 "app_name": "myapplication",
                 "author": "Grace Hopper",
@@ -761,9 +756,8 @@ def test_custom_bootstrap(
     class GuiBootstrap:
         fields = ["requires", "platform"]
 
-        def __init__(self, logger, input, context):
-            self.logger = logger
-            self.input = input
+        def __init__(self, console, context):
+            self.console = console
             self.context = context
 
         def extra_context(self, project_overrides):
@@ -791,8 +785,7 @@ def test_custom_bootstrap(
 
     context = new_command.build_gui_context(
         GuiBootstrap(
-            new_command.logger,
-            new_command.input,
+            new_command.console,
             {
                 "app_name": "myapplication",
                 "author": "Grace Hopper",

--- a/tests/commands/new/test_create_bootstrap.py
+++ b/tests/commands/new/test_create_bootstrap.py
@@ -36,7 +36,7 @@ def test_question_sequence_bootstrap_context(
     class GuiBootstrap:
         fields = []
 
-        def __init__(self, logger, input, context):
+        def __init__(self, console, context):
             nonlocal passed_context
             passed_context = context.copy()
 
@@ -51,7 +51,7 @@ def test_question_sequence_bootstrap_context(
         ),
     )
 
-    new_command.input.enabled = False
+    new_command.console.input_enabled = False
 
     bootstrap = new_command.create_bootstrap(
         context={
@@ -73,7 +73,7 @@ def test_question_sequence_bootstrap_context(
 def test_question_sequence_toga(new_command):
     """The Toga bootstrap can be selected."""
 
-    new_command.input.values = [
+    new_command.console.values = [
         "1",  # Toga GUI toolkit
     ]
 
@@ -95,7 +95,7 @@ def test_question_sequence_toga(new_command):
 def test_question_sequence_console(new_command):
     """A console bootstrap can be constructed."""
 
-    new_command.input.values = [
+    new_command.console.values = [
         "4",  # Console app
     ]
 
@@ -117,7 +117,7 @@ def test_question_sequence_console(new_command):
 def test_question_sequence_pyside6(new_command):
     """A Pyside6 bootstrap can be created."""
 
-    new_command.input.values = [
+    new_command.console.values = [
         "2",  # PySide6 GUI toolkit
     ]
 
@@ -139,7 +139,7 @@ def test_question_sequence_pyside6(new_command):
 def test_question_sequence_pygame(new_command):
     """A Pygame bootstrap can be constructed."""
 
-    new_command.input.values = [
+    new_command.console.values = [
         "3",  # Pygame GUI toolkit
     ]
 
@@ -162,7 +162,7 @@ def test_question_sequence_none(new_command):
     """If no bootstrap is selected, the empty bootstrap is used."""
 
     # Prime answers for all the questions.
-    new_command.input.values = [
+    new_command.console.values = [
         "5",  # None
     ]
 
@@ -189,12 +189,12 @@ def test_question_sequence_with_overrides(
     """The answer to the bootstrap question can be overridden."""
 
     # Prime answers for none of the questions.
-    new_command.input.values = []
+    new_command.console.values = []
 
     class GuiBootstrap:
         fields = []
 
-        def __init__(self, logger, input, context):
+        def __init__(self, console, context):
             self.context = context.copy()
 
     monkeypatch.setattr(
@@ -233,7 +233,7 @@ def test_question_sequence_with_bad_bootstrap_override(
     """A bad override for the bootstrap uses user input instead."""
 
     # Prime a bad answer for the bootstrap question
-    new_command.input.values = [
+    new_command.console.values = [
         "6",  # None
     ]
 
@@ -242,7 +242,7 @@ def test_question_sequence_with_bad_bootstrap_override(
         # requires() would cause an error
         fields = ["requires"]
 
-        def __init__(self, logger, input, context):
+        def __init__(self, console, context):
             pass
 
     monkeypatch.setattr(
@@ -276,7 +276,7 @@ def test_question_sequence_with_bad_bootstrap_override(
 def test_question_sequence_with_no_user_input(new_command):
     """If no user input is provided, all user inputs are taken as default."""
 
-    new_command.input.enabled = False
+    new_command.console.input_enabled = False
 
     bootstrap = new_command.create_bootstrap(
         context={

--- a/tests/commands/new/test_new_app.py
+++ b/tests/commands/new/test_new_app.py
@@ -8,7 +8,7 @@ from cookiecutter.main import cookiecutter
 import briefcase
 from briefcase.bootstraps import BaseGuiBootstrap
 from briefcase.commands import NewCommand
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import (
     BriefcaseCommandError,
     InvalidTemplateBranch,
@@ -21,7 +21,6 @@ def new_command(tmp_path):
     return NewCommand(
         base_path=tmp_path / "base",
         data_path=tmp_path / "data",
-        logger=Log(),
         console=Console(),
     )
 
@@ -53,7 +52,7 @@ def test_new_app(
         "app_name": "myapplication",
     }
     new_command.build_app_context = mock.MagicMock(return_value=app_context)
-    bootstrap = BaseGuiBootstrap(new_command.logger, new_command.input, {})
+    bootstrap = BaseGuiBootstrap(new_command.console, {})
     new_command.create_bootstrap = mock.MagicMock(return_value=bootstrap)
     new_command.build_gui_context = mock.MagicMock(
         return_value={
@@ -111,7 +110,7 @@ def test_new_app_missing_template(monkeypatch, new_command, tmp_path):
         "app_name": "myapplication",
     }
     new_command.build_app_context = mock.MagicMock(return_value=app_context)
-    bootstrap = BaseGuiBootstrap(new_command.logger, new_command.input, {})
+    bootstrap = BaseGuiBootstrap(new_command.console, {})
     new_command.create_bootstrap = mock.MagicMock(return_value=bootstrap)
     new_command.build_gui_context = mock.MagicMock(
         return_value={
@@ -181,7 +180,7 @@ def test_new_app_dev(monkeypatch, new_command, tmp_path, briefcase_version):
         "app_name": "myapplication",
     }
     new_command.build_app_context = mock.MagicMock(return_value=app_context)
-    bootstrap = BaseGuiBootstrap(new_command.logger, new_command.input, {})
+    bootstrap = BaseGuiBootstrap(new_command.console, {})
     new_command.create_bootstrap = mock.MagicMock(return_value=bootstrap)
     new_command.build_gui_context = mock.MagicMock(
         return_value={
@@ -277,7 +276,7 @@ def test_new_app_with_template(monkeypatch, new_command, tmp_path):
         "app_name": "myapplication",
     }
     new_command.build_app_context = mock.MagicMock(return_value=app_context)
-    bootstrap = BaseGuiBootstrap(new_command.logger, new_command.input, {})
+    bootstrap = BaseGuiBootstrap(new_command.console, {})
     new_command.create_bootstrap = mock.MagicMock(return_value=bootstrap)
     new_command.build_gui_context = mock.MagicMock(
         return_value={
@@ -335,7 +334,7 @@ def test_new_app_with_invalid_template(monkeypatch, new_command, tmp_path):
         "app_name": "myapplication",
     }
     new_command.build_app_context = mock.MagicMock(return_value=app_context)
-    bootstrap = BaseGuiBootstrap(new_command.logger, new_command.input, {})
+    bootstrap = BaseGuiBootstrap(new_command.console, {})
     new_command.create_bootstrap = mock.MagicMock(return_value=bootstrap)
     new_command.build_gui_context = mock.MagicMock(
         return_value={
@@ -403,7 +402,7 @@ def test_new_app_with_invalid_template_branch(monkeypatch, new_command, tmp_path
         "app_name": "myapplication",
     }
     new_command.build_app_context = mock.MagicMock(return_value=app_context)
-    bootstrap = BaseGuiBootstrap(new_command.logger, new_command.input, {})
+    bootstrap = BaseGuiBootstrap(new_command.console, {})
     new_command.create_bootstrap = mock.MagicMock(return_value=bootstrap)
     new_command.build_gui_context = mock.MagicMock(
         return_value={
@@ -471,7 +470,7 @@ def test_new_app_with_branch(monkeypatch, new_command, tmp_path):
         "app_name": "myapplication",
     }
     new_command.build_app_context = mock.MagicMock(return_value=app_context)
-    bootstrap = BaseGuiBootstrap(new_command.logger, new_command.input, {})
+    bootstrap = BaseGuiBootstrap(new_command.console, {})
     new_command.create_bootstrap = mock.MagicMock(return_value=bootstrap)
     new_command.build_gui_context = mock.MagicMock(
         return_value={
@@ -534,7 +533,7 @@ def test_new_app_unused_project_overrides(
         "app_name": "myapplication",
     }
     new_command.build_app_context = mock.MagicMock(return_value=app_context)
-    bootstrap = BaseGuiBootstrap(new_command.logger, new_command.input, {})
+    bootstrap = BaseGuiBootstrap(new_command.console, {})
     new_command.create_bootstrap = mock.MagicMock(return_value=bootstrap)
     new_command.build_gui_context = mock.MagicMock(
         return_value={
@@ -605,7 +604,7 @@ def test_abort_if_directory_exists(monkeypatch, new_command, tmp_path):
         "app_name": "myapplication",
     }
     new_command.build_app_context = mock.MagicMock(return_value=app_context)
-    bootstrap = BaseGuiBootstrap(new_command.logger, new_command.input, {})
+    bootstrap = BaseGuiBootstrap(new_command.console, {})
     new_command.create_bootstrap = mock.MagicMock(return_value=bootstrap)
     new_command.build_gui_context = mock.MagicMock(
         return_value={

--- a/tests/commands/open/conftest.py
+++ b/tests/commands/open/conftest.py
@@ -6,10 +6,9 @@ import pytest
 from briefcase.commands import OpenCommand
 from briefcase.commands.base import full_options
 from briefcase.config import AppConfig
-from briefcase.console import Console, Log
 from briefcase.integrations.subprocess import Subprocess
 
-from ...utils import create_file
+from ...utils import DummyConsole, create_file
 
 
 class DummyOpenCommand(OpenCommand):
@@ -24,8 +23,7 @@ class DummyOpenCommand(OpenCommand):
     description = "Dummy Open command"
 
     def __init__(self, *args, apps, **kwargs):
-        kwargs.setdefault("logger", Log())
-        kwargs.setdefault("console", Console())
+        kwargs.setdefault("console", DummyConsole())
         super().__init__(*args, apps=apps, **kwargs)
 
         # Override the OS services that are used when opening

--- a/tests/commands/package/conftest.py
+++ b/tests/commands/package/conftest.py
@@ -3,9 +3,8 @@ import pytest
 from briefcase.commands import PackageCommand
 from briefcase.commands.base import full_options
 from briefcase.config import AppConfig
-from briefcase.console import Console, Log
 
-from ...utils import create_file
+from ...utils import DummyConsole, create_file
 
 
 class DefaultPackageCommand(PackageCommand):
@@ -25,7 +24,7 @@ class DefaultPackageCommand(PackageCommand):
 
 @pytest.fixture
 def default_package_command(tmp_path):
-    return DefaultPackageCommand(base_path=tmp_path, logger=Log(), console=Console())
+    return DefaultPackageCommand(base_path=tmp_path, console=DummyConsole())
 
 
 class DummyPackageCommand(PackageCommand):
@@ -48,8 +47,7 @@ class DummyPackageCommand(PackageCommand):
         return "pkg"
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("logger", Log())
-        kwargs.setdefault("console", Console())
+        kwargs.setdefault("console", DummyConsole())
         super().__init__(*args, apps={}, **kwargs)
 
         self.actions = []

--- a/tests/commands/publish/conftest.py
+++ b/tests/commands/publish/conftest.py
@@ -3,9 +3,8 @@ import pytest
 from briefcase.commands import PublishCommand
 from briefcase.commands.base import full_options
 from briefcase.config import AppConfig
-from briefcase.console import Console, Log
 
-from ...utils import create_file
+from ...utils import DummyConsole, create_file
 
 
 class DummyPublishCommand(PublishCommand):
@@ -20,8 +19,7 @@ class DummyPublishCommand(PublishCommand):
     description = "Dummy publish command"
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("logger", Log())
-        kwargs.setdefault("console", Console())
+        kwargs.setdefault("console", DummyConsole())
         super().__init__(*args, apps={}, **kwargs)
 
         self.actions = []

--- a/tests/commands/run/conftest.py
+++ b/tests/commands/run/conftest.py
@@ -3,9 +3,8 @@ import pytest
 from briefcase.commands import RunCommand
 from briefcase.commands.base import full_options
 from briefcase.config import AppConfig
-from briefcase.console import Console, Log
 
-from ...utils import create_file
+from ...utils import DummyConsole, create_file
 
 
 class DummyRunCommand(RunCommand):
@@ -20,8 +19,7 @@ class DummyRunCommand(RunCommand):
     description = "Dummy run command"
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("logger", Log())
-        kwargs.setdefault("console", Console())
+        kwargs.setdefault("console", DummyConsole())
         super().__init__(*args, apps={}, **kwargs)
 
         self.actions = []

--- a/tests/commands/update/conftest.py
+++ b/tests/commands/update/conftest.py
@@ -2,9 +2,8 @@ import pytest
 
 from briefcase.commands import UpdateCommand
 from briefcase.config import AppConfig
-from briefcase.console import Console, Log
 
-from ...utils import create_file
+from ...utils import DummyConsole, create_file
 
 
 class DummyUpdateCommand(UpdateCommand):
@@ -19,8 +18,7 @@ class DummyUpdateCommand(UpdateCommand):
     description = "Dummy update command"
 
     def __init__(self, *args, apps, **kwargs):
-        kwargs.setdefault("logger", Log())
-        kwargs.setdefault("console", Console())
+        kwargs.setdefault("console", DummyConsole())
         super().__init__(*args, apps=apps, **kwargs)
 
         self.actions = []

--- a/tests/commands/upgrade/conftest.py
+++ b/tests/commands/upgrade/conftest.py
@@ -4,9 +4,10 @@ import pytest
 
 import briefcase.commands.upgrade
 from briefcase.commands import UpgradeCommand
-from briefcase.console import Console, Log
 from briefcase.exceptions import MissingToolError
 from briefcase.integrations.base import ManagedTool, Tool
+
+from ...utils import DummyConsole
 
 
 @pytest.fixture
@@ -28,8 +29,7 @@ class DummyUpgradeCommand(UpgradeCommand):
     description = "Dummy update command"
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("logger", Log())
-        kwargs.setdefault("console", Console())
+        kwargs.setdefault("console", DummyConsole())
         super().__init__(*args, **kwargs)
 
     def bundle_path(self, app):

--- a/tests/config/test_parse_config.py
+++ b/tests/config/test_parse_config.py
@@ -16,7 +16,7 @@ def test_invalid_toml():
             config_file,
             platform="macOS",
             output_format="Xcode",
-            logger=Mock(),
+            console=Mock(),
         )
 
 
@@ -35,7 +35,7 @@ def test_no_briefcase_section():
             config_file,
             platform="macOS",
             output_format="Xcode",
-            logger=Mock(),
+            console=Mock(),
         )
 
 
@@ -54,7 +54,7 @@ def test_no_apps():
             config_file,
             platform="macOS",
             output_format="Xcode",
-            logger=Mock(),
+            console=Mock(),
         )
 
 
@@ -74,7 +74,7 @@ def test_single_minimal_app():
         config_file,
         platform="macOS",
         output_format="Xcode",
-        logger=Mock(),
+        console=Mock(),
     )
 
     # There's a single global option
@@ -110,7 +110,7 @@ def test_multiple_minimal_apps():
         config_file,
         platform="macOS",
         output_format="Xcode",
-        logger=Mock(),
+        console=Mock(),
     )
 
     # There are no global options
@@ -159,7 +159,7 @@ def test_platform_override():
         config_file,
         platform="macOS",
         output_format="Xcode",
-        logger=Mock(),
+        console=Mock(),
     )
 
     # The global options are exactly as specified
@@ -225,7 +225,7 @@ def test_platform_override_ordering():
         config_file,
         platform="macOS",
         output_format="Xcode",
-        logger=Mock(),
+        console=Mock(),
     )
 
     # The global options are exactly as specified
@@ -307,7 +307,7 @@ def test_format_override():
         config_file,
         platform="macOS",
         output_format="app",
-        logger=Mock(),
+        console=Mock(),
     )
 
     # The global options are exactly as specified
@@ -390,7 +390,7 @@ def test_format_override_ordering():
         config_file,
         platform="macOS",
         output_format="app",
-        logger=Mock(),
+        console=Mock(),
     )
 
     # The global options are exactly as specified
@@ -461,7 +461,7 @@ def test_requires():
         config_file,
         platform="macOS",
         output_format="app",
-        logger=Mock(),
+        console=Mock(),
     )
 
     # The global options are exactly as specified
@@ -501,7 +501,7 @@ def test_requires():
         config_file,
         platform="macOS",
         output_format="Xcode",
-        logger=Mock(),
+        console=Mock(),
     )
 
     # The global options are exactly as specified
@@ -540,7 +540,7 @@ def test_requires():
         config_file,
         platform="linux",
         output_format="appimage",
-        logger=Mock(),
+        console=Mock(),
     )
 
     # The global options are exactly as specified
@@ -604,7 +604,7 @@ def test_document_types():
         config_file,
         platform="macOS",
         output_format="Xcode",
-        logger=Mock(),
+        console=Mock(),
     )
 
     # The macOS my_app app specifies a full inherited chain.
@@ -678,7 +678,7 @@ def test_pep621_defaults():
         config_file,
         platform="macOS",
         output_format="app",
-        logger=Mock(),
+        console=Mock(),
     )
 
     awesome = apps["awesome"]
@@ -714,9 +714,9 @@ def test_license_is_string_project():
         """
     )
 
-    logger = Mock()
+    console = Mock()
     global_options, apps = parse_config(
-        config_file, platform="macOS", output_format="app", logger=logger
+        config_file, platform="macOS", output_format="app", console=console
     )
 
     assert global_options == {
@@ -729,7 +729,7 @@ def test_license_is_string_project():
         "appvalue": "the app",
         "license": {"file": "LICENSE"},
     }
-    logger.warning.assert_called_once_with(
+    console.warning.assert_called_once_with(
         """
 *************************************************************************
 ** WARNING: License Definition for the Project is Deprecated           **
@@ -771,9 +771,9 @@ def test_license_is_string_project_and_app():
         """
     )
 
-    logger = Mock()
+    console = Mock()
     global_options, apps = parse_config(
-        config_file, platform="macOS", output_format="app", logger=logger
+        config_file, platform="macOS", output_format="app", console=console
     )
 
     assert global_options == {
@@ -786,7 +786,7 @@ def test_license_is_string_project_and_app():
         "appvalue": "the app",
         "license": {"file": "LICENSE"},
     }
-    logger.warning.assert_has_calls(
+    console.warning.assert_has_calls(
         [
             call(
                 """

--- a/tests/console/Console/test_input.py
+++ b/tests/console/Console/test_input.py
@@ -9,12 +9,14 @@ def test_call_returns_user_input_when_enabled(console):
     """If input wrapper is enabled, call returns user input."""
     value = "abs"
     prompt = "> "
-    console.input.return_value = value
+    console._console_impl.input.return_value = value
 
-    actual_value = console(prompt=prompt)
+    actual_value = console.input(prompt=prompt)
 
     assert actual_value == value
-    console.input.assert_called_once_with(default_rich_prompt(prompt), markup=True)
+    console._console_impl.input.assert_called_once_with(
+        default_rich_prompt(prompt), markup=True
+    )
 
 
 def test_call_returns_user_input_when_enabled_with_markup_prompt(console):
@@ -22,12 +24,12 @@ def test_call_returns_user_input_when_enabled_with_markup_prompt(console):
     markup."""
     value = "abs"
     prompt = f"[red]{escape('this is prompt with escaped [markup] text')}[/red]"
-    console.input.return_value = value
+    console._console_impl.input.return_value = value
 
-    actual_value = console(prompt=prompt, markup=True)
+    actual_value = console.input(prompt=prompt, markup=True)
 
     assert actual_value == value
-    console.input.assert_called_once_with(prompt, markup=True)
+    console._console_impl.input.assert_called_once_with(prompt, markup=True)
 
 
 def test_call_raise_exception_when_disabled(disabled_console):
@@ -35,13 +37,13 @@ def test_call_raise_exception_when_disabled(disabled_console):
     prompt = "> "
 
     with pytest.raises(InputDisabled):
-        disabled_console(prompt=prompt)
-    disabled_console.input.assert_not_called()
+        disabled_console.input(prompt=prompt)
+    disabled_console._console_impl.input.assert_not_called()
 
 
 def test_call_raise_keyboardinterrupt_for_eoferror(console):
     """Ensure KeyboardInterrupt is raised when users send EOF to an input prompt."""
-    console.input.side_effect = EOFError()
+    console._console_impl.input.side_effect = EOFError()
 
     with pytest.raises(KeyboardInterrupt):
-        console(prompt="")
+        console.input(prompt="")

--- a/tests/console/Console/test_input_boolean.py
+++ b/tests/console/Console/test_input_boolean.py
@@ -26,67 +26,73 @@ from tests.utils import default_rich_prompt
 def test_boolean(console, user_input, expected):
     question = "Are you handsome"
     prompt = "Are you handsome [y/N]? "
-    console.input.side_effect = [user_input]
+    console._console_impl.input.side_effect = [user_input]
 
-    result = console.boolean(question=question)
+    result = console.input_boolean(question=question)
 
     assert result == expected
-    console.input.assert_called_once_with(default_rich_prompt(prompt), markup=True)
+    console._console_impl.input.assert_called_once_with(
+        default_rich_prompt(prompt), markup=True
+    )
 
 
 def test_boolean_default_true(console):
     """If True is the default, it is returned."""
     question = "Are you handsome"
     prompt = "Are you handsome [Y/n]? "
-    console.input.side_effect = [""]
+    console._console_impl.input.side_effect = [""]
 
-    result = console.boolean(question=question, default=True)
+    result = console.input_boolean(question=question, default=True)
 
     assert result
-    console.input.assert_called_once_with(default_rich_prompt(prompt), markup=True)
+    console._console_impl.input.assert_called_once_with(
+        default_rich_prompt(prompt), markup=True
+    )
 
 
 def test_boolean_default_false(console):
     """If False is the default, it is returned."""
     question = "Are you handsome"
     prompt = "Are you handsome [y/N]? "
-    console.input.side_effect = [""]
+    console._console_impl.input.side_effect = [""]
 
-    result = console.boolean(question=question, default=False)
+    result = console.input_boolean(question=question, default=False)
 
     assert not result
-    console.input.assert_called_once_with(default_rich_prompt(prompt), markup=True)
+    console._console_impl.input.assert_called_once_with(
+        default_rich_prompt(prompt), markup=True
+    )
 
 
 def test_boolean_default_None(console):
     """If no default is specified, no response is not accepted."""
     question = "Are you handsome"
-    console.input.side_effect = ["", "y"]
+    console._console_impl.input.side_effect = ["", "y"]
 
-    result = console.boolean(question=question, default=None)
+    result = console.input_boolean(question=question, default=None)
 
     assert result
-    assert console.input.call_count == 2
+    assert console._console_impl.input.call_count == 2
 
 
 def test_bad_input(console):
     question = "Are you handsome"
-    console.input.side_effect = ["pork", "ham", "spam", "Yam"]
+    console._console_impl.input.side_effect = ["pork", "ham", "spam", "Yam"]
 
-    result = console.boolean(question=question)
+    result = console.input_boolean(question=question)
 
     assert result
-    assert console.input.call_count == 4
+    assert console._console_impl.input.call_count == 4
 
 
 def test_disabled(disabled_console):
     """If input is disabled, the default is returned."""
     question = "Are you handsome "
 
-    result = disabled_console.boolean(question=question)
+    result = disabled_console.input_boolean(question=question)
 
     assert not result
-    disabled_console.input.assert_not_called()
+    disabled_console._console_impl.input.assert_not_called()
 
 
 def test_disabled_no_default(disabled_console):
@@ -94,6 +100,6 @@ def test_disabled_no_default(disabled_console):
     question = "Are you handsome "
 
     with pytest.raises(InputDisabled):
-        disabled_console.boolean(question=question, default=None)
+        disabled_console.input_boolean(question=question, default=None)
 
-    disabled_console.input.assert_not_called()
+    disabled_console._console_impl.input.assert_not_called()

--- a/tests/console/Console/test_input_selection.py
+++ b/tests/console/Console/test_input_selection.py
@@ -15,13 +15,13 @@ from tests.utils import default_rich_prompt
         ("c", "C", None, str.upper),
     ],
 )
-def test_selection(console, value, expected, default, transform):
+def test_input_selection(console, value, expected, default, transform):
     prompt = "> "
     options = ["A", "B", "C", "D", "E", "F"]
 
     console._console_impl.input.side_effect = [value]
 
-    actual = console._selection(
+    actual = console.input_selection(
         prompt=prompt,
         choices=options,
         default=default,
@@ -41,7 +41,7 @@ def test_bad_input(console):
 
     console._console_impl.input.side_effect = ["G", "Q", "C"]
 
-    actual = console._selection(prompt=prompt, choices=options)
+    actual = console.input_selection(prompt=prompt, choices=options)
 
     assert actual == "C"
     assert console._console_impl.input.call_count == 3
@@ -60,7 +60,9 @@ def test_disabled(disabled_console):
     prompt = "> "
     options = ["A", "B", "C", "D", "E", "F"]
 
-    actual = disabled_console._selection(prompt=prompt, choices=options, default="C")
+    actual = disabled_console.input_selection(
+        prompt=prompt, choices=options, default="C"
+    )
 
     assert actual == "C"
     disabled_console._console_impl.input.assert_not_called()
@@ -71,7 +73,7 @@ def test_disabled_no_default(disabled_console):
     options = ["A", "B", "C", "D", "E", "F"]
 
     with pytest.raises(InputDisabled):
-        disabled_console._selection(
+        disabled_console.input_selection(
             prompt=prompt,
             choices=options,
             default=None,

--- a/tests/console/Console/test_input_text.py
+++ b/tests/console/Console/test_input_text.py
@@ -11,35 +11,37 @@ from tests.utils import default_rich_prompt
         ("", "Default"),
     ],
 )
-def test_text(console, value, expected):
-    console.input.return_value = value
+def test_text_question(console, value, expected):
+    console._console_impl.input.return_value = value
 
-    actual = console.text(
+    actual = console.input_text(
         prompt="> ",
         default="Default",
     )
 
     assert actual == expected
-    console.input.assert_called_once_with(default_rich_prompt("> "), markup=True)
+    console._console_impl.input.assert_called_once_with(
+        default_rich_prompt("> "), markup=True
+    )
 
 
 def test_disabled(disabled_console):
     """If input is disabled, the default is returned."""
-    actual = disabled_console.text(
+    actual = disabled_console.input_text(
         prompt="> ",
         default="Default",
     )
 
     assert actual == "Default"
-    disabled_console.input.assert_not_called()
+    disabled_console._console_impl.input.assert_not_called()
 
 
 def test_disabled_no_default(disabled_console):
     """If input is disabled and there is no default, an error is raised."""
     with pytest.raises(InputDisabled):
-        disabled_console.text(
+        disabled_console.input_text(
             prompt="> ",
             default=None,
         )
 
-    disabled_console.input.assert_not_called()
+    disabled_console._console_impl.input.assert_not_called()

--- a/tests/console/Console/test_is_color_enabled.py
+++ b/tests/console/Console/test_is_color_enabled.py
@@ -3,7 +3,7 @@ from unittest.mock import PropertyMock
 import pytest
 from rich.console import ColorSystem
 
-from briefcase.console import Console, Printer
+from briefcase.console import Console
 
 
 @pytest.mark.parametrize(
@@ -17,17 +17,16 @@ from briefcase.console import Console, Printer
 )
 def test_is_color_enabled(no_color, color_system, is_enabled, monkeypatch):
     """Color is enabled/disabled based on no_color and color_system."""
-    printer = Printer()
+    console = Console()
+    console._console_impl.no_color = no_color
     monkeypatch.setattr(
-        type(printer.console),
+        type(console._console_impl),
         "color_system",
         PropertyMock(return_value=color_system),
     )
-    printer.console.no_color = no_color
-    console = Console(printer=printer)
 
     # confirm these values to make sure they didn't change somehow...
-    assert printer.console.no_color is no_color
-    assert printer.console.color_system is color_system
+    assert console._console_impl.no_color is no_color
+    assert console._console_impl.color_system is color_system
 
     assert console.is_color_enabled is is_enabled

--- a/tests/console/Console/test_primitives.py
+++ b/tests/console/Console/test_primitives.py
@@ -2,16 +2,16 @@ import re
 
 import pytest
 
-from briefcase.console import Printer
+from briefcase.console import Console
 
 
 @pytest.fixture
-def printer():
-    printer = Printer()
+def console():
+    console = Console()
     # clear log; since Printer is a pseudo-singleton,
     # the log can contain existing entries.
-    printer.export_log()
-    return printer
+    console.export_log()
+    return console
 
 
 def norm_sp(text: str, max_spaces: int = 100) -> str:
@@ -30,38 +30,38 @@ def norm_sp(text: str, max_spaces: int = 100) -> str:
         (False, "a line of output", ""),
     ],
 )
-def test_call(capsys, printer, message, show, expected_console_output):
-    """Printer prints to console and log appropriately."""
-    printer(message, show=show, stack_offset=1)
+def test_print(capsys, console, message, show, expected_console_output):
+    """Console prints to console and log appropriately."""
+    console.print(message, show=show, stack_offset=1)
     assert capsys.readouterr().out == expected_console_output
-    log = printer.export_log()
+    log = console.export_log()
     assert len(log.splitlines()) == 1
     # The number of spaces in not consistent on Windows
     assert norm_sp(" " + message + " " * 139 + "console.py") in norm_sp(log)
 
 
-def test_to_console(capsys, printer):
-    """Printer prints only to console."""
-    printer.to_console("a line of output")
+def test_to_console(capsys, console):
+    """Console prints only to console."""
+    console.to_console("a line of output")
     assert capsys.readouterr().out == "a line of output\n"
-    assert printer.export_log() == ""
+    assert console.export_log() == ""
 
 
-def test_to_log(capsys, printer):
+def test_to_log(capsys, console):
     """Printer prints only to log."""
-    printer.to_log("a line of output", stack_offset=1)
+    console.to_log("a line of output", stack_offset=1)
     assert capsys.readouterr().out == ""
-    log = printer.export_log()
+    log = console.export_log()
     assert len(log.splitlines()) == 1
     # The number of spaces in not consistent on Windows
     assert norm_sp(" a line of output" + " " * 139 + "console.py") in norm_sp(log)
 
 
-def test_very_long_line(capsys, printer):
+def test_very_long_line(capsys, console):
     """Very long lines are split."""
-    printer.to_log("A very long line of output!! " * 6, stack_offset=1)
+    console.to_log("A very long line of output!! " * 6, stack_offset=1)
     assert capsys.readouterr().out == ""
-    log = printer.export_log()
+    log = console.export_log()
     assert len(log.splitlines()) == 2
     # The number of spaces in not consistent on Windows
     assert norm_sp(

--- a/tests/console/Console/test_properties.py
+++ b/tests/console/Console/test_properties.py
@@ -4,31 +4,31 @@ from briefcase.console import Console
 def test_default_constructor():
     """A console is enabled by default."""
     console = Console()
-    assert console.enabled
+    assert console.input_enabled
 
 
 def test_constructor_with_enabled_false():
     """A console can be constructed in a disabled state."""
-    console = Console(enabled=False)
-    assert not console.enabled
+    console = Console(input_enabled=False)
+    assert not console.input_enabled
 
 
 def test_enable(disabled_console):
     """A disabled console can be enabled."""
-    assert not disabled_console.enabled
+    assert not disabled_console.input_enabled
 
-    disabled_console.enabled = True
+    disabled_console.input_enabled = True
 
-    assert disabled_console.enabled
+    assert disabled_console.input_enabled
 
 
 def test_disable():
     """A disabled console can be enabled."""
     console = Console()
-    assert console.enabled
+    assert console.input_enabled
 
-    console.enabled = False
-    assert not console.enabled
+    console.input_enabled = False
+    assert not console.input_enabled
 
 
 def test_is_interactive_non_interactive(non_interactive_console):

--- a/tests/console/Console/test_selection.py
+++ b/tests/console/Console/test_selection.py
@@ -19,7 +19,7 @@ def test_selection(console, value, expected, default, transform):
     prompt = "> "
     options = ["A", "B", "C", "D", "E", "F"]
 
-    console.input.side_effect = [value]
+    console._console_impl.input.side_effect = [value]
 
     actual = console._selection(
         prompt=prompt,
@@ -29,7 +29,9 @@ def test_selection(console, value, expected, default, transform):
     )
 
     assert actual == expected
-    console.input.assert_called_once_with(default_rich_prompt(prompt), markup=True)
+    console._console_impl.input.assert_called_once_with(
+        default_rich_prompt(prompt), markup=True
+    )
 
 
 def test_bad_input(console):
@@ -37,19 +39,19 @@ def test_bad_input(console):
     prompt = "> "
     options = ["A", "B", "C", "D", "E", "F"]
 
-    console.input.side_effect = ["G", "Q", "C"]
+    console._console_impl.input.side_effect = ["G", "Q", "C"]
 
     actual = console._selection(prompt=prompt, choices=options)
 
     assert actual == "C"
-    assert console.input.call_count == 3
-    assert console.input.call_args_list[0] == call(
+    assert console._console_impl.input.call_count == 3
+    assert console._console_impl.input.call_args_list[0] == call(
         default_rich_prompt(prompt), markup=True
     )
-    assert console.input.call_args_list[1] == call(
+    assert console._console_impl.input.call_args_list[1] == call(
         default_rich_prompt(prompt), markup=True
     )
-    assert console.input.call_args_list[2] == call(
+    assert console._console_impl.input.call_args_list[2] == call(
         default_rich_prompt(prompt), markup=True
     )
 
@@ -61,7 +63,7 @@ def test_disabled(disabled_console):
     actual = disabled_console._selection(prompt=prompt, choices=options, default="C")
 
     assert actual == "C"
-    disabled_console.input.assert_not_called()
+    disabled_console._console_impl.input.assert_not_called()
 
 
 def test_disabled_no_default(disabled_console):
@@ -75,4 +77,4 @@ def test_disabled_no_default(disabled_console):
             default=None,
         )
 
-    disabled_console.input.assert_not_called()
+    disabled_console._console_impl.input.assert_not_called()

--- a/tests/console/Console/test_text_question.py
+++ b/tests/console/Console/test_text_question.py
@@ -119,7 +119,7 @@ def test_input_with_default():
 
 def test_input_disabled():
     """If input is disabled, the default is returned."""
-    console = DummyConsole(enabled=False)
+    console = DummyConsole(input_enabled=False)
 
     value = console.text_question(
         intro="Some introduction",
@@ -133,7 +133,7 @@ def test_input_disabled():
 
 def test_input_disabled_with_override():
     """If input is disabled, the override is returned."""
-    console = DummyConsole(enabled=False)
+    console = DummyConsole(input_enabled=False)
 
     value = console.text_question(
         intro="Some introduction",
@@ -148,7 +148,7 @@ def test_input_disabled_with_override():
 
 def test_input_disabled_validation_failure():
     """If input is disabled, and validation fails, an error is raised."""
-    console = DummyConsole(enabled=False)
+    console = DummyConsole(input_enabled=False)
 
     with pytest.raises(InputDisabled, match=r"Well that won't work..."):
 
@@ -167,7 +167,7 @@ def test_input_disabled_validation_failure():
 
 def test_input_disabled_validation_failure_with_override():
     """If input is disabled, and validation fails for override, an error is raised."""
-    console = DummyConsole(enabled=False)
+    console = DummyConsole(input_enabled=False)
 
     with pytest.raises(InputDisabled, match=r"Well that won't work..."):
 

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -9,7 +9,7 @@ from briefcase.console import Console
 @pytest.fixture
 def console(monkeypatch) -> Console:
     console = Console()
-    console.input = mock.MagicMock(spec_set=input)
+    console._console_impl.input = mock.MagicMock(spec_set=input)
     # default console is always interactive
     monkeypatch.setattr(os, "isatty", lambda _: True)
     return console
@@ -17,8 +17,8 @@ def console(monkeypatch) -> Console:
 
 @pytest.fixture
 def disabled_console() -> Console:
-    console = Console(enabled=False)
-    console.input = mock.MagicMock(spec_set=input)
+    console = Console(input_enabled=False)
+    console._console_impl.input = mock.MagicMock(spec_set=input)
     return console
 
 

--- a/tests/console/test_NotDeadYet.py
+++ b/tests/console/test_NotDeadYet.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 import briefcase.console
-from briefcase.console import NotDeadYet, Printer
+from briefcase.console import Console, NotDeadYet
 
 
 def test_update(capsys, monkeypatch):
@@ -15,7 +15,7 @@ def test_update(capsys, monkeypatch):
         MagicMock(side_effect=[0] + [10 - 5, 10 + 5, 0] * 3),
     )
 
-    keep_alive = NotDeadYet(printer=Printer())
+    keep_alive = NotDeadYet(console=Console())
 
     for _ in range(3):
         keep_alive.update()
@@ -37,7 +37,7 @@ def test_reset(capsys, monkeypatch):
         MagicMock(side_effect=[0] + [10, 15] * 10),
     )
 
-    keep_alive = NotDeadYet(printer=Printer())
+    keep_alive = NotDeadYet(console=Console())
 
     for _ in range(10):
         keep_alive.reset()

--- a/tests/integrations/android_sdk/ADB/test_logcat.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat.py
@@ -9,7 +9,7 @@ def test_logcat(mock_tools, adb, is_color_enabled, monkeypatch):
     """Invoking `logcat()` calls `Popen()` with the appropriate parameters."""
     # Mock whether color is enabled for the console
     monkeypatch.setattr(
-        type(mock_tools.input),
+        type(mock_tools.console),
         "is_color_enabled",
         mock.PropertyMock(return_value=is_color_enabled),
     )

--- a/tests/integrations/android_sdk/ADB/test_logcat_tail.py
+++ b/tests/integrations/android_sdk/ADB/test_logcat_tail.py
@@ -12,7 +12,7 @@ def test_logcat_tail(mock_tools, adb, is_color_enabled, monkeypatch):
     """Invoking `logcat_tail()` calls `run()` with the appropriate parameters."""
     # Mock whether color is enabled for the console
     monkeypatch.setattr(
-        type(mock_tools.input),
+        type(mock_tools.console),
         "is_color_enabled",
         PropertyMock(return_value=is_color_enabled),
     )

--- a/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
@@ -237,7 +237,7 @@ def test_default_name(mock_tools, android_sdk, tmp_path):
     # it only checks that the emulator is created with the default name.
 
     # User provides no input; default name will be used
-    mock_tools.input.values = [""]
+    mock_tools.console.values = [""]
 
     # Mock the initial output of an AVD config file.
     avd_config_path = tmp_path / "home/.android/avd/beePhone.avd/config.ini"
@@ -266,7 +266,7 @@ def test_default_name_with_collisions(mock_tools, android_sdk, tmp_path):
         ]
     )
     # User provides no input; default name will be used
-    mock_tools.input.values = [""]
+    mock_tools.console.values = [""]
 
     # Mock the initial output of an AVD config file.
     avd_config_path = tmp_path / "home/.android/avd/beePhone3.avd/config.ini"

--- a/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
@@ -54,7 +54,7 @@ def test_create_emulator(
     mock_tools.host_arch = host_arch
 
     # Mock the user providing several invalid names before getting it right.
-    mock_tools.input.values = [
+    mock_tools.console.values = [
         "runningEmulator",  # an existing emulator
         "invalid name",  # A name with a space
         "annoying!",  # a name with non-alpha characters
@@ -91,7 +91,7 @@ def test_default_name(mock_tools, android_sdk, tmp_path):
     # it only checks that the emulator is created with the default name.
 
     # User provides no input; default name will be used
-    mock_tools.input.values = [""]
+    mock_tools.console.values = [""]
 
     # Mock the internal emulator creation method
     android_sdk._create_emulator = MagicMock()
@@ -116,7 +116,7 @@ def test_default_name_with_collisions(mock_tools, android_sdk, tmp_path):
             "beePhone",
         ]
     )
-    mock_tools.input.values = [""]
+    mock_tools.console.values = [""]
 
     # Mock the internal emulator creation method
     android_sdk._create_emulator = MagicMock()

--- a/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
@@ -62,7 +62,7 @@ def test_explicit_device(mock_tools, android_sdk):
     assert avd is None
 
     # No input was requested
-    assert mock_tools.input.prompts == []
+    assert mock_tools.console.prompts == []
 
 
 def test_explicit_unauthorized_device(mock_tools, android_sdk):
@@ -74,7 +74,7 @@ def test_explicit_unauthorized_device(mock_tools, android_sdk):
         android_sdk.select_target_device("041234567892009a")
 
     # No input was requested
-    assert mock_tools.input.prompts == []
+    assert mock_tools.console.prompts == []
 
 
 def test_explicit_running_emulator_by_id(mock_tools, android_sdk):
@@ -89,7 +89,7 @@ def test_explicit_running_emulator_by_id(mock_tools, android_sdk):
     assert avd == "runningEmulator"
 
     # No input was requested
-    assert mock_tools.input.prompts == []
+    assert mock_tools.console.prompts == []
 
 
 def test_explicit_running_emulator_by_avd(mock_tools, android_sdk):
@@ -104,7 +104,7 @@ def test_explicit_running_emulator_by_avd(mock_tools, android_sdk):
     assert avd == "runningEmulator"
 
     # No input was requested
-    assert mock_tools.input.prompts == []
+    assert mock_tools.console.prompts == []
 
 
 def test_explicit_idle_emulator(mock_tools, android_sdk):
@@ -119,7 +119,7 @@ def test_explicit_idle_emulator(mock_tools, android_sdk):
     assert avd == "idleEmulator"
 
     # No input was requested
-    assert mock_tools.input.prompts == []
+    assert mock_tools.console.prompts == []
 
 
 def test_explicit_invalid_device(mock_tools, android_sdk):
@@ -130,7 +130,7 @@ def test_explicit_invalid_device(mock_tools, android_sdk):
         device, name, avd = android_sdk.select_target_device("deadbeefcafe")
 
     # No input was requested
-    assert mock_tools.input.prompts == []
+    assert mock_tools.console.prompts == []
 
 
 def test_explicit_invalid_avd(mock_tools, android_sdk):
@@ -141,13 +141,13 @@ def test_explicit_invalid_avd(mock_tools, android_sdk):
         device, name, avd = android_sdk.select_target_device("@invalidEmulator")
 
     # No input was requested
-    assert mock_tools.input.prompts == []
+    assert mock_tools.console.prompts == []
 
 
 def test_select_device(mock_tools, android_sdk, capsys):
     """If the user manually selects a physical device, details are returned."""
     # Mock the user input
-    mock_tools.input.values = ["2"]
+    mock_tools.console.values = ["2"]
 
     # Run the selection with no pre-existing choice
     device, name, avd = android_sdk.select_target_device(None)
@@ -158,7 +158,7 @@ def test_select_device(mock_tools, android_sdk, capsys):
     assert avd is None
 
     # The user was asked to select a device
-    assert len(mock_tools.input.prompts) == 1
+    assert len(mock_tools.console.prompts) == 1
 
     # A re-run prompt has been provided
     out = capsys.readouterr().out
@@ -169,7 +169,7 @@ def test_select_unauthorized_device(mock_tools, android_sdk):
     """If the user manually selects an unauthorized running device, an error is
     raised."""
     # Mock the user input
-    mock_tools.input.values = ["3"]
+    mock_tools.console.values = ["3"]
 
     # Run the selection with no pre-existing choice
     with pytest.raises(AndroidDeviceNotAuthorized):
@@ -179,7 +179,7 @@ def test_select_unauthorized_device(mock_tools, android_sdk):
 def test_select_running_emulator(mock_tools, android_sdk, capsys):
     """If the user manually selects a running emulator, details are returned."""
     # Mock the user input
-    mock_tools.input.values = ["1"]
+    mock_tools.console.values = ["1"]
 
     # Run the selection with no pre-existing choice
     device, name, avd = android_sdk.select_target_device(None)
@@ -197,7 +197,7 @@ def test_select_running_emulator(mock_tools, android_sdk, capsys):
 def test_select_idle_emulator(mock_tools, android_sdk, capsys):
     """If the user manually selects a running device, details are returned."""
     # Mock the user input
-    mock_tools.input.values = ["4"]
+    mock_tools.console.values = ["4"]
 
     # Run the selection with no pre-existing choice
     device, name, avd = android_sdk.select_target_device(None)
@@ -215,7 +215,7 @@ def test_select_idle_emulator(mock_tools, android_sdk, capsys):
 def test_select_create_emulator(mock_tools, android_sdk, capsys):
     """If the user manually selects a running device, details are returned."""
     # Mock the user input
-    mock_tools.input.values = ["5"]
+    mock_tools.console.values = ["5"]
 
     # Run the selection with no pre-existing choice
     device, name, avd = android_sdk.select_target_device(None)
@@ -233,19 +233,19 @@ def test_select_create_emulator(mock_tools, android_sdk, capsys):
 def test_input_disabled(mock_tools, android_sdk):
     """If input has been disabled, and there are multiple simulators, an error is
     raised."""
-    mock_tools.input.enabled = False
+    mock_tools.console.input_enabled = False
 
     # Run the selection with no pre-existing choice
     with pytest.raises(BriefcaseCommandError):
         android_sdk.select_target_device(None)
 
     # No input was requested
-    assert mock_tools.input.prompts == []
+    assert mock_tools.console.prompts == []
 
 
 def test_input_disabled_no_simulators(mock_tools, android_sdk):
     """If input has been disabled, and there are no simulators, 'create' is selected."""
-    mock_tools.input.enabled = False
+    mock_tools.console.input_enabled = False
 
     # Remove all the devices and emulators
     android_sdk.devices = MagicMock(return_value={})
@@ -260,12 +260,12 @@ def test_input_disabled_no_simulators(mock_tools, android_sdk):
     assert avd is None
 
     # No input was requested
-    assert mock_tools.input.prompts == []
+    assert mock_tools.console.prompts == []
 
 
 def test_input_disabled_one_device(mock_tools, android_sdk):
     """If input has been disabled, and there is a single device, it is selected."""
-    mock_tools.input.enabled = False
+    mock_tools.console.input_enabled = False
 
     # Set up a single device.
     android_sdk.devices = MagicMock(
@@ -287,7 +287,7 @@ def test_input_disabled_one_device(mock_tools, android_sdk):
     assert avd is None
 
     # No input was requested
-    assert mock_tools.input.prompts == []
+    assert mock_tools.console.prompts == []
 
 
 def test_explicit_new_device(android_sdk):

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify.py
@@ -162,7 +162,7 @@ def test_succeeds_immediately_in_happy_path(mock_tools, tmp_path):
 def test_user_provided_sdk(mock_tools, env_var, tmp_path, capsys):
     """If the user environment specifies a valid Android SDK, it is used."""
     # Increase the log level.
-    mock_tools.logger.verbosity = LogLevel.DEBUG
+    mock_tools.console.verbosity = LogLevel.DEBUG
 
     # Create `sdkmanager` and the license file.
     existing_android_sdk_root_path = tmp_path / "other_sdk"
@@ -201,7 +201,7 @@ def test_consistent_user_provided_sdk(mock_tools, tmp_path, capsys):
     """If the user environment specifies a valid Android SDK in both ANDROID_HOME and
     ANDROID_SDK_ROOT, it is used."""
     # Increase the log level.
-    mock_tools.logger.verbosity = LogLevel.DEBUG
+    mock_tools.console.verbosity = LogLevel.DEBUG
 
     # Create `sdkmanager` and the license file.
     existing_android_sdk_root_path = tmp_path / "other_sdk"
@@ -239,7 +239,7 @@ def test_consistent_user_provided_sdk(mock_tools, tmp_path, capsys):
 def test_inconsistent_user_provided_sdk(mock_tools, tmp_path, capsys):
     """A warning is logged if ANDROID_HOME and ANDROID_SDK_ROOT are not the same."""
     # Increase the log level.
-    mock_tools.logger.verbosity = LogLevel.DEBUG
+    mock_tools.console.verbosity = LogLevel.DEBUG
 
     # Create `sdkmanager` and the license file.
     existing_android_sdk_root_path = tmp_path / "other_sdk"

--- a/tests/integrations/base/conftest.py
+++ b/tests/integrations/base/conftest.py
@@ -1,9 +1,9 @@
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.base import ToolCache
 
 
 @pytest.fixture
 def simple_tools(tmp_path):
-    return ToolCache(logger=Log(), console=Console(), base_path=tmp_path)
+    return ToolCache(console=Console(), base_path=tmp_path)

--- a/tests/integrations/base/test_ToolCache.py
+++ b/tests/integrations/base/test_ToolCache.py
@@ -12,7 +12,7 @@ import pytest
 from cookiecutter.main import cookiecutter
 
 import briefcase.integrations
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.base import ToolCache
 
 from .test_tool_registry import integrations_modules, tools_for_module
@@ -115,7 +115,6 @@ def test_base_path_is_path(simple_tools):
     # The BaseCommand tests have much more extensive tests for this path.
     assert isinstance(simple_tools.base_path, Path)
     tools = ToolCache(
-        logger=Log(),
         console=Console(),
         base_path="/home/data",
     )
@@ -140,7 +139,6 @@ def test_home_path_default(simple_tools):
 def test_nonwindows_home_path(home_path, expected_path, tmp_path):
     """Home path is always expanded or defaulted."""
     tools = ToolCache(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path,
         home_path=home_path,
@@ -161,7 +159,6 @@ def test_nonwindows_home_path(home_path, expected_path, tmp_path):
 def test_windows_home_path(home_path, expected_path, tmp_path):
     """Home path is always expanded or defaulted."""
     tools = ToolCache(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path,
         home_path=home_path,
@@ -175,7 +172,6 @@ def test_is_32bit_python(maxsize, is_32bit, monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "maxsize", maxsize)
 
     tools = ToolCache(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path,
     )

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from briefcase.config import AppConfig
-from briefcase.console import Log
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.file import File
 from briefcase.integrations.subprocess import Subprocess
@@ -17,7 +16,6 @@ from tests.utils import DummyConsole
 @pytest.fixture
 def mock_tools(tmp_path) -> ToolCache:
     mock_tools = ToolCache(
-        logger=Log(),
         console=DummyConsole(),
         base_path=tmp_path / "tools",
         home_path=tmp_path / "home",

--- a/tests/integrations/docker/test_DockerAppContext__Popen.py
+++ b/tests/integrations/docker/test_DockerAppContext__Popen.py
@@ -58,7 +58,7 @@ def test_call_with_extra_kwargs(mock_tools, my_app, tmp_path, capsys):
 @pytest.mark.usefixtures("mock_docker_app_context")
 def test_simple_verbose_call(mock_tools, my_app, tmp_path, sub_kw, capsys):
     """If verbosity is turned out, there is output."""
-    mock_tools[my_app].app_context.tools.logger.verbosity = LogLevel.DEBUG
+    mock_tools[my_app].app_context.tools.console.verbosity = LogLevel.DEBUG
 
     process = mock_tools[my_app].app_context.Popen(["hello", "world"])
 

--- a/tests/integrations/docker/test_DockerAppContext__check_output.py
+++ b/tests/integrations/docker/test_DockerAppContext__check_output.py
@@ -65,7 +65,7 @@ def test_simple_verbose_call(
     capsys,
 ):
     """If verbosity is turned out, there is output."""
-    mock_tools[my_app].app_context.tools.logger.verbosity = LogLevel.DEBUG
+    mock_tools[my_app].app_context.tools.console.verbosity = LogLevel.DEBUG
 
     output = mock_tools[my_app].app_context.check_output(["hello", "world"])
 

--- a/tests/integrations/docker/test_DockerAppContext__run.py
+++ b/tests/integrations/docker/test_DockerAppContext__run.py
@@ -111,7 +111,7 @@ def test_call_with_extra_kwargs(
 @pytest.mark.usefixtures("mock_docker_app_context")
 def test_simple_verbose_call(mock_tools, my_app, tmp_path, sub_stream_kw, capsys):
     """If verbosity is turned out, there is output."""
-    mock_tools[my_app].app_context.tools.logger.verbosity = LogLevel.DEBUG
+    mock_tools[my_app].app_context.tools.console.verbosity = LogLevel.DEBUG
 
     mock_tools[my_app].app_context.run(["hello", "world"])
 

--- a/tests/integrations/flatpak/test_Flatpak__build.py
+++ b/tests/integrations/flatpak/test_Flatpak__build.py
@@ -11,7 +11,7 @@ def test_build(flatpak, tool_debug_mode, tmp_path):
     """A Flatpak project can be built."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        flatpak.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     flatpak.build(
         bundle_identifier="com.example.my-app",

--- a/tests/integrations/flatpak/test_Flatpak__bundle.py
+++ b/tests/integrations/flatpak/test_Flatpak__bundle.py
@@ -11,7 +11,7 @@ def test_bundle(flatpak, tool_debug_mode, tmp_path):
     """A Flatpak project can be bundled."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        flatpak.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     flatpak.bundle(
         repo_url="https://example.com/flatpak",

--- a/tests/integrations/flatpak/test_Flatpak__run.py
+++ b/tests/integrations/flatpak/test_Flatpak__run.py
@@ -11,7 +11,7 @@ def test_run(flatpak, tool_debug_mode):
     """A Flatpak project can be executed."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        flatpak.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     # Set up the log streamer to return a known stream
     log_popen = mock.MagicMock()
@@ -43,7 +43,7 @@ def test_run_with_args(flatpak, tool_debug_mode):
     """A Flatpak project can be executed with additional arguments."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        flatpak.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     # Set up the log streamer to return a known stream
     log_popen = mock.MagicMock()
@@ -79,7 +79,7 @@ def test_run_non_streaming(flatpak, tool_debug_mode):
     """A Flatpak project can be executed in non-streaming mode."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        flatpak.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     # Call run()
     flatpak.run(
@@ -108,7 +108,7 @@ def test_main_module_override(flatpak, tool_debug_mode):
     """The main module can be overridden."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        flatpak.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     # Set up the log streamer to return a known stream
     log_popen = mock.MagicMock()

--- a/tests/integrations/flatpak/test_Flatpak__verify_repo.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_repo.py
@@ -11,7 +11,7 @@ def test_verify_repo(flatpak, tool_debug_mode):
     """A Flatpak repo can be verified."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        flatpak.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     flatpak.verify_repo(
         repo_alias="test-alias",

--- a/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
@@ -11,7 +11,7 @@ def test_verify_runtime(flatpak, tool_debug_mode):
     """A Flatpak runtime and SDK can be verified."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        flatpak.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        flatpak.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     flatpak.verify_runtime(
         repo_alias="test-alias",

--- a/tests/integrations/git/test_Git__verify.py
+++ b/tests/integrations/git/test_Git__verify.py
@@ -41,7 +41,7 @@ def test_unsupported_os(mock_tools):
 )
 def test_git_stdlib_logging(mock_tools, logging_level, handler_expected):
     """A logging handler is configured for GitPython when DEEP_DEBUG is enabled."""
-    mock_tools.logger.verbosity = logging_level
+    mock_tools.console.verbosity = logging_level
 
     Git.verify(mock_tools)
 

--- a/tests/integrations/subprocess/test_PopenOutputStreamer.py
+++ b/tests/integrations/subprocess/test_PopenOutputStreamer.py
@@ -3,7 +3,7 @@ from io import StringIO
 
 import pytest
 
-from briefcase.console import Log
+from briefcase.console import Console
 from briefcase.integrations import subprocess
 from briefcase.integrations.subprocess import PopenOutputStreamer
 
@@ -13,7 +13,7 @@ def streamer(streaming_process):
     return PopenOutputStreamer(
         label="test",
         popen_process=streaming_process,
-        logger=Log(),
+        console=Console(),
     )
 
 

--- a/tests/integrations/subprocess/test_Subprocess__Popen.py
+++ b/tests/integrations/subprocess/test_Subprocess__Popen.py
@@ -124,7 +124,7 @@ def test_call_windows_with_start_new_session_and_creationflags(
 
 def test_debug_call(mock_sub, capsys, sub_kw):
     """If verbosity is turned up, there is output."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
     mock_sub.Popen(["hello", "world"])
 
     mock_sub._subprocess.Popen.assert_called_with(["hello", "world"], **sub_kw)
@@ -140,7 +140,7 @@ def test_debug_call(mock_sub, capsys, sub_kw):
 
 def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_kw):
     """If verbosity is turned up, and injected env vars are included output."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     env = {"NewVar": "NewVarValue"}
     mock_sub.Popen(["hello", "world"], env=env, cwd=tmp_path / "cwd")

--- a/tests/integrations/subprocess/test_Subprocess__check_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__check_output.py
@@ -131,7 +131,7 @@ def test_call_windows_with_start_new_session_and_creationflags(
 
 def test_debug_call(mock_sub, capsys, sub_check_output_kw):
     """If verbosity is turned up, there is output."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     mock_sub.check_output(["hello", "world"])
 
@@ -157,7 +157,7 @@ def test_debug_call(mock_sub, capsys, sub_check_output_kw):
 
 def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_check_output_kw):
     """If verbosity is turned up, injected env vars are included in output."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     env = {"NewVar": "NewVarValue"}
     mock_sub.check_output(["hello", "world"], env=env, cwd=tmp_path / "cwd")
@@ -191,7 +191,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_check_output_kw):
 
 def test_debug_call_with_quiet(mock_sub, capsys, tmp_path, sub_check_output_kw):
     """If quiet mode is on, calls aren't logged, even if verbosity is turned up."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     env = {"NewVar": "NewVarValue"}
     mock_sub.check_output(
@@ -217,7 +217,7 @@ def test_debug_call_with_quiet(mock_sub, capsys, tmp_path, sub_check_output_kw):
 
 def test_debug_call_with_stderr(mock_sub, capsys, tmp_path, sub_check_output_kw):
     """If stderr is specified, it is not defaulted to stdout."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     mock_sub.check_output(
         ["hello", "world"],
@@ -250,7 +250,7 @@ def test_debug_call_with_stderr(mock_sub, capsys, tmp_path, sub_check_output_kw)
 
 def test_calledprocesserror_exception_logging(mock_sub, capsys):
     """If command errors, ensure command output is printed."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     called_process_error = CalledProcessError(
         returncode=-1,
@@ -283,7 +283,7 @@ def test_calledprocesserror_exception_logging(mock_sub, capsys):
 
 def test_calledprocesserror_exception_quiet(mock_sub, capsys):
     """If command errors in quiet mode, no command output is printed."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     called_process_error = CalledProcessError(
         returncode=-1,
@@ -302,7 +302,7 @@ def test_calledprocesserror_exception_quiet(mock_sub, capsys):
 
 def test_calledprocesserror_exception_logging_no_cmd_output(mock_sub, capsys):
     """If command errors, and there is no command output, errors are still printed."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     called_process_error = CalledProcessError(
         returncode=-1,

--- a/tests/integrations/subprocess/test_Subprocess__run__controlled_console.py
+++ b/tests/integrations/subprocess/test_Subprocess__run__controlled_console.py
@@ -11,7 +11,7 @@ from briefcase.console import LogLevel
 def test_call(mock_sub, sub_stream_kw, sleep_zero, capsys):
     """A simple call will be invoked."""
 
-    with mock_sub.tools.input.wait_bar():
+    with mock_sub.tools.console.wait_bar():
         mock_sub.run(["hello", "world"])
 
     mock_sub._subprocess.Popen.assert_called_with(["hello", "world"], **sub_stream_kw)
@@ -29,7 +29,7 @@ def test_call(mock_sub, sub_stream_kw, sleep_zero, capsys):
 def test_call_with_arg(mock_sub, sub_stream_kw, sleep_zero, capsys):
     """Any extra keyword arguments are passed through as-is."""
 
-    with mock_sub.tools.input.wait_bar():
+    with mock_sub.tools.console.wait_bar():
         mock_sub.run(["hello", "world"], extra_kw="extra")
 
     mock_sub._subprocess.Popen.assert_called_with(
@@ -50,9 +50,9 @@ def test_call_with_arg(mock_sub, sub_stream_kw, sleep_zero, capsys):
 
 def test_debug_call(mock_sub, sub_stream_kw, sleep_zero, capsys):
     """If verbosity is turned up, there is debug output."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
-    with mock_sub.tools.input.wait_bar():
+    with mock_sub.tools.console.wait_bar():
         mock_sub.run(["hello", "world"])
 
     mock_sub._subprocess.Popen.assert_called_with(["hello", "world"], **sub_stream_kw)
@@ -73,10 +73,10 @@ def test_debug_call(mock_sub, sub_stream_kw, sleep_zero, capsys):
 
 def test_debug_call_with_env(mock_sub, sub_stream_kw, sleep_zero, capsys, tmp_path):
     """If verbosity is turned up, injected env vars are included in debug output."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     env = {"NewVar": "NewVarValue"}
-    with mock_sub.tools.input.wait_bar():
+    with mock_sub.tools.console.wait_bar():
         mock_sub.run(
             ["hello", "world"],
             env=env,
@@ -132,7 +132,7 @@ def test_debug_call_with_env(mock_sub, sub_stream_kw, sleep_zero, capsys, tmp_pa
 def test_text_eq_true_default_overriding(mock_sub, in_kwargs, kwargs, sleep_zero):
     """If text or universal_newlines is explicitly provided, those should override
     text=true default and universal_newlines should be converted to text."""
-    with mock_sub.tools.input.wait_bar():
+    with mock_sub.tools.console.wait_bar():
         mock_sub.run(["hello", "world"], **in_kwargs)
 
     mock_sub._subprocess.Popen.assert_called_with(
@@ -154,7 +154,7 @@ def test_stderr_is_redirected(
     stderr_output = "stderr output\nline 2"
     streaming_process.stderr.read.return_value = stderr_output
 
-    with mock_sub.tools.input.wait_bar():
+    with mock_sub.tools.console.wait_bar():
         run_result = mock_sub.run(
             ["hello", "world"],
             stderr=subprocess.PIPE,
@@ -188,7 +188,7 @@ def test_stderr_dev_null(
     """When stderr is discarded, it should be None in the result."""
     streaming_process.stderr = None
 
-    with mock_sub.tools.input.wait_bar():
+    with mock_sub.tools.console.wait_bar():
         run_result = mock_sub.run(
             ["hello", "world"],
             stderr=subprocess.DEVNULL,
@@ -218,7 +218,7 @@ def test_calledprocesserror(mock_sub, streaming_process, sleep_zero, capsys):
     streaming_process.stderr.read.return_value = stderr_output
 
     with pytest.raises(subprocess.CalledProcessError) as exc:
-        with mock_sub.tools.input.wait_bar():
+        with mock_sub.tools.console.wait_bar():
             mock_sub.run(
                 ["hello", "world"],
                 check=True,
@@ -242,7 +242,7 @@ def test_calledprocesserror(mock_sub, streaming_process, sleep_zero, capsys):
 def test_invalid_invocations(mock_sub):
     """Ensure run cannot be used in a Wait Bar with invalid arguments."""
     with pytest.raises(AssertionError):
-        with mock_sub.tools.input.wait_bar():
+        with mock_sub.tools.console.wait_bar():
             mock_sub.run(
                 ["hello", "world"],
                 stdout=subprocess.PIPE,
@@ -250,5 +250,5 @@ def test_invalid_invocations(mock_sub):
 
     for invalid_arg in ("timeout", "input"):
         with pytest.raises(AssertionError):
-            with mock_sub.tools.input.wait_bar():
+            with mock_sub.tools.console.wait_bar():
                 mock_sub.run(["hello", "world"], **{invalid_arg: "value"})

--- a/tests/integrations/subprocess/test_Subprocess__run__stream_output__False.py
+++ b/tests/integrations/subprocess/test_Subprocess__run__stream_output__False.py
@@ -133,7 +133,7 @@ def test_call_windows_with_start_new_session_and_creationflags(
 
 def test_debug_call(mock_sub, capsys, sub_kw):
     """If verbosity is turned up, there is output."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     mock_sub.run(["hello", "world"], stream_output=False)
 
@@ -154,7 +154,7 @@ def test_debug_call(mock_sub, capsys, sub_kw):
 
 def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_kw):
     """If verbosity is turned up, injected env vars are included output."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     env = {"NewVar": "NewVarValue"}
     mock_sub.run(["hello", "world"], env=env, cwd=tmp_path / "cwd", stream_output=False)
@@ -182,7 +182,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_kw):
 
 
 def test_calledprocesserror_exception_logging(mock_sub, capsys):
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     mock_sub._subprocess.run.side_effect = CalledProcessError(
         returncode=-1,

--- a/tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py
+++ b/tests/integrations/subprocess/test_Subprocess__run__stream_output__True.py
@@ -158,7 +158,7 @@ def test_call_windows_with_start_new_session_and_creationflags(
 
 def test_debug_call(mock_sub, capsys, sub_stream_kw, sleep_zero):
     """If verbosity is turned up, there is output."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     mock_sub.run(["hello", "world"])
 
@@ -182,7 +182,7 @@ def test_debug_call(mock_sub, capsys, sub_stream_kw, sleep_zero):
 
 def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_stream_kw, sleep_zero):
     """If verbosity is turned up, injected env vars are included output."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     env = {"NewVar": "NewVarValue"}
     mock_sub.run(["hello", "world"], env=env, cwd=tmp_path / "cwd")
@@ -213,7 +213,7 @@ def test_debug_call_with_env(mock_sub, capsys, tmp_path, sub_stream_kw, sleep_ze
 
 
 def test_calledprocesserror_exception_logging(mock_sub, sleep_zero, capsys):
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     with pytest.raises(CalledProcessError):
         mock_sub.run(["hello", "world"], check=True)

--- a/tests/integrations/subprocess/test_Subprocess__stream_output.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output.py
@@ -31,7 +31,7 @@ def test_output(mock_sub, streaming_process, sleep_zero, capsys):
 
 def test_output_debug(mock_sub, streaming_process, sleep_zero, capsys):
     """Process output is printed; no debug output for only stream_output."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     mock_sub.stream_output("testing", streaming_process)
 

--- a/tests/integrations/subprocess/test_Subprocess__stream_output_non_blocking.py
+++ b/tests/integrations/subprocess/test_Subprocess__stream_output_non_blocking.py
@@ -18,7 +18,7 @@ def test_output(mock_sub, streaming_process, sleep_zero, capsys):
 def test_output_debug(mock_sub, streaming_process, sleep_zero, capsys):
     """Process output is printed; no debug output for only
     stream_output_non_blocking."""
-    mock_sub.tools.logger.verbosity = LogLevel.DEBUG
+    mock_sub.tools.console.verbosity = LogLevel.DEBUG
 
     streamer = mock_sub.stream_output_non_blocking("testing", streaming_process)
     streamer.join()

--- a/tests/integrations/subprocess/test_ensure_console_is_safe.py
+++ b/tests/integrations/subprocess/test_ensure_console_is_safe.py
@@ -8,8 +8,8 @@ from briefcase.integrations.subprocess import Subprocess
 
 @pytest.fixture
 def mock_sub(mock_tools):
-    mock_tools.input.release_console_control = Mock(
-        wraps=mock_tools.input.release_console_control
+    mock_tools.console.release_console_control = Mock(
+        wraps=mock_tools.console.release_console_control
     )
     mock_sub = Subprocess(mock_tools)
     mock_sub._subprocess = MagicMock(spec_set=subprocess)
@@ -23,14 +23,14 @@ def test_run_windows_batch_script(mock_sub, batch_script):
     # Console control is only released on Windows
     mock_sub.tools.host_os = "Windows"
 
-    with mock_sub.tools.input.wait_bar("Testing..."):
+    with mock_sub.tools.console.wait_bar("Testing..."):
         mock_sub.run([batch_script, "World"])
 
     mock_sub._run_and_stream_output.assert_called_with(
         [batch_script, "World"],
         filter_func=None,
     )
-    mock_sub.tools.input.release_console_control.assert_called_once()
+    mock_sub.tools.console.release_console_control.assert_called_once()
 
 
 @pytest.mark.parametrize("batch_script", ["HELLO.BAT", "hello.bat", "hElLo.BaT"])
@@ -39,36 +39,36 @@ def test_check_output_windows_batch_script(mock_sub, batch_script, sub_check_out
     # Console control is only released on Windows for batch scripts
     mock_sub.tools.host_os = "Windows"
 
-    with mock_sub.tools.input.wait_bar("Testing..."):
+    with mock_sub.tools.console.wait_bar("Testing..."):
         mock_sub.check_output([batch_script, "World"])
 
     mock_sub._subprocess.check_output.assert_called_with(
         [batch_script, "World"],
         **sub_check_output_kw,
     )
-    mock_sub.tools.input.release_console_control.assert_called_once()
+    mock_sub.tools.console.release_console_control.assert_called_once()
 
 
 @pytest.mark.parametrize("sub_kwargs", [{"stream_output": True}, {}])
 def test_run_stream_output_true(mock_sub, sub_kwargs):
     """Console control is not released when stream_output=True or is unspecified."""
-    with mock_sub.tools.input.wait_bar("Testing..."):
+    with mock_sub.tools.console.wait_bar("Testing..."):
         mock_sub.run(["Hello", "World"], **sub_kwargs)
 
     mock_sub._run_and_stream_output.assert_called_with(
         ["Hello", "World"],
         filter_func=None,
     )
-    mock_sub.tools.input.release_console_control.assert_not_called()
+    mock_sub.tools.console.release_console_control.assert_not_called()
 
 
 def test_run_stream_output_false(mock_sub, sub_kw):
     """Console control is released when stream_output=False."""
-    with mock_sub.tools.input.wait_bar("Testing..."):
+    with mock_sub.tools.console.wait_bar("Testing..."):
         mock_sub.run(["Hello", "World"], stream_output=False)
 
     mock_sub._subprocess.run.assert_called_with(["Hello", "World"], **sub_kw)
-    mock_sub.tools.input.release_console_control.assert_called_once()
+    mock_sub.tools.console.release_console_control.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -98,7 +98,7 @@ def test_negative_condition_not_controlled(
 
     final_kwargs = {**sub_check_output_kw, **kwargs}
     mock_sub._subprocess.check_output.assert_called_with(cmdline, **final_kwargs)
-    mock_sub.tools.input.release_console_control.assert_not_called()
+    mock_sub.tools.console.release_console_control.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -112,7 +112,7 @@ def test_negative_condition_not_controlled(
 def test_negative_condition_controlled(mock_sub, cmdline, kwargs, sub_check_output_kw):
     """Passthrough to Subprocess if conditions to release console control are not met
     while the console is controlled."""
-    with mock_sub.tools.input.wait_bar("Testing..."):
+    with mock_sub.tools.console.wait_bar("Testing..."):
         mock_sub.run(cmdline, **kwargs)
         mock_sub.check_output(cmdline, **kwargs)
 
@@ -123,4 +123,4 @@ def test_negative_condition_controlled(mock_sub, cmdline, kwargs, sub_check_outp
     )
     final_kwargs = {**sub_check_output_kw, **kwargs}
     mock_sub._subprocess.check_output.assert_called_with(cmdline, **final_kwargs)
-    mock_sub.tools.input.release_console_control.assert_not_called()
+    mock_sub.tools.console.release_console_control.assert_not_called()

--- a/tests/integrations/subprocess/test_get_process_id_by_command.py
+++ b/tests/integrations/subprocess/test_get_process_id_by_command.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import pytest
 
-from briefcase.console import Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import get_process_id_by_command
 
 Process = namedtuple("Process", "info")
@@ -78,7 +78,7 @@ def test_get_process_id_by_command_w_command_line(
 ):
     """Finds correct process for command line or returns None."""
     monkeypatch.setattr("psutil.process_iter", lambda attrs: process_list)
-    found_pid = get_process_id_by_command(command_list=command_list, logger=Log())
+    found_pid = get_process_id_by_command(command_list=command_list, console=Console())
     assert found_pid == expected_pid
     assert capsys.readouterr().out == expected_stdout
 
@@ -113,7 +113,7 @@ def test_get_process_id_by_command_w_command(
 ):
     """Finds correct process for command or returns None."""
     monkeypatch.setattr("psutil.process_iter", lambda attrs: process_list)
-    found_pid = get_process_id_by_command(command=command, logger=Log())
+    found_pid = get_process_id_by_command(command=command, console=Console())
     assert found_pid == expected_pid
     assert capsys.readouterr().out == expected_stdout
 

--- a/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
@@ -169,7 +169,7 @@ def test_winsdk_latest_install_from_reg(mock_tools, mock_winreg, tmp_path, monke
     mock_tools.os.environ.get.return_value = None
 
     # Turn on verbose logging
-    mock_tools.logger.verbosity = LogLevel.DEBUG
+    mock_tools.console.verbosity = LogLevel.DEBUG
 
     # Patch target SDK version
     monkeypatch.setattr(WindowsSDK, "SDK_VERSION", "83.0")
@@ -208,7 +208,7 @@ def test_winsdk_nonlatest_install_from_reg(
     mock_tools.os.environ.get.return_value = None
 
     # Turn on verbose logging
-    mock_tools.logger.verbosity = LogLevel.DEBUG
+    mock_tools.console.verbosity = LogLevel.DEBUG
 
     # Patch target SDK version
     monkeypatch.setattr(WindowsSDK, "SDK_VERSION", "85.0")
@@ -294,7 +294,7 @@ def test_winsdk_invalid_install_from_reg(
     WindowsSDK.DEFAULT_SDK_DIRS = []
 
     # Turn on verbose logging
-    mock_tools.logger.verbosity = LogLevel.DEBUG
+    mock_tools.console.verbosity = LogLevel.DEBUG
 
     # Patch target SDK version
     monkeypatch.setattr(WindowsSDK, "SDK_VERSION", "85.0")
@@ -361,7 +361,7 @@ def test_winsdk_valid_install_from_default_dir(
     mock_tools.os.environ.get.return_value = None
 
     # Turn on verbose logging
-    mock_tools.logger.verbosity = LogLevel.DEBUG
+    mock_tools.console.verbosity = LogLevel.DEBUG
 
     # Patch target SDK version
     monkeypatch.setattr(WindowsSDK, "SDK_VERSION", "86.0")
@@ -404,7 +404,7 @@ def test_winsdk_invalid_install_from_default_dir(
     mock_tools.os.environ.get.return_value = None
 
     # Turn on verbose logging
-    mock_tools.logger.verbosity = LogLevel.DEBUG
+    mock_tools.console.verbosity = LogLevel.DEBUG
 
     # Patch target SDK version
     monkeypatch.setattr(WindowsSDK, "SDK_VERSION", "87.0")

--- a/tests/integrations/xcode/test_get_simulators.py
+++ b/tests/integrations/xcode/test_get_simulators.py
@@ -14,7 +14,7 @@ from briefcase.integrations.xcode import get_simulators
 
 @pytest.fixture
 def mock_tools(mock_tools) -> ToolCache:
-    mock_tools.input = mock.MagicMock(spec_set=Console)
+    mock_tools.console = mock.MagicMock(spec_set=Console)
     mock_tools.subprocess = Subprocess(mock_tools)
     mock_tools.subprocess._subprocess = mock.MagicMock(spec_set=subprocess)
     mock_tools.subprocess.check_output = mock.MagicMock()
@@ -47,7 +47,7 @@ def test_simulator_is_missing(mock_tools, tmp_path):
     )
 
     # The prompt was displayed
-    assert mock_tools.input.call_count == 1
+    assert mock_tools.console.call_count == 1
 
     # The call returned without error.
     assert simulators == {}
@@ -84,7 +84,7 @@ def test_no_runtimes(mock_tools, simulator):
     assert simulators == {}
 
     # The prompt was not shown
-    mock_tools.input.assert_not_called()
+    mock_tools.console.assert_not_called()
 
 
 def test_single_iOS_runtime(mock_tools, simulator):
@@ -113,7 +113,7 @@ def test_single_iOS_runtime(mock_tools, simulator):
     }
 
     # The prompt was not shown
-    mock_tools.input.assert_not_called()
+    mock_tools.console.assert_not_called()
 
 
 def test_watchOS_runtime(mock_tools, simulator):
@@ -136,7 +136,7 @@ def test_watchOS_runtime(mock_tools, simulator):
     }
 
     # The prompt was not shown
-    mock_tools.input.assert_not_called()
+    mock_tools.console.assert_not_called()
 
 
 def test_multiple_iOS_runtime(mock_tools, simulator):
@@ -185,7 +185,7 @@ def test_multiple_iOS_runtime(mock_tools, simulator):
     }
 
     # The prompt was not shown
-    mock_tools.input.assert_not_called()
+    mock_tools.console.assert_not_called()
 
 
 def test_unknown_runtime(mock_tools, simulator):
@@ -203,7 +203,7 @@ def test_unknown_runtime(mock_tools, simulator):
     assert simulators == {}
 
     # The prompt was not shown
-    mock_tools.input.assert_not_called()
+    mock_tools.console.assert_not_called()
 
 
 def test_alternate_format(mock_tools, simulator):

--- a/tests/platforms/android/gradle/conftest.py
+++ b/tests/platforms/android/gradle/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, PropertyMock
 import httpx
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.android_sdk import AndroidSDK
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.android.gradle import GradlePackageCommand
@@ -16,7 +16,6 @@ from ....utils import create_file
 @pytest.fixture
 def package_command(tmp_path, first_app_config, monkeypatch):
     command = GradlePackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/android/gradle/test_build.py
+++ b/tests/platforms/android/gradle/test_build.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, PropertyMock
 import httpx
 import pytest
 
-from briefcase.console import Console, Log, LogLevel
+from briefcase.console import Console, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.android_sdk import AndroidSDK
 from briefcase.integrations.subprocess import Subprocess
@@ -16,7 +16,6 @@ from briefcase.platforms.android.gradle import GradleBuildCommand
 @pytest.fixture
 def build_command(tmp_path, first_app_generated, monkeypatch):
     command = GradleBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -72,7 +71,7 @@ def test_build_app(
     build_command.tools.host_os = host_os
     # Enable verbose tool logging
     if tool_debug_mode:
-        build_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        build_command.tools.console.verbosity = LogLevel.DEEP_DEBUG
     # Create mock environment with `key`, which we expect to be preserved, and
     # `ANDROID_SDK_ROOT`, which we expect to be overwritten.
     build_command.tools.os.environ = {"ANDROID_SDK_ROOT": "somewhere", "key": "value"}
@@ -139,7 +138,7 @@ def test_build_app_test_mode(
     build_command.tools.host_os = host_os
     # Enable verbose tool logging
     if debug_mode:
-        build_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        build_command.tools.console.verbosity = LogLevel.DEEP_DEBUG
     # Create mock environment with `key`, which we expect to be preserved, and
     # `ANDROID_SDK_ROOT`, which we expect to be overwritten.
     build_command.tools.os.environ = {"ANDROID_SDK_ROOT": "somewhere", "key": "value"}

--- a/tests/platforms/android/gradle/test_create.py
+++ b/tests/platforms/android/gradle/test_create.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.platforms.android.gradle import GradleCreateCommand
 
@@ -11,7 +11,6 @@ from briefcase.platforms.android.gradle import GradleCreateCommand
 @pytest.fixture
 def create_command(tmp_path, first_app_config):
     command = GradleCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/android/gradle/test_open.py
+++ b/tests/platforms/android/gradle/test_open.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.android_sdk import AndroidSDK
 from briefcase.integrations.file import File
@@ -32,7 +32,6 @@ def create_sdk_manager(tmp_path, extension=""):
 @pytest.fixture
 def open_command(tmp_path, first_app_config):
     command = GradleOpenCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/android/gradle/test_package__aab.py
+++ b/tests/platforms/android/gradle/test_package__aab.py
@@ -67,7 +67,7 @@ def test_execute_gradle(
 
     # Enable verbose tool logging
     if tool_debug_mode:
-        package_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        package_command.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     # Set up a side effect of invoking gradle to create a bundle
     def create_bundle(*args, **kwargs):

--- a/tests/platforms/android/gradle/test_package__apk.py
+++ b/tests/platforms/android/gradle/test_package__apk.py
@@ -68,7 +68,7 @@ def test_execute_gradle(
 
     # Enable verbose tool logging
     if tool_debug_mode:
-        package_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        package_command.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     # Set up a side effect of invoking gradle to create a bundle
     def create_bundle(*args, **kwargs):

--- a/tests/platforms/android/gradle/test_package__debug_apk.py
+++ b/tests/platforms/android/gradle/test_package__debug_apk.py
@@ -68,7 +68,7 @@ def test_execute_gradle(
 
     # Enable verbose tool logging
     if tool_debug_mode:
-        package_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        package_command.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     # Set up a side effect of invoking gradle to create a bundle
     def create_bundle(*args, **kwargs):

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -9,7 +9,7 @@ from unittest import mock
 import httpx
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.android_sdk import ADB, AndroidSDK
 from briefcase.integrations.java import JDK
@@ -32,7 +32,6 @@ def jdk():
 @pytest.fixture
 def run_command(tmp_path, first_app_config, jdk):
     command = GradleRunCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -544,8 +543,8 @@ def test_log_file_extra(run_command, monkeypatch):
     run_command.tools.subprocess.check_output.assert_not_called()
 
     # list_packages() is called when saving the log
-    run_command.tools.logger.save_log = True
-    run_command.tools.logger.save_log_to_file(run_command)
+    run_command.tools.console.save_log = True
+    run_command.tools.console.save_log_to_file(run_command)
 
     sdk_manager = Path(
         f"/path/to/android_sdk/cmdline-tools/{AndroidSDK.SDK_MANAGER_VER}"

--- a/tests/platforms/iOS/xcode/mixin/test_select_target_device.py
+++ b/tests/platforms/iOS/xcode/mixin/test_select_target_device.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from briefcase.commands.base import BaseCommand
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError, InvalidDeviceError
 from briefcase.platforms.iOS.xcode import iOSXcodeMixin
 from tests.utils import DummyConsole
@@ -15,10 +15,9 @@ class DummyCommand(iOSXcodeMixin, BaseCommand):
     command = "dummy"
 
     def __init__(self, base_path, **kwargs):
-        kwargs.setdefault("logger", Log())
         kwargs.setdefault("console", Console())
         super().__init__(base_path=base_path, **kwargs)
-        self.tools.input = DummyConsole()
+        self.tools.console = DummyConsole()
 
 
 @pytest.fixture
@@ -82,7 +81,7 @@ def test_explicit_device_name_should_find_highest_version(dummy_command):
     assert device == "iPhone 8"
 
     # User input was not solicited
-    assert dummy_command.input.prompts == []
+    assert dummy_command.console.prompts == []
 
 
 def test_explicit_device_name_should_find_highest_version_no_os(dummy_command):
@@ -114,7 +113,7 @@ def test_explicit_device_name_should_find_highest_version_no_os(dummy_command):
     assert device == "iPhone 8"
 
     # User input was not solicited
-    assert dummy_command.input.prompts == []
+    assert dummy_command.console.prompts == []
 
 
 def test_explicit_device_name_and_version(dummy_command):
@@ -143,7 +142,7 @@ def test_explicit_device_name_and_version(dummy_command):
     assert device == "iPhone 8"
 
     # User input was not solicited
-    assert dummy_command.input.prompts == []
+    assert dummy_command.console.prompts == []
 
 
 def test_invalid_explicit_device_udid(dummy_command):
@@ -162,7 +161,7 @@ def test_invalid_explicit_device_udid(dummy_command):
         dummy_command.select_target_device("deadbeef-dead-beef-cafe-deadbeefdead")
 
     # User input was not solicited
-    assert dummy_command.input.prompts == []
+    assert dummy_command.console.prompts == []
 
 
 def test_invalid_explicit_device_name(dummy_command):
@@ -181,7 +180,7 @@ def test_invalid_explicit_device_name(dummy_command):
         dummy_command.select_target_device("iphone 99")
 
     # User input was not solicited
-    assert dummy_command.input.prompts == []
+    assert dummy_command.console.prompts == []
 
 
 def test_explicit_name_invalid_version(dummy_command):
@@ -236,7 +235,7 @@ def test_implied_device(dummy_command):
     assert device == "iPhone 11"
 
     # No user input was solicited
-    assert dummy_command.input.prompts == []
+    assert dummy_command.console.prompts == []
 
 
 def test_implied_os(dummy_command):
@@ -251,7 +250,7 @@ def test_implied_os(dummy_command):
     }
 
     # Return option 2 (iPhone 11)
-    dummy_command.input.values = ["2"]
+    dummy_command.console.values = ["2"]
 
     udid, iOS_version, device = dummy_command.select_target_device()
 
@@ -260,7 +259,7 @@ def test_implied_os(dummy_command):
     assert device == "iPhone 11"
 
     # User input was solicited once
-    assert dummy_command.input.prompts == ["Simulator: "]
+    assert dummy_command.console.prompts == ["Simulator: "]
 
 
 def test_multiple_os_implied_device(dummy_command):
@@ -279,7 +278,7 @@ def test_multiple_os_implied_device(dummy_command):
     }
 
     # Return option 1 (13.2)
-    dummy_command.input.values = ["2"]
+    dummy_command.console.values = ["2"]
 
     # Device for iOS 13.2 is implied.
     udid, iOS_version, device = dummy_command.select_target_device()
@@ -289,7 +288,7 @@ def test_multiple_os_implied_device(dummy_command):
     assert device == "iPhone 11"
 
     # User input was solicited once
-    assert dummy_command.input.prompts == ["iOS Version: "]
+    assert dummy_command.console.prompts == ["iOS Version: "]
 
 
 def test_os_and_device_options(dummy_command):
@@ -309,7 +308,7 @@ def test_os_and_device_options(dummy_command):
     }
 
     # Return option 2 (13.2), then option 1 (iPhone 8)
-    dummy_command.input.values = ["2", "1"]
+    dummy_command.console.values = ["2", "1"]
 
     udid, iOS_version, device = dummy_command.select_target_device()
 
@@ -318,7 +317,7 @@ def test_os_and_device_options(dummy_command):
     assert device == "iPhone 8"
 
     # User input was solicited twice
-    assert dummy_command.input.prompts == ["iOS Version: ", "Simulator: "]
+    assert dummy_command.console.prompts == ["iOS Version: ", "Simulator: "]
 
 
 def test_no_os_versions(dummy_command):

--- a/tests/platforms/iOS/xcode/test_build.py
+++ b/tests/platforms/iOS/xcode/test_build.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log, LogLevel
+from briefcase.console import Console, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.iOS.xcode import iOSXcodeBuildCommand
@@ -13,7 +13,6 @@ from briefcase.platforms.iOS.xcode import iOSXcodeBuildCommand
 @pytest.fixture
 def build_command(tmp_path):
     return iOSXcodeBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -30,7 +29,7 @@ def test_build_app(build_command, first_app_generated, tool_debug_mode, tmp_path
 
     # Enable verbose tool logging
     if tool_debug_mode:
-        build_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        build_command.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     build_command.build_app(first_app_generated)
 

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.iOS.xcode import iOSXcodeCreateCommand
@@ -12,7 +12,6 @@ from briefcase.platforms.iOS.xcode import iOSXcodeCreateCommand
 @pytest.fixture
 def create_command(tmp_path):
     return iOSXcodeCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/iOS/xcode/test_mixin.py
+++ b/tests/platforms/iOS/xcode/test_mixin.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import briefcase.integrations.xcode
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import NoDistributionArtefact
 from briefcase.platforms.iOS.xcode import iOSXcodeCreateCommand
 
@@ -11,7 +11,6 @@ from briefcase.platforms.iOS.xcode import iOSXcodeCreateCommand
 @pytest.fixture
 def create_command(tmp_path):
     return iOSXcodeCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/iOS/xcode/test_open.py
+++ b/tests/platforms/iOS/xcode/test_open.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.iOS.xcode import iOSXcodeOpenCommand
 
@@ -15,7 +15,6 @@ from ....utils import create_file
 @pytest.fixture
 def open_command(tmp_path, first_app_config):
     command = iOSXcodeOpenCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/iOS/xcode/test_package.py
+++ b/tests/platforms/iOS/xcode/test_package.py
@@ -1,13 +1,12 @@
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.platforms.iOS.xcode import iOSXcodePackageCommand
 
 
 @pytest.fixture
 def package_command(tmp_path, first_app_config):
     command = iOSXcodePackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/iOS/xcode/test_run.py
+++ b/tests/platforms/iOS/xcode/test_run.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.integrations.xcode import DeviceState
@@ -15,7 +15,6 @@ from briefcase.platforms.macOS import macOS_log_clean_filter
 @pytest.fixture
 def run_command(tmp_path):
     command = iOSXcodeRunCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -67,7 +66,7 @@ def test_run_multiple_devices_input_disabled(run_command, first_app_config):
     )
 
     # Disable console input.
-    run_command.tools.input.enabled = False
+    run_command.tools.console.input_enabled = False
 
     with pytest.raises(
         BriefcaseCommandError,

--- a/tests/platforms/iOS/xcode/test_update.py
+++ b/tests/platforms/iOS/xcode/test_update.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.iOS.xcode import iOSXcodeUpdateCommand
 
@@ -11,7 +11,6 @@ from briefcase.platforms.iOS.xcode import iOSXcodeUpdateCommand
 @pytest.fixture
 def update_command(tmp_path):
     return iOSXcodeUpdateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/appimage/test_build.py
+++ b/tests/platforms/linux/appimage/test_build.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 import tomli_w
 
-from briefcase.console import Console, Log, LogLevel
+from briefcase.console import Console, LogLevel
 from briefcase.exceptions import (
     BriefcaseCommandError,
     NetworkFailure,
@@ -41,7 +41,6 @@ def first_app(first_app_config, tmp_path):
 @pytest.fixture
 def build_command(tmp_path, first_app_config):
     command = LinuxAppImageBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -142,7 +141,7 @@ def test_build_appimage(build_command, first_app, debug_mode, tmp_path, sub_stre
     """A Linux app can be packaged as an AppImage."""
     # Enable verbose tool logging
     if debug_mode:
-        build_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        build_command.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     build_command.verify_app_tools(first_app)
     build_command.build_app(first_app)

--- a/tests/platforms/linux/appimage/test_create.py
+++ b/tests/platforms/linux/appimage/test_create.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseConfigError, UnsupportedHostError
 from briefcase.platforms.linux.appimage import LinuxAppImageCreateCommand
 
@@ -10,7 +10,6 @@ from briefcase.platforms.linux.appimage import LinuxAppImageCreateCommand
 @pytest.fixture
 def create_command(first_app_config, tmp_path):
     command = LinuxAppImageCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/appimage/test_mixin.py
+++ b/tests/platforms/linux/appimage/test_mixin.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import briefcase.platforms.linux.appimage
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.docker import Docker, DockerAppContext
 from briefcase.integrations.linuxdeploy import LinuxDeploy
 from briefcase.integrations.subprocess import Subprocess
@@ -17,7 +17,6 @@ from briefcase.platforms.linux.appimage import (
 @pytest.fixture
 def create_command(tmp_path):
     command = LinuxAppImageCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -232,7 +231,6 @@ def test_verify_non_linux_docker(
 def test_clone_options(tmp_path):
     """Docker options are cloned."""
     build_command = LinuxAppImageBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/appimage/test_package.py
+++ b/tests/platforms/linux/appimage/test_package.py
@@ -1,6 +1,6 @@
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.platforms.linux.appimage import LinuxAppImagePackageCommand
 
 from ....utils import create_file
@@ -9,7 +9,6 @@ from ....utils import create_file
 @pytest.fixture
 def package_command(tmp_path, first_app_config):
     command = LinuxAppImagePackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/appimage/test_run.py
+++ b/tests/platforms/linux/appimage/test_run.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log, LogLevel
+from briefcase.console import Console, LogLevel
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.linux.appimage import LinuxAppImageRunCommand
@@ -12,7 +12,6 @@ from briefcase.platforms.linux.appimage import LinuxAppImageRunCommand
 @pytest.fixture
 def run_command(tmp_path):
     command = LinuxAppImageRunCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -75,7 +74,7 @@ def test_run_gui_app(run_command, first_app_config, tmp_path):
 
 def test_run_gui_app_with_passthrough(run_command, first_app_config, tmp_path):
     """A linux GUI App can be started in debug mode with args."""
-    run_command.logger.verbosity = LogLevel.DEBUG
+    run_command.console.verbosity = LogLevel.DEBUG
 
     # Set up the log streamer to return a known stream
     log_popen = mock.MagicMock()
@@ -159,7 +158,7 @@ def test_run_console_app(run_command, first_app_config, tmp_path):
 
 def test_run_console_app_with_passthrough(run_command, first_app_config, tmp_path):
     """A linux console App can be started in debug mode with args."""
-    run_command.logger.verbosity = LogLevel.DEBUG
+    run_command.console.verbosity = LogLevel.DEBUG
 
     first_app_config.console_app = True
 

--- a/tests/platforms/linux/flatpak/test_build.py
+++ b/tests/platforms/linux/flatpak/test_build.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseConfigError
 from briefcase.integrations.flatpak import Flatpak
 from briefcase.platforms.linux.flatpak import LinuxFlatpakBuildCommand
@@ -11,7 +11,6 @@ from briefcase.platforms.linux.flatpak import LinuxFlatpakBuildCommand
 @pytest.fixture
 def build_command(tmp_path):
     return LinuxFlatpakBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/flatpak/test_create.py
+++ b/tests/platforms/linux/flatpak/test_create.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseConfigError, UnsupportedHostError
 from briefcase.integrations.flatpak import Flatpak
 from briefcase.platforms.linux.flatpak import LinuxFlatpakCreateCommand
@@ -11,7 +11,6 @@ from briefcase.platforms.linux.flatpak import LinuxFlatpakCreateCommand
 @pytest.fixture
 def create_command(tmp_path):
     return LinuxFlatpakCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/flatpak/test_mixin.py
+++ b/tests/platforms/linux/flatpak/test_mixin.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import briefcase.platforms.linux.flatpak
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseConfigError
 from briefcase.integrations.flatpak import Flatpak
 from briefcase.integrations.subprocess import Subprocess
@@ -13,7 +13,6 @@ from briefcase.platforms.linux.flatpak import LinuxFlatpakCreateCommand
 @pytest.fixture
 def create_command(tmp_path):
     return LinuxFlatpakCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/flatpak/test_open.py
+++ b/tests/platforms/linux/flatpak/test_open.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.linux.flatpak import LinuxFlatpakOpenCommand
 
@@ -14,7 +14,6 @@ from ....utils import create_file
 @pytest.fixture
 def open_command(tmp_path, first_app_config):
     command = LinuxFlatpakOpenCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/flatpak/test_package.py
+++ b/tests/platforms/linux/flatpak/test_package.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.flatpak import Flatpak
 from briefcase.platforms.linux.flatpak import LinuxFlatpakPackageCommand
 
@@ -10,7 +10,6 @@ from briefcase.platforms.linux.flatpak import LinuxFlatpakPackageCommand
 @pytest.fixture
 def package_command(tmp_path):
     return LinuxFlatpakPackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/flatpak/test_run.py
+++ b/tests/platforms/linux/flatpak/test_run.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log, LogLevel
+from briefcase.console import Console, LogLevel
 from briefcase.integrations.flatpak import Flatpak
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.linux.flatpak import LinuxFlatpakRunCommand
@@ -11,7 +11,6 @@ from briefcase.platforms.linux.flatpak import LinuxFlatpakRunCommand
 @pytest.fixture
 def run_command(tmp_path):
     command = LinuxFlatpakRunCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -51,7 +50,7 @@ def test_run_gui_app(run_command, first_app_config):
 
 def test_run_gui_app_with_passthrough(run_command, first_app_config):
     """A GUI flatpak can be executed in debug mode with args."""
-    run_command.logger.verbosity = LogLevel.DEBUG
+    run_command.console.verbosity = LogLevel.DEBUG
 
     # Set up the log streamer to return a known stream and a good return code
     log_popen = mock.MagicMock()
@@ -118,7 +117,7 @@ def test_run_console_app(run_command, first_app_config):
 
 def test_run_console_app_with_passthrough(run_command, first_app_config):
     """A console flatpak can be executed in debug mode with args."""
-    run_command.logger.verbosity = LogLevel.DEBUG
+    run_command.console.verbosity = LogLevel.DEBUG
     first_app_config.console_app = True
 
     # Run the app with args

--- a/tests/platforms/linux/system/conftest.py
+++ b/tests/platforms/linux/system/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.platforms.linux.system import LinuxSystemCreateCommand
 
 from ....utils import create_file
@@ -9,7 +9,6 @@ from ....utils import create_file
 @pytest.fixture
 def create_command(tmp_path):
     return LinuxSystemCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/system/test_build.py
+++ b/tests/platforms/linux/system/test_build.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux.system import LinuxSystemBuildCommand
 
@@ -16,7 +16,6 @@ from ....utils import create_file
 @pytest.fixture
 def build_command(tmp_path, first_app):
     command = LinuxSystemBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -176,12 +175,12 @@ def test_license_text_warns_with_single_line_license(build_command, first_app):
     """A warning is logged if the license text is a single line."""
 
     first_app.license = {"text": "Some license text"}
-    build_command.logger.warning = mock.MagicMock()
+    build_command.console.warning = mock.MagicMock()
 
     # Build the app
     build_command.build_app(first_app)
 
-    build_command.logger.warning.assert_called_once_with(
+    build_command.console.warning.assert_called_once_with(
         """
 Your app specifies a license using `license.text`, but the value doesn't appear to be a
 full license. Briefcase will generate a `copyright` file for your project; you should
@@ -194,7 +193,7 @@ def test_exception_with_no_license(build_command, first_app):
     """An exception is raised if there is no license defined."""
 
     first_app.license = {}
-    build_command.logger.warning = mock.MagicMock()
+    build_command.console.warning = mock.MagicMock()
 
     # Build the app
     with pytest.raises(
@@ -209,11 +208,11 @@ def test_license_text_doesnt_warn_with_multi_line_license(
 ):
     """No warning is logged if the license text is multi-line."""
     first_app.license = {"text": "Some license text\nsome more text"}
-    build_command.logger.warning = mock.MagicMock()
+    build_command.console.warning = mock.MagicMock()
 
     # Build the app
     build_command.build_app(first_app)
-    build_command.logger.warning.assert_not_called()
+    build_command.console.warning.assert_not_called()
 
 
 def test_missing_changelog(build_command, first_app, tmp_path):

--- a/tests/platforms/linux/system/test_mixin__finalize_app_config.py
+++ b/tests/platforms/linux/system/test_mixin__finalize_app_config.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux import parse_freedesktop_os_release
 from briefcase.platforms.linux.system import LinuxSystemRunCommand
@@ -499,7 +499,6 @@ def test_properties_no_version(create_command, first_app_config):
 def test_passive_mixin(first_app_config, tmp_path):
     """An app using the PassiveMixin can be finalized."""
     run_command = LinuxSystemRunCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/system/test_mixin__properties.py
+++ b/tests/platforms/linux/system/test_mixin__properties.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux.system import LinuxSystemBuildCommand
 
@@ -164,7 +164,6 @@ def test_docker_image_tag_uppercase_name(
 def test_clone_options(create_command, tmp_path):
     """Docker options are cloned."""
     build_command = LinuxSystemBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/system/test_mixin__verify_python.py
+++ b/tests/platforms/linux/system/test_mixin__verify_python.py
@@ -90,7 +90,7 @@ def test_target_too_old(create_command, first_app_config):
     first_app_config.python_version_tag = "3"
     first_app_config.target_image = "somevendor:surprising"
 
-    create_command.logger.warning = MagicMock()
+    create_command.console.warning = MagicMock()
     create_command.tools[first_app_config].app_context = DockerAppContext(
         tools=create_command.tools,
         app=first_app_config,

--- a/tests/platforms/linux/system/test_mixin__verify_system_packages.py
+++ b/tests/platforms/linux/system/test_mixin__verify_system_packages.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux.system import LinuxSystemBuildCommand
 
@@ -11,7 +11,6 @@ from briefcase.platforms.linux.system import LinuxSystemBuildCommand
 @pytest.fixture
 def build_command(tmp_path, first_app):
     command = LinuxSystemBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/system/test_package.py
+++ b/tests/platforms/linux/system/test_package.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.linux.system import LinuxSystemPackageCommand
@@ -12,7 +12,6 @@ from briefcase.platforms.linux.system import LinuxSystemPackageCommand
 @pytest.fixture
 def package_command(monkeypatch, first_app, tmp_path):
     command = LinuxSystemPackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/system/test_package__deb.py
+++ b/tests/platforms/linux/system/test_package__deb.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux import system
 from briefcase.platforms.linux.system import (
@@ -20,7 +20,6 @@ from ....utils import create_file
 @pytest.fixture
 def package_command(first_app, tmp_path):
     command = LinuxSystemPackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/system/test_package__pkg.py
+++ b/tests/platforms/linux/system/test_package__pkg.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux import system
 from briefcase.platforms.linux.system import LinuxSystemPackageCommand
@@ -18,7 +18,6 @@ from ....utils import create_file, create_tgz_file
 @pytest.fixture
 def package_command(first_app, tmp_path):
     command = LinuxSystemPackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/system/test_package__rpm.py
+++ b/tests/platforms/linux/system/test_package__rpm.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.linux import system
 from briefcase.platforms.linux.system import LinuxSystemPackageCommand
@@ -18,7 +18,6 @@ from ....utils import create_file, create_tgz_file
 @pytest.fixture
 def package_command(first_app, tmp_path):
     command = LinuxSystemPackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/system/test_run.py
+++ b/tests/platforms/linux/system/test_run.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log, LogLevel
+from briefcase.console import Console, LogLevel
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.integrations.docker import Docker
 from briefcase.integrations.subprocess import Subprocess
@@ -19,7 +19,6 @@ from ....utils import create_file
 @pytest.fixture
 def run_command(tmp_path, first_app, monkeypatch):
     command = LinuxSystemRunCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -274,7 +273,7 @@ def test_run_gui_app(run_command, first_app, sub_kw, tmp_path):
 
 def test_run_gui_app_passthrough(run_command, first_app, sub_kw, tmp_path):
     """A bootstrap binary for a GUI app can be started in debug mode with arguments."""
-    run_command.logger.verbosity = LogLevel.DEBUG
+    run_command.console.verbosity = LogLevel.DEBUG
 
     # Set up tool cache
     run_command.verify_app_tools(app=first_app)
@@ -378,7 +377,7 @@ def test_run_console_app(run_command, first_app, tmp_path):
 
 def test_run_console_app_passthrough(run_command, first_app, tmp_path):
     """A console app can be started in debug mode with command line arguments."""
-    run_command.logger.verbosity = LogLevel.DEBUG
+    run_command.console.verbosity = LogLevel.DEBUG
 
     first_app.console_app = True
 

--- a/tests/platforms/linux/test_DockerOpenCommand.py
+++ b/tests/platforms/linux/test_DockerOpenCommand.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.docker import Docker, DockerAppContext
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.linux.appimage import LinuxAppImageOpenCommand
@@ -15,7 +15,6 @@ from ...utils import create_file
 @pytest.fixture
 def open_command(tmp_path):
     command = LinuxAppImageOpenCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/linux/test_LocalRequirementsMixin.py
+++ b/tests/platforms/linux/test_LocalRequirementsMixin.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, call
 import pytest
 
 from briefcase.commands import CreateCommand
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.docker import Docker, DockerAppContext
 from briefcase.integrations.subprocess import Subprocess
@@ -29,7 +29,6 @@ class DummyCreateCommand(LocalRequirementsMixin, CreateCommand):
 @pytest.fixture
 def no_docker_create_command(first_app_config, tmp_path):
     command = DummyCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/macOS/app/package/conftest.py
+++ b/tests/platforms/macOS/app/package/conftest.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS.app import macOSAppPackageCommand
 
@@ -10,7 +10,6 @@ from briefcase.platforms.macOS.app import macOSAppPackageCommand
 @pytest.fixture
 def package_command(tmp_path):
     command = macOSAppPackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/macOS/app/package/test_notarize.py
+++ b/tests/platforms/macOS/app/package/test_notarize.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError, NotarizationInterrupted
 from briefcase.integrations.subprocess import Subprocess, json_parser
 from briefcase.platforms.macOS.app import macOSAppPackageCommand
@@ -15,7 +15,6 @@ from briefcase.platforms.macOS.app import macOSAppPackageCommand
 @pytest.fixture
 def package_command(tmp_path):
     command = macOSAppPackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -696,7 +695,7 @@ def test_credential_storage_disabled_input_app(
     ]
 
     # Disable console input
-    package_command.tools.input.enabled = False
+    package_command.tools.console.input_enabled = False
 
     # The notarization call will fail with an error
     with pytest.raises(
@@ -760,7 +759,7 @@ def test_credential_storage_disabled_input_dmg(
     ]
 
     # Disable console input
-    package_command.tools.input.enabled = False
+    package_command.tools.console.input_enabled = False
 
     # The notarization call will fail with an error
     with pytest.raises(

--- a/tests/platforms/macOS/app/test_build.py
+++ b/tests/platforms/macOS/app/test_build.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.platforms.macOS import SigningIdentity
 from briefcase.platforms.macOS.app import macOSAppBuildCommand
 
@@ -10,7 +10,6 @@ from briefcase.platforms.macOS.app import macOSAppBuildCommand
 @pytest.fixture
 def build_command(tmp_path):
     command = macOSAppBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/macOS/app/test_create.py
+++ b/tests/platforms/macOS/app/test_create.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS.app import macOSAppCreateCommand
@@ -17,7 +17,6 @@ from ....utils import create_file, create_installed_package, mock_tgz_download
 @pytest.fixture
 def create_command(tmp_path, first_app_templated):
     command = macOSAppCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/macOS/app/test_mixin.py
+++ b/tests/platforms/macOS/app/test_mixin.py
@@ -1,6 +1,6 @@
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.platforms.macOS.app import macOSAppCreateCommand, macOSAppPackageCommand
 
@@ -8,7 +8,6 @@ from briefcase.platforms.macOS.app import macOSAppCreateCommand, macOSAppPackage
 @pytest.fixture
 def create_command(tmp_path):
     return macOSAppCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -18,7 +17,6 @@ def create_command(tmp_path):
 @pytest.fixture
 def package_command(tmp_path):
     return macOSAppPackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/macOS/app/test_open.py
+++ b/tests/platforms/macOS/app/test_open.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS.app import macOSAppOpenCommand
 
@@ -14,7 +14,6 @@ from ....utils import create_file
 @pytest.fixture
 def open_command(tmp_path, first_app_config):
     command = macOSAppOpenCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/macOS/app/test_run.py
+++ b/tests/platforms/macOS/app/test_run.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log, LogLevel
+from briefcase.console import Console, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS import macOS_log_clean_filter
@@ -14,7 +14,6 @@ from briefcase.platforms.macOS.app import macOSAppRunCommand
 @pytest.fixture
 def run_command(tmp_path):
     command = macOSAppRunCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -94,7 +93,7 @@ def test_run_gui_app_with_passthrough(
     monkeypatch,
 ):
     """A macOS app can be started in debug mode with args."""
-    run_command.logger.verbosity = LogLevel.DEBUG
+    run_command.console.verbosity = LogLevel.DEBUG
 
     # Mock a popen object that represents the log stream
     log_stream_process = mock.MagicMock(spec_set=subprocess.Popen)
@@ -327,7 +326,7 @@ def test_run_console_app_with_passthrough(
     tmp_path,
 ):
     """A macOS console app can be started in debug mode with args."""
-    run_command.logger.verbosity = LogLevel.DEBUG
+    run_command.console.verbosity = LogLevel.DEBUG
 
     # Set the app to be a console app
     first_app_config.console_app = True
@@ -390,7 +389,7 @@ def test_run_console_app_test_mode_with_passthrough(
 ):
     """A macOS console app can be started in test mode with parameters and debug
     mode."""
-    run_command.logger.verbosity = LogLevel.DEBUG
+    run_command.console.verbosity = LogLevel.DEBUG
 
     first_app_config.console_app = True
 

--- a/tests/platforms/macOS/conftest.py
+++ b/tests/platforms/macOS/conftest.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from briefcase.commands.base import BaseCommand
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS.app import macOSAppMixin, macOSCreateMixin
 from tests.utils import DummyConsole
@@ -15,10 +15,9 @@ class DummyInstallCommand(macOSAppMixin, macOSCreateMixin, BaseCommand):
     command = "install"
 
     def __init__(self, base_path, **kwargs):
-        kwargs.setdefault("logger", Log())
         kwargs.setdefault("console", Console())
         super().__init__(base_path=base_path / "base_path", **kwargs)
-        self.tools.input = DummyConsole()
+        self.tools.console = DummyConsole()
 
 
 @pytest.fixture

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__ensure_thin_binary.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__ensure_thin_binary.py
@@ -12,7 +12,7 @@ from ...utils import create_file, file_content
 def test_thin_binary(dummy_command, verbose, tmp_path, capsys):
     """A thin binary is left as-is."""
     if verbose:
-        dummy_command.logger.verbosity = LogLevel.VERBOSE
+        dummy_command.console.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
     create_file(tmp_path / "path/to/file.dylib", "dylib-original")
@@ -52,7 +52,7 @@ def test_thin_binary(dummy_command, verbose, tmp_path, capsys):
 def test_fat_dylib(dummy_command, verbose, tmp_path, capsys):
     """A fat binary library can be thinned."""
     if verbose:
-        dummy_command.logger.verbosity = LogLevel.VERBOSE
+        dummy_command.console.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
     create_file(tmp_path / "path/to/file.dylib", "dylib-fat")
@@ -108,7 +108,7 @@ def test_fat_dylib(dummy_command, verbose, tmp_path, capsys):
 def test_fat_dylib_arch_mismatch(dummy_command, verbose, tmp_path, capsys):
     """If a fat binary doesn't contain the target architecture, an error is raised."""
     if verbose:
-        dummy_command.logger.verbosity = LogLevel.VERBOSE
+        dummy_command.console.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
     create_file(tmp_path / "path/to/file.dylib", "dylib-fat")
@@ -146,7 +146,7 @@ def test_fat_dylib_unknown_info(dummy_command, verbose, tmp_path, capsys):
     """If the lipo info call succeeds, but generates unknown output, an error is
     raised."""
     if verbose:
-        dummy_command.logger.verbosity = LogLevel.VERBOSE
+        dummy_command.console.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
     create_file(tmp_path / "path/to/file.dylib", "dylib-fat")
@@ -215,7 +215,7 @@ def test_lipo_info_fail(dummy_command, tmp_path):
 def test_lipo_thin_fail(dummy_command, verbose, tmp_path, capsys):
     """If lipo fails thinning the binary, an error is raised."""
     if verbose:
-        dummy_command.logger.verbosity = LogLevel.VERBOSE
+        dummy_command.console.verbosity = LogLevel.VERBOSE
 
     # Create a source binary.
     create_file(tmp_path / "path/to/file.dylib", "dylib-fat")

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__lipo_dylib.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__lipo_dylib.py
@@ -13,7 +13,7 @@ from ...utils import create_file
 def test_lipo_dylib(dummy_command, verbose, tmp_path, capsys):
     """A binary library can be merged with lipo."""
     if verbose:
-        dummy_command.logger.verbosity = LogLevel.VERBOSE
+        dummy_command.console.verbosity = LogLevel.VERBOSE
 
     # Create 3 source binaries.
     create_file(tmp_path / "source-1/path/to/file.dylib", "dylib-1")
@@ -57,7 +57,7 @@ def test_lipo_dylib(dummy_command, verbose, tmp_path, capsys):
 def test_lipo_dylib_partial(dummy_command, verbose, tmp_path, capsys):
     """If a source doesn't have the library, it isn't included in the merge."""
     if verbose:
-        dummy_command.logger.verbosity = LogLevel.VERBOSE
+        dummy_command.console.verbosity = LogLevel.VERBOSE
 
     # Create 2 source binaries. Source-2 doesn't have the binary.
     create_file(tmp_path / "source-1/path/to/file.dylib", "dylib-1")
@@ -98,7 +98,7 @@ def test_lipo_dylib_partial(dummy_command, verbose, tmp_path, capsys):
 def test_lipo_dylib_merge_error(dummy_command, verbose, tmp_path, capsys):
     """If the merge process fails, an exception is raised."""
     if verbose:
-        dummy_command.logger.verbosity = LogLevel.VERBOSE
+        dummy_command.console.verbosity = LogLevel.VERBOSE
 
     # Create 3 source binaries.
     create_file(tmp_path / "source-1/path/to/file.dylib", "dylib-1")

--- a/tests/platforms/macOS/xcode/test_build.py
+++ b/tests/platforms/macOS/xcode/test_build.py
@@ -3,7 +3,7 @@ from unittest.mock import ANY, MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log, LogLevel
+from briefcase.console import Console, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS.xcode import macOSXcodeBuildCommand
@@ -12,7 +12,6 @@ from briefcase.platforms.macOS.xcode import macOSXcodeBuildCommand
 @pytest.fixture
 def build_command(tmp_path):
     return macOSXcodeBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -24,7 +23,7 @@ def test_build_app(build_command, first_app_generated, tool_debug_mode, tmp_path
     """An macOS App can be built."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        build_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        build_command.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     build_command.tools.subprocess = MagicMock(spec_set=Subprocess)
     build_command.build_app(first_app_generated, test_mode=False)

--- a/tests/platforms/macOS/xcode/test_mixin.py
+++ b/tests/platforms/macOS/xcode/test_mixin.py
@@ -1,6 +1,6 @@
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.platforms.macOS.xcode import macOSXcodeCreateCommand
 
@@ -8,7 +8,6 @@ from briefcase.platforms.macOS.xcode import macOSXcodeCreateCommand
 @pytest.fixture
 def create_command(tmp_path):
     return macOSXcodeCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/macOS/xcode/test_open.py
+++ b/tests/platforms/macOS/xcode/test_open.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS.xcode import macOSXcodeOpenCommand
 
@@ -15,7 +15,6 @@ from ....utils import create_file
 @pytest.fixture
 def open_command(tmp_path, first_app_config):
     command = macOSXcodeOpenCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/macOS/xcode/test_package.py
+++ b/tests/platforms/macOS/xcode/test_package.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 import briefcase.integrations.xcode
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.platforms.macOS.xcode import macOSXcodePackageCommand
 
 # skip most tests since packaging uses the same code as app command
@@ -12,7 +12,6 @@ from briefcase.platforms.macOS.xcode import macOSXcodePackageCommand
 @pytest.fixture
 def package_command(tmp_path):
     command = macOSXcodePackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/macOS/xcode/test_run.py
+++ b/tests/platforms/macOS/xcode/test_run.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.macOS import macOS_log_clean_filter
 from briefcase.platforms.macOS.xcode import macOSXcodeRunCommand
@@ -16,7 +16,6 @@ from briefcase.platforms.macOS.xcode import macOSXcodeRunCommand
 @pytest.fixture
 def run_command(tmp_path):
     command = macOSXcodeRunCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/web/static/test_build.py
+++ b/tests/platforms/web/static/test_build.py
@@ -10,7 +10,7 @@ else:  # pragma: no-cover-if-gte-py311
 
 import pytest
 
-from briefcase.console import Console, Log, LogLevel
+from briefcase.console import Console, LogLevel
 from briefcase.exceptions import BriefcaseCommandError, BriefcaseConfigError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.web.static import StaticWebBuildCommand
@@ -21,7 +21,6 @@ from ....utils import create_file, create_wheel
 @pytest.fixture
 def build_command(tmp_path):
     command = StaticWebBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -36,7 +35,7 @@ def build_command(tmp_path):
 def test_build_app(build_command, first_app_generated, logging_level, tmp_path):
     """An app can be built."""
     # Configure logging level
-    build_command.logger.verbosity = logging_level
+    build_command.console.verbosity = logging_level
 
     bundle_path = tmp_path / "base_path/build/first-app/web/static"
 

--- a/tests/platforms/web/static/test_build__process_wheel.py
+++ b/tests/platforms/web/static/test_build__process_wheel.py
@@ -2,7 +2,7 @@ from io import StringIO
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.platforms.web.static import StaticWebBuildCommand
 
 from ....utils import create_wheel
@@ -11,7 +11,6 @@ from ....utils import create_wheel
 @pytest.fixture
 def build_command(tmp_path):
     return StaticWebBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/web/static/test_build__trim_file.py
+++ b/tests/platforms/web/static/test_build__trim_file.py
@@ -1,6 +1,6 @@
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.platforms.web.static import StaticWebBuildCommand
 
 from ....utils import create_file
@@ -9,7 +9,6 @@ from ....utils import create_file
 @pytest.fixture
 def build_command(tmp_path):
     return StaticWebBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/web/static/test_create.py
+++ b/tests/platforms/web/static/test_create.py
@@ -1,6 +1,6 @@
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.platforms.web.static import StaticWebCreateCommand
 
@@ -8,7 +8,6 @@ from briefcase.platforms.web.static import StaticWebCreateCommand
 @pytest.fixture
 def create_command(tmp_path):
     return StaticWebCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/web/static/test_mixin.py
+++ b/tests/platforms/web/static/test_mixin.py
@@ -1,13 +1,12 @@
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.platforms.web.static import StaticWebCreateCommand
 
 
 @pytest.fixture
 def create_command(tmp_path):
     return StaticWebCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/web/static/test_package.py
+++ b/tests/platforms/web/static/test_package.py
@@ -2,14 +2,13 @@ from zipfile import ZipFile
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.platforms.web.static import StaticWebPackageCommand
 
 
 @pytest.fixture
 def package_command(tmp_path):
     command = StaticWebPackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/web/static/test_run.py
+++ b/tests/platforms/web/static/test_run.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.platforms.web.static import (
     HTTPHandler,
@@ -25,7 +25,6 @@ class ErrnoError(OSError):
 @pytest.fixture
 def run_command(tmp_path):
     command = StaticWebRunCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/windows/app/test_build.py
+++ b/tests/platforms/windows/app/test_build.py
@@ -8,7 +8,7 @@ import pytest
 import tomli_w
 
 import briefcase.platforms.windows.app
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.rcedit import RCEdit
 from briefcase.integrations.subprocess import Subprocess
@@ -21,7 +21,6 @@ from ....utils import create_file
 @pytest.fixture
 def build_command(tmp_path):
     command = WindowsAppBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/windows/app/test_create.py
+++ b/tests/platforms/windows/app/test_create.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.platforms.windows.app import WindowsAppCreateCommand
 
@@ -10,7 +10,6 @@ from briefcase.platforms.windows.app import WindowsAppCreateCommand
 @pytest.fixture
 def create_command(tmp_path):
     return WindowsAppCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/windows/app/test_mixin.py
+++ b/tests/platforms/windows/app/test_mixin.py
@@ -1,13 +1,12 @@
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.platforms.windows.app import WindowsAppCreateCommand
 
 
 @pytest.fixture
 def create_command(tmp_path):
     return WindowsAppCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/windows/app/test_open.py
+++ b/tests/platforms/windows/app/test_open.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.windows.app import WindowsAppOpenCommand
 
@@ -12,7 +12,6 @@ from briefcase.platforms.windows.app import WindowsAppOpenCommand
 @pytest.fixture
 def open_command(tmp_path, first_app_config):
     command = WindowsAppOpenCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/windows/app/test_package.py
+++ b/tests/platforms/windows/app/test_package.py
@@ -6,7 +6,7 @@ from zipfile import ZipFile
 import pytest
 
 import briefcase.platforms.windows
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.integrations.windows_sdk import WindowsSDK
@@ -19,7 +19,6 @@ from ....utils import create_file
 @pytest.fixture
 def package_command(tmp_path):
     command = WindowsAppPackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/windows/app/test_run.py
+++ b/tests/platforms/windows/app/test_run.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log, LogLevel
+from briefcase.console import Console, LogLevel
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.windows.app import WindowsAppRunCommand
 
@@ -11,7 +11,6 @@ from briefcase.platforms.windows.app import WindowsAppRunCommand
 @pytest.fixture
 def run_command(tmp_path):
     command = WindowsAppRunCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -54,7 +53,7 @@ def test_run_gui_app(run_command, first_app_config, tmp_path):
 
 def test_run_gui_app_with_passthrough(run_command, first_app_config, tmp_path):
     """A Windows GUI app can be started in debug mode with args."""
-    run_command.logger.verbosity = LogLevel.DEBUG
+    run_command.console.verbosity = LogLevel.DEBUG
 
     # Set up the log streamer to return a known stream
     log_popen = mock.MagicMock()
@@ -139,7 +138,7 @@ def test_run_console_app(run_command, first_app_config, tmp_path):
 
 def test_run_console_app_with_passthrough(run_command, first_app_config, tmp_path):
     """A Windows console app can be started in debug mode with args."""
-    run_command.logger.verbosity = LogLevel.DEBUG
+    run_command.console.verbosity = LogLevel.DEBUG
 
     first_app_config.console_app = True
 

--- a/tests/platforms/windows/visualstudio/test_build.py
+++ b/tests/platforms/windows/visualstudio/test_build.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 import briefcase.platforms.windows.visualstudio
-from briefcase.console import Console, Log, LogLevel
+from briefcase.console import Console, LogLevel
 from briefcase.exceptions import BriefcaseCommandError
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.integrations.visualstudio import VisualStudio
@@ -15,7 +15,6 @@ from briefcase.platforms.windows.visualstudio import WindowsVisualStudioBuildCom
 @pytest.fixture
 def build_command(tmp_path):
     command = WindowsVisualStudioBuildCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",
@@ -51,7 +50,7 @@ def test_build_app(build_command, first_app_config, tool_debug_mode, tmp_path):
     """The solution will be compiled when the project is built."""
     # Enable verbose tool logging
     if tool_debug_mode:
-        build_command.tools.logger.verbosity = LogLevel.DEEP_DEBUG
+        build_command.tools.console.verbosity = LogLevel.DEEP_DEBUG
 
     build_command.build_app(first_app_config)
 

--- a/tests/platforms/windows/visualstudio/test_mixin.py
+++ b/tests/platforms/windows/visualstudio/test_mixin.py
@@ -1,6 +1,6 @@
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.exceptions import UnsupportedHostError
 from briefcase.platforms.windows.visualstudio import WindowsVisualStudioCreateCommand
 
@@ -8,7 +8,6 @@ from briefcase.platforms.windows.visualstudio import WindowsVisualStudioCreateCo
 @pytest.fixture
 def create_command(tmp_path):
     return WindowsVisualStudioCreateCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/windows/visualstudio/test_open.py
+++ b/tests/platforms/windows/visualstudio/test_open.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.windows.visualstudio import WindowsVisualStudioOpenCommand
 
@@ -14,7 +14,6 @@ from ....utils import create_file
 @pytest.fixture
 def open_command(tmp_path, first_app_config):
     command = WindowsVisualStudioOpenCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/windows/visualstudio/test_package.py
+++ b/tests/platforms/windows/visualstudio/test_package.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.integrations.wix import WiX
 from briefcase.platforms.windows.visualstudio import WindowsVisualStudioPackageCommand
@@ -16,7 +16,6 @@ from briefcase.platforms.windows.visualstudio import WindowsVisualStudioPackageC
 @pytest.fixture
 def package_command(tmp_path):
     command = WindowsVisualStudioPackageCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/platforms/windows/visualstudio/test_run.py
+++ b/tests/platforms/windows/visualstudio/test_run.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from briefcase.console import Console, Log
+from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.windows.visualstudio import WindowsVisualStudioRunCommand
 
@@ -14,7 +14,6 @@ from briefcase.platforms.windows.visualstudio import WindowsVisualStudioRunComma
 @pytest.fixture
 def run_command(tmp_path):
     command = WindowsVisualStudioRunCommand(
-        logger=Log(),
         console=Console(),
         base_path=tmp_path / "base_path",
         data_path=tmp_path / "briefcase",

--- a/tests/test_mainline.py
+++ b/tests/test_mainline.py
@@ -6,7 +6,7 @@ import pytest
 from briefcase.__main__ import main
 from briefcase.commands.create import CreateCommand
 from briefcase.commands.run import RunCommand
-from briefcase.console import Log
+from briefcase.console import Console
 from briefcase.exceptions import BriefcaseTestSuiteFailure, BriefcaseWarning
 
 from .utils import create_file
@@ -51,7 +51,7 @@ def test_help(monkeypatch, tmp_path, capsys):
     )
 
     # No log file was written
-    assert len(list(tmp_path.glob(f"{Log.LOG_DIR}/briefcase.*.log"))) == 0
+    assert len(list(tmp_path.glob(f"{Console.LOG_DIR}/briefcase.*.log"))) == 0
 
 
 def test_command(monkeypatch, tmp_path, capsys):
@@ -79,7 +79,7 @@ def test_command(monkeypatch, tmp_path, capsys):
     )
 
     # No log file was written
-    assert len(list(tmp_path.glob(f"{Log.LOG_DIR}/briefcase.*.log"))) == 0
+    assert len(list(tmp_path.glob(f"{Console.LOG_DIR}/briefcase.*.log"))) == 0
 
 
 def test_command_warning(monkeypatch, pyproject_toml, tmp_path, capsys):
@@ -106,7 +106,7 @@ def test_command_warning(monkeypatch, pyproject_toml, tmp_path, capsys):
     assert output.endswith("\nThis is bad, but not *really* bad\n")
 
     # Log files are not created for BriefcaseWarnings
-    assert len(list(tmp_path.glob(f"{Log.LOG_DIR}/briefcase.*.create.log"))) == 0
+    assert len(list(tmp_path.glob(f"{Console.LOG_DIR}/briefcase.*.create.log"))) == 0
 
 
 def test_command_error(monkeypatch, tmp_path, capsys):
@@ -126,7 +126,7 @@ def test_command_error(monkeypatch, tmp_path, capsys):
     )
 
     # Log files are not created for BriefcaseConfigError errors
-    assert len(list(tmp_path.glob(f"{Log.LOG_DIR}/briefcase.*.create.log"))) == 0
+    assert len(list(tmp_path.glob(f"{Console.LOG_DIR}/briefcase.*.create.log"))) == 0
 
 
 def test_unknown_command_error(monkeypatch, pyproject_toml, capsys):
@@ -165,7 +165,7 @@ def test_interrupted_command(monkeypatch, pyproject_toml, tmp_path, capsys):
     assert "\nAborted by user.\n" in output
 
     # No log file was written
-    assert len(list(tmp_path.glob(f"{Log.LOG_DIR}/briefcase.*.create.log"))) == 0
+    assert len(list(tmp_path.glob(f"{Console.LOG_DIR}/briefcase.*.create.log"))) == 0
 
 
 def test_interrupted_command_with_log(monkeypatch, pyproject_toml, tmp_path, capsys):
@@ -187,7 +187,7 @@ def test_interrupted_command_with_log(monkeypatch, pyproject_toml, tmp_path, cap
     assert "\nAborted by user.\n" in output
 
     # A log file was written
-    assert len(list(tmp_path.glob(f"{Log.LOG_DIR}/briefcase.*.create.log"))) == 1
+    assert len(list(tmp_path.glob(f"{Console.LOG_DIR}/briefcase.*.create.log"))) == 1
 
 
 def test_test_failure(monkeypatch, pyproject_toml, tmp_path, capsys):
@@ -208,4 +208,4 @@ def test_test_failure(monkeypatch, pyproject_toml, tmp_path, capsys):
     assert output == ""
 
     # Log files are not created for BriefcaseTestSuiteFailures
-    assert len(list(tmp_path.glob(f"{Log.LOG_DIR}/briefcase.*.create.log"))) == 0
+    assert len(list(tmp_path.glob(f"{Console.LOG_DIR}/briefcase.*.create.log"))) == 0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,13 +29,13 @@ class NoMatchString(str):
 
 
 class DummyConsole(Console):
-    def __init__(self, *values, enabled=True):
-        super().__init__(enabled=enabled)
+    def __init__(self, *values, input_enabled=True):
+        super().__init__(input_enabled=input_enabled)
         self.prompts = []
         self.values = list(values)
 
-    def __call__(self, prompt, *args, **kwargs):
-        if not self.enabled:
+    def input(self, prompt, *args, **kwargs):
+        if not self.input_enabled:
             raise InputDisabled()
         self.prompts.append(prompt)
         return self.values.pop(0)


### PR DESCRIPTION
Following the discussion in #2115 - unifies the `Printer`, `Logger` and `Console` classes into a single Console class. 

This allows a single representation of "interaction with the user", capturing both input and output, which also writes to a log file as required. It also cleans up some odd API usage (such as needing to invoke `input.wait_bar()`, and the `__call__` interface on input (it can now be replaced with an `input()` method.

~This PR builds on #2115 to avoid collisions with that work. You could either review, approve and merge this PR by itself; or review and merge #2115, then rebase, review and merge this one.~ UPDATE: PR has now been rebased onto main.

It is, unfortunately, a very large PR... but most of the changes are renames.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
