### PR TITLE
Allow for in-framework platform-config folders.

### DIFF
--- a/changes/2155.misc.rst
+++ b/changes/2155.misc.rst
@@ -1,0 +1,1 @@
+Briefcase will now default to using the ``platform-config`` folders that were added to the iOS support package as part of supporting cibuildwheel on iOS.

--- a/tests/platforms/iOS/xcode/conftest.py
+++ b/tests/platforms/iOS/xcode/conftest.py
@@ -50,4 +50,18 @@ def first_app_generated(first_app_config, tmp_path):
             ]
         ),
     )
+    # Create the package-config folders for each platform.
+    # We don't need anything in them; they just need to exist.
+    xcframework_path = (
+        tmp_path / "base_path/build/first-app/ios/xcode/Support/Python.xcframework"
+    )
+    (xcframework_path / "ios-arm64/platform-config/arm64-iphoneos").mkdir(parents=True)
+    (
+        xcframework_path
+        / "ios-arm64_x86_64-simulator/platform-config/arm64-iphonesimulator"
+    ).mkdir(parents=True)
+    (
+        xcframework_path
+        / "ios-arm64_x86_64-simulator/platform-config/x86_64-iphonesimulator"
+    ).mkdir(parents=True)
     return first_app_config

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 from unittest.mock import MagicMock, call
 
@@ -30,8 +31,37 @@ def test_unsupported_host_os(create_command, host_os):
         create_command()
 
 
-def test_extra_pip_args(create_command, first_app_generated, tmp_path):
+@pytest.mark.parametrize(
+    "old_config, device_config_path, sim_config_path",
+    [
+        (
+            False,
+            "Python.xcframework/ios-arm64/platform-config/arm64-iphoneos",
+            "Python.xcframework/ios-arm64_x86_64-simulator/platform-config/wonky-iphonesimulator",
+        ),
+        (
+            True,
+            "platform-site/iphoneos.arm64",
+            "platform-site/iphonesimulator.wonky",
+        ),
+    ],
+)
+def test_extra_pip_args(
+    create_command,
+    first_app_generated,
+    old_config,
+    device_config_path,
+    sim_config_path,
+    tmp_path,
+):
     """Extra iOS-specific args are included in calls to pip during update."""
+    # If we're testing an old config, delete the xcframework. This deletes the platform
+    # config folders, forcing a fallback to the older locations.
+    if old_config:
+        shutil.rmtree(
+            tmp_path / "base_path/build/first-app/ios/xcode/Support/Python.xcframework"
+        )
+
     # Hard code the current architecture for testing. We only install simulator
     # requirements for the current platform.
     create_command.tools.host_arch = "wonky"
@@ -71,14 +101,8 @@ def test_extra_pip_args(create_command, first_app_generated, tmp_path):
             env={
                 "PYTHONPATH": str(
                     tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "Support"
-                    / "platform-site"
-                    / "iphoneos.arm64"
+                    / "base_path/build/first-app/ios/xcode/Support"
+                    / device_config_path
                 )
             },
         ),
@@ -107,14 +131,8 @@ def test_extra_pip_args(create_command, first_app_generated, tmp_path):
             env={
                 "PYTHONPATH": str(
                     tmp_path
-                    / "base_path"
-                    / "build"
-                    / "first-app"
-                    / "ios"
-                    / "xcode"
-                    / "Support"
-                    / "platform-site"
-                    / "iphonesimulator.wonky"
+                    / "base_path/build/first-app/ios/xcode/Support"
+                    / sim_config_path
                 )
             },
         ),


### PR DESCRIPTION
As part of developing a PR for cibuildwheel, it has become necessary (or, at least, much more convenient) to move the platform site folder into the XCframework itself. It's also more convenient to use the multiarch name to identify the specific configuration, rather than the `iphoneos.arm64` name that is more an artefact of the Makefile used to build the framework.

This PR modifies Briefcase to look for the new location, but falls back onto the older location if the new location can't be found. That allows briefcase to continue to work with support packages in the old format until the support packages are set as the default.

Refs beeware/Python-Apple-support#246

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
