### PR TITLE
changed error text in build_app to hint user for virus scanner problems

### DIFF
--- a/src/briefcase/platforms/windows/app.py
+++ b/src/briefcase/platforms/windows/app.py
@@ -138,7 +138,12 @@ Recreating the app layout may also help resolve this issue:
                 )
             except subprocess.CalledProcessError as e:
                 raise BriefcaseCommandError(
-                    f"Unable to update details on stub app for {app.app_name}."
+                    f"""\
+Unable to update details on stub app for {app.app_name}.
+
+Try to disable your virus scanner or whitelist rcedit.exe and build again
+
+"""
                 ) from e
 
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
I adapted the text output on the BriefcaseCommandError in the build_app function in the windows platforms app.py to hint the user on disabling the virus scanner or adding rcedit to the whitelist. The error originates from the rcedit subprocess and to prevent hunting process-specific errors the error message was added here. 

The issue was that sometimes a very generic error popped up when the Windows build failed because of use of rcedit.exe being blocked by virus scanners. 

This PR related to issue #1530 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
The tests failed on MacOS tests, which shouldn't have run on my platform. This may be a my-environment-problem or something else. To trigger the tests on PR i created the PR after consulting Russel. 
- [ ] All new features have been documented 
Not Applicable
- [x] I have read the **CONTRIBUTING.md** file 
- [x] I will abide by the code of conduct
