### PR TITLE
Support for GUI Toolkit/Toga owned pyscript configurations (Phase 2)

### DIFF
--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -144,8 +144,7 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
                     if (
                         len(path.parts) > 1
                         and path.parts[1] == "deploy"
-                        and path.suffix == ".toml"
-                        and path.name == "config"
+                        and path.name == "config.toml"
                     ):
                         self.console.info(f"    Found {filename}")
                         config_counter += 1


### PR DESCRIPTION
Update Briefcase’s build system to support toolkit-owned pyscript/backend configuration.
Modified platforms/web/static.py to detect and load deploy/config.toml and pyscript.toml as well as validate that only one toolkit provides deployment configuration.
Refs#2337 

## PR Checklist:
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
