### PR TITLE
Correct version pin for PyGObject.

### DIFF
--- a/changes/2354.bugfix.rst
+++ b/changes/2354.bugfix.rst
@@ -1,0 +1,1 @@
+The version pin for PyGObject has been modified to ensure that the installed version is guaranteed to be compatible with ``libgirepository1.0``.

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -60,10 +60,11 @@ requires = [
         return """\
 requires = [
     "toga-gtk~=0.5.0",
-    # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
+    # PyGObject 3.50.0 is the last version that is known to be dependent on
+    # libgirepository1.0-dev. Newer releases depend on libgirepository-2.0-dev, which
     # isn't available on Debian 12/Ubuntu 22.04. If you don't need to support those (or
     # older) releases, you can remove this version pin. See beeware/toga#3143.
-    "pygobject < 3.52.1",
+    "pygobject <= 3.50.0",
 ]
 """
 

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -64,7 +64,7 @@ requires = [
     # libgirepository1.0-dev. Newer releases depend on libgirepository-2.0-dev, which
     # isn't available on Debian 12/Ubuntu 22.04. If you don't need to support those (or
     # older) releases, you can remove this version pin. See beeware/toga#3143.
-    "pygobject <= 3.50.0",
+    "pygobject == 3.50.0",
 ]
 """
 

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -86,10 +86,11 @@ requires = [
         pyproject_table_linux="""\
 requires = [
     "toga-gtk~=0.5.0",
-    # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
+    # PyGObject 3.50.0 is the last version that is known to be dependent on
+    # libgirepository1.0-dev. Newer releases depend on libgirepository-2.0-dev, which
     # isn't available on Debian 12/Ubuntu 22.04. If you don't need to support those (or
     # older) releases, you can remove this version pin. See beeware/toga#3143.
-    "pygobject < 3.52.1",
+    "pygobject <= 3.50.0",
 ]
 """,
         pyproject_table_linux_system_debian="""\

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -90,7 +90,7 @@ requires = [
     # libgirepository1.0-dev. Newer releases depend on libgirepository-2.0-dev, which
     # isn't available on Debian 12/Ubuntu 22.04. If you don't need to support those (or
     # older) releases, you can remove this version pin. See beeware/toga#3143.
-    "pygobject <= 3.50.0",
+    "pygobject == 3.50.0",
 ]
 """,
         pyproject_table_linux_system_debian="""\


### PR DESCRIPTION
After we added an upper version pin to PyGObject in #2190, PyGObject published a new version that is *less* than the pinned version, but *doesn't* meet our binary requirements (not depending on libgirepository 2.0).

This modifies the version pin to what it probably should have been to start with a hard <= pin on a known good version, rather than a < pin on a known bad version.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
