### PR TITLE
Bump Android commandline tools from 12.0 to 19.0

### DIFF
--- a/changes/2260.feature.rst
+++ b/changes/2260.feature.rst
@@ -1,0 +1,1 @@
+Android packages are now built using version 19.0 of Android's Command-line Tools; this version will be automatically installed at first use.

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -37,7 +37,7 @@ If you have an existing install of the Android SDK, it will be used by Briefcase
 if the ``ANDROID_HOME`` environment variable is set. If ``ANDROID_HOME`` is not
 present in the environment, Briefcase will honor the deprecated
 ``ANDROID_SDK_ROOT`` environment variable. Additionally, an existing SDK install
-must have version 12.0 of Command-line Tools installed; this version can be
+must have version 19.0 of Command-line Tools installed; this version can be
 installed in the SDK Manager in Android Studio.
 
 Packaging format

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -60,10 +60,10 @@ class AndroidSDK(ManagedTool):
     name = "android_sdk"
     full_name = "Android SDK"
 
-    # Latest version for Command-Line Tools download as of May 2024
+    # Latest version for Command-Line Tools download as of May 2025
     # **Be sure the gradle.rst docs stay in sync with version updates here**
-    SDK_MANAGER_DOWNLOAD_VER = "11076708"
-    SDK_MANAGER_VER = "12.0"
+    SDK_MANAGER_DOWNLOAD_VER = "13114758"
+    SDK_MANAGER_VER = "19.0"
 
     def __init__(self, tools: ToolCache, root_path: Path):
         super().__init__(tools=tools)

--- a/tests/integrations/android_sdk/conftest.py
+++ b/tests/integrations/android_sdk/conftest.py
@@ -10,8 +10,8 @@ from briefcase.integrations.java import JDK
 from briefcase.integrations.subprocess import Subprocess
 
 # current versions of Android SDK Manager
-SDK_MGR_VER = "12.0"
-SDK_MGR_DL_VER = "11076708"
+SDK_MGR_VER = "19.0"
+SDK_MGR_DL_VER = "13114758"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Changes
- Use latest (v19.0) version of Android's commandline tools
- This will cause Briefcase to install this version of commandline tools alongside v12.0

## Notes
- They're really moving through the versions it seems now...
![image](https://github.com/user-attachments/assets/cf1c5ea6-27bd-4181-b991-e60b46b46074)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
