### PR TITLE
Bump Toga bootstrap to 0.5.

### DIFF
--- a/changes/2193.feature.rst
+++ b/changes/2193.feature.rst
@@ -1,0 +1,1 @@
+The Toga app bootstrap now generates apps that use Toga 0.5.

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -51,7 +51,7 @@ test_requires = [
         return """\
 universal_build = true
 requires = [
-    "toga-cocoa~=0.4.7",
+    "toga-cocoa~=0.5.0",
     "std-nslog~=1.0.3",
 ]
 """
@@ -59,7 +59,7 @@ requires = [
     def pyproject_table_linux(self):
         return """\
 requires = [
-    "toga-gtk~=0.4.7",
+    "toga-gtk~=0.5.0",
     # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
     # isn't available on Debian 12/Ubuntu 22.04. If you don't need to support those (or
     # older) releases, you can remove this version pin. See beeware/toga#3143.
@@ -199,14 +199,14 @@ flatpak_sdk = "org.gnome.Sdk"
     def pyproject_table_windows(self):
         return """\
 requires = [
-    "toga-winforms~=0.4.7",
+    "toga-winforms~=0.5.0",
 ]
 """
 
     def pyproject_table_iOS(self):
         return """\
 requires = [
-    "toga-iOS~=0.4.7",
+    "toga-iOS~=0.5.0",
     "std-nslog~=1.0.3",
 ]
 """
@@ -214,7 +214,7 @@ requires = [
     def pyproject_table_android(self):
         return """\
 requires = [
-    "toga-android~=0.4.7",
+    "toga-android~=0.5.0",
 ]
 
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
@@ -231,7 +231,7 @@ build_gradle_dependencies = [
     def pyproject_table_web(self):
         return """\
 requires = [
-    "toga-web~=0.4.7",
+    "toga-web~=0.5.0",
 ]
 style_framework = "Shoelace v2.3"
 """

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -79,13 +79,13 @@ test_requires = [
         pyproject_table_macOS="""\
 universal_build = true
 requires = [
-    "toga-cocoa~=0.4.7",
+    "toga-cocoa~=0.5.0",
     "std-nslog~=1.0.3",
 ]
 """,
         pyproject_table_linux="""\
 requires = [
-    "toga-gtk~=0.4.7",
+    "toga-gtk~=0.5.0",
     # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
     # isn't available on Debian 12/Ubuntu 22.04. If you don't need to support those (or
     # older) releases, you can remove this version pin. See beeware/toga#3143.
@@ -211,18 +211,18 @@ flatpak_sdk = "org.gnome.Sdk"
 """,
         pyproject_table_windows="""\
 requires = [
-    "toga-winforms~=0.4.7",
+    "toga-winforms~=0.5.0",
 ]
 """,
         pyproject_table_iOS="""\
 requires = [
-    "toga-iOS~=0.4.7",
+    "toga-iOS~=0.5.0",
     "std-nslog~=1.0.3",
 ]
 """,
         pyproject_table_android="""\
 requires = [
-    "toga-android~=0.4.7",
+    "toga-android~=0.5.0",
 ]
 
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
@@ -237,7 +237,7 @@ build_gradle_dependencies = [
 """,
         pyproject_table_web="""\
 requires = [
-    "toga-web~=0.4.7",
+    "toga-web~=0.5.0",
 ]
 style_framework = "Shoelace v2.3"
 """,


### PR DESCRIPTION
With Toga 0.5 released, we can bump the Briefcase bootstrap to use that release.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
