### PR TITLE
docs: Direct people at cibuildwheel and PyPI uploads

### DIFF
--- a/changes/2423.doc.rst
+++ b/changes/2423.doc.rst
@@ -1,0 +1,1 @@
+Details on usage of iOS and Android third-party wheels have been updated to reflect recent changes in the Python packaging ecosystem.

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -406,7 +406,7 @@ build an Android wheel.
 
 The recommended way to build Android-compatible wheels is to use `cibuildwheel
 <https://cibuildwheel.pypa.io/en/stable/platforms/#android>`__. Despite the name, the
-tool is not limited to CI environments; it can be run locally on a macOS and Linux
+tool is not limited to CI environments; it can be run locally on macOS and Linux
 machines. Many projects already use cibuildwheel to manage publication of binary wheels.
 For those projects, it may be possible to generate Android wheels by invoking
 ``cibuildwheel --platform=android``. Some modifications of the cibuildwheel
@@ -429,4 +429,4 @@ file for distribution, the file is *not* usable as-is. It must be signed
 regardless of whether you're distributing your app through the Play Store, or
 via loading the APK directly. For details on how to manually sign your code,
 see the instructions on `signing an Android App Bundle
-<https://briefcase.readthedocs.io/en/stable/how-to/publishing/android.html#sign-the-android-app-bundle>`__.```
+<https://briefcase.readthedocs.io/en/stable/how-to/publishing/android.html#sign-the-android-app-bundle>`__.

--- a/docs/reference/platforms/android/gradle.rst
+++ b/docs/reference/platforms/android/gradle.rst
@@ -379,10 +379,12 @@ extensions (e.g., ``-cp311-cp311-macosx_11_0_universal2.whl``), then the wheel c
 a binary component.
 
 If the package contains a binary component, that wheel needs to be compiled for Android.
-PyPI does not currently support uploading Android-compatible wheels, so you can't rely
-on PyPI to provide those wheels. Briefcase uses a `secondary repository
-<https://chaquo.com/pypi-13.1/>`__ to provide pre-compiled Android wheels.
+PyPI allows projects to upload Android-compatible wheels (identified by suffixes like
+``-cp314-cp314-android_24_arm64.whl``). However, at this time, most projects do not
+provide Android-compatible wheels.
 
+This is expected to improve over time. In the mean time, Briefcase uses a `secondary
+repository <https://chaquo.com/pypi-13.1/>`__ to provide pre-compiled Android wheels.
 This repository is maintained by the BeeWare project, and as a result, it does not have
 binary wheels for *every* package that is available on PyPI, or even every *version* of
 every package that is on PyPI. If you see any of the following messages when building an
@@ -402,13 +404,25 @@ build tools that don't support Android, such as a compiler that can't target And
 a PEP517 build system that doesn't support cross-compilation, it may not be possible to
 build an Android wheel.
 
-The `Chaquopy repository <https://github.com/chaquo/chaquopy/blob/master/server/pypi/README.md>`__
-contains tools to assist with cross-compiling Android binary wheels. This repository contains
-recipes for building the packages that are stored in the `secondary package repository
-<https://chaquo.com/pypi-13.1/>`__. Contributions of new package recipes are welcome, and
-can be submitted as pull requests. Or, if you have a particular package that you'd like
-us to support, please visit the `issue tracker
-<https://github.com/chaquo/chaquopy/issues>`__ and provide details about that package.
+The recommended way to build Android-compatible wheels is to use `cibuildwheel
+<https://cibuildwheel.pypa.io/en/stable/platforms/#android>`__. Despite the name, the
+tool is not limited to CI environments; it can be run locally on a macOS and Linux
+machines. Many projects already use cibuildwheel to manage publication of binary wheels.
+For those projects, it may be possible to generate Android wheels by invoking
+``cibuildwheel --platform=android``. Some modifications of the cibuildwheel
+configuration may be necessary to provide Android-specific customizations.
+
+The `Chaquopy repository
+<https://github.com/chaquo/chaquopy/blob/master/server/pypi/README.md>`__ also contains
+tools to assist with cross-compiling Android binary wheels. This project is mostly of
+historical significance; the BeeWare and Chaquopy teams are now focused on contributing
+Android support upstream, rather than maintaining independent packaging efforts. If you
+would like a project to officially support Android, you should open a feature request
+with that project requesting Android support, and consider providing a PR to contribute
+that support.
+
+Signing of ``briefcase package`` artefacts
+------------------------------------------
 
 While it is possible to use `briefcase package android` to produce an APK or AAB
 file for distribution, the file is *not* usable as-is. It must be signed

