### PR TITLE
Fix the grammar in the missing changelog message on Linux

### DIFF
--- a/changes/+a5f71499.bugfix.rst
+++ b/changes/+a5f71499.bugfix.rst
@@ -1,0 +1,1 @@
+On Linux, fixed the grammar of the message pertaining to a missing changelog file.

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -777,7 +777,7 @@ app's configuration.
                 raise BriefcaseCommandError(
                     """\
 Your project does not contain a changelog file with a known file name. You
-must provided a changelog file in the same directory as your `pyproject.toml`,
+must provide a changelog file in the same directory as your `pyproject.toml`,
 with a known changelog file name (one of 'CHANGELOG', 'HISTORY', 'NEWS' or
 'RELEASES'; the file may have an extension of '.md', '.rst', or '.txt', or have
 no extension).
@@ -1157,7 +1157,7 @@ class LinuxSystemPackageCommand(LinuxSystemMixin, PackageCommand):
                     raise BriefcaseCommandError(
                         """\
 Your project does not contain a changelog file with a known file name. You
-must provided a changelog file in the same directory as your `pyproject.toml`,
+must provide a changelog file in the same directory as your `pyproject.toml`,
 with a known changelog file name (one of 'CHANGELOG', 'HISTORY', 'NEWS' or
 'RELEASES'; the file may have an extension of '.md', '.rst', or '.txt', or have
 no extension).


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
