### PR TITLE
Add support for Windows using pre-release support packages

### DIFF
--- a/changes/2432.feature.rst
+++ b/changes/2432.feature.rst
@@ -1,0 +1,1 @@
+Windows apps can now reference pre-release Python versions as a support revision.

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -58,9 +58,10 @@ class WindowsCreateCommand(CreateCommand):
         return f"python-{self.python_version_tag}.{support_revision}-embed-amd64.zip"
 
     def support_package_url(self, support_revision):
+        micro = re.match(r"\d+", str(support_revision)).group(0)
         return (
             f"https://www.python.org/ftp/python/"
-            f"{self.python_version_tag}.{support_revision}/"
+            f"{self.python_version_tag}.{micro}/"
             f"{self.support_package_filename(support_revision)}"
         )
 

--- a/tests/platforms/windows/app/test_create.py
+++ b/tests/platforms/windows/app/test_create.py
@@ -122,12 +122,26 @@ def test_explicit_guid(create_command, first_app_config, tmp_path):
     assert context["guid"] == "e822176f-b755-589f-849c-6c6600f7efb1"
 
 
-def test_support_package_url(create_command, first_app_config, tmp_path):
+@pytest.mark.parametrize(
+    "revision, micro",
+    [
+        # Numerical revision
+        (5, "5"),
+        # Text revision
+        ("5", "5"),
+        # Pre-release revision
+        ("0a3", "0"),
+        ("0b2", "0"),
+        ("0rc1", "0"),
+    ],
+)
+def test_support_package_url(
+    create_command, revision, micro, first_app_config, tmp_path
+):
     """A valid support package URL is created for a support revision."""
-    revision = 5
     expected_link = (
         f"https://www.python.org/ftp/python"
-        f"/{sys.version_info.major}.{sys.version_info.minor}.{revision}"
+        f"/{sys.version_info.major}.{sys.version_info.minor}.{micro}"
         f"/python-{sys.version_info.major}.{sys.version_info.minor}.{revision}-embed-amd64.zip"
     )
     assert create_command.support_package_url(revision) == expected_link


### PR DESCRIPTION
Windows support packages are referenced by their minor release. Pre-releases are stored in the same folder as the `0` revision (e.g., https://www.python.org/ftp/python/3.14.0/ has the 0aN, 0bN, and 0rcN release downloads).

This PR normalises the micro version out of a string like `0rc1`, allowing the use of pre-release versions of support packages.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
