### PR TITLE
Add `--debug` option to `briefcase run`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ distribute-*
 .coverage.*
 coverage.xml
 venv*/
+.venv*/
 .vscode/
 .eggs/
 .tox/

--- a/changes/###.added.rst
+++ b/changes/###.added.rst
@@ -1,0 +1,1 @@
+Added debugging support in bundled app through ``run --debug``.

--- a/docs/reference/commands/run.rst
+++ b/docs/reference/commands/run.rst
@@ -34,6 +34,60 @@ corresponding to test suite completion. Briefcase has built-in support for
 other test frameworks can be added using the ``test_success_regex`` and
 ``test_failure_regex`` settings.
 
+Debug mode
+----------
+
+The debug mode can be used to (remote) debug an bundled app. The debugger to
+use can be configured via ``pyproject.toml`` an can then be activated through
+``run --debug``.
+
+This is incredible useful when developing an iOS or Android app that can't be
+debugged via ``briefcase dev``.
+
+To debug an bundled app you need a socket connection from your host system to
+the device running your bundled app. Depending on the debugger selected the
+bundled app is either a socket server or socket client.
+
+This feature needs to inject some code into your app to create the socket
+connection. So you have to add ``import __briefcase_startup__`` to your
+``__main__.py`` to get this running.
+TODO: Better use .pth Files for this, so no modification of the app is needed.
+      But using this currently creates an import error on android...
+
+Some debuggers (like ``debugpy``) also support the mapping of the source code
+from your bundled app to your local copy of the apps source code in the
+``build`` folder.
+
+The configuration is done via ``pyproject.toml``:
+
+- ``debugger``:
+   - ``pdb`` (default):
+        This is used for debugging via console.
+        Currently it only supports ``debgger_mode=server``.
+        It creates a socket server that streams all stdout/stderr/stdin to
+        the host PC. The host PC can connect to it via:
+            - ``telnet localhost 5678``
+            - ``nc -C localhost 5678``
+            - ``socat readline tcp:localhost:5678``.
+        The app will start after the connection is established.
+   - ``debugpy``:
+        This is used for debugging via VSCode:
+            - If ``debgger_mode=server``: The bundled app creates an socket server an VSCode can connect to it.
+            - If ``debgger_mode=client``: This is used for debugging via VSCode. VSCode has to create an socket server and the bundled app connects to VSCode.
+   - ``debugpy-client``:
+        This is used for debugging via VSCode. VSCode has to create an socket server and the bundled app connects to VSCode.
+- ``debugger_mode``:
+    - ``server`` (default):
+        The bundled app creates an socket server and the host system connects to it.
+    - ``client``:
+        The bundled app creates an socket client and the host system creates an socket server.
+    Note, that not all debuggers support all modes.
+- ``debugger_ip``:
+    Specifies the IP of the socket connection (defaults to ``localhost``)
+- ``debugger_port``:
+    Specifies the Port of the socket connection (defaults to ``5678``)
+
+
 Usage
 =====
 
@@ -136,6 +190,14 @@ contains the most recent test code. To prevent this update and build, use the
 
 Prevent the automated update and build of app code that is performed when
 specifying by the ``--test`` option.
+
+``--debug``
+----------
+
+Run the app in debug mode in the bundled app environment. This option can be used
+standalone or in combination with the test mode ``run --test --debug``.
+
+On Android this also forwards the ``debugger_port`` from the android device to the host pc via adb.
 
 Passthrough arguments
 ---------------------

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -864,8 +864,8 @@ any compatibility problems, and then add the compatibility declaration.
                 help=f"Prevent any automated update{context_label}",
             )
 
-    def _add_test_options(self, parser, context_label):
-        """Internal utility method for adding common test-related options.
+    def _add_test_and_debug_options(self, parser, context_label):
+        """Internal utility method for adding common test- and debug-related options.
 
         :param parser: The parser to which options should be added.
         :param context_label: Label text for commands; the capitalized action being
