### PR TITLE
Bump codespell from v2.3.0 to v2.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
     - id: codespell
       # remove toml extra once Python 3.10 is no longer supported

--- a/changes/2136.misc.rst
+++ b/changes/2136.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``codespell`` was updated to its latest version.

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -61,7 +61,7 @@ def make_class_name(formal_name):
             "Mn",  # nonspacing marks
             "Mc",  # spacing combining marks
             "Nd",  # decimal number
-            "Pc",  # connector punctuations
+            "Pc",  # connector punctuation
         }
     )
 

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -415,7 +415,7 @@ class Console:
         """Register a function to be called in the event that a log file is written.
 
         This can be used to provide additional debugging information which is too
-        expensive to gather pre-emptively.
+        expensive to gather preemptively.
         """
         self.log_file_extras.append(func)
 

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -53,7 +53,7 @@ def is_process_dead(pid: int) -> bool:
     """Returns True if a PID is not assigned to a process.
 
     Checking if a PID exists is only a semi-safe proxy to determine if a process is dead
-    since PIDs can be re-used. Therefore, this function should only be used via constant
+    since PIDs can be reused. Therefore, this function should only be used via constant
     monitoring of a PID to identify when the process goes from existing to not existing.
 
     :param pid: integer value to be checked if assigned as a PID.


### PR DESCRIPTION
Bumps `pre-commit` hook for `codespell` from v2.3.0 to v2.4.0 and ran the update against the repo.