### PR TITLE
fix: toga gui bootstrap imports

### DIFF
--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -5,7 +5,6 @@ class TogaGuiBootstrap(BaseGuiBootstrap):
     def app_source(self):
         return '''\
 import toga
-from toga.style import Pack
 from toga.style.pack import COLUMN, ROW
 
 

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -39,7 +39,6 @@ def test_toga_bootstrap(new_command):
     assert context == {
         "app_source": '''\
 import toga
-from toga.style import Pack
 from toga.style.pack import COLUMN, ROW
 
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
This removes the `from toga.style import Pack` import from the TogaGuiBootstrap as it is no longer needed for the minimal application. The relevant unit test was adjusted. 

The [relevant tutorial on what was generated](https://docs.beeware.org/en/latest/tutorial/tutorial-2.html#what-was-generated) already does not include the import as expected. At the same time, the tutorial mentions the `Pack` object, including the import as an advanced technique via a [note](https://docs.beeware.org/en/latest/tutorial/tutorial-2.html#adding-some-content-of-our-own).

There is no PR. 


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
