### PR TITLE
Read iOS/macOS minimum versions from the framework, where possible.

### DIFF
--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -184,17 +184,31 @@ class macOSCreateMixin(AppPackagesMergeMixin):
         app_packages_path: Path,
         **kwargs,
     ):
-        # Determine the min macOS version from the VERSIONS file in the support package.
-        versions = dict(
-            [part.strip() for part in line.split(": ", 1)]
-            for line in (
-                (self.support_path(app) / "VERSIONS")
-                .read_text(encoding="UTF-8")
-                .split("\n")
+        try:
+            # Determine the min macOS version from the framework metadata
+            # of the macos-arm64_x86_64 slice of the XCframework
+            plist_file = (
+                self.support_path(app)
+                / "Python.xcframework/macos-arm64_x86_64"
+                / "Python.framework/Resources/Info.plist"
             )
-            if ": " in line
-        )
-        support_min_version = Version(versions.get("Min macOS version", "11.0"))
+            with plist_file.open("rb") as f:
+                info_plist = plistlib.load(f)
+
+            support_min_version = Version(info_plist.get("MinimumOSVersion", "11.0"))
+        except FileNotFoundError:
+            # If a plist file couldn't be found, it's an old-style support package;
+            # Determine the min macOS version from the VERSIONS file in the support package.
+            versions = dict(
+                [part.strip() for part in line.split(": ", 1)]
+                for line in (
+                    (self.support_path(app) / "VERSIONS")
+                    .read_text(encoding="UTF-8")
+                    .split("\n")
+                )
+                if ": " in line
+            )
+            support_min_version = Version(versions.get("Min macOS version", "11.0"))
 
         # Check that the app's definition is compatible with the support package
         macOS_min_version = Version(getattr(app, "min_os_version", "11.0"))

--- a/tests/platforms/iOS/xcode/conftest.py
+++ b/tests/platforms/iOS/xcode/conftest.py
@@ -32,30 +32,24 @@ def first_app_generated(first_app_config, tmp_path):
         },
     )
 
-    # Create the support package VERSIONS file
-    # with a deliberately weird min iOS version
-    create_file(
-        tmp_path / "base_path/build/first-app/ios/xcode/Support/VERSIONS",
-        "\n".join(
-            [
-                "Python version: 3.10.15",
-                "Build: b11",
-                "Min iOS version: 12.0",
-                "---------------------",
-                "BZip2: 1.0.8-1",
-                "libFFI: 3.4.6-1",
-                "OpenSSL: 3.0.15-1",
-                "XZ: 5.6.2-1",
-                "",
-            ]
-        ),
-    )
     # Create the package-config folders for each platform.
     # We don't need anything in them; they just need to exist.
     xcframework_path = (
         tmp_path / "base_path/build/first-app/ios/xcode/Support/Python.xcframework"
     )
+
+    # Create the XCframeworks's ios-arm64 Info.plist file
+    # with a deliberately weird min iOS version
+    create_plist_file(
+        xcframework_path / "ios-arm64/Python.framework/Info.plist",
+        {
+            "CFBundleSupportedPlatforms": "iPhoneOS",
+            "CFBundleVersion": "3.10.15",
+            "MinimumOSVersion": "12.0",
+        },
+    )
     (xcframework_path / "ios-arm64/platform-config/arm64-iphoneos").mkdir(parents=True)
+
     (
         xcframework_path
         / "ios-arm64_x86_64-simulator/platform-config/arm64-iphonesimulator"

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -15,6 +15,8 @@ from briefcase.exceptions import (
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.iOS.xcode import iOSXcodeCreateCommand
 
+from ....utils import create_file
+
 
 @pytest.fixture
 def create_command(tmp_path):
@@ -66,6 +68,23 @@ def test_extra_pip_args(
     if old_config:
         shutil.rmtree(
             tmp_path / "base_path/build/first-app/ios/xcode/Support/Python.xcframework"
+        )
+        # Create the old-style VERSIONS file with a deliberately weird min iOS version
+        create_file(
+            tmp_path / "base_path/build/first-app/ios/xcode/Support/VERSIONS",
+            "\n".join(
+                [
+                    "Python version: 3.10.15",
+                    "Build: b11",
+                    "Min iOS version: 12.0",
+                    "---------------------",
+                    "BZip2: 1.0.8-1",
+                    "libFFI: 3.4.6-1",
+                    "OpenSSL: 3.0.15-1",
+                    "XZ: 5.6.2-1",
+                    "",
+                ]
+            ),
         )
 
     # Hard code the current architecture for testing. We only install simulator

--- a/tests/platforms/iOS/xcode/test_update.py
+++ b/tests/platforms/iOS/xcode/test_update.py
@@ -8,6 +8,8 @@ from briefcase.console import Console
 from briefcase.integrations.subprocess import Subprocess
 from briefcase.platforms.iOS.xcode import iOSXcodeUpdateCommand
 
+from ....utils import create_file
+
 
 @pytest.fixture
 def update_command(tmp_path):
@@ -47,6 +49,23 @@ def test_extra_pip_args(
     if old_config:
         shutil.rmtree(
             tmp_path / "base_path/build/first-app/ios/xcode/Support/Python.xcframework"
+        )
+        # Create the old-style VERSIONS file with a deliberately weird min iOS version
+        create_file(
+            tmp_path / "base_path/build/first-app/ios/xcode/Support/VERSIONS",
+            "\n".join(
+                [
+                    "Python version: 3.10.15",
+                    "Build: b11",
+                    "Min iOS version: 12.0",
+                    "---------------------",
+                    "BZip2: 1.0.8-1",
+                    "libFFI: 3.4.6-1",
+                    "OpenSSL: 3.0.15-1",
+                    "XZ: 5.6.2-1",
+                    "",
+                ]
+            ),
         )
 
     # Hard code the current architecture for testing. We only install simulator

--- a/tests/platforms/macOS/conftest.py
+++ b/tests/platforms/macOS/conftest.py
@@ -76,18 +76,17 @@ entitlements_path="Entitlements.plist"
         """<?xml?>\n<installer-script></installer-script>""",
     )
 
-    # Create the support package VERSIONS file
-    # with a deliberately weird min macOS version
-    create_file(
-        tmp_path / "base_path/build/first-app/macos/app/support/VERSIONS",
-        "\n".join(
-            [
-                "Python version: 3.10.15",
-                "Build: b11",
-                "Min macOS version: 10.12",
-                "",
-            ]
+    # Create the XCframework Info.plist file, with a deliberately weird min macOS version
+    create_plist_file(
+        (
+            tmp_path
+            / "base_path/build/first-app/macos/app/support/Python.xcframework"
+            / "macos-arm64_x86_64/Python.framework/Resources/Info.plist"
         ),
+        {
+            "CFBundleVersion": "3.10.15",
+            "MinimumOSVersion": "10.12",
+        },
     )
 
     # Select dmg packaging by default


### PR DESCRIPTION
One of the files included in a BeeWare iOS/macOS support package is the VERSIONS file. This describes the version of Python that has been packaged, and some other metadata, including the minimum supported iOS version.

While this file exists for historical reasons, it (a) isn't in an inherently parseable format, and (b) likely won't be included in an official Python release of an iOS or macOS XCframework distribution.

However, the only piece of metadata that is important for runtime purposes is the minimum OS version - and that is available in the Framework metadata.

This PR modifies the iOS and macOS backends to read the minimum OS version from the XCframework, rather than from the VERSIONS file. This will allow for the VERSIONS file to be removed in later support packages.

A fallback to VERSION files is retained for older support packages that weren't distributed as XCframeworks.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
