### PR TITLE
Fix some Liskov Substitution Principle crimes

### DIFF
--- a/changes/2422.misc.rst
+++ b/changes/2422.misc.rst
@@ -1,0 +1,1 @@
+Some Liskov substitution issues with typing were resolved.

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -27,7 +27,7 @@ class ConvertCommand(NewCommand):
     cmd_line = "briefcase convert"
     command = "convert"
     platform = "all"
-    output_format = None
+    output_format = ""
     description = "Set up an existing project for Briefcase."
 
     @cached_property

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -631,9 +631,10 @@ class CreateCommand(BaseCommand):
         app: AppConfig,
         requires: list[str],
         app_packages_path: Path,
+        *,
         progress_message: str = "Installing app requirements...",
         pip_args: list[str] | None = None,
-        pip_kwargs: dict[str, str] | None = None,
+        pip_kwargs: dict[str, dict[str, str | None]] | None = None,
         install_hint: str = "",
     ):
         """Install requirements for the app with pip.

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -16,7 +16,7 @@ from .create import write_dist_info
 class DevCommand(RunAppMixin, BaseCommand):
     cmd_line = "briefcase dev"
     command = "dev"
-    output_format = None
+    output_format = ""
     description = "Run a Briefcase project in the dev environment."
 
     # On macOS CoreFoundation/NSApplication will do its own independent parsing of argc/argv.

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -76,7 +76,7 @@ class NewCommand(BaseCommand):
     cmd_line = "briefcase new"
     command = "new"
     platform = "all"
-    output_format = None
+    output_format = ""
     description = "Create a new Briefcase project."
 
     def bundle_path(self, app):

--- a/src/briefcase/commands/run.py
+++ b/src/briefcase/commands/run.py
@@ -250,7 +250,11 @@ class RunCommand(RunAppMixin, BaseCommand):
 
     @abstractmethod
     def run_app(
-        self, app: AppConfig, *, passthrough: list[str], **options
+        self,
+        app: AppConfig,
+        *,
+        passthrough: list[str],
+        **options,
     ) -> dict | None:
         """Start an application.
 

--- a/src/briefcase/commands/run.py
+++ b/src/briefcase/commands/run.py
@@ -249,7 +249,9 @@ class RunCommand(RunAppMixin, BaseCommand):
         return args
 
     @abstractmethod
-    def run_app(self, app: AppConfig, **options) -> dict | None:
+    def run_app(
+        self, app: AppConfig, *, passthrough: list[str], **options
+    ) -> dict | None:
         """Start an application.
 
         :param app: The application to start

--- a/src/briefcase/commands/upgrade.py
+++ b/src/briefcase/commands/upgrade.py
@@ -16,7 +16,7 @@ from .base import BaseCommand
 class UpgradeCommand(BaseCommand):
     cmd_line = "briefcase upgrade"
     command = "upgrade"
-    output_format = None
+    output_format = ""
     description = "Upgrade Briefcase-managed tools."
 
     @property

--- a/src/briefcase/platforms/iOS/__init__.py
+++ b/src/briefcase/platforms/iOS/__init__.py
@@ -10,7 +10,7 @@ class iOSMixin:
         "iOS applications require Xcode, which is only available on macOS."
     )
     # 0.3.20 introduced PEP 730-style dynamic libraries.
-    platform_target_version = "0.3.20"
+    platform_target_version: str | None = "0.3.20"
 
     def verify_tools(self):
         Xcode.verify(self.tools, min_version=(13, 0, 0))

--- a/src/briefcase/platforms/iOS/__init__.py
+++ b/src/briefcase/platforms/iOS/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from briefcase.integrations.xcode import Xcode
 
 DEFAULT_OUTPUT_FORMAT = "Xcode"

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -320,6 +320,7 @@ class iOSXcodeCreateCommand(iOSXcodePassiveMixin, CreateCommand):
         app: AppConfig,
         requires: list[str],
         app_packages_path: Path,
+        **kwargs,
     ):
         # Determine the min iOS version from the VERSIONS file in the support package.
         versions = dict(
@@ -493,10 +494,11 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
     def run_app(
         self,
         app: AppConfig,
+        *,
         passthrough: list[str],
         udid=None,
-        **kwargs,
-    ):
+        **options,
+    ) -> dict | None:
         """Start the application.
 
         :param app: The config object for the app

--- a/src/briefcase/platforms/linux/__init__.py
+++ b/src/briefcase/platforms/linux/__init__.py
@@ -135,6 +135,7 @@ class LocalRequirementsMixin:  # pragma: no-cover-if-is-windows
         app: AppConfig,
         requires: list[str],
         app_packages_path: Path,
+        **kwargs,
     ):
         """Install requirements for the app with pip.
 

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -37,7 +37,7 @@ class LinuxAppImagePassiveMixin(LinuxMixin):
     supported_host_os_reason = (
         "Linux AppImages can only be built on Linux, or on macOS using Docker."
     )
-    platform_target_version = "0.3.20"
+    platform_target_version: str | None = "0.3.20"
 
     def appdir_path(self, app):
         return self.bundle_path(app) / f"{app.formal_name}.AppDir"

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -80,7 +80,7 @@ class macOSMixin:
     supported_host_os = {"Darwin"}
     supported_host_os_reason = "macOS applications can only be built on macOS."
     # 0.3.20 introduced a framework-based support package.
-    platform_target_version = "0.3.20"
+    platform_target_version: str | None = "0.3.20"
 
     def bundle_package_path(self, app) -> Path:
         return self.binary_path(app)
@@ -182,6 +182,7 @@ class macOSCreateMixin(AppPackagesMergeMixin):
         app: AppConfig,
         requires: list[str],
         app_packages_path: Path,
+        **kwargs,
     ):
         # Determine the min macOS version from the VERSIONS file in the support package.
         versions = dict(

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -121,7 +121,7 @@ def test_new_command(console, cmdline, expected_options, expected_overrides):
 
     assert isinstance(cmd, NewCommand)
     assert cmd.platform == "all"
-    assert cmd.output_format is None
+    assert cmd.output_format == ""
     assert cmd.console.input_enabled
     assert cmd.console.verbosity == LogLevel.INFO
     assert options == expected_options
@@ -160,7 +160,7 @@ def test_convert_command(console, cmdline, expected_options, expected_overrides)
 
     assert isinstance(cmd, ConvertCommand)
     assert cmd.platform == "all"
-    assert cmd.output_format is None
+    assert cmd.output_format == ""
     assert cmd.console.input_enabled
     assert cmd.console.verbosity == LogLevel.INFO
     assert options == expected_options
@@ -328,7 +328,7 @@ def test_upgrade_command(
 
     assert isinstance(cmd, UpgradeCommand)
     assert cmd.platform == "macOS"
-    assert cmd.output_format is None
+    assert cmd.output_format == ""
     assert cmd.console.input_enabled
     assert cmd.console.verbosity == LogLevel.INFO
     assert options == expected_options


### PR DESCRIPTION
Makes mypy happier. The gist of it is that it should be possible to use instances of subclasses in any place an instance of a base class would be accepted. That means you:
- can't narrow field types in subclasses (this is why `platform_target_version` needs to still specify it's either a string or None);
- can't remove arguments from methods in subclasses or change their return type (that's why `run_app` and `install_app_requirements` were adjusted);
- assign `None` to fields in subclasses that declared a non-optional type in a base class (hence the `output_format` change to an empty string, which ends up being cleaner than doing the `str | None` forever like we did in `platform_target_version`).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented (this is effectively a refactor)
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
