### PR TITLE
[docs] Explain why macOS entitlement changes aren't incorporated on rebuild

### DIFF
--- a/docs/reference/platforms/macOS/index.rst
+++ b/docs/reference/platforms/macOS/index.rst
@@ -121,6 +121,10 @@ enable library validation, you could add the following to your ``pyproject.toml`
 
     entitlement."com.apple.security.cs.disable-library-validation" = false
 
+Entitlements are interpolated into the macOS template by `briefcase create` but are not
+updated on each build. In order to incororate changed entitlements into your builds you
+should re-run `briefcase create` or remove the existing macOS build files.
+
 ``info``
 ~~~~~~~~
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->

My understanding is that entitlements are interpolated into the macOS template, but that the template is not repopulated on each rebuild (because delta updates are hard). This can be confusing for users (like me 😉) trying to add new entitlements to an existing app that's being rebuilt (rather than built for the first time).

<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
