### PR TITLE
Ensure PIP_REQUIRE_VIRTUALENV isn't passed through to iOS environment.

### DIFF
--- a/changes/2325.bugfix.rst
+++ b/changes/2325.bugfix.rst
@@ -1,0 +1,1 @@
+The presence of a ``PIP_REQUIRE_VIRTUALENV`` environment marker no longer influences the operation of dependency installation on iOS. The iOS installation environments is inherently isolated, so this flag is redundant; but in some circumstances, it would prevent the installation of dependencies into a project.

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -373,6 +373,7 @@ class iOSXcodeCreateCommand(iOSXcodePassiveMixin, CreateCommand):
             pip_kwargs={
                 "env": {
                     "PYTHONPATH": str(device_platform_site),
+                    "PIP_REQUIRE_VIRTUALENV": None,
                 }
             },
             install_hint=f"""
@@ -395,6 +396,7 @@ with a minimum iOS version of {ios_min_version}.
             pip_kwargs={
                 "env": {
                     "PYTHONPATH": str(simulator_platform_site),
+                    "PIP_REQUIRE_VIRTUALENV": None,
                 },
             },
             install_hint=f"""

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -109,7 +109,8 @@ def test_extra_pip_args(
                     tmp_path
                     / "base_path/build/first-app/ios/xcode/Support"
                     / device_config_path
-                )
+                ),
+                "PIP_REQUIRE_VIRTUALENV": None,
             },
         ),
         call(
@@ -139,7 +140,8 @@ def test_extra_pip_args(
                     tmp_path
                     / "base_path/build/first-app/ios/xcode/Support"
                     / sim_config_path
-                )
+                ),
+                "PIP_REQUIRE_VIRTUALENV": None,
             },
         ),
     ]
@@ -193,7 +195,8 @@ def test_min_os_version(create_command, first_app_generated, tmp_path):
                     / "base_path/build/first-app/ios/xcode/Support"
                     / "Python.xcframework/ios-arm64"
                     / "platform-config/arm64-iphoneos"
-                )
+                ),
+                "PIP_REQUIRE_VIRTUALENV": None,
             },
         ),
         call(
@@ -224,7 +227,8 @@ def test_min_os_version(create_command, first_app_generated, tmp_path):
                     / "base_path/build/first-app/ios/xcode/Support"
                     / "Python.xcframework/ios-arm64_x86_64-simulator"
                     / "platform-config/wonky-iphonesimulator"
-                )
+                ),
+                "PIP_REQUIRE_VIRTUALENV": None,
             },
         ),
     ]

--- a/tests/platforms/iOS/xcode/test_update.py
+++ b/tests/platforms/iOS/xcode/test_update.py
@@ -90,7 +90,8 @@ def test_extra_pip_args(
                     tmp_path
                     / "base_path/build/first-app/ios/xcode/Support"
                     / device_config_path
-                )
+                ),
+                "PIP_REQUIRE_VIRTUALENV": None,
             },
         ),
         call(
@@ -120,7 +121,8 @@ def test_extra_pip_args(
                     tmp_path
                     / "base_path/build/first-app/ios/xcode/Support"
                     / sim_config_path
-                )
+                ),
+                "PIP_REQUIRE_VIRTUALENV": None,
             },
         ),
     ]


### PR DESCRIPTION
Recent changes to the iOS support package mean it now presents as if it's *not* in a virtual environment; as a result, if Briefcase attempts to call `pip`, and the environment where Briefcase is installed has `PIP_REQUIRE_VIRTUALENV` set, the install fails because it will refuse to install into an environment that isn't virtualized.

This is a false positive. The `pip install` Briefcase is performing is targeted to a specific install location, using a `--platform` marker; this has all the *effects* of being a standalone virtual environment, but pip can't tell that. 

The long term fix is to use an actual iOS cross environment for the installation; but in the short term, explicitly unsetting `PIP_REQUIRE_VIRTUALENV` works around the limitation.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
