### PR TITLE
Add changenote for MSI long filename support.

### DIFF
--- a/changes/948.bugfix.rst
+++ b/changes/948.bugfix.rst
@@ -1,0 +1,1 @@
+Apps that contain file paths longer than 260 characters can now be included in MSI installers.


### PR DESCRIPTION
It occurred to me that the 2 template fixes that resolved long filename support would leave no documentation surface in Briefcase itself; this is a change note-only PR to ensure it's mentioned in the next release.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
