### PR TITLE
Include girepository-2.0 as a system depdendency for Toga on Debian

### DIFF
--- a/changes/2187.bugfix.rst
+++ b/changes/2187.bugfix.rst
@@ -1,1 +1,1 @@
-New Toga projects on Debian-derived distributions now include ``libgirepository-2.0`` and ``libgirepository-2.0-dev`` as a system requirement. This is needed for support for PyGobject 3.52.1 and later.
+New Toga projects on Debian-derived distributions now include ``libgirepository-2.0-0`` and ``libgirepository-2.0-dev`` as a system requirement. This is needed for support for PyGObject 3.52.1 and later.

--- a/changes/2187.bugfix.rst
+++ b/changes/2187.bugfix.rst
@@ -1,1 +1,1 @@
-New Toga projects now enforce an upper version bound of ``pygobject < 3.52.1``. PyGObject 3.52.1 introduced a system requirement of ``libgirepository-2.0-dev``; that library isn't available on Debian 12 or Ubuntu 22.04 LTS. If you have a project that isn't targeting those platforms, you can likely remove this pin.
+New Toga projects on Debian-derived distributions now include ``libgirepository-2.0`` and ``libgirepository-2.0-dev`` as a system requirement. This is needed for support for PyGobject 3.52.1 and later.

