### PR TITLE
For MacOS app, remove redundant adhoc sign during ``briefcase package`` or ``briefcase package -u``

### DIFF
--- a/changes/1099.bugfix.rst
+++ b/changes/1099.bugfix.rst
@@ -1,0 +1,1 @@
+For MacOS app, remove redundant adhoc signing during ``briefcase package`` or ``briefcase package -u``

--- a/changes/1099.bugfix.rst
+++ b/changes/1099.bugfix.rst
@@ -1,1 +1,1 @@
-For MacOS app, remove redundant adhoc signing during ``briefcase package`` or ``briefcase package -u``
+A redundant signing phase has been removed when packaging an apps for macOS.

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -127,9 +127,14 @@ class macOSAppBuildCommand(
         # macOS apps don't have anything to compile, but they do need to be
         # signed to be able to execute on Apple Silicon hardware - even if it's only an
         # ad-hoc signing identity. Apply an ad-hoc signing identity to the
-        # app bundle.
-        self.console.info("Ad-hoc signing app...", prefix=app.app_name)
-        self.sign_app(app=app, identity=SigningIdentity())
+        # app bundle. However, the app only needs to be signed once. If the build is
+        # being done as part of a package command, the signing will happen during
+        # packaging. The two case can be distinguished because "adhoc_sign" will
+        # be absent from kwargs if only doing a build command, but will be present if
+        # the build is being done as part of a package command.
+        if "adhoc_sign" not in kwargs:
+            self.console.info("Ad-hoc signing app...", prefix=app.app_name)
+            self.sign_app(app=app, identity=SigningIdentity())
 
 
 class macOSAppRunCommand(macOSRunMixin, macOSAppMixin, RunCommand):


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Detect when a `build` command is being executed as part of a `package` command and skip the redundant adhoc signing of the app during the build. This is safe to do because the adhoc signing will happen later in the package command itself.

<!--- What problem does this change solve? -->
When running `briefcase package -u` on MacOS the app was being adhoc signed twice - once during the build and once during the package. The adhoc signing during the build is redundant since the adhoc signing will happen during the packaging.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #1099 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