@@ -876,6 +876,12 @@ any compatibility problems, and then add the compatibility declaration.
             dest="test_mode",
             action="store_true",
             help=f"{context_label} the app in test mode",
+        )
+        parser.add_argument(
+            "--debug",
+            dest="debug_mode",
+            action="store_true",
+            help=f"{context_label} the app in debug mode",
         )
 
     def add_options(self, parser):

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -12,7 +12,7 @@ class BuildCommand(BaseCommand):
 
     def add_options(self, parser):
         self._add_update_options(parser, context_label=" before building")
-        self._add_test_options(parser, context_label="Build")
+        self._add_test_and_debug_options(parser, context_label="Build")
 
     def build_app(self, app: AppConfig, **options):
         """Build an application.

--- a/src/briefcase/commands/run.py
+++ b/src/briefcase/commands/run.py
@@ -218,7 +218,7 @@ class RunCommand(RunAppMixin, BaseCommand):
         )
 
         self._add_update_options(parser, context_label=" before running")
-        self._add_test_options(parser, context_label="Run")
+        self._add_test_and_debug_options(parser, context_label="Run")
 
     def _prepare_app_kwargs(self, app: AppConfig, test_mode: bool):
         """Prepare the kwargs for running an app as a log stream.

--- a/src/briefcase/commands/update.py
+++ b/src/briefcase/commands/update.py
@@ -12,7 +12,7 @@ class UpdateCommand(CreateCommand):
 
     def add_options(self, parser):
         self._add_update_options(parser, update=False)
-        self._add_test_options(parser, context_label="Update")
+        self._add_test_and_debug_options(parser, context_label="Update")
 
     def update_app(
         self,
@@ -22,6 +22,7 @@ class UpdateCommand(CreateCommand):
         update_support: bool,
         update_stub: bool,
         test_mode: bool,
+        debug_mode: bool,
         **options,
     ) -> dict | None:
         """Update an existing application bundle.
@@ -32,6 +33,7 @@ class UpdateCommand(CreateCommand):
         :param update_support: Should app support be updated?
         :param update_stub: Should stub binary be updated?
         :param test_mode: Should the app be updated in test mode?
+        :param debug_mode: Should the app be updated in debug mode?
         """
 
         if not self.bundle_path(app).exists():
@@ -43,11 +45,13 @@ class UpdateCommand(CreateCommand):
         self.verify_app(app)
 
         self.console.info("Updating application code...", prefix=app.app_name)
-        self.install_app_code(app=app, test_mode=test_mode)
+        self.install_app_code(app=app, test_mode=test_mode, debug_mode=debug_mode)
 
         if update_requirements:
             self.console.info("Updating requirements...", prefix=app.app_name)
-            self.install_app_requirements(app=app, test_mode=test_mode)
+            self.install_app_requirements(
+                app=app, test_mode=test_mode, debug_mode=debug_mode
+            )
 
         if update_resources:
             self.console.info("Updating application resources...", prefix=app.app_name)
@@ -84,6 +88,7 @@ class UpdateCommand(CreateCommand):
         update_support: bool = False,
         update_stub: bool = False,
         test_mode: bool = False,
+        debug_mode: bool = False,
         **options,
     ) -> dict | None:
         # Confirm host compatibility, that all required tools are available,
@@ -98,6 +103,7 @@ class UpdateCommand(CreateCommand):
                 update_support=update_support,
                 update_stub=update_stub,
                 test_mode=test_mode,
+                debug_mode=debug_mode,
                 **options,
             )
         else:
@@ -110,6 +116,7 @@ class UpdateCommand(CreateCommand):
                     update_support=update_support,
                     update_stub=update_stub,
                     test_mode=test_mode,
+                    debug_mode=debug_mode,
                     **full_options(state, options),
                 )
 

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -263,6 +263,10 @@ class AppConfig(BaseConfig):
         template_branch=None,
         test_sources=None,
         test_requires=None,
+        debugger=None,
+        debugger_mode=None,
+        debugger_ip=None,
+        debugger_port=None,
         supported=True,
         long_description=None,
         console_app=False,
