### PR TITLE
Add recognition of financial members.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. |logo| image:: https://beeware.org/project/projects/tools/briefcase/briefcase.png
+.. |logo| image:: https://beeware.org/project/briefcase/briefcase.png
    :width: 72px
    :target: https://beeware.org/briefcase
 
@@ -55,6 +55,23 @@ To install Briefcase, run::
 If you would like a full introduction to using Briefcase, try the `BeeWare tutorial
 <https://docs.beeware.org>`__. This tutorial walks you through the process of creating
 and packaging a new application with Briefcase.
+
+Financial support
+-----------------
+
+The BeeWare project would not be possible without the generous support of our financial
+members:
+
+.. image:: https://beeware.org/community/members/anaconda/anaconda-large.png
+    :target: https://anaconda.com/
+    :alt: Anaconda logo
+
+Anaconda is the world's most trusted open ecosystem for sourcing, building, and
+deploying data science and AI initiatives.
+
+Plus individual contributions from `users like you
+<https://beeware.org/community/members/>`__. If you find Briefcase, or other BeeWare
+tools useful, please consider becoming a financial member.
 
 Documentation
 -------------

--- a/README.rst
+++ b/README.rst
@@ -66,8 +66,7 @@ members:
     :target: https://anaconda.com/
     :alt: Anaconda logo
 
-Anaconda is the world's most trusted open ecosystem for sourcing, building, and
-deploying data science and AI initiatives.
+Anaconda Inc. - Advancing AI through open source.
 
 Plus individual contributions from `users like you
 <https://beeware.org/community/members/>`__. If you find Briefcase, or other BeeWare

--- a/changes/2172.misc.rst
+++ b/changes/2172.misc.rst
@@ -1,0 +1,1 @@
+Recognition of financial supporters was added to the README.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,6 +130,8 @@ linkcheck_ignore = [
     r"^https://github.com/beeware/briefcase/pull/\d+$",
     # Ignore WiX URLs, because they client block RTD's build.
     r"^https://www.firegiant.com/wixtoolset/$",
+    # PyGame seems to be having a long-term outage of their homepage.
+    r"^https://www.pygame.org/news$",
 ]
 
 # -- Options for copy button ---------------------------------------------------


### PR DESCRIPTION
Add a block to the README recognizing financial members.

Also adds the updated logo location after the refactor from https://github.com/beeware/beeware.github.io/pull/578

URL for Anaconda logo will not be valid until https://github.com/beeware/beeware.github.io/pull/597 lands. Leaving as a draft for that, plus final approval from Anaconda of their blurb.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
