### PR TITLE
Briefcase open ios link to doc

### DIFF
--- a/changes/2364.misc.rst
+++ b/changes/2364.misc.rst
@@ -1,0 +1,1 @@
+Add link to the ``briefcase package iOS`` warning message to the iOS deployment documentation.

--- a/docs/reference/platforms/iOS/xcode.rst
+++ b/docs/reference/platforms/iOS/xcode.rst
@@ -225,6 +225,7 @@ can do this using the ``cleanup_paths`` configuration option::
 This will find and purge all ``.a`` content in your app's dependencies. You can add
 additional patterns to remove other problematic content.
 
+.. _ios-deploy:
 
 Deployment to Simulated and Physical iOS Devices
 ------------------------------------------------

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -68,7 +68,8 @@ class iOSXcodePassiveMixin(iOSMixin):
 
         briefcase open iOS
 
-    and use Xcode's app distribution workflow.
+    and use Xcode's app distribution workflow described at:
+    https://briefcase.readthedocs.io/en/stable/reference/platforms/iOS/xcode.html#deployment-to-simulated-and-physical-ios-devices.
 
 *************************************************************************
 """

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -69,7 +69,8 @@ class iOSXcodePassiveMixin(iOSMixin):
         briefcase open iOS
 
     and use Xcode's app distribution workflow described at:
-    https://briefcase.readthedocs.io/en/stable/reference/platforms/iOS/xcode.html#deployment-to-simulated-and-physical-ios-devices.
+
+        https://briefcase.readthedocs.io/en/stable/reference/platforms/iOS/xcode.html#ios-deploy
 
 *************************************************************************
 """


### PR DESCRIPTION
<!--- Describe your changes in detail -->
The warning message for the `briefcase package iOS` command include a link to the Xcode iOS deployment documentation.
<!--- What problem does this change solve? -->
This would make it easier for users to find and understand the iOS application workflow in Xcode.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #2364 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
