### PR TITLE
Add XML content escaping filter to cookiecutter,py

### DIFF
--- a/changes/2103.bugfix.rst
+++ b/changes/2103.bugfix.rst
@@ -1,0 +1,1 @@
+Cookiecutter has been improved to escape special characters & < and >.

--- a/changes/2103.bugfix.rst
+++ b/changes/2103.bugfix.rst
@@ -1,1 +1,0 @@
-Cookiecutter has been improved to escape special characters & < and >.

--- a/changes/2103.feature.rst
+++ b/changes/2103.feature.rst
@@ -1,0 +1,2 @@
+A Cookiecutter filter for escaping XML content has been added.
+A Cookiecutter filter for quoting XML attributes appropriately.

--- a/changes/2103.feature.rst
+++ b/changes/2103.feature.rst
@@ -1,2 +1,1 @@
-A Cookiecutter filter for escaping XML content has been added.
-A Cookiecutter filter for quoting XML attributes appropriately.
+Cookiecutter filters for escaping XML content and attributes have been added.

--- a/src/briefcase/integrations/cookiecutter.py
+++ b/src/briefcase/integrations/cookiecutter.py
@@ -1,6 +1,7 @@
 """Jinja2 extensions."""
 
 import uuid
+from xml.sax.saxutils import escape
 
 from jinja2.ext import Extension
 
@@ -139,7 +140,12 @@ class XMLExtension(Extension):
             """Render value in XML format appropriate for an attribute."""
             return "true" if obj else "false"
 
+        def xml_escape(obj):
+            """Filter to escape characters <, >, &, " and '"""
+            return escape(obj)
+
         environment.filters["bool_attr"] = bool_attr
+        environment.filters["xml_escape"] = xml_escape
 
 
 class UUIDExtension(Extension):

--- a/src/briefcase/integrations/cookiecutter.py
+++ b/src/briefcase/integrations/cookiecutter.py
@@ -1,7 +1,7 @@
 """Jinja2 extensions."""
 
 import uuid
-from xml.sax.saxutils import escape
+from xml.sax.saxutils import escape, quoteattr
 
 from jinja2.ext import Extension
 
@@ -144,8 +144,13 @@ class XMLExtension(Extension):
             """Filter to escape characters <, >, &, " and '"""
             return escape(obj)
 
+        def xml_attr(obj):
+            """ "Filter to quote an XML value appropriately."""
+            return quoteattr(obj)
+
         environment.filters["bool_attr"] = bool_attr
         environment.filters["xml_escape"] = xml_escape
+        environment.filters["xml_attr"] = xml_attr
 
 
 class UUIDExtension(Extension):

--- a/tests/integrations/cookiecutter/test_XMLExtension.py
+++ b/tests/integrations/cookiecutter/test_XMLExtension.py
@@ -53,10 +53,8 @@ def test_xml_escape(value, expected):
         ("Hello ' World", '"Hello \' World"'),
         # A double quote wrapped in single quotes
         ('Hello " World', "'Hello \" World'"),
-        # A double quote and a single quote wrapped in single quotes
+        # A double quote and a single quote in the same string value
         ("Hello \" And ' World", '"Hello &quot; And \' World"'),
-        # A double quote and a single quote wrapped in double quotes
-        ("Hello \" Or ' World", '"Hello &quot; Or \' World"'),
     ],
 )
 def test_xml_attr(value, expected):

--- a/tests/integrations/cookiecutter/test_XMLExtension.py
+++ b/tests/integrations/cookiecutter/test_XMLExtension.py
@@ -44,3 +44,23 @@ def test_xml_escape(value, expected):
     env.filters = {}
     XMLExtension(env)
     assert env.filters["xml_escape"](value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # A single quote wrapped in double quotes
+        ("Hello ' World", '"Hello \' World"'),
+        # A double quote wrapped in single quotes
+        ('Hello " World', "'Hello \" World'"),
+        # A double quote and a single quote wrapped in single quotes
+        ("Hello \" And ' World", '"Hello &quot; And \' World"'),
+        # A double quote and a single quote wrapped in double quotes
+        ("Hello \" Or ' World", '"Hello &quot; Or \' World"'),
+    ],
+)
+def test_xml_attr(value, expected):
+    env = MagicMock()
+    env.filters = {}
+    XMLExtension(env)
+    assert env.filters["xml_attr"](value) == expected

--- a/tests/integrations/cookiecutter/test_XMLExtension.py
+++ b/tests/integrations/cookiecutter/test_XMLExtension.py
@@ -24,3 +24,23 @@ def test_bool_attr(value, expected):
     env.filters = {}
     XMLExtension(env)
     assert env.filters["bool_attr"](value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # No special characters
+        ("Hello World", "Hello World"),
+        # Ampersands escaped
+        ("Hello & World", "Hello &amp; World"),
+        # Less than
+        ("Hello < World", "Hello &lt; World"),
+        # Greater than
+        ("Hello > World", "Hello &gt; World"),
+    ],
+)
+def test_xml_escape(value, expected):
+    env = MagicMock()
+    env.filters = {}
+    XMLExtension(env)
+    assert env.filters["xml_escape"](value) == expected


### PR DESCRIPTION
Added an XML content escaping filter to cookiecutter.py.
By using this filter in the windows app and visual studio templates, special characters  & < and > will be escaped. refs #2103 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
