### PR TITLE
Add --app option to briefcase build/package (#2148)

### DIFF
--- a/changes/2148.feature.rst
+++ b/changes/2148.feature.rst
@@ -1,0 +1,1 @@
+Added the `-a / --app` option to `briefcase build` and `briefcase package` to allow building/packaging a specific app instead of all apps.

--- a/changes/2148.feature.rst
+++ b/changes/2148.feature.rst
@@ -1,1 +1,1 @@
-The `build` and `package` commands can now be run on a single or multiple app(s) in a project by using the `-a / --app` option
+The `build` and `package` commands can now be run on a single app within a multi-app project by using the `-a / --app` option.

--- a/changes/2148.feature.rst
+++ b/changes/2148.feature.rst
@@ -1,1 +1,1 @@
-Added the `-a / --app` option to `briefcase build` and `briefcase package` to allow building/packaging a specific app instead of all apps.
+The `build` and `package` commands can now be run on a single or multiple app(s) in a project by using the `-a / --app` option

--- a/docs/reference/commands/build.rst
+++ b/docs/reference/commands/build.rst
@@ -43,6 +43,13 @@ Options
 
 The following options can be provided at the command line.
 
+``-a <app name>`` / ``--app <app name>``
+----------------------------------------
+
+Run a specific application target in your project. This argument is only
+required if your project contains more than one application target. The app
+name specified should be the machine-readable package name for the app.
+
 ``-u`` / ``--update``
 ---------------------
 

--- a/docs/reference/commands/package.rst
+++ b/docs/reference/commands/package.rst
@@ -41,6 +41,13 @@ Options
 
 The following options can be provided at the command line.
 
+``-a <app name>`` / ``--app <app name>``
+----------------------------------------
+
+Run a specific application target in your project. This argument is only
+required if your project contains more than one application target. The app
+name specified should be the machine-readable package name for the app.
+
 ``-u`` / ``--update``
 ---------------------
 

--- a/docs/reference/commands/run.rst
+++ b/docs/reference/commands/run.rst
@@ -60,8 +60,8 @@ Options
 
 The following options can be provided at the command line.
 
-``-a <app name>`` / ``--app <app name``
----------------------------------------
+``-a <app name>`` / ``--app <app name>``
+----------------------------------------
 
 Run a specific application target in your project. This argument is only
 required if your project contains more than one application target. The app

--- a/docs/reference/commands/update.rst
+++ b/docs/reference/commands/update.rst
@@ -36,6 +36,13 @@ Options
 
 The following options can be provided at the command line.
 
+``-a <app name>`` / ``--app <app name>``
+----------------------------------------
+
+Run a specific application target in your project. This argument is only
+required if your project contains more than one application target. The app
+name specified should be the machine-readable package name for the app.
+
 ``-r`` / ``--update-requirements``
 ----------------------------------
 

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -14,6 +14,13 @@ class BuildCommand(BaseCommand):
         self._add_update_options(parser, context_label=" before building")
         self._add_test_options(parser, context_label="Build")
 
+        parser.add_argument(
+            "-a",
+            "--app",
+            dest="app_name",
+            help="Name of the app to build (if multiple apps exist in the project)",
+        )
+
     def build_app(self, app: AppConfig, **options):
         """Build an application.
 
@@ -86,6 +93,7 @@ class BuildCommand(BaseCommand):
     def __call__(
         self,
         app: AppConfig | None = None,
+        app_name: str | None = None,  # New argument for filtering
         update: bool = False,
         update_requirements: bool = False,
         update_resources: bool = False,
@@ -123,19 +131,24 @@ class BuildCommand(BaseCommand):
         # and that the app configuration is finalized.
         self.finalize(app)
 
-        if app:
-            state = self._build_app(
-                app,
-                update=update,
-                update_requirements=update_requirements,
-                update_resources=update_resources,
-                update_support=update_support,
-                update_stub=update_stub,
-                no_update=no_update,
-                test_mode=test_mode,
-                **options,
-            )
+        if app_name:
+            # Build only the specified app
+            if app_name in self.apps:
+                state = self._build_app(
+                    self.apps[app_name],
+                    update=update,
+                    update_requirements=update_requirements,
+                    update_resources=update_resources,
+                    update_support=update_support,
+                    update_stub=update_stub,
+                    no_update=no_update,
+                    test_mode=test_mode,
+                    **options,
+                )
+            else:
+                raise BriefcaseCommandError(f"App '{app_name}' not found in project.")
         else:
+            # Default: Build all apps
             state = None
             for app_name, app in sorted(self.apps.items()):
                 state = self._build_app(

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -17,9 +17,8 @@ class BuildCommand(BaseCommand):
         parser.add_argument(
             "-a",
             "--app",
-            dest="apps",
-            action="append",
-            help="Name of the app(s) to build (if multiple apps exist in the project)",
+            dest="app_name",
+            help="Name of the app to build (if multiple apps exist in the project)",
         )
 
     def build_app(self, app: AppConfig, **options):
@@ -94,7 +93,7 @@ class BuildCommand(BaseCommand):
     def __call__(
         self,
         app: AppConfig | None = None,
-        apps: list[str] | None = None,
+        app_name: str | None = None,
         update: bool = False,
         update_requirements: bool = False,
         update_resources: bool = False,
@@ -132,15 +131,12 @@ class BuildCommand(BaseCommand):
         # and that the app configuration is finalized.
         self.finalize(app)
 
-        if apps:
-            selected_apps = {}
-            for name in apps:
-                if name not in self.apps:
-                    raise BriefcaseCommandError(
-                        f"App '{name}' does not exist in this project."
-                    )
-                selected_apps[name] = self.apps[name]
-            apps_to_build = selected_apps
+        if app_name:
+            if app_name not in self.apps:
+                raise BriefcaseCommandError(
+                    f"App '{app_name}' does not exist in this project."
+                )
+            apps_to_build = {app_name: self.apps[app_name]}
         elif app:
             apps_to_build = {app.app_name: app}
         else:

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -132,11 +132,12 @@ class BuildCommand(BaseCommand):
         self.finalize(app)
 
         if app_name:
-            if app_name not in self.apps:
+            try:
+                apps_to_build = {app_name: self.apps[app_name]}
+            except KeyError:
                 raise BriefcaseCommandError(
                     f"App '{app_name}' does not exist in this project."
                 )
-            apps_to_build = {app_name: self.apps[app_name]}
         elif app:
             apps_to_build = {app.app_name: app}
         else:

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -122,9 +122,8 @@ class PackageCommand(BaseCommand):
         parser.add_argument(
             "-a",
             "--app",
-            dest="apps",
-            action="append",
-            help="Name of the app(s) to build (if multiple apps exist in the project)",
+            dest="app_name",
+            help="Name of the app to package (if multiple apps exist in the project)",
         )
 
         parser.add_argument(
@@ -160,7 +159,7 @@ class PackageCommand(BaseCommand):
     def __call__(
         self,
         app: AppConfig | None = None,
-        apps: list[str] | None = None,
+        app_name: str | None = None,
         update: bool = False,
         **options,
     ) -> dict | None:
@@ -169,15 +168,12 @@ class PackageCommand(BaseCommand):
         # and that the app configuration is finalized.
         self.finalize(app)
 
-        if apps:
-            selected_apps = {}
-            for name in apps:
-                if name not in self.apps:
-                    raise BriefcaseCommandError(
-                        f"App '{name}' does not exist in this project."
-                    )
-                selected_apps[name] = self.apps[name]
-            apps_to_package = selected_apps
+        if app_name:
+            if app_name not in self.apps:
+                raise BriefcaseCommandError(
+                    f"App '{app_name}' does not exist in this project."
+                )
+            apps_to_package = {app_name: self.apps[app_name]}
         elif app:
             apps_to_package = {app.app_name: app}
         else:
@@ -196,7 +192,7 @@ class PackageCommand(BaseCommand):
     def parse_options(self, extra=None):
         options, overrides = super().parse_options(extra=extra)
 
-        if options.get("apps") is None:
-            options.pop("apps", None)
+        if options.get("app_name") is None:
+            options.pop("app_name", None)
 
         return options, overrides

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -124,7 +124,6 @@ class PackageCommand(BaseCommand):
             "--app",
             dest="apps",
             action="append",
-            default=None,
             help="Name of the app(s) to build (if multiple apps exist in the project)",
         )
 
@@ -166,7 +165,6 @@ class PackageCommand(BaseCommand):
         **options,
     ) -> dict | None:
 
-        options.pop("apps", None)
         # Confirm host compatibility, that all required tools are available,
         # and that the app configuration is finalized.
         self.finalize(app)

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -124,6 +124,7 @@ class PackageCommand(BaseCommand):
             "--app",
             dest="apps",
             action="append",
+            default=None,
             help="Name of the app(s) to build (if multiple apps exist in the project)",
         )
 
@@ -164,6 +165,8 @@ class PackageCommand(BaseCommand):
         update: bool = False,
         **options,
     ) -> dict | None:
+
+        options.pop("apps", None)
         # Confirm host compatibility, that all required tools are available,
         # and that the app configuration is finalized.
         self.finalize(app)
@@ -191,3 +194,11 @@ class PackageCommand(BaseCommand):
             )
 
         return state
+
+    def parse_options(self, extra=None):
+        options, overrides = super().parse_options(extra=extra)
+
+        if options.get("apps") is None:
+            options.pop("apps", None)
+
+        return options, overrides

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -169,11 +169,12 @@ class PackageCommand(BaseCommand):
         self.finalize(app)
 
         if app_name:
-            if app_name not in self.apps:
+            try:
+                apps_to_package = {app_name: self.apps[app_name]}
+            except KeyError:
                 raise BriefcaseCommandError(
                     f"App '{app_name}' does not exist in this project."
                 )
-            apps_to_package = {app_name: self.apps[app_name]}
         elif app:
             apps_to_package = {app.app_name: app}
         else:

--- a/tests/commands/build/test_call.py
+++ b/tests/commands/build/test_call.py
@@ -1219,16 +1219,18 @@ def test_test_app_unbuilt(build_command, first_app_unbuilt, second_app):
     ]
 
 
-def test_build_app_single(build_command, first_app, second_app):
-    """If the --app flag is used, only the selected app is built."""
+# Parametrize both --apps/-a flags
+@pytest.mark.parametrize("app_flags", ["--app", "-a"])
+def test_build_app_single(build_command, first_app, second_app, app_flags):
+    """If the --app or -a flag is used, only the selected app is built."""
     # Add two apps
     build_command.apps = {
         "first": first_app,
         "second": second_app,
     }
 
-    # Configure command line options
-    options, _ = build_command.parse_options(["--app", "first"])
+    # Configure command line options with the parameterized flag
+    options, _ = build_command.parse_options([app_flags, "first"])
 
     # Run the build command
     build_command(**options)
@@ -1291,6 +1293,7 @@ def test_build_app_all_flags(build_command, first_app, second_app):
     # Add two apps
     build_command.apps = {
         "first": first_app,
+        "second": second_app,
     }
 
     # Configure command line with all available flags
@@ -1318,6 +1321,7 @@ def test_build_app_all_flags(build_command, first_app, second_app):
         ("verify-tools",),
         # App configs have been finalized
         ("finalize-app-config", "first"),
+        ("finalize-app-config", "second"),
         # First app is updated with all update flags
         (
             "update",

--- a/tests/commands/build/test_call.py
+++ b/tests/commands/build/test_call.py
@@ -11,11 +11,11 @@ def test_specific_app(build_command, first_app, second_app):
         "second": second_app,
     }
 
-    # Configure no command line options
-    options, _ = build_command.parse_options([])
+    # Configure command line options for building a specific app
+    options, _ = build_command.parse_options(["--app", "first"])
 
     # Run the build command
-    build_command(first_app, **options)
+    build_command(**options)
 
     # The right sequence of things will be done
     assert build_command.actions == [
@@ -25,6 +25,8 @@ def test_specific_app(build_command, first_app, second_app):
         ("verify-tools",),
         # App config has been finalized
         ("finalize-app-config", "first"),
+        # Finalises all apps
+        ("finalize-app-config", "second"),
         # App template is verified
         ("verify-app-template", "first"),
         # App tools are verified for app

--- a/tests/commands/package/test_call.py
+++ b/tests/commands/package/test_call.py
@@ -764,20 +764,23 @@ def test_already_packaged(package_command, first_app, tmp_path):
     assert not artefact_path.exists()
 
 
-def test_package_app_single(package_command, first_app):
-    """If the --app flag is used, only the selected app is packaged."""
-    # Add a single app
+# Parametrize both --apps/-a flags
+@pytest.mark.parametrize("app_flags", ["--app", "-a"])
+def test_package_app_single(package_command, first_app, second_app, app_flags):
+    """If the --app or -a flag is used, only the selected app is packaged."""
+    # Add two apps
     package_command.apps = {
         "first": first_app,
+        "second": second_app,
     }
 
-    # Configure the --app option
-    options, _ = package_command.parse_options(["--app", "first"])
+    # Configure command line options with the parameterized flag
+    options, _ = package_command.parse_options([app_flags, "first"])
 
     # Run the package command
     package_command(**options)
 
-    # The right sequence of things will be done
+    # Only the selected app is packaged
     assert package_command.actions == [
         # Host OS is verified
         ("verify-host",),
@@ -785,6 +788,7 @@ def test_package_app_single(package_command, first_app):
         ("verify-tools",),
         # App config has been finalized
         ("finalize-app-config", "first"),
+        ("finalize-app-config", "second"),
         # App template is verified
         ("verify-app-template", "first"),
         # App tools are verified
@@ -841,10 +845,13 @@ def test_package_app_none_defined(package_command):
     ]
 
 
-def test_package_app_all_flags(package_command, first_app, tmp_path):
+def test_package_app_all_flags(package_command, first_app, second_app):
     """Verify that all package-related flags work correctly with -a."""
     # Add a single app
-    package_command.apps = {"first": first_app}
+    package_command.apps = {
+        "first": first_app,
+        "second": second_app,
+    }
 
     # Configure command line options with all available flags
     options, _ = package_command.parse_options(
@@ -870,6 +877,7 @@ def test_package_app_all_flags(package_command, first_app, tmp_path):
         ("verify-tools",),
         # App config has been finalized
         ("finalize-app-config", "first"),
+        ("finalize-app-config", "second"),
         # App is updated with all update options
         (
             "update",

--- a/tests/commands/package/test_call.py
+++ b/tests/commands/package/test_call.py
@@ -52,11 +52,11 @@ def test_package_one_explicit_app(package_command, first_app, second_app, tmp_pa
         "second": second_app,
     }
 
-    # Configure no command line arguments
-    options, _ = package_command.parse_options([])
+    # Pass the app name
+    options, _ = package_command.parse_options(["--app", "first"])
 
-    # Run the build command on a specific app
-    package_command(first_app, **options)
+    # Run the package command
+    package_command(None, **options)
 
     # The right sequence of things will be done
     assert package_command.actions == [
@@ -66,6 +66,8 @@ def test_package_one_explicit_app(package_command, first_app, second_app, tmp_pa
         ("verify-tools",),
         # App config has been finalized
         ("finalize-app-config", "first"),
+        # All app configurations are finalized before packaging
+        ("finalize-app-config", "second"),
         # App template is verified
         ("verify-app-template", "first"),
         # App tools are verified for app


### PR DESCRIPTION
This pull request introduces the `-a / --app` option for `briefcase build` and `briefcase package`, allowing users to specify which app(s) to build/package instead of processing all apps in a project.

Allow specifying app name(s) to briefcase build and briefcase package #2148

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] All new features have been tested
- [ x ] All new features have been documented
- [ x ] I have read the **CONTRIBUTING.md** file
- [ x ] I will abide by the code of conduct