--- a/changes/2187.bugfix.rst
+++ b/changes/2187.bugfix.rst
@@ -1,0 +1,1 @@
+New Toga projects now enforce an upper version bound of ``pygobject < 3.52.1``. PyGObject 3.52.1 introduced a system requirement of ``libgirepository-2.0-dev``; that library isn't available on Debian 12 or Ubuntu 22.04 LTS. If you have a project that isn't targeting those platforms, you can likely remove this pin.

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -60,18 +60,15 @@ requires = [
         return """\
 requires = [
     "toga-gtk~=0.4.7",
-]
-"""
-
-    def pyproject_table_linux_system_debian(self):
-        return """\
-requires = [
     # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
     # isn't available on Debian 12/Ubuntu 22.04. If you need to support those (or older)
     # releases, uncomment this version pin. See beeware/toga#3143.
     # "pygobject < 3.52.1",
 ]
+"""
 
+    def pyproject_table_linux_system_debian(self):
+        return """\
 system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -92,7 +92,7 @@ system_runtime_requires = [
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-module",
     # Needed to provide WebKit2 at runtime
-    # Note: Debian 11 and Ubuntu 20.04 require gir1.2-webkit2-4.0 instead
+    # Note: Debian 11 requires gir1.2-webkit2-4.0 instead
     # "gir1.2-webkit2-4.1",
 ]
 """

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -67,7 +67,7 @@ requires = [
         return """\
 requires = [
     # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
-    # isn't available on Debian 13/Ubuntu 22.04. If you need to support those (or older)
+    # isn't available on Debian 12/Ubuntu 22.04. If you need to support those (or older)
     # releases, uncomment this version pin. See beeware/toga#3143.
     # "pygobject < 3.52.1",
 ]
@@ -76,7 +76,7 @@ system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",
     # One of the following two packages are needed to compile PyGObject wheel.
-    # Debian 13/Ubuntu 22.04 only has the older 1.0 version of the library.
+    # Debian 12/Ubuntu 22.04 only has the older 1.0 version of the library.
     # If you use the older version, you'll also need to apply the pygobject pin
     # (see the linux requires table). See beeware/toga#3143.
     "libgirepository-2.0-dev",
@@ -87,7 +87,7 @@ system_runtime_requires = [
     # Needed to provide GTK and its GI bindings
     "gir1.2-gtk-3.0",
     # One of the following two packages are needed to use PyGObject at runtime.
-    # Debian 13/Ubuntu 22.04 only has the older 1.0 version of the library.
+    # Debian 12/Ubuntu 22.04 only has the older 1.0 version of the library.
     # If you use the older version, you'll also need to apply the pygobject pin
     # (see the linux requires table). See beeware/toga#3143.
     "libgirepository-2.0-0",

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -60,6 +60,11 @@ requires = [
         return """\
 requires = [
     "toga-gtk~=0.4.7",
+    # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
+    # isn't available on Debian 12/Ubuntu 22.04. Enforce an upper pin on the last
+    # release known to work on those releases. If you don't need to support older
+    # Debian/Ubuntu releases, you can likely remove this pin. See beeware/toga#3143.
+    "pygobject<=3.50.0",
 ]
 """
 

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -61,10 +61,10 @@ requires = [
 requires = [
     "toga-gtk~=0.4.7",
     # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
-    # isn't available on Debian 12/Ubuntu 22.04. Enforce an upper pin on the last
-    # release known to work on those releases. If you don't need to support older
+    # isn't available on Debian 12/Ubuntu 22.04. Enforce an upper pin that prevents that
+    # release (or newer) from being selected. If you don't need to support older
     # Debian/Ubuntu releases, you can likely remove this pin. See beeware/toga#3143.
-    "pygobject<=3.50.0",
+    "pygobject < 3.52.1",
 ]
 """
 

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -60,27 +60,38 @@ requires = [
         return """\
 requires = [
     "toga-gtk~=0.4.7",
-    # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
-    # isn't available on Debian 12/Ubuntu 22.04. Enforce an upper pin that prevents that
-    # release (or newer) from being selected. If you don't need to support older
-    # Debian/Ubuntu releases, you can likely remove this pin. See beeware/toga#3143.
-    "pygobject < 3.52.1",
 ]
 """
 
     def pyproject_table_linux_system_debian(self):
         return """\
+requires = [
+    # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
+    # isn't available on Debian 13/Ubuntu 22.04. If you need to support those (or older)
+    # releases, uncomment this version pin. See beeware/toga#3143.
+    # "pygobject < 3.52.1",
+]
+
 system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",
-    # Needed to compile PyGObject wheel
-    "libgirepository1.0-dev",
+    # One of the following two packages are needed to compile PyGObject wheel.
+    # Debian 13/Ubuntu 22.04 only has the older 1.0 version of the library.
+    # If you use the older version, you'll also need to apply the pygobject pin
+    # (see the linux requires table). See beeware/toga#3143.
+    "libgirepository-2.0-dev",
+    # "libgirepository1.0-dev",
 ]
 
 system_runtime_requires = [
     # Needed to provide GTK and its GI bindings
     "gir1.2-gtk-3.0",
-    "libgirepository-1.0-1",
+    # One of the following two packages are needed to use PyGObject at runtime.
+    # Debian 13/Ubuntu 22.04 only has the older 1.0 version of the library.
+    # If you use the older version, you'll also need to apply the pygobject pin
+    # (see the linux requires table). See beeware/toga#3143.
+    "libgirepository-2.0-0",
+    # "libgirepository-1.0-1",
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-module",
     # Needed to provide WebKit2 at runtime

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -91,7 +91,7 @@ requires = [
         pyproject_table_linux_system_debian="""\
 requires = [
     # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
-    # isn't available on Debian 13/Ubuntu 22.04. If you need to support those (or older)
+    # isn't available on Debian 12/Ubuntu 22.04. If you need to support those (or older)
     # releases, uncomment this version pin. See beeware/toga#3143.
     # "pygobject < 3.52.1",
 ]
@@ -100,7 +100,7 @@ system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",
     # One of the following two packages are needed to compile PyGObject wheel.
-    # Debian 13/Ubuntu 22.04 only has the older 1.0 version of the library.
+    # Debian 12/Ubuntu 22.04 only has the older 1.0 version of the library.
     # If you use the older version, you'll also need to apply the pygobject pin
     # (see the linux requires table). See beeware/toga#3143.
     "libgirepository-2.0-dev",
@@ -111,7 +111,7 @@ system_runtime_requires = [
     # Needed to provide GTK and its GI bindings
     "gir1.2-gtk-3.0",
     # One of the following two packages are needed to use PyGObject at runtime.
-    # Debian 13/Ubuntu 22.04 only has the older 1.0 version of the library.
+    # Debian 12/Ubuntu 22.04 only has the older 1.0 version of the library.
     # If you use the older version, you'll also need to apply the pygobject pin
     # (see the linux requires table). See beeware/toga#3143.
     "libgirepository-2.0-0",

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -116,7 +116,7 @@ system_runtime_requires = [
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-module",
     # Needed to provide WebKit2 at runtime
-    # Note: Debian 11 and Ubuntu 20.04 require gir1.2-webkit2-4.0 instead
+    # Note: Debian 11 requires gir1.2-webkit2-4.0 instead
     # "gir1.2-webkit2-4.1",
 ]
 """,

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -87,10 +87,10 @@ requires = [
 requires = [
     "toga-gtk~=0.4.7",
     # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
-    # isn't available on Debian 12/Ubuntu 22.04. Enforce an upper pin on the last
-    # release known to work on those releases. If you don't need to support older
+    # isn't available on Debian 12/Ubuntu 22.04. Enforce an upper pin that prevents that
+    # release (or newer) from being selected. If you don't need to support older
     # Debian/Ubuntu releases, you can likely remove this pin. See beeware/toga#3143.
-    "pygobject<=3.50.0",
+    "pygobject < 3.52.1",
 ]
 """,
         pyproject_table_linux_system_debian="""\

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -86,6 +86,11 @@ requires = [
         pyproject_table_linux="""\
 requires = [
     "toga-gtk~=0.4.7",
+    # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
+    # isn't available on Debian 12/Ubuntu 22.04. Enforce an upper pin on the last
+    # release known to work on those releases. If you don't need to support older
+    # Debian/Ubuntu releases, you can likely remove this pin. See beeware/toga#3143.
+    "pygobject<=3.50.0",
 ]
 """,
         pyproject_table_linux_system_debian="""\

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -86,16 +86,13 @@ requires = [
         pyproject_table_linux="""\
 requires = [
     "toga-gtk~=0.4.7",
-]
-""",
-        pyproject_table_linux_system_debian="""\
-requires = [
     # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
     # isn't available on Debian 12/Ubuntu 22.04. If you need to support those (or older)
     # releases, uncomment this version pin. See beeware/toga#3143.
     # "pygobject < 3.52.1",
 ]
-
+""",
+        pyproject_table_linux_system_debian="""\
 system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -86,25 +86,36 @@ requires = [
         pyproject_table_linux="""\
 requires = [
     "toga-gtk~=0.4.7",
-    # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
-    # isn't available on Debian 12/Ubuntu 22.04. Enforce an upper pin that prevents that
-    # release (or newer) from being selected. If you don't need to support older
-    # Debian/Ubuntu releases, you can likely remove this pin. See beeware/toga#3143.
-    "pygobject < 3.52.1",
 ]
 """,
         pyproject_table_linux_system_debian="""\
+requires = [
+    # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
+    # isn't available on Debian 13/Ubuntu 22.04. If you need to support those (or older)
+    # releases, uncomment this version pin. See beeware/toga#3143.
+    # "pygobject < 3.52.1",
+]
+
 system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",
-    # Needed to compile PyGObject wheel
-    "libgirepository1.0-dev",
+    # One of the following two packages are needed to compile PyGObject wheel.
+    # Debian 13/Ubuntu 22.04 only has the older 1.0 version of the library.
+    # If you use the older version, you'll also need to apply the pygobject pin
+    # (see the linux requires table). See beeware/toga#3143.
+    "libgirepository-2.0-dev",
+    # "libgirepository1.0-dev",
 ]
 
 system_runtime_requires = [
     # Needed to provide GTK and its GI bindings
     "gir1.2-gtk-3.0",
-    "libgirepository-1.0-1",
+    # One of the following two packages are needed to use PyGObject at runtime.
+    # Debian 13/Ubuntu 22.04 only has the older 1.0 version of the library.
+    # If you use the older version, you'll also need to apply the pygobject pin
+    # (see the linux requires table). See beeware/toga#3143.
+    "libgirepository-2.0-0",
+    # "libgirepository-1.0-1",
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-module",
     # Needed to provide WebKit2 at runtime


### PR DESCRIPTION
Adds libgirepository-2.0-dev as a system dependency for Toga apps on Debian-based releases. This is required by 
PyGObject 3.52.1. 

This library isn't available on Debian 12/Ubuntu 22.04. To accomodate those releases, the workaround is included in the template, commented out.

Refs beeware/toga#3143

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