@@ -292,6 +296,10 @@ class AppConfig(BaseConfig):
         self.template_branch = template_branch
         self.test_sources = test_sources
         self.test_requires = test_requires
+        self.debugger = debugger
+        self.debugger_mode = debugger_mode
+        self.debugger_ip = debugger_ip
+        self.debugger_port = debugger_port
         self.supported = supported
         self.long_description = long_description
         self.license = license

--- a/src/briefcase/debugger.py
+++ b/src/briefcase/debugger.py
@@ -1,0 +1,273 @@
+import dataclasses
+import enum
+import textwrap
+from datetime import datetime
+from pathlib import Path
+from typing import TextIO
+
+from briefcase.config import AppConfig
+
+
+class Debugger(enum.StrEnum):
+    PDB = "pdb"
+    DEBUGPY = "debugpy"
+
+
+class DebuggerMode(enum.StrEnum):
+    SERVER = "server"
+    CLIENT = "client"
+
+
+_DEBGGER_REQUIREMENTS_MAPPING = {
+    Debugger.PDB: [],
+    Debugger.DEBUGPY: ["debugpy~=1.8.12"],
+}
+
+
+@dataclasses.dataclass
+class DebuggerConfig:
+    debugger: Debugger
+    debugger_mode: DebuggerMode
+    ip: str
+    port: int
+
+    @property
+    def additional_requirements(self) -> list[str]:
+        return _DEBGGER_REQUIREMENTS_MAPPING[self.debugger]
+
+    @staticmethod
+    def from_app(app: AppConfig) -> "DebuggerConfig":
+        debugger = app.debugger or Debugger.PDB
+        debugger_mode = app.debugger_mode or DebuggerMode.SERVER
+        debugger_ip = app.debugger_ip or "localhost"
+        debugger_port = app.debugger_port or 5678
+
+        try:
+            debugger = Debugger(debugger)
+        except Exception:
+            raise ValueError("debugger has a wrong value")
+
+        try:
+            debugger_port = int(debugger_port)
+        except Exception:
+            raise ValueError("debugger_port has to be an integer")
+
+        return DebuggerConfig(
+            debugger,
+            debugger_mode,
+            debugger_ip,
+            debugger_port,
+        )
+
+
+def write_debugger_startup_file(
+    app_path: Path,
+    pth_folder_path: Path | None,
+    app: AppConfig,
+    path_mappings: str,
+):
+    debugger_cfg = DebuggerConfig.from_app(app)
+
+    startup_modul = "__briefcase_startup__"
+    startup_code_path = app_path / f"{startup_modul}.py"
+
+    if debugger_cfg.debugger == Debugger.PDB:
+        if debugger_cfg.debugger_mode != DebuggerMode.SERVER:
+            raise ValueError(
+                f"{debugger_cfg.debugger_mode} not supported by {debugger_cfg.debugger}"
+            )
+
+        with startup_code_path.open("w", encoding="utf-8") as f:
+            create_remote_pdb_startup_file(
+                f,
+                debugger_cfg,
+            )
+    elif debugger_cfg.debugger == Debugger.DEBUGPY:
+        if debugger_cfg.debugger_mode not in (DebuggerMode.SERVER, DebuggerMode.CLIENT):
+            raise ValueError(
+                f"{debugger_cfg.debugger_mode} not supported by {debugger_cfg.debugger}"
+            )
+
+        with startup_code_path.open("w", encoding="utf-8") as f:
+            create_debugpy_startup_file(
+                f,
+                debugger_cfg,
+                path_mappings,
+            )
+    else:
+        raise ValueError(f"debugger '{debugger_cfg.debugger}' not found")
+
+    if pth_folder_path:
+        startup_pth_path = pth_folder_path / f"{startup_modul}.pth"
+        with startup_pth_path.open("w", encoding="utf-8") as f:
+            f.write(f"import {startup_modul}")
+
+
+def create_remote_pdb_startup_file(
+    file: TextIO,
+    debugger_cfg: DebuggerConfig,
+) -> str:
+    file.write(
+        f"""
+# Generated {datetime.now()}
+
+import socket
+import sys
+import re
+
+NEWLINE_REGEX = re.compile("\\r?\\n")
+
+class SocketFileWrapper(object):
+    def __init__(self, connection: socket.socket):
+        self.connection = connection
+        self.stream = connection.makefile('rw')
+
+        self.read = self.stream.read
+        self.readline = self.stream.readline
+        self.readlines = self.stream.readlines
+        self.close = self.stream.close
+        self.isatty = self.stream.isatty
+        self.flush = self.stream.flush
+        self.fileno = lambda: -1
+        self.__iter__ = self.stream.__iter__
+
+    @property
+    def encoding(self):
+        return self.stream.encoding
+
+    def write(self, data):
+        data = NEWLINE_REGEX.sub("\\r\\n", data)
+        self.connection.sendall(data.encode(self.stream.encoding))
+
+    def writelines(self, lines):
+        for line in lines:
+            self.write(line)
+
+def redirect_stdio():
+    f'''Open a socket server and stream all stdio via the connection bidirectional.'''
+    ip = "{debugger_cfg.ip}"
+    port = {debugger_cfg.port}
+    print(f'''
+Stdio redirector server opened at {{ip}}:{{port}}, waiting for connection...
+To connect to stdio redirector use eg.:
+    - telnet {{ip}} {{port}}
+    - nc -C {{ip}} {{port}}
+    - socat readline tcp:{{ip}}:{{port}}
+''')
+
+    listen_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+    listen_socket.bind((ip, port))
+    listen_socket.listen(1)
+    connection, address = listen_socket.accept()
+    print(f"Stdio redirector accepted connection from {{repr(address)}}.")
+
+    file_wrapper = SocketFileWrapper(connection)
+
+    sys.stderr = file_wrapper
+    sys.stdout = file_wrapper
+    sys.stdin = file_wrapper
+    sys.__stderr__ = file_wrapper
+    sys.__stdout__ = file_wrapper
+    sys.__stdin__ = file_wrapper
+
+redirect_stdio()
+"""
+    )
+
+
+def create_debugpy_startup_file(
+    file: TextIO,
+    debugger_cfg: DebuggerConfig,
+    path_mappings: str,
+) -> str:
+    """Create the code that is necessary to start the debugger"""
+    file.write(
+        f"""
+# Generated {datetime.now()}
+
+import os
+import sys
+from pathlib import Path
+
+def start_debugger():
+    ip = "{debugger_cfg.ip}"
+    port = {debugger_cfg.port}
+    path_mappings = []
+    {textwrap.indent(path_mappings, "    ")}
+
+    # When an app is bundled with briefcase "os.__file__" is not set at runtime
+    # on some platforms (eg. windows). But debugpy accesses it internally, so it
+    # has to be set or an Exception is raised from debugpy.
+    if not hasattr(os, "__file__"):
+        os.__file__ = ""
+
+"""
+    )
+    if debugger_cfg.debugger_mode == DebuggerMode.CLIENT:
+        file.write(
+            """
+    print(f'''
+Connecting to debugpy server at {ip}:{port}...
+To create the debugpy server using VSCode add the following configuration to launch.json and start the debugger:
+{{
+    "version": "0.2.0",
+    "configurations": [
+        {{
+            "name": "Briefcase: Attach (Listen)",
+            "type": "debugpy",
+            "request": "attach",
+            "listen": {{
+                "host": "{ip}",
+                "port": {port}
+            }}
+        }}
+    ]
+}}
+''')
+    import debugpy
+    try:
+        debugpy.connect((ip, port))
+    except ConnectionRefusedError as e:
+        print("Could not connect to debugpy server. Is it already started? We continue with the app...")
+        return
+"""
+        )
+    elif debugger_cfg.debugger_mode == DebuggerMode.SERVER:
+        file.write(
+            """
+    print(f'''
+The debugpy server started at {ip}:{port}, waiting for connection...
+To connect to debugpy using VSCode add the following configuration to launch.json:
+{{
+    "version": "0.2.0",
+    "configurations": [
+        {{
+            "name": "Briefcase: Attach (Connect)",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {{
+                "host": "{ip}",
+                "port": {port}
+            }}
+        }}
+    ]
+}}
+''')
+    import debugpy
+    debugpy.listen((ip, port), in_process_debug_adapter=True)
+"""
+        )
+
+    file.write(
+        """
+    if (len(path_mappings) > 0):
+        # path_mappings has to be applied after connection is established. If no connection is
+        # established this import will fail.
+        import pydevd_file_utils
+
+        pydevd_file_utils.setup_client_server_paths(path_mappings)
+
+start_debugger()
+"""
+    )

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -238,6 +238,32 @@ in the macOS configuration section of your pyproject.toml.
             "entitlements": entitlements,
         }
 
