### PR TITLE
Add changenotes for recent .pth fixes to templates.

### DIFF
--- a/changes/2204.removal.rst
+++ b/changes/2204.removal.rst
@@ -1,0 +1,1 @@
+The ``app_packages`` folder now occurs *after* the ``app`` folder in the package resolution path on Windows, Linux, macOS and iOS. This will result in subtle changes in behavior if you have packages defined in your ``sources``  that have the same name as packages installed from your ``requires``.

--- a/changes/381.bugfix.rst
+++ b/changes/381.bugfix.rst
@@ -1,0 +1,1 @@
+``.pth`` files created by packages installed as dependencies are now correctly processed during application startup on macOS, Windows, Linux and iOS.


### PR DESCRIPTION
This PR doesn't fix anything itself, as the fixes are all in platform templates:

* beeware/briefcase-macOS-Xcode-template#72
* beeware/briefcase-windows-VisualStudio-template#52
* beeware/briefcase-linux-flatpak-template#58
* beeware/briefcase-linux-system-template#36
* beeware/briefcase-iOS-Xcode-template#49

There is also a change on the support testbed (beeware/Python-support-testbed#118)

This should not be merged until beeware/Python-support-testbed#118 has been reviewed and merged.

It won't fix the ``.pth`` issue on Web or Android. Android requires a new Chaquopy release to fix the problem; web requires a much more complex injection process that Emscripten and pyscript don't support as of yet.

Fixes #381.
Refs #2204.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
