### PR TITLE
Briefcase Issue 2286

### DIFF
--- a/src/briefcase/integrations/xcode.py
+++ b/src/briefcase/integrations/xcode.py
@@ -202,6 +202,19 @@ installation is complete.
 """
                 ) from e
 
+        try:
+        # Check for iOS simulated devices
+        result = subprocess.run(['xcrun', 'simctl', 'list', 'devices'], 
+                                capture_output=True, text=True, check=True)
+        output = result.stdout
+        if re.search(r"== Devices ==\s*$", output):
+            raise BriefcaseCommandError(
+                preamble = """\
+There are no Apple Simulator Control devices installed.  They are usually
+part of the Xcode iOS Component installation.  It can be installed
+from the Xcode GUI, settings -> Components -> iOS.
+"""
+            ) from e
 
 class XcodeCliTools(Tool):
     name = "xcode_cli"


### PR DESCRIPTION
Unless an Apple Simulator Control Device is installed, a 'briefcase build iOS' will fail.  It can be determined from the command `xcrun simctl list devices`.  A successful output will return a number of iOS devices.

<!--- Describe your changes in detail -->
I added a "try" routine to check if the Apple Simulator Control devices are installed.  If just the line
"== Devices ==" is returned, an exception is raised and a helpful message is added to the Preamble
<!--- What problem does this change solve? -->
The problem is described in Issue 2286.  Unless the full Xcode app along with the iOS SDK is installed, 
a `briefcase build iOS` will fail.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #2286 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X ] I have read the **CONTRIBUTING.md** file
- [X ] I will abide by the code of conduct