+    def debugger_path_mappings(self, app: AppConfig, app_sources: list[str]):
+        """Path mappings for enhanced debugger support
+
+        :param app: The config object for the app
+        :param app_sources: All source files of the app
+        :return: A list of code snippets that add a path mapping to the
+            'path_mappings' variable.
+        """
+        # Normally app & requirements are automatically found, because
+        # developing an macOS app also requires a macOs host. But the app
+        # path is pointing to a copy of the source in some temporary folder,
+        # so we redirect it to the original source.
+
+        path_mappings = """
+device_app_folder = list(filter(lambda p: True if p.endswith("app") else False, sys.path))
+if len(device_app_folder) > 0:
+    pass
+"""
+        for src in app_sources:
+            original = self.base_path / src
+            path_mappings += f"""
+    path_mappings.append((r"{original.absolute()}", str(Path(device_app_folder[0]) / "{original.name}")))
+"""
+
+        return path_mappings
+
 
 class macOSRunMixin:
     def run_app(

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -124,6 +124,32 @@ class WindowsCreateCommand(CreateCommand):
 """
         )
 
+    def debugger_path_mappings(self, app: AppConfig, app_sources: list[str]):
+        """Path mappings for enhanced debugger support
+
+        :param app: The config object for the app
+        :param app_sources: All source files of the app
+        :return: A list of code snippets that add a path mapping to the
+            'path_mappings' variable.
+        """
+        # Normally app & requirements are automatically found, because
+        # developing an windows app also requires a windows host. But the app
+        # path is pointing to a copy of the source in some temporary folder,
+        # so we redirect it to the original source.
+
+        path_mappings = """
+device_app_folder = list(filter(lambda p: True if p.endswith("app") else False, sys.path))
+if len(device_app_folder) > 0:
+    pass
+"""
+        for src in app_sources:
+            original = self.base_path / src
+            path_mappings += f"""
+    path_mappings.append((r"{original.absolute()}", str(Path(device_app_folder[0]) / "{original.name}")))
+"""
+
+        return path_mappings
+
 
 class WindowsRunCommand(RunCommand):
     def run_app(


### PR DESCRIPTION
This is an first attempt for adding (remote) debugging support for bundled apps. This is not ready yet but i would like to share this anyways.

It supports:
- pdb
- debugpy (for VSCode)

I have tested the following platforms:
- Windows
- Android (on Windows)
- macOS
- iOS Simulator (on macOS)

The following points are missing:
- Test this on an real iPhone (unfortunately I don't have one)
- Currently you have to add `import __briefcase_startup__` in your `__main__.py`. Instead of this it is possible to use .pth files. On windows it is working, but this creates at least problems on Android... I dont have tested iOS and macOS yet.
- As suggested in https://github.com/beeware/briefcase/issues/2147#issuecomment-2646812554 `pyproject.toml` is probably not in the right place for the configuration. @freakboy3742 suggested to add user-level configuration. But this is totally out of scope for this PR. So I used the `pyproject.toml` even if it is not ideal.
- Adding pycharm is probably also possible, but it makes some problems, so it can be added later (https://github.com/beeware/briefcase/issues/2152).
- Enhance the documentation.

Fixes #2147 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
