### PR TITLE
Simplify Toga bootstrap

### DIFF
--- a/automation/src/automation/bootstraps/toga.py
+++ b/automation/src/automation/bootstraps/toga.py
@@ -8,8 +8,6 @@ class TogaAutomationBootstrap(TogaGuiBootstrap):
 import asyncio
 
 import toga
-from toga.style import Pack
-from toga.style.pack import COLUMN, ROW
 
 
 class {{{{ cookiecutter.class_name }}}}(toga.App):
@@ -17,13 +15,11 @@ class {{{{ cookiecutter.class_name }}}}(toga.App):
         """Construct and show the Toga application.
 
         Usually, you would add your application to a main content box.
-        We then create a main window (with a name matching the app), and
-        show the main window.
+        We then create a main window and show it.
         """
         main_box = toga.Box()
 
-        self.main_window = toga.MainWindow(title=self.formal_name)
-        self.main_window.content = main_box
+        self.main_window = toga.MainWindow(content=main_box)
         self.main_window.show()
 
     async def on_running(self):

--- a/changes/2338.feature.rst
+++ b/changes/2338.feature.rst
@@ -1,0 +1,1 @@
+The code template generated for a new Toga project has been simplified.

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -5,8 +5,6 @@ class TogaGuiBootstrap(BaseGuiBootstrap):
     def app_source(self):
         return '''\
 import toga
-from toga.style import Pack
-from toga.style.pack import COLUMN, ROW
 
 
 class {{ cookiecutter.class_name }}(toga.App):
@@ -14,13 +12,11 @@ class {{ cookiecutter.class_name }}(toga.App):
         """Construct and show the Toga application.
 
         Usually, you would add your application to a main content box.
-        We then create a main window (with a name matching the app), and
-        show the main window.
+        We then create a main window and show it.
         """
         main_box = toga.Box()
 
-        self.main_window = toga.MainWindow(title=self.formal_name)
-        self.main_window.content = main_box
+        self.main_window = toga.MainWindow(content=main_box)
         self.main_window.show()
 
 

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -39,8 +39,6 @@ def test_toga_bootstrap(new_command):
     assert context == dict(
         app_source='''\
 import toga
-from toga.style import Pack
-from toga.style.pack import COLUMN, ROW
 
 
 class {{ cookiecutter.class_name }}(toga.App):
@@ -48,13 +46,11 @@ class {{ cookiecutter.class_name }}(toga.App):
         """Construct and show the Toga application.
 
         Usually, you would add your application to a main content box.
-        We then create a main window (with a name matching the app), and
-        show the main window.
+        We then create a main window and show it.
         """
         main_box = toga.Box()
 
-        self.main_window = toga.MainWindow(title=self.formal_name)
-        self.main_window.content = main_box
+        self.main_window = toga.MainWindow(content=main_box)
         self.main_window.show()
 
 


### PR DESCRIPTION
- Those Pack imports weren't being used. `Pack` itself shouldn't often be needed anymore at all (at least by most users), but I could see there being an argument to including some imports of constants just to show it as a starting point.
- Main windows now get the app's title by default.
- Window's content can be specified upon creation. (I think this was at one point not the case, right?)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
