### PR TITLE
Change for commands to install briefcase

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,11 +48,11 @@ Support for AppleTV, watchOS, and wearOS deployments is planned.
 Getting started
 ---------------
 
-To install Briefcase for windows or linux, run:
+To install Briefcase for Windows, run:
 
    $ python -m pip install briefcase 
 
-For macOS, run:
+For macOS and Linux, run:
 
    $ python3 -m pip install briefcase
 

--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,13 @@ Support for AppleTV, watchOS, and wearOS deployments is planned.
 Getting started
 ---------------
 
-To install Briefcase, run::
+To install Briefcase for windows or linux, run:
 
-   $ python -m pip install briefcase
+   $ python -m pip install briefcase 
+
+For macOS, run:
+
+   $ python3 -m pip install briefcase
 
 If you would like a full introduction to using Briefcase, try the `BeeWare tutorial
 <https://docs.beeware.org>`__. This tutorial walks you through the process of creating


### PR DESCRIPTION
Changed "python -m pip install briefcase" to "python3 -m pip install briefcase" because it will not run on linux or macOS 

<!--- Describe your changes in detail -->
I changed """
To install Briefcase, run::
  $ python -m pip install briefcase
"""
to """
To install Briefcase for Windows, run:
   $ python -m pip install briefcase 

For macOS and Linux, run:

   $ python3 -m pip install briefcase


<!--- What problem does this change solve? -->
I cannot run python -m pip install briefcase on my Mac.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
