### PR TITLE
Bump flatpak runtimes for gnome and kde

### DIFF
--- a/changes/2258.feature.rst
+++ b/changes/2258.feature.rst
@@ -1,0 +1,1 @@
+The Flatpak runtimes for new projects were updated. ``org.gnome.Platform`` will now default to 47; and ``org.kde.Platform`` will now default to 6.9.

--- a/src/briefcase/bootstraps/pyside6.py
+++ b/src/briefcase/bootstraps/pyside6.py
@@ -148,7 +148,7 @@ linuxdeploy_plugins = [
     def pyproject_table_linux_flatpak(self):
         return """\
 flatpak_runtime = "org.kde.Platform"
-flatpak_runtime_version = "6.7"
+flatpak_runtime_version = "6.9"
 flatpak_sdk = "org.kde.Sdk"
 """
 

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -192,7 +192,7 @@ linuxdeploy_plugins = [
     def pyproject_table_linux_flatpak(self):
         return """\
 flatpak_runtime = "org.gnome.Platform"
-flatpak_runtime_version = "47"
+flatpak_runtime_version = "48"
 flatpak_sdk = "org.gnome.Sdk"
 """
 

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -206,7 +206,7 @@ linuxdeploy_plugins = [
 """,
         pyproject_table_linux_flatpak="""\
 flatpak_runtime = "org.gnome.Platform"
-flatpak_runtime_version = "47"
+flatpak_runtime_version = "48"
 flatpak_sdk = "org.gnome.Sdk"
 """,
         pyproject_table_windows="""\
@@ -491,7 +491,7 @@ linuxdeploy_plugins = [
 """,
         pyproject_table_linux_flatpak="""\
 flatpak_runtime = "org.kde.Platform"
-flatpak_runtime_version = "6.7"
+flatpak_runtime_version = "6.9"
 flatpak_sdk = "org.kde.Sdk"
 """,
         pyproject_table_windows="""\


### PR DESCRIPTION
## Change
- Bump GNOME Flatpak runtime from 47 -> 48 (49 will release in sept)
- Bump KDE Flatpak runtime from 6.7 -> 6.9

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct