### PR TITLE
fix: finding stub app on macOS with `.` in formal name

### DIFF
--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -401,9 +401,12 @@ a custom location for Briefcase's tools.
 
         :param app: The app config
         """
-        return self.binary_executable_path(app).parent / (
-            "Stub" + self.binary_executable_path(app).suffix
-        )
+        if sys.platform == "win32":
+            return self.binary_executable_path(app).parent / (
+                "Stub" + self.binary_executable_path(app).suffix
+            )
+        else:
+            return self.binary_executable_path(app).parent / ("Stub")
 
     def briefcase_toml(self, app: AppConfig) -> dict[str, ...]:
         """Load the ``briefcase.toml`` file provided by the app template.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

fix: #2151 

- fix issue in finding stub app on macOS with `.` in formal name




## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