--- a/docs/reference/platforms/iOS/xcode.rst
+++ b/docs/reference/platforms/iOS/xcode.rst
@@ -141,10 +141,14 @@ extensions (e.g., ``-cp311-cp311-macosx_11_0_universal2.whl``), then the wheel c
 a binary component.
 
 If the package contains a binary component, that wheel needs to be compiled for iOS.
-PyPI does not currently support uploading iOS-compatible wheels, so you can't rely on
-PyPI to provide those wheels. Briefcase uses a `secondary repository
-<https://anaconda.org/beeware/repo>`__ to store pre-compiled iOS wheels.
+PyPI `recently <https://github.com/pypi/warehouse/pull/17559>`_ gained support for
+uploading iOS-compatible wheels (identified by suffixes like
+``-cp314-cp314-ios_15_4_arm64_iphoneos.whl`` or
+``-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl``). Most packages do not yet provide
+iOS-compatible wheels, but this is expected to improve over time.
 
+In the mean time, Briefcase uses a `secondary repository
+<https://anaconda.org/beeware/repo>`__ to store some popular pre-compiled iOS wheels.
 This repository is maintained by the BeeWare project, and as a result, it does not have
 binary wheels for *every* package that is available on PyPI, or even every *version* of
 every package that is on PyPI. If you see the message::
@@ -162,10 +166,13 @@ build tools that don't support iOS, such as a compiler that can't target iOS, or
 PEP517 build system that doesn't support cross-compilation, it may not be possible to
 build an iOS wheel.
 
-The BeeWare Project provides the `Mobile Forge
+The recommended way to build iOS-compatible wheels is to use `cibuildwheel
+<https://cibuildwheel.pypa.io/en/stable/platforms/#ios>`__. Despite the name,
+the tool is not limited to CI environments; it can be run locally on a Mac.
+
+The BeeWare Project also provides the `Mobile Forge
 <https://github.com/beeware/mobile-forge>`__ project to assist with cross-compiling iOS
-binary wheels. This repository contains recipes for building the packages that are
-stored in the `secondary package repository <https://anaconda.org/beeware/repo>`__.
+binary wheels for the `secondary package repository <https://anaconda.org/beeware/repo>`__.
 Contributions of new package recipes are welcome, and can be submitted as pull requests.
 Or, if you have a particular package that you'd like us to support, please visit the
 `issue tracker <https://github.com/beeware/mobile-forge/issues>`__ and provide details
@@ -181,9 +188,10 @@ This is an inherent limitation in the use of source tarballs as a distribution f
 If you need to install a package in an iOS app that is only published as a source
 tarball, you'll need to compile that package into a wheel first. If the package is pure
 Python, you can generate a ``py3-none-any`` wheel using ``pip wheel <package name>``. If
-the project has a binary component, you'll need to use `Mobile Forge
-<https://github.com/beeware/mobile-forge>`__ (or similar tooling) to compile compatible
-wheels.
+the project has a binary component, you'll need to use `cibuildwheel
+<https://cibuildwheel.pypa.io/en/stable/platforms/#ios>`__, `Mobile Forge
+<https://github.com/beeware/mobile-forge>`__, or other similar tooling to compile
+compatible wheels.
 
 You can then directly add the wheel file to the :attr:`requires` definition for your app, or
 put the wheel in a folder and add:

--- a/docs/reference/platforms/iOS/xcode.rst
+++ b/docs/reference/platforms/iOS/xcode.rst
@@ -193,9 +193,8 @@ If you need to install a package in an iOS app that is only published as a sourc
 tarball, you'll need to compile that package into a wheel first. If the package is pure
 Python, you can generate a ``py3-none-any`` wheel using ``pip wheel <package name>``. If
 the project has a binary component, you'll need to use `cibuildwheel
