### PR TITLE
Update Documentation for iOS Physical Devices Support

### DIFF
--- a/changes/1190.doc.rst
+++ b/changes/1190.doc.rst
@@ -1,0 +1,1 @@
+Updates Documentation for iOS Physical Devices Support

--- a/changes/1190.doc.rst
+++ b/changes/1190.doc.rst
@@ -1,1 +1,1 @@
-Updates Documentation for iOS Physical Devices Support
+Updated Documentation to Clarify iOS Physical vs. Simulated Devices Support

--- a/docs/reference/platforms/iOS/xcode.rst
+++ b/docs/reference/platforms/iOS/xcode.rst
@@ -216,3 +216,25 @@ can do this using the ``cleanup_paths`` configuration option::
 
 This will find and purge all ``.a`` content in your app's dependencies. You can add
 additional patterns to remove other problematic content.
+
+
+Deployment to Physical iOS Devices
+-----------------------------------
+
+**Version 1**
+
+Briefcase provides support for deployment to iOS devices through XCode but first
+requires that you to setup your Apple Developer account with your certificate in
+XCode.
+
+**Version 2**
+
+Briefcase provides support for deployment to iOS devices through XCode.
+the following steps.
+
+1. Setup your Apple Developer account with your certificate in XCode.
+2. Run ``briefcase open ios``. This will open your application in XCode.
+3. Select your application.
+4. Select the `Signing and Capabilities` tab.
+5. Select your Apple Develoepr team or account from the `Team` dropdown.
+6. Select your specific device.

--- a/docs/reference/platforms/iOS/xcode.rst
+++ b/docs/reference/platforms/iOS/xcode.rst
@@ -218,23 +218,19 @@ This will find and purge all ``.a`` content in your app's dependencies. You can 
 additional patterns to remove other problematic content.
 
 
-Deployment to Physical iOS Devices
------------------------------------
+Deployment to Simulated and Physical iOS Devices
+------------------------------------------------
 
-**Version 1**
+Briefcase provides support for deployment to simulated iOS devices through the
+command line.
 
-Briefcase provides support for deployment to iOS devices through Xcode but first
-requires that you to setup your Apple Developer account with your certificate in
-Xcode.
+If you want to deploy to a physical iOS device, you will need need to use Xcode through
+the following steps:
 
-**Version 2**
-
-Briefcase provides support for deployment to iOS devices through Xcode.
-the following steps.
-
-1. Setup your Apple Developer account with your certificate in Xcode.
-2. Run ``briefcase open ios``. This will open your application in Xcode.
-3. Select your application.
-4. Select the `Signing and Capabilities` tab.
-5. Select your Apple Developer team or account from the `Team` drop-down.
+1. Run ``briefcase open ios`` in the command line. This will open your application in Xcode.
+2. Setup your Apple Developer account with your certificate in Xcode.
+3. In the project navigator, select your application at the top level (the root of the project).
+4. Select the `Signing and Capabilities` tab in the editor area.
+5. Select your Apple Developer team or individual account from the `Team` drop-down.
 6. Select your specific device.
+7. Press the run button.

--- a/docs/reference/platforms/iOS/xcode.rst
+++ b/docs/reference/platforms/iOS/xcode.rst
@@ -223,18 +223,18 @@ Deployment to Physical iOS Devices
 
 **Version 1**
 
-Briefcase provides support for deployment to iOS devices through XCode but first
+Briefcase provides support for deployment to iOS devices through Xcode but first
 requires that you to setup your Apple Developer account with your certificate in
-XCode.
+Xcode.
 
 **Version 2**
 
-Briefcase provides support for deployment to iOS devices through XCode.
+Briefcase provides support for deployment to iOS devices through Xcode.
 the following steps.
 
-1. Setup your Apple Developer account with your certificate in XCode.
-2. Run ``briefcase open ios``. This will open your application in XCode.
+1. Setup your Apple Developer account with your certificate in Xcode.
+2. Run ``briefcase open ios``. This will open your application in Xcode.
 3. Select your application.
 4. Select the `Signing and Capabilities` tab.
-5. Select your Apple Develoepr team or account from the `Team` dropdown.
+5. Select your Apple Developer team or account from the `Team` drop-down.
 6. Select your specific device.


### PR DESCRIPTION
This PR updates the [iOS Xcode project documentation](https://briefcase.readthedocs.io/en/stable/reference/platforms/iOS/xcode.html#platform-quirks) to clarify support for iOS physical vs simulated devices.


Fixes #1190

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
