### PR TITLE
Corrections to bootstrap handling

### DIFF
--- a/changes/2126.misc.rst
+++ b/changes/2126.misc.rst
@@ -1,0 +1,1 @@
+The base path provided to post_generate was corrected to include the app name.

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -560,7 +560,7 @@ class NewCommand(BaseCommand):
         )
 
         # Perform any post-template processing required by the bootstrap.
-        bootstrap.post_generate(base_path=self.base_path)
+        bootstrap.post_generate(base_path=self.base_path / context["app_name"])
 
         self.logger.info(
             f"Generated new application {context['formal_name']!r}",

--- a/tests/commands/new/test_new_app.py
+++ b/tests/commands/new/test_new_app.py
@@ -54,6 +54,7 @@ def test_new_app(
     }
     new_command.build_app_context = mock.MagicMock(return_value=app_context)
     bootstrap = BaseGuiBootstrap(new_command.logger, new_command.input, {})
+    bootstrap.post_generate = mock.MagicMock()
     new_command.create_bootstrap = mock.MagicMock(return_value=bootstrap)
     new_command.build_gui_context = mock.MagicMock(
         return_value={
@@ -99,6 +100,11 @@ def test_new_app(
             "pyproject_requires": "toga",
         },
         default_config={"replay_dir": str(tmp_path / "data/templates/.replay")},
+    )
+
+    # Bootstrap post-generate step is invoked with correct path
+    bootstrap.post_generate.assert_called_once_with(
+        base_path=tmp_path / "base" / "myapplication"
     )
 
 


### PR DESCRIPTION
A bootstrap post_generate step was added in #2119, but there was not explicit test for the step. As a result, it missed the fact that in the context of `new`, `base_path` is the path where the *parent* of the path that is usually the base_path (i.e., the path that contains the `pyproject.toml`), because the `new` command is responsible for *creating* the folder that contains pyproject.toml.

Since you'll always be wanting to post_generate content in the project folder, this adds the extra path element - and adds a test that the path is correct.

This was revealed when I re-tested my prototype Positron bootstrap against the merged version of the code. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
