### PR TITLE
Initial pep639 support

### DIFF
--- a/changes/2146.feature.rst
+++ b/changes/2146.feature.rst
@@ -1,0 +1,1 @@
+Add initial support for PEP639-style license metadata


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
This PR (co-authored with @yngvem) adds initial support for PEP639-style license metadata (#2146). This means that the `briefcase create` command will work with PEP639-style metadata (for users that follow the happy path of only one license file). However, full support for is still lacking. Specifically, this still need to be implemented:

- Hinting based on PEP639-style license metadata in the `briefcase convert`-command
- Support for multiple license files (currently, the first license file is used and a warning is shown if multiple license files match the provided glob patterns)

Currently, in this PR, support is implemented by converting PEP639-style metadata to the PEP621-style license metadata internally. We think this can make sense in an initial effort to add support, as it keeps backwards compatibility. However, when full PEP639-style metadata is implemented, it might make sense to "switch it around" so PEP621-style metadata is transformed into the PEP639-style.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
