### PR TITLE
Create Kivy bootstrap

### DIFF
--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -623,6 +623,10 @@ class CreateCommand(BaseCommand):
                 encoding="UTF-8",
                 **pip_kwargs,
             )
+
+            # move kivy share deps to briefcase default sys.prefix
+            if self.platform.lower() == "window" and "kivy" in pip_args:
+                shutil.move(app_packages_path / "share", app_packages_path.parent)
         except subprocess.CalledProcessError as e:
             raise RequirementsInstallError(install_hint=install_hint) from e
 


### PR DESCRIPTION
This pull request introduces a targeted improvement to the dependency installation process for Kivy apps on Windows platforms. Specifically, it ensures that shared Kivy dependencies are moved to the default system prefix after installation. It also includes a bootstrap for kivy as a gui option in briefcase

Dependency management improvement for Kivy on Windows:

* In the `_pip_install` function in `src/briefcase/commands/create.py`, after installing dependencies, if the platform is Windows and Kivy is among the dependencies, the `share` directory is moved from the app's packages path to the parent directory to align with Briefcase's default system prefix.fixes kivy app crash when `briefcase run` command is executed due to kivy unable to find core dependency in sys.prefix location

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