-<https://cibuildwheel.pypa.io/en/stable/platforms/#ios>`__, `Mobile Forge
-<https://github.com/beeware/mobile-forge>`__, or other similar tooling to compile
-compatible wheels.
+<https://cibuildwheel.pypa.io/en/stable/platforms/#ios>`__ or other similar tooling to
+compile compatible wheels.
 
 You can then directly add the wheel file to the :attr:`requires` definition for your app, or
 put the wheel in a folder and add:

--- a/docs/reference/platforms/iOS/xcode.rst
+++ b/docs/reference/platforms/iOS/xcode.rst
@@ -141,17 +141,16 @@ extensions (e.g., ``-cp311-cp311-macosx_11_0_universal2.whl``), then the wheel c
 a binary component.
 
 If the package contains a binary component, that wheel needs to be compiled for iOS.
-PyPI `recently <https://github.com/pypi/warehouse/pull/17559>`_ gained support for
-uploading iOS-compatible wheels (identified by suffixes like
+PyPI allows projects to upload iOS-compatible wheels (identified by suffixes like
 ``-cp314-cp314-ios_15_4_arm64_iphoneos.whl`` or
-``-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl``). Most packages do not yet provide
-iOS-compatible wheels, but this is expected to improve over time.
+``-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl``). However, at this time, most
+projects do not provide iOS-compatible wheels.
 
-In the mean time, Briefcase uses a `secondary repository
-<https://anaconda.org/beeware/repo>`__ to store some popular pre-compiled iOS wheels.
-This repository is maintained by the BeeWare project, and as a result, it does not have
-binary wheels for *every* package that is available on PyPI, or even every *version* of
-every package that is on PyPI. If you see the message::
+This is expected to improve over time. In the mean time, Briefcase uses a `secondary
+repository <https://anaconda.org/beeware/repo>`__ to store some popular pre-compiled iOS
+wheels. This repository is maintained by the BeeWare project, and as a result, it does
+not have binary wheels for *every* package that is available on PyPI, or even every
+*version* of every package that is on PyPI. If you see the message::
 
     ERROR: Could not find a version that satisfies the requirement <package name> (from versions: none)
     ERROR: No matching distribution found for <package name>
@@ -167,16 +166,21 @@ PEP517 build system that doesn't support cross-compilation, it may not be possib
 build an iOS wheel.
 
 The recommended way to build iOS-compatible wheels is to use `cibuildwheel
-<https://cibuildwheel.pypa.io/en/stable/platforms/#ios>`__. Despite the name,
-the tool is not limited to CI environments; it can be run locally on a Mac.
+<https://cibuildwheel.pypa.io/en/stable/platforms/#ios>`__. Despite the name, the tool
+is not limited to CI environments; it can be run locally on macOS machines. Many
+projects already use cibuildwheel to manage publication of binary wheels. For those
+projects, it may be possible to generate iOS wheels by invoking ``cibuildwheel
+--platform=ios``. Some modifications of the cibuildwheel configuration may be necessary
+to provide iOS-specific customizations.
 
 The BeeWare Project also provides the `Mobile Forge
 <https://github.com/beeware/mobile-forge>`__ project to assist with cross-compiling iOS
-binary wheels for the `secondary package repository <https://anaconda.org/beeware/repo>`__.
-Contributions of new package recipes are welcome, and can be submitted as pull requests.
-Or, if you have a particular package that you'd like us to support, please visit the
-`issue tracker <https://github.com/beeware/mobile-forge/issues>`__ and provide details
-about that package.
+binary wheels for the `secondary package repository
+<https://anaconda.org/beeware/repo>`__. This project is mostly of historical
+significance; the BeeWare team is now focused on contributing iOS support upstream,
+rather than maintaining independent packaging efforts. If you would like a project to
+officially support iOS, you should open a feature request with that project requesting
+iOS support, and consider providing a PR to contribute that support.
 
 Requirements cannot be provided as source tarballs
 --------------------------------------------------

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -13,7 +13,9 @@ blobless
 Bugfix
 Bugfixes
 ce
+Chaquopy
 checkmarks
+cibuildwheel
 codebase
 Cookiecutter
 cryptographic


### PR DESCRIPTION
I mostly wanted to remove the no longer true assertion that PyPI doesn't support iOS wheels. I also mention cibuildwheel in one go as I've heard mobile-forge is winding down.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
