### PR TITLE
Accept other changelog name and extension #2116

### DIFF
--- a/changes/2116.feature.rst
+++ b/changes/2116.feature.rst
@@ -1,1 +1,1 @@
-Briefcase now supports multiple valid changelog filenames when building and packaging applications
+Briefcase now supports the use of ``HISTORY``, ``NEWS`` and ``RELEASES`` as filenames for the change log of a project (in addition to ``CHANGELOG``). It also supports the use of ``.md``, ``.rst`` and ``.txt`` extensions on those files.

--- a/changes/2116.feature.rst
+++ b/changes/2116.feature.rst
@@ -1,0 +1,1 @@
+Briefcase now supports multiple valid changelog filenames when building and packaging applications

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -686,10 +686,10 @@ class ConvertCommand(NewCommand):
 
         if matched_changelog_name is False:
             self.console.warning(
-                f"\nChangelog file not found in '{self.base_path}'. You should either "
-                f"create a new '{self.base_path / 'changelog_file'}' file, or rename an "
-                f"existing changelog file with the following as its name "
-                f"(CHANGELOG, HISTORY, NEWS or RELEASES) with extensions (.md, .rst, .txt or no extension)"
+                f"create a new changelog file in {self.base_path}, or rename an "
+                "existing file to a known changelog file name (one of 'CHANGELOG', "
+                "'HISTORY', 'NEWS' or 'RELEASES'; the file may have an extension of "
+                "'.md', '.rst', '.txt', or have no extension)"
             )
 
         # Copy tests or test entry script

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -674,7 +674,8 @@ class ConvertCommand(NewCommand):
 
         if changelog is None:
             self.console.warning(
-                f"Create a new changelog file in {self.base_path}, or rename an "
+                f"\nChangelog file not found in {self.base_path!r}. You should either "
+                f"create a new changelog file in {self.base_path!r}, or rename an "
                 "existing file to a known changelog file name (one of 'CHANGELOG', "
                 "'HISTORY', 'NEWS' or 'RELEASES'; the file may have an extension of "
                 "'.md', '.rst', '.txt', or have no extension)"

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -799,8 +799,12 @@ To run your application, type:
 
 
 def find_changelog_filename(base_path):
-    """Search for a valid changelog file in the specified directory
-    and return its format name if it exists, otherwise return None"""
+    """Find a valid changelog file in a given directory.
+    
+    :param base_path: The directory to search
+    :returns: The filename of the changelog that was found; None if a changelog
+        with a known name could not be found.
+    """
     changelog_formats = [
         f"{name}{extension}"
         for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -670,21 +670,9 @@ class ConvertCommand(NewCommand):
             copy2(project_dir / "LICENSE", self.base_path / "LICENSE")
 
         # See if changefile exists
-        matched_changelog_name = False
-        changelog_formats = [
-            f"{name}{extension}"
-            for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
-            for extension in ["", ".md", ".rst", ".txt"]
-        ]
+        changelog = find_changelog_filename(self.base_path)
 
-        # Stops checking once a match is found
-        for format in changelog_formats:
-            changelog_source = self.base_path / format
-            if changelog_source.is_file():
-                matched_changelog_name = True
-                break
-
-        if matched_changelog_name is False:
+        if changelog is None:
             self.console.warning(
                 f"create a new changelog file in {self.base_path}, or rename an "
                 "existing file to a known changelog file name (one of 'CHANGELOG', "
@@ -808,3 +796,19 @@ To run your application, type:
                 project_overrides=parse_project_overrides(project_overrides),
                 **options,
             )
+
+
+def find_changelog_filename(base_path):
+
+    changelog_formats = [
+        f"{name}{extension}"
+        for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
+        for extension in ["", ".md", ".rst", ".txt"]
+    ]
+
+    # Stops checking once a match is found
+    for format in changelog_formats:
+        changelog = base_path / format
+        if changelog.is_file():
+            return format
+    return None

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -799,7 +799,8 @@ To run your application, type:
 
 
 def find_changelog_filename(base_path):
-
+    """Search for a valid changelog file in the specified directory
+    and return its format name if it exists, otherwise return None"""
     changelog_formats = [
         f"{name}{extension}"
         for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -670,8 +670,33 @@ class ConvertCommand(NewCommand):
             copy2(project_dir / "LICENSE", self.base_path / "LICENSE")
 
         # Copy changelog file
-        changelog_file = self.base_path / "CHANGELOG"
-        if not changelog_file.is_file():
+        changelog_name_formats = [
+            "CHANGELOG",
+            "HISTORY",
+            "NEWS",
+            "RELEASES",
+            "CHANGELOG.md",
+            "CHANGELOG.rst",
+            "CHANGELOG.txt",
+            "HISTORY.md",
+            "HISTORY.rst",
+            "HISTORY.txt",
+            "NEWS.md",
+            "NEWS.rst",
+            "NEWS.txt",
+            "RELEASES.md",
+            "RELEASES.rst",
+            "RELEASES.txt",
+        ]
+        matched_changelog_name = None
+
+        for name in changelog_name_formats:
+            changelog = self.base_path / name
+            if changelog.is_file():
+                matched_changelog_name = name
+                break
+
+        if matched_changelog_name is None:
             self.console.warning(
                 f"\nChangelog file not found in '{self.base_path}'. You should either "
                 f"create a new '{self.base_path / 'CHANGELOG'}' file, or rename an "

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -674,7 +674,7 @@ class ConvertCommand(NewCommand):
 
         if changelog is None:
             self.console.warning(
-                f"create a new changelog file in {self.base_path}, or rename an "
+                f"Create a new changelog file in {self.base_path}, or rename an "
                 "existing file to a known changelog file name (one of 'CHANGELOG', "
                 "'HISTORY', 'NEWS' or 'RELEASES'; the file may have an extension of "
                 "'.md', '.rst', '.txt', or have no extension)"

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -801,7 +801,7 @@ To run your application, type:
 
 def find_changelog_filename(base_path):
     """Find a valid changelog file in a given directory.
-    
+
     :param base_path: The directory to search
     :returns: The filename of the changelog that was found; None if a changelog
         with a known name could not be found.

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -669,38 +669,27 @@ class ConvertCommand(NewCommand):
             )
             copy2(project_dir / "LICENSE", self.base_path / "LICENSE")
 
-        # Copy changelog file
-        changelog_name_formats = [
-            "CHANGELOG",
-            "HISTORY",
-            "NEWS",
-            "RELEASES",
-            "CHANGELOG.md",
-            "CHANGELOG.rst",
-            "CHANGELOG.txt",
-            "HISTORY.md",
-            "HISTORY.rst",
-            "HISTORY.txt",
-            "NEWS.md",
-            "NEWS.rst",
-            "NEWS.txt",
-            "RELEASES.md",
-            "RELEASES.rst",
-            "RELEASES.txt",
+        # See if changefile exists
+        matched_changelog_name = False
+        changelog_formats = [
+            f"{name}{extension}"
+            for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
+            for extension in ["", ".md", ".rst", ".txt"]
         ]
-        matched_changelog_name = None
 
-        for name in changelog_name_formats:
-            changelog = self.base_path / name
-            if changelog.is_file():
-                matched_changelog_name = name
+        # Stops checking once a match is found
+        for format in changelog_formats:
+            changelog_source = self.base_path / format
+            if changelog_source.is_file():
+                matched_changelog_name = True
                 break
 
-        if matched_changelog_name is None:
+        if matched_changelog_name is False:
             self.console.warning(
                 f"\nChangelog file not found in '{self.base_path}'. You should either "
-                f"create a new '{self.base_path / 'CHANGELOG'}' file, or rename an "
-                "already existing changelog file to 'CHANGELOG'."
+                f"create a new '{self.base_path / 'changelog_file'}' file, or rename an "
+                f"existing changelog file with the following as its name "
+                f"(CHANGELOG, HISTORY, NEWS or RELEASES) with extensions (.md, .rst, .txt or no extension)"
             )
 
         # Copy tests or test entry script

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -765,10 +765,11 @@ app's configuration.
             if changelog is None:
                 raise BriefcaseCommandError(
                     """\
-Your project does not contain a changelog file with a valid file name.
-Create a changelog file with the following as its name (CHANGELOG, HISTORY, NEWS or RELEASES)
-with extensions (.md, .rst, .txt or no extension) in the same directory as your `pyproject.toml`
-with details about the release.
+Your project does not contain a changelog file with a known file name. You
+must provided a changelog file in the same directory as your `pyproject.toml`,
+with a known changelog file name (one of 'CHANGELOG', 'HISTORY', 'NEWS' or
+'RELEASES'; the file may have an extension of '.md', '.rst', or '.txt', or have
+no extension).
 """
                 )
 
@@ -1147,10 +1148,11 @@ class LinuxSystemPackageCommand(LinuxSystemMixin, PackageCommand):
                 if changelog is None:
                     raise BriefcaseCommandError(
                         """\
-Your project does not contain a changelog file with a valid file name.
-Create a changelog file with the following as its name (CHANGELOG, HISTORY, NEWS or RELEASES)
-with extensions (.md, .rst, .txt or no extension) in the same directory as your `pyproject.toml`
-with details about the release.
+Your project does not contain a changelog file with a known file name. You
+must provided a changelog file in the same directory as your `pyproject.toml`,
+with a known changelog file name (one of 'CHANGELOG', 'HISTORY', 'NEWS' or
+'RELEASES'; the file may have an extension of '.md', '.rst', or '.txt', or have
+no extension).
 """
                     )
 

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -14,6 +14,7 @@ from briefcase.commands import (
     RunCommand,
     UpdateCommand,
 )
+from briefcase.commands.convert import find_changelog_filename
 from briefcase.config import AppConfig
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.integrations.docker import Docker, DockerAppContext
@@ -1304,22 +1305,6 @@ with details about the release.
 
 class LinuxSystemPublishCommand(LinuxSystemMixin, PublishCommand):
     description = "Publish a Linux system project."
-
-
-def find_changelog_filename(base_path):
-
-    changelog_formats = [
-        f"{name}{extension}"
-        for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
-        for extension in ["", ".md", ".rst", ".txt"]
-    ]
-
-    # Stops checking once a match is found
-    for format in changelog_formats:
-        changelog = base_path / format
-        if changelog.is_file():
-            return format
-    return None
 
 
 # Declare the briefcase command bindings

--- a/tests/commands/convert/test__find_changelog_filename.py
+++ b/tests/commands/convert/test__find_changelog_filename.py
@@ -1,8 +1,7 @@
 import pytest
+from utils import create_file
 
 from briefcase.platforms.linux.system import find_changelog_filename
-
-from ....utils import create_file
 
 
 def test_no_changelog(tmp_path):

--- a/tests/commands/convert/test__find_changelog_filename.py
+++ b/tests/commands/convert/test__find_changelog_filename.py
@@ -1,10 +1,12 @@
 import pytest
-from utils import create_file
 
 from briefcase.platforms.linux.system import find_changelog_filename
 
+from ..utils import create_file
+
 
 def test_no_changelog(tmp_path):
+    """Changelog file does not exist"""
     assert find_changelog_filename(tmp_path) is None
 
 
@@ -32,7 +34,6 @@ def test_has_changelog(tmp_path, changelog_filename):
 
 def test_multiple_changefile(tmp_path):
     """If there's more than one changelog, only one if found."""
-
     changelog_file1 = tmp_path / "base_path/NEWS.txt"
     changelog_file2 = tmp_path / "base_path/CHANGELOG.md"
     create_file(changelog_file1, "First App Changelog")

--- a/tests/commands/convert/test__find_changelog_filename.py
+++ b/tests/commands/convert/test__find_changelog_filename.py
@@ -33,7 +33,8 @@ def test_has_changelog(tmp_path, changelog_filename):
 
 
 def test_multiple_changefile(tmp_path):
-    """If there's more than one changelog, only one if found."""
+    """If there's more than one changelog, only one is found."""
+
     changelog_file1 = tmp_path / "base_path/NEWS.txt"
     changelog_file2 = tmp_path / "base_path/CHANGELOG.md"
     create_file(changelog_file1, "First App Changelog")

--- a/tests/commands/convert/test__find_changelog_filename.py
+++ b/tests/commands/convert/test__find_changelog_filename.py
@@ -2,7 +2,7 @@ import pytest
 
 from briefcase.platforms.linux.system import find_changelog_filename
 
-from ..utils import create_file
+from ...utils import create_file
 
 
 def test_no_changelog(tmp_path):

--- a/tests/commands/convert/test_migrate_necessary_files.py
+++ b/tests/commands/convert/test_migrate_necessary_files.py
@@ -199,9 +199,7 @@ def test_warning_without_changelog_file(
 @pytest.mark.parametrize(
     "changelog_filename",
     [
-        f"{name}{extension}"
-        for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
-        for extension in ["", ".md", ".rst", ".txt"]
+        format_name for name in ["CHANGELOG", "NEWS.txt"]
     ],
 )
 @pytest.mark.parametrize("test_source_dir", ["tests"])

--- a/tests/commands/convert/test_migrate_necessary_files.py
+++ b/tests/commands/convert/test_migrate_necessary_files.py
@@ -189,7 +189,8 @@ def test_warning_without_changelog_file(
     )
 
     convert_command.console.warning.assert_called_once_with(
-        f"Create a new changelog file in {convert_command.base_path}, or rename an "
+        f"\nChangelog file not found in {convert_command.base_path!r}. You should either "
+        f"create a new changelog file in {convert_command.base_path!r}, or rename an "
         "existing file to a known changelog file name (one of 'CHANGELOG', "
         "'HISTORY', 'NEWS' or 'RELEASES'; the file may have an extension of "
         "'.md', '.rst', '.txt', or have no extension)"
@@ -198,9 +199,7 @@ def test_warning_without_changelog_file(
 
 @pytest.mark.parametrize(
     "changelog_filename",
-    [
-        format_name for name in ["CHANGELOG", "NEWS.txt"]
-    ],
+    [format for format in ["CHANGELOG", "NEWS.txt"]],
 )
 @pytest.mark.parametrize("test_source_dir", ["tests"])
 def test_no_warning_with_license_and_changelog_file(
@@ -248,7 +247,8 @@ def test_two_warnings_without_license_and_changelog_file(
         "Briefcase will create a template 'LICENSE' file."
     )
     changelog_warning = (
-        f"Create a new changelog file in {convert_command.base_path}, or rename an "
+        f"\nChangelog file not found in {convert_command.base_path!r}. You should either "
+        f"create a new changelog file in {convert_command.base_path!r}, or rename an "
         "existing file to a known changelog file name (one of 'CHANGELOG', "
         "'HISTORY', 'NEWS' or 'RELEASES'; the file may have an extension of "
         "'.md', '.rst', '.txt', or have no extension)"

--- a/tests/commands/convert/test_migrate_necessary_files.py
+++ b/tests/commands/convert/test_migrate_necessary_files.py
@@ -189,10 +189,10 @@ def test_warning_without_changelog_file(
     )
 
     convert_command.console.warning.assert_called_once_with(
-        f"\nChangelog file not found in '{convert_command.base_path}'. You should either "
-        f"create a new '{convert_command.base_path / 'changelog_file'}' file, or rename an "
-        f"existing changelog file with the following as its name "
-        f"(CHANGELOG, HISTORY, NEWS or RELEASES) with extensions (.md, .rst, .txt or no extension)"
+        f"Create a new changelog file in {convert_command.base_path}, or rename an "
+        "existing file to a known changelog file name (one of 'CHANGELOG', "
+        "'HISTORY', 'NEWS' or 'RELEASES'; the file may have an extension of "
+        "'.md', '.rst', '.txt', or have no extension)"
     )
 
 
@@ -250,10 +250,10 @@ def test_two_warnings_without_license_and_changelog_file(
         "Briefcase will create a template 'LICENSE' file."
     )
     changelog_warning = (
-        f"\nChangelog file not found in '{convert_command.base_path}'. You should either "
-        f"create a new '{convert_command.base_path / 'changelog_file'}' file, or rename an "
-        f"existing changelog file with the following as its name "
-        f"(CHANGELOG, HISTORY, NEWS or RELEASES) with extensions (.md, .rst, .txt or no extension)"
+        f"Create a new changelog file in {convert_command.base_path}, or rename an "
+        "existing file to a known changelog file name (one of 'CHANGELOG', "
+        "'HISTORY', 'NEWS' or 'RELEASES'; the file may have an extension of "
+        "'.md', '.rst', '.txt', or have no extension)"
     )
     assert convert_command.console.warning.mock_calls == [
         mock.call(license_warning),

--- a/tests/commands/convert/test_migrate_necessary_files.py
+++ b/tests/commands/convert/test_migrate_necessary_files.py
@@ -199,7 +199,7 @@ def test_warning_without_changelog_file(
 
 @pytest.mark.parametrize(
     "changelog_filename",
-    [format for format in ["CHANGELOG", "NEWS.txt"]],
+    ["CHANGELOG", "NEWS.txt"],
 )
 @pytest.mark.parametrize("test_source_dir", ["tests"])
 def test_no_warning_with_license_and_changelog_file(

--- a/tests/commands/convert/test_migrate_necessary_files.py
+++ b/tests/commands/convert/test_migrate_necessary_files.py
@@ -190,17 +190,27 @@ def test_warning_without_changelog_file(
 
     convert_command.console.warning.assert_called_once_with(
         f"\nChangelog file not found in '{convert_command.base_path}'. You should either "
-        f"create a new '{convert_command.base_path / 'CHANGELOG'}' file, or rename an "
-        "already existing changelog file to 'CHANGELOG'."
+        f"create a new '{convert_command.base_path / 'changelog_file'}' file, or rename an "
+        f"existing changelog file with the following as its name "
+        f"(CHANGELOG, HISTORY, NEWS or RELEASES) with extensions (.md, .rst, .txt or no extension)"
     )
 
 
+@pytest.mark.parametrize(
+    "changelog_filename",
+    [
+        f"{name}{extension}"
+        for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
+        for extension in ["", ".md", ".rst", ".txt"]
+    ],
+)
 @pytest.mark.parametrize("test_source_dir", ["tests"])
 def test_no_warning_with_license_and_changelog_file(
     convert_command,
     project_dir_with_files,
     dummy_app_name,
     test_source_dir,
+    changelog_filename,
 ):
     """No warning is raised if both license file and changelog file is present."""
     convert_command.console.warning = mock.MagicMock()
@@ -210,7 +220,7 @@ def test_no_warning_with_license_and_changelog_file(
         '[project]\nlicense = { file = "LICENSE.txt" }',
     )
     create_file(convert_command.base_path / "LICENSE.txt", "")
-    create_file(convert_command.base_path / "CHANGELOG", "")
+    create_file(convert_command.base_path / changelog_filename, "")
     convert_command.migrate_necessary_files(
         project_dir_with_files,
         test_source_dir,
@@ -241,8 +251,9 @@ def test_two_warnings_without_license_and_changelog_file(
     )
     changelog_warning = (
         f"\nChangelog file not found in '{convert_command.base_path}'. You should either "
-        f"create a new '{convert_command.base_path / 'CHANGELOG'}' file, or rename an "
-        "already existing changelog file to 'CHANGELOG'."
+        f"create a new '{convert_command.base_path / 'changelog_file'}' file, or rename an "
+        f"existing changelog file with the following as its name "
+        f"(CHANGELOG, HISTORY, NEWS or RELEASES) with extensions (.md, .rst, .txt or no extension)"
     )
     assert convert_command.console.warning.mock_calls == [
         mock.call(license_warning),

--- a/tests/platforms/linux/system/test__find_changelog_filename.py
+++ b/tests/platforms/linux/system/test__find_changelog_filename.py
@@ -1,0 +1,48 @@
+import pytest
+
+from briefcase.platforms.linux.system import find_changelog_filename
+
+from ....utils import create_file
+
+
+def test_no_changelog(tmp_path):
+    assert find_changelog_filename(tmp_path) is None
+
+
+def test_no_valid_changelog(tmp_path):
+    """Changelog file exists but with invalid name format so its not accepted"""
+    changelog_file = tmp_path / "base_path/invalid_changelog_format"
+    create_file(changelog_file, "First App Changelog")
+    assert find_changelog_filename(tmp_path / "base_path") is None
+
+
+@pytest.mark.parametrize(
+    "changelog_filename",
+    [
+        f"{name}{extension}"
+        for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
+        for extension in ["", ".md", ".rst", ".txt"]
+    ],
+)
+def test_has_changelog(tmp_path, changelog_filename):
+    """Makes sure all formats are accepted"""
+    changelog_file = tmp_path / f"base_path/{changelog_filename}"
+    create_file(changelog_file, "First App Changelog")
+    assert find_changelog_filename(tmp_path / "base_path") == changelog_filename
+
+
+def test_multiple_changefile(tmp_path):
+    """
+    More than one changelog exists but only first one according
+    the below search order is accepted:
+
+    CHANGELOG, CHANGELOG.md, CHANGELOG.rst, CHANGELOG.txt,
+    HISTORY, HISTORY.md, HISTORY.rst, HISTORY.txt,
+    NEWS, NEWS.md, NEWS.rst, NEWS.txt,
+    RELEASES, RELEASES.md, RELEASES.rst, RELEASES.txt"""
+
+    changelog_file1 = tmp_path / "base_path/NEWS.txt"
+    changelog_file2 = tmp_path / "base_path/CHANGELOG.md"
+    create_file(changelog_file1, "First App Changelog")
+    create_file(changelog_file2, "First App Changelog")
+    assert find_changelog_filename(tmp_path / "base_path") == "CHANGELOG.md"

--- a/tests/platforms/linux/system/test__find_changelog_filename.py
+++ b/tests/platforms/linux/system/test__find_changelog_filename.py
@@ -32,14 +32,7 @@ def test_has_changelog(tmp_path, changelog_filename):
 
 
 def test_multiple_changefile(tmp_path):
-    """
-    More than one changelog exists but only first one according
-    the below search order is accepted:
-
-    CHANGELOG, CHANGELOG.md, CHANGELOG.rst, CHANGELOG.txt,
-    HISTORY, HISTORY.md, HISTORY.rst, HISTORY.txt,
-    NEWS, NEWS.md, NEWS.rst, NEWS.txt,
-    RELEASES, RELEASES.md, RELEASES.rst, RELEASES.txt"""
+    """If there's more than one changelog, only one if found."""
 
     changelog_file1 = tmp_path / "base_path/NEWS.txt"
     changelog_file2 = tmp_path / "base_path/CHANGELOG.md"

--- a/tests/platforms/linux/system/test_build.py
+++ b/tests/platforms/linux/system/test_build.py
@@ -33,9 +33,25 @@ def build_command(tmp_path, first_app):
     return command
 
 
+@pytest.mark.parametrize(
+    "changelog_filename",
+    [
+        f"{name}{extension}"
+        for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
+        for extension in ["", ".md", ".rst", ".txt"]
+    ],
+)
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build Linux apps on Windows")
-def test_build_app(build_command, first_app, tmp_path):
+def test_build_app(build_command, first_app, tmp_path, changelog_filename):
     """An app can be built as a deb."""
+
+    # Remove CHANGELOG made in conftest.py and replace with another possible changelog format
+    base_path = tmp_path / "base_path"
+    old_changelog = base_path / "CHANGELOG"
+    new_changelog = base_path / changelog_filename
+    old_changelog.unlink()
+    create_file(new_changelog, "First App Changelog")
+
     # Build the app
     build_command.build_app(first_app)
 
@@ -225,7 +241,7 @@ def test_missing_changelog(build_command, first_app, tmp_path):
     # Build the app; it will fail
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"Your project does not contain a CHANGELOG file.",
+        match=r"Your project does not contain a changelog file.",
     ):
         build_command.build_app(first_app)
 

--- a/tests/platforms/linux/system/test_build.py
+++ b/tests/platforms/linux/system/test_build.py
@@ -33,25 +33,9 @@ def build_command(tmp_path, first_app):
     return command
 
 
-@pytest.mark.parametrize(
-    "changelog_filename",
-    [
-        f"{name}{extension}"
-        for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
-        for extension in ["", ".md", ".rst", ".txt"]
-    ],
-)
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build Linux apps on Windows")
-def test_build_app(build_command, first_app, tmp_path, changelog_filename):
+def test_build_app(build_command, first_app, tmp_path):
     """An app can be built as a deb."""
-
-    # Remove CHANGELOG made in conftest.py and replace with another possible changelog format
-    base_path = tmp_path / "base_path"
-    old_changelog = base_path / "CHANGELOG"
-    new_changelog = base_path / changelog_filename
-    old_changelog.unlink()
-    create_file(new_changelog, "First App Changelog")
-
     # Build the app
     build_command.build_app(first_app)
 

--- a/tests/platforms/linux/system/test_package__pkg.py
+++ b/tests/platforms/linux/system/test_package__pkg.py
@@ -146,31 +146,16 @@ def test_verify_docker(package_command, first_app_pkg, monkeypatch):
     makepkg.exists.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "changelog_filename",
-    [
-        f"{name}{extension}"
-        for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
-        for extension in ["", ".md", ".rst", ".txt"]
-    ],
-)
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build PKGs on Windows")
-def test_pkg_package(package_command, first_app_pkg, tmp_path, changelog_filename):
-    """A pkg app can be packaged for every changelog format."""
+def test_pkg_package(package_command, first_app_pkg, tmp_path):
+    """A pkg app can be packaged."""
     bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
-
-    # Remove CHANGELOG made in conftest.py and replace with another possible changelog format
-    base_path = tmp_path / "base_path"
-    old_changelog = base_path / "CHANGELOG"
-    new_changelog = base_path / changelog_filename
-    old_changelog.unlink()
-    create_file(new_changelog, "First App Changelog")
 
     # Package the app
     package_command.package_app(first_app_pkg)
 
     # The CHANGELOG file is copied
-    assert (bundle_path / f"pkgbuild/{changelog_filename}").exists()
+    assert (bundle_path / "pkgbuild/CHANGELOG").exists()
 
     # The PKGBUILD file is written
     assert (bundle_path / "pkgbuild/PKGBUILD").exists()

--- a/tests/platforms/linux/system/test_package__pkg.py
+++ b/tests/platforms/linux/system/test_package__pkg.py
@@ -146,16 +146,30 @@ def test_verify_docker(package_command, first_app_pkg, monkeypatch):
     makepkg.exists.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "changelog_filename",
+    [
+        format_name
+        for name in ["HISTORY", "NEWS.txt"]
+    ],
+)
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build PKGs on Windows")
-def test_pkg_package(package_command, first_app_pkg, tmp_path):
+def test_pkg_package(package_command, first_app_pkg, tmp_path, changelog_filename):
     """A pkg app can be packaged."""
     bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
+    # Remove CHANGELOG made in conftest.py and replace with another possible changelog format
+    base_path = tmp_path / "base_path"
+    old_changelog = base_path / "CHANGELOG"
+    new_changelog = base_path / changelog_filename
+    old_changelog.unlink()
+    create_file(new_changelog, "First App Changelog")
+    
     # Package the app
     package_command.package_app(first_app_pkg)
 
     # The CHANGELOG file is copied
-    assert (bundle_path / "pkgbuild/CHANGELOG").exists()
+    assert (bundle_path / f"pkgbuild/{changelog_filename}").exists()
 
     # The PKGBUILD file is written
     assert (bundle_path / "pkgbuild/PKGBUILD").exists()

--- a/tests/platforms/linux/system/test_package__pkg.py
+++ b/tests/platforms/linux/system/test_package__pkg.py
@@ -148,7 +148,7 @@ def test_verify_docker(package_command, first_app_pkg, monkeypatch):
 
 @pytest.mark.parametrize(
     "changelog_filename",
-    [format for format in ["HISTORY", "NEWS.txt"]],
+    ["HISTORY", "NEWS.txt"],
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build PKGs on Windows")
 def test_pkg_package(package_command, first_app_pkg, tmp_path, changelog_filename):

--- a/tests/platforms/linux/system/test_package__pkg.py
+++ b/tests/platforms/linux/system/test_package__pkg.py
@@ -148,10 +148,7 @@ def test_verify_docker(package_command, first_app_pkg, monkeypatch):
 
 @pytest.mark.parametrize(
     "changelog_filename",
-    [
-        format_name
-        for name in ["HISTORY", "NEWS.txt"]
-    ],
+    [format for format in ["HISTORY", "NEWS.txt"]],
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build PKGs on Windows")
 def test_pkg_package(package_command, first_app_pkg, tmp_path, changelog_filename):
@@ -164,7 +161,7 @@ def test_pkg_package(package_command, first_app_pkg, tmp_path, changelog_filenam
     new_changelog = base_path / changelog_filename
     old_changelog.unlink()
     create_file(new_changelog, "First App Changelog")
-    
+
     # Package the app
     package_command.package_app(first_app_pkg)
 

--- a/tests/platforms/linux/system/test_package__pkg.py
+++ b/tests/platforms/linux/system/test_package__pkg.py
@@ -146,16 +146,31 @@ def test_verify_docker(package_command, first_app_pkg, monkeypatch):
     makepkg.exists.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "changelog_filename",
+    [
+        f"{name}{extension}"
+        for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
+        for extension in ["", ".md", ".rst", ".txt"]
+    ],
+)
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build PKGs on Windows")
-def test_pkg_package(package_command, first_app_pkg, tmp_path):
-    """A pkg app can be packaged."""
+def test_pkg_package(package_command, first_app_pkg, tmp_path, changelog_filename):
+    """A pkg app can be packaged for every changelog format."""
     bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
+
+    # Remove CHANGELOG made in conftest.py and replace with another possible changelog format
+    base_path = tmp_path / "base_path"
+    old_changelog = base_path / "CHANGELOG"
+    new_changelog = base_path / changelog_filename
+    old_changelog.unlink()
+    create_file(new_changelog, "First App Changelog")
 
     # Package the app
     package_command.package_app(first_app_pkg)
 
     # The CHANGELOG file is copied
-    assert (bundle_path / "pkgbuild/CHANGELOG").exists()
+    assert (bundle_path / f"pkgbuild/{changelog_filename}").exists()
 
     # The PKGBUILD file is written
     assert (bundle_path / "pkgbuild/PKGBUILD").exists()
@@ -465,7 +480,7 @@ def test_no_changelog(package_command, first_app_pkg, tmp_path):
 
     # Package the app; this will fail
     with pytest.raises(
-        BriefcaseCommandError, match=r"Your project does not contain a CHANGELOG file."
+        BriefcaseCommandError, match=r"Your project does not contain a changelog file."
     ):
         package_command.package_app(first_app_pkg)
 

--- a/tests/platforms/linux/system/test_package__rpm.py
+++ b/tests/platforms/linux/system/test_package__rpm.py
@@ -146,10 +146,25 @@ def test_verify_docker(package_command, first_app_rpm, monkeypatch):
     rpmbuild.exists.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "changelog_filename",
+    [
+        format_name
+        for name in ["HISTORY", "NEWS.txt"]
+    ],
+)
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build RPMs on Windows")
-def test_rpm_package(package_command, first_app_rpm, tmp_path):
+def test_rpm_package(package_command, first_app_rpm, tmp_path, changelog_filename):
     """A rpm app can be packaged."""
     bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
+
+
+        # Remove CHANGELOG made in conftest.py and replace with another possible changelog format
+    base_path = tmp_path / "base_path"
+    old_changelog = base_path / "CHANGELOG"
+    new_changelog = base_path / changelog_filename
+    old_changelog.unlink()
+    create_file(new_changelog, "First App Changelog")
 
     # Package the app
     package_command.package_app(first_app_rpm)

--- a/tests/platforms/linux/system/test_package__rpm.py
+++ b/tests/platforms/linux/system/test_package__rpm.py
@@ -147,7 +147,8 @@ def test_verify_docker(package_command, first_app_rpm, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "changelog_filename", [format for format in ["HISTORY", "NEWS.txt"]]
+    "changelog_filename",
+    ["HISTORY", "NEWS.txt"],
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build RPMs on Windows")
 def test_rpm_package(package_command, first_app_rpm, tmp_path, changelog_filename):

--- a/tests/platforms/linux/system/test_package__rpm.py
+++ b/tests/platforms/linux/system/test_package__rpm.py
@@ -147,19 +147,14 @@ def test_verify_docker(package_command, first_app_rpm, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "changelog_filename",
-    [
-        format_name
-        for name in ["HISTORY", "NEWS.txt"]
-    ],
+    "changelog_filename", [format for format in ["HISTORY", "NEWS.txt"]]
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build RPMs on Windows")
 def test_rpm_package(package_command, first_app_rpm, tmp_path, changelog_filename):
     """A rpm app can be packaged."""
     bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
 
-
-        # Remove CHANGELOG made in conftest.py and replace with another possible changelog format
+    # Remove CHANGELOG made in conftest.py and replace with another possible changelog format
     base_path = tmp_path / "base_path"
     old_changelog = base_path / "CHANGELOG"
     new_changelog = base_path / changelog_filename

--- a/tests/platforms/linux/system/test_package__rpm.py
+++ b/tests/platforms/linux/system/test_package__rpm.py
@@ -146,10 +146,25 @@ def test_verify_docker(package_command, first_app_rpm, monkeypatch):
     rpmbuild.exists.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "changelog_filename",
+    [
+        f"{name}{extension}"
+        for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
+        for extension in ["", ".md", ".rst", ".txt"]
+    ],
+)
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build RPMs on Windows")
-def test_rpm_package(package_command, first_app_rpm, tmp_path):
-    """A rpm app can be packaged."""
+def test_rpm_package(package_command, first_app_rpm, tmp_path, changelog_filename):
+    """A rpm app can be packaged for every changelog format."""
     bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
+
+    # Remove CHANGELOG made in conftest.py and replace with another possible changelog format
+    base_path = tmp_path / "base_path"
+    old_changelog = base_path / "CHANGELOG"
+    new_changelog = base_path / changelog_filename
+    old_changelog.unlink()
+    create_file(new_changelog, "First App Changelog")
 
     # Package the app
     package_command.package_app(first_app_rpm)
@@ -619,7 +634,7 @@ def test_no_changelog(package_command, first_app_rpm, tmp_path):
 
     # Package the app; this will fail
     with pytest.raises(
-        BriefcaseCommandError, match=r"Your project does not contain a CHANGELOG file."
+        BriefcaseCommandError, match=r"Your project does not contain a changelog file."
     ):
         package_command.package_app(first_app_rpm)
 

--- a/tests/platforms/linux/system/test_package__rpm.py
+++ b/tests/platforms/linux/system/test_package__rpm.py
@@ -146,25 +146,10 @@ def test_verify_docker(package_command, first_app_rpm, monkeypatch):
     rpmbuild.exists.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "changelog_filename",
-    [
-        f"{name}{extension}"
-        for name in ["CHANGELOG", "HISTORY", "NEWS", "RELEASES"]
-        for extension in ["", ".md", ".rst", ".txt"]
-    ],
-)
 @pytest.mark.skipif(sys.platform == "win32", reason="Can't build RPMs on Windows")
-def test_rpm_package(package_command, first_app_rpm, tmp_path, changelog_filename):
-    """A rpm app can be packaged for every changelog format."""
+def test_rpm_package(package_command, first_app_rpm, tmp_path):
+    """A rpm app can be packaged."""
     bundle_path = tmp_path / "base_path/build/first-app/somevendor/surprising"
-
-    # Remove CHANGELOG made in conftest.py and replace with another possible changelog format
-    base_path = tmp_path / "base_path"
-    old_changelog = base_path / "CHANGELOG"
-    new_changelog = base_path / changelog_filename
-    old_changelog.unlink()
-    create_file(new_changelog, "First App Changelog")
 
     # Package the app
     package_command.package_app(first_app_rpm)


### PR DESCRIPTION
This pull request fixes BUILD and PACKAGE in linux to accept changelog name and extension in any combination of CHANGELOG, HISTORY, NEWS and RELEASES with an extension of like .md, .rst, .txt or no extension.

Fixes #2116

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
