### PR TITLE
[fix-1650] refactor warning message and link the documentation

### DIFF
--- a/src/briefcase/platforms/macOS/utils.py
+++ b/src/briefcase/platforms/macOS/utils.py
@@ -243,7 +243,9 @@ class AppPackagesMergeMixin:
                             ):
                                 self.console.warning(
                                     f"{relative_path} has different content "
-                                    f"between sources; ignoring {source_app_packages.suffix[1:]} version."
+                                    f"between sources; ignoring {source_app_packages.suffix[1:]} version. "
+                                    f"This is usually safe if the file content is not used at runtime. "
+                                    f"See https://briefcase.readthedocs.io/en/stable/reference/platforms/macOS/index.html#inconsistent-content-in-non-universal-wheels for more details."
                                 )
                         else:
                             # The file doesn't exist yet; copy it as is (including


### PR DESCRIPTION
This PR completes the issue #1650 and:

- refactors the error message to be more specific (No issues if the content is not used during runtime)
- links the updated documentation (Related documentation has already been [updated](https://briefcase.readthedocs.io/en/stable/reference/platforms/macOS/index.html#inconsistent-content-in-non-universal-wheels) by other contributors)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
