### PR TITLE
Add http retry handler for unit tests

### DIFF
--- a/changes/2434.misc.rst
+++ b/changes/2434.misc.rst
@@ -1,0 +1,1 @@
+Unit tests are now more resilient to HTTP request failures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ dependencies = [
 dev = [
     "coverage[toml] == 7.10.1",
     "coverage-conditional-plugin == 0.9.0",
+    "httpx-retries == 0.4.0",
     "pre-commit == 4.2.0",
     "pytest == 8.4.1",
     "pytest-xdist == 3.8.0",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,7 @@ import plistlib
 import tarfile
 import zipfile
 from email.message import EmailMessage
-from http import HTTPMethod, HTTPStatus
+from http import HTTPStatus
 from pathlib import Path
 
 import httpx
@@ -349,12 +349,12 @@ def assert_url_resolvable(url: str):
             backoff_factor=0.6,
             backoff_jitter=0.3,
             allowed_methods=[
-                HTTPMethod.HEAD,
-                HTTPMethod.GET,
-                HTTPMethod.PUT,
-                HTTPMethod.DELETE,
-                HTTPMethod.OPTIONS,
-                HTTPMethod.TRACE,
+                "HEAD",
+                "GET",
+                "PUT",
+                "DELETE",
+                "OPTIONS",
+                "TRACE",
             ],
             status_forcelist=[
                 HTTPStatus.TOO_MANY_REQUESTS,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,9 +6,11 @@ import plistlib
 import tarfile
 import zipfile
 from email.message import EmailMessage
+from http import HTTPMethod, HTTPStatus
 from pathlib import Path
 
 import httpx
+from httpx_retries import Retry, RetryTransport
 from rich.markup import escape
 
 from briefcase.console import Console, InputDisabled
@@ -333,17 +335,46 @@ def file_content(path: Path) -> str | bytes | None:
 
 def assert_url_resolvable(url: str):
     """Tests whether a URL is resolvable with retries; raises for failure."""
-    transport = httpx.HTTPTransport(
-        # Retry for connection issues
-        retries=3,
+    transport = RetryTransport(
+        # this retry for the underlying transport only applies to connection attempts
+        transport=httpx.HTTPTransport(retries=3),
+        # the underlying retry timing algorithm (first retry is immediate):
+        #  > backoff_factor * (2^attempt) * random.uniform(jitter, 1)
+        # Here are some example backoff timings using the defaults below:
+        #   [0.0, 0.694, 1.939, 3.588]
+        #   [0.0, 0.529, 1.589, 2.002]
+        #   [0.0, 0.599, 1.948, 4.184]
+        retry=Retry(
+            total=3,
+            backoff_factor=0.6,
+            backoff_jitter=0.3,
+            allowed_methods=[
+                HTTPMethod.HEAD,
+                HTTPMethod.GET,
+                HTTPMethod.PUT,
+                HTTPMethod.DELETE,
+                HTTPMethod.OPTIONS,
+                HTTPMethod.TRACE,
+            ],
+            status_forcelist=[
+                HTTPStatus.TOO_MANY_REQUESTS,
+                HTTPStatus.BAD_GATEWAY,
+                HTTPStatus.SERVICE_UNAVAILABLE,
+                HTTPStatus.GATEWAY_TIMEOUT,
+            ],
+            retry_on_exceptions=[
+                httpx.TimeoutException,
+                httpx.NetworkError,
+                httpx.RemoteProtocolError,
+                httpx.ReadTimeout,
+            ],
+        ),
     )
-    with httpx.Client(transport=transport, follow_redirects=True) as client:
-        bad_response_retries = 3
-        retry_status_codes = {500, 502, 504}
-        while bad_response_retries > 0:
-            response = client.head(url)
-            if response.status_code not in retry_status_codes:
-                # break if the status code is not one we care to retry (hopefully a success!)
-                break
 
+    try:
+        with httpx.Client(transport=transport, follow_redirects=True) as client:
+            response = client.head(url, timeout=10)
         response.raise_for_status()
+    finally:
+        # RetryTransport doesn't close its transport...so close it manually
+        transport._sync_transport.close()


### PR DESCRIPTION
## Changes
- Introduce more robust retry handler for HTTP requests during unit tests
- It may be reasonable to use such a handler more broadly for calls with httpx

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
