### PR TITLE
Use the system certificate store for downloads, where possible.

### DIFF
--- a/changes/2296.bugfix.rst
+++ b/changes/2296.bugfix.rst
@@ -1,0 +1,1 @@
+Briefcase will now default to using the system certificate store when performing HTTPS downloads.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ dependencies = [
     "setuptools >= 60",
     "wheel >= 0.37",
     "build >= 0.10",
+    # truststore is only available on 3.10+
+    "truststore >= 0.10.1; python_version >= '3.10'",
     #
     # For the remaining packages: We set the lower version limit to the lowest possible
     # version that satisfies our API needs. If the package uses semver, we set a limit

--- a/src/briefcase/integrations/file.py
+++ b/src/briefcase/integrations/file.py
@@ -17,7 +17,7 @@ if sys.version_info >= (3, 10):  # pragma: no-cover-if-lt-py310
     import truststore
 else:  # pragma: no-cover-if-gte-py310
     # truststore is only available for python 3.10+
-    pass
+    truststore = None
 
 from briefcase.exceptions import (
     BadNetworkResourceError,

--- a/src/briefcase/integrations/file.py
+++ b/src/briefcase/integrations/file.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import httpx
 
-if sys.version_info > (3, 10):  # pragma: no-cover-if-lt-py310
+if sys.version_info >= (3, 10):  # pragma: no-cover-if-lt-py310
     import truststore
 else:  # pragma: no-cover-if-gte-py310
     # truststore is only available for python 3.10+

--- a/tests/integrations/file/test_File__download.py
+++ b/tests/integrations/file/test_File__download.py
@@ -161,6 +161,7 @@ def test_new_download_oneshot(mock_tools, file_perms, url, content_disposition):
         "GET",
         "https://example.com/support?useful=Yes",
         follow_redirects=True,
+        verify=mock_tools.file.ssl_context,
     )
     response.headers.get.assert_called_with("content-length")
     response.read.assert_called_once()
@@ -213,6 +214,7 @@ def test_new_download_chunked(mock_tools, file_perms):
         "GET",
         "https://example.com/support?useful=Yes",
         follow_redirects=True,
+        verify=mock_tools.file.ssl_context,
     )
     response.headers.get.assert_called_with("content-length")
     response.iter_bytes.assert_called_once_with(chunk_size=1048576)
@@ -276,6 +278,7 @@ def test_already_downloaded(mock_tools):
         "GET",
         url,
         follow_redirects=True,
+        verify=mock_tools.file.ssl_context,
     )
 
     # The request's Content-Disposition header is consumed to
@@ -316,6 +319,7 @@ def test_missing_resource(mock_tools):
         "GET",
         url,
         follow_redirects=True,
+        verify=mock_tools.file.ssl_context,
     )
     response.headers.get.assert_not_called()
 
@@ -351,6 +355,7 @@ def test_bad_resource(mock_tools):
         "GET",
         url,
         follow_redirects=True,
+        verify=mock_tools.file.ssl_context,
     )
     response.headers.get.assert_not_called()
 
@@ -389,6 +394,7 @@ def test_iter_bytes_connection_error(mock_tools):
         "GET",
         "https://example.com/something.zip?useful=Yes",
         follow_redirects=True,
+        verify=mock_tools.file.ssl_context,
     )
     response.headers.get.assert_called_with("content-length")
 
@@ -430,6 +436,7 @@ def test_connection_error(mock_tools):
         "GET",
         url,
         follow_redirects=True,
+        verify=mock_tools.file.ssl_context,
     )
 
     # The file doesn't exist as a result of the download failure
@@ -466,6 +473,7 @@ def test_redirect_connection_error(mock_tools):
         "GET",
         "https://example.com/something.zip?useful=Yes",
         follow_redirects=True,
+        verify=mock_tools.file.ssl_context,
     )
 
     # The file doesn't exist as a result of the download failure

--- a/tests/integrations/file/test_File__ssl_context.py
+++ b/tests/integrations/file/test_File__ssl_context.py
@@ -1,0 +1,17 @@
+import sys
+
+if sys.version_info >= (3, 10):  # pragma: no-cover-if-lt-py310
+    import truststore
+else:  # pragma: no-cover-if-gte-py310
+    # truststore is only available for python 3.10+
+    truststore = None
+
+
+def test_ssl_context(mock_tools):
+    """The SSL context is of the expected type."""
+    if sys.version_info >= (3, 10):
+        expected_type = truststore.SSLContext
+    else:
+        expected_type = bool
+
+    assert isinstance(mock_tools.file.ssl_context, expected_type)


### PR DESCRIPTION

Introduces the use of `truststore` when performing downloads in Briefcase. This should hopefully avoid the issues with the use of proxies and VPNs. httpx uses certifi as a trust store by default; but corporate proxy/VPN configurations often involve manipulation of the system trust store. This leads to situations where a URL can be reached by a browser, but *not* by Briefcase. Using `truststore` means that Briefcase will have the same trust configuration as the browser.

Fixes #2296.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
