### PR TITLE
Replacing optional-dependencies with dependency-groups

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,11 +30,6 @@ formats:
 # Install extras for build - dev is needed to run tox
 python:
   install:
-  # Docs requirements are *mostly* handled by the `docs` extra; but we can't include
-  # the theme that way, so the theme is installed using a requirements.txt file,
-  # independent of the docs extra. Ideally, we'd use dependency groups for docs
-  # dependencies, but RTD doesn't support them yet.
-  - requirements: requirements-docs.txt
   - method: pip
     path: .
     extra_requirements:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dependencies = [
     "tomli_w >= 1.0, < 2.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 # Extras used by developers *of* briefcase are pinned to specific versions to
 # ensure environment consistency.
 dev = [
@@ -122,6 +122,7 @@ docs = [
     "sphinx-autobuild == 2024.10.3",
     "sphinx-copybutton == 0.5.2",
     "sphinxcontrib-spelling == 8.0.1",
+    "beeware_theme @ git+https://github.com/beeware/beeware-theme",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,11 @@ docs = [
     "sphinxcontrib-spelling == 8.0.1",
     "beeware_theme @ git+https://github.com/beeware/beeware-theme",
 ]
+# In case you want to install all the dependencies for development, docs, and testing
+all = [
+    {include-group = "dev"},
+    {include-group = "docs"},
+]
 
 [project.urls]
 Homepage = "https://beeware.org/briefcase"

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,1 +1,0 @@
-beeware_theme @ git+https://github.com/beeware/beeware-theme

--- a/tox.ini
+++ b/tox.ini
@@ -87,12 +87,6 @@ base_python = py312
 suicide_timeout = 1
 package = wheel
 wheel_build_env = .pkg
-deps =
-    # Docs requirements are *mostly* handled by the `docs` extra; but we can't include
-    # the theme that way, so the theme is installed using a requirements.txt file,
-    # independent of the docs extra. Ideally, we'd use dependency groups for docs
-    # dependencies, but RTD doesn't support them yet.
-    -r {tox_root}/requirements-docs.txt
 extras = docs
 passenv =
     # On macOS Apple Silicon, you need to manually set the location of the PyEnchant


### PR DESCRIPTION
 Summary

  - Migrated from optional-dependencies to modern PEP 735 dependency groups in pyproject.toml
  - Added convenience all group that includes both dev and docs dependencies using include-group syntax
  - Removed obsolete requirements-docs.txt file as dependencies are now managed through dependency groups

  Changes

  - Replaced [project.optional-dependencies] with [dependency-groups] section
  - Created dev group with pinned development dependencies (coverage, pytest, pre-commit, etc.)
  - Created docs group with documentation dependencies (sphinx, furo theme, etc.)
  - Added all group using {include-group = "dev"} and {include-group = "docs"} syntax
  - Removed requirements-docs.txt as theme is now included in docs dependency group

  Benefits

  - Modernizes dependency management using latest Python packaging standards
  - Provides cleaner separation between different types of dependencies
  - Enables installing all development dependencies with single command: pip install -e .[all]                                                                                      
  - Maintains backward compatibility with existing .[dev] and .[docs] installation patterns

  Test plan

  - Verify pip install -e .[dev] installs development dependencies
  - Verify pip install -e .[docs] installs documentation dependencies
  - Verify pip install -e .[all] installs both dev and docs dependencies
  - Test documentation build process works with new dependency groups
  - Confirm CI/CD processes work with updated dependency structure

Fixes #2387

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
