### PR TITLE
Bump black-pre-commit-mirror from 24.10.0 to 25.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   #     - id: docformatter
   #       args: [--in-place, --black]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
         language_version: python3

--- a/changes/2143.misc.rst
+++ b/changes/2143.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``black-pre-commit-mirror`` was updated to its latest version.

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -426,12 +426,12 @@ def is_mach_o_binary(path):  # pragma: no-cover-if-is-windows
         with path.open("rb") as f:
             magic = f.read(4)
             return magic in (
-                b"\xCA\xFE\xBA\xBE",
-                b"\xCF\xFA\xED\xFE",
-                b"\xCE\xFA\xED\xFE",
-                b"\xBE\xBA\xFE\xCA",
-                b"\xFE\xED\xFA\xCF",
-                b"\xFE\xED\xFA\xCE",
+                b"\xca\xfe\xba\xbe",
+                b"\xcf\xfa\xed\xfe",
+                b"\xce\xfa\xed\xfe",
+                b"\xbe\xba\xfe\xca",
+                b"\xfe\xed\xfa\xcf",
+                b"\xfe\xed\xfa\xce",
             )
     else:
         # Not a binary

--- a/tests/config/test_make_class_name.py
+++ b/tests/config/test_make_class_name.py
@@ -22,12 +22,12 @@ from briefcase.config import make_class_name
         ("Hallo Vögel", "HalloVögel"),
         ("Bonjour Garçon", "BonjourGarçon"),
         # Unicode codepoints that can be at the start of an identifier
-        ("\u02EC World", "\u02ECWorld"),  # Unicode category Lm
+        ("\u02ec World", "\u02ecWorld"),  # Unicode category Lm
         ("\u3006 World", "\u3006World"),  # Unicode category Lo
         ("\u3021 World", "\u3021World"),  # Unicode category Nl
         # ('\u2118 World', '\u2118World'),  # in Other_ID_Start
         # Unicode codepoints that cannot be at the start of an identifier
-        ("\u20E1 World", "_\u20E1World"),  # Unicode Category Mn
+        ("\u20e1 World", "_\u20e1World"),  # Unicode Category Mn
         ("\u0903 World", "_\u0903World"),  # Unicode Category Mc
         ("\u2040 World", "_\u2040World"),  # Category Pc
         # ('\u00B7 World', '_\u00B7World'),  # in Other_ID_Continue

--- a/tests/console/test_sanitize_text.py
+++ b/tests/console/test_sanitize_text.py
@@ -15,7 +15,7 @@ from briefcase.console import sanitize_text
             "ls\nexamplefile.zip\n",
         ),
         (
-            "log output: \u001b[31mRed\u001B[0m",
+            "log output: \u001b[31mRed\u001b[0m",
             "log output: Red",
         ),
         (

--- a/tests/platforms/macOS/app/conftest.py
+++ b/tests/platforms/macOS/app/conftest.py
@@ -97,14 +97,14 @@ def first_app_with_binaries(first_app_templated, first_app_config, tmp_path):
         create_file(
             lib_path / lib,
             mode="wb",
-            content=b"\xCA\xFE\xBA\xBEBinary content here",
+            content=b"\xca\xfe\xba\xbeBinary content here",
         )
 
     # Mach-O file that is executable, with an odd extension
     create_file(
         lib_path / "special.binary",
         mode="wb",
-        content=b"\xCA\xFE\xBA\xBEBinary content here",
+        content=b"\xca\xfe\xba\xbeBinary content here",
     )
     os.chmod(lib_path / "special.binary", 0o755)
 
@@ -112,7 +112,7 @@ def first_app_with_binaries(first_app_templated, first_app_config, tmp_path):
     create_file(
         lib_path / "Extras.app/Contents/MacOS/Extras",
         mode="wb",
-        content=b"\xCA\xFE\xBA\xBEBinary content here",
+        content=b"\xca\xfe\xba\xbeBinary content here",
     )
 
     # An embedded framework
@@ -120,7 +120,7 @@ def first_app_with_binaries(first_app_templated, first_app_config, tmp_path):
     create_file(
         frameworks_path / "Extras.framework/Versions/1.2/libs/extras.dylib",
         mode="wb",
-        content=b"\xCA\xFE\xBA\xBEBinary content here",
+        content=b"\xca\xfe\xba\xbeBinary content here",
     )
     (frameworks_path / "Extras.framework/Versions/1.2/Extras").symlink_to(
         frameworks_path / "Extras.framework/Versions/1.2/libs/extras.dylib"
@@ -140,7 +140,7 @@ def first_app_with_binaries(first_app_templated, first_app_config, tmp_path):
     create_file(
         lib_path / "unknown.binary",
         mode="wb",
-        content=b"\xCA\xFE\xBA\xBEother",
+        content=b"\xca\xfe\xba\xbeother",
     )
 
     return first_app_config


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 24.10.0 to 25.1.0 and ran the update against the repo.