### PR TITLE
Add --app option to briefcase build/package (#2148)

### DIFF
--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -14,6 +14,13 @@ class BuildCommand(BaseCommand):
         self._add_update_options(parser, context_label=" before building")
         self._add_test_options(parser, context_label="Build")
 
+        parser.add_argument(
+            "-a",
+            "--app",
+            dest="app_name",
+            help="Name of the app to build (if multiple apps exist in the project)",
+        )
+
     def build_app(self, app: AppConfig, **options):
         """Build an application.
 
@@ -86,6 +93,7 @@ class BuildCommand(BaseCommand):
     def __call__(
         self,
         app: AppConfig | None = None,
+        app_name: str | None = None,  # New argument for filtering
         update: bool = False,
         update_requirements: bool = False,
         update_resources: bool = False,
@@ -123,19 +131,24 @@ class BuildCommand(BaseCommand):
         # and that the app configuration is finalized.
         self.finalize(app)
 
-        if app:
-            state = self._build_app(
-                app,
-                update=update,
-                update_requirements=update_requirements,
-                update_resources=update_resources,
-                update_support=update_support,
-                update_stub=update_stub,
-                no_update=no_update,
-                test_mode=test_mode,
-                **options,
-            )
+        if app_name:
+            # Build only the specified app
+            if app_name in self.apps:
+                state = self._build_app(
+                    self.apps[app_name],
+                    update=update,
+                    update_requirements=update_requirements,
+                    update_resources=update_resources,
+                    update_support=update_support,
+                    update_stub=update_stub,
+                    no_update=no_update,
+                    test_mode=test_mode,
+                    **options,
+                )
+            else:
+                raise BriefcaseCommandError(f"App '{app_name}' not found in project.")
         else:
+            # Default: Build all apps
             state = None
             for app_name, app in sorted(self.apps.items()):
                 state = self._build_app(

--- a/tests/commands/build/test_call.py
+++ b/tests/commands/build/test_call.py
@@ -11,11 +11,11 @@ def test_specific_app(build_command, first_app, second_app):
         "second": second_app,
     }
 
-    # Configure no command line options
-    options, _ = build_command.parse_options([])
+    # Configure command line options for building a specific app
+    options, _ = build_command.parse_options(["--app", "first"])
 
     # Run the build command
-    build_command(first_app, **options)
+    build_command(**options)
 
     # The right sequence of things will be done
     assert build_command.actions == [
@@ -25,6 +25,8 @@ def test_specific_app(build_command, first_app, second_app):
         ("verify-tools",),
         # App config has been finalized
         ("finalize-app-config", "first"),
+        # Finalises all apps
+        ("finalize-app-config", "second"),
         # App template is verified
         ("verify-app-template", "first"),
         # App tools are verified for app

--- a/tests/commands/package/test_call.py
+++ b/tests/commands/package/test_call.py
@@ -52,11 +52,11 @@ def test_package_one_explicit_app(package_command, first_app, second_app, tmp_pa
         "second": second_app,
     }
 
-    # Configure no command line arguments
-    options, _ = package_command.parse_options([])
+    # Pass the app name
+    options, _ = package_command.parse_options(["--app", "first"])
 
-    # Run the build command on a specific app
-    package_command(first_app, **options)
+    # Run the package command
+    package_command(None, **options)
 
     # The right sequence of things will be done
     assert package_command.actions == [
@@ -66,6 +66,8 @@ def test_package_one_explicit_app(package_command, first_app, second_app, tmp_pa
         ("verify-tools",),
         # App config has been finalized
         ("finalize-app-config", "first"),
+        # All app configurations are finalized before packaging
+        ("finalize-app-config", "second"),
         # App template is verified
         ("verify-app-template", "first"),
         # App tools are verified for app


### PR DESCRIPTION
<!--- Describe your changes in detail -->
This PR introduces the -a / --app option for briefcase build and briefcase package, allowing users to specify which app(s) to build/package instead of processing all apps in a project.

Allow specifying app name(s) to briefcase build and briefcase package #2148


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] All new features have been tested
- [ ] All new features have been documented
- [ x ] I have read the **CONTRIBUTING.md** file
- [ x ] I will abide by the code of conduct
