### PR TITLE
Correct references to Java paths in Android docs.

### DIFF
--- a/changes/2457.misc.rst
+++ b/changes/2457.misc.rst
@@ -1,0 +1,1 @@
+The path for some Java signing tools was corrected.

--- a/docs/how-to/code-signing/android.rst
+++ b/docs/how-to/code-signing/android.rst
@@ -48,14 +48,14 @@ Google Play.
     .. code-block:: console
 
       $ mkdir -p ~/.android
-      $ ~/Library/Caches/org.beeware.briefcase/tools/java/Contents/Home/bin/keytool -keyalg RSA -deststoretype pkcs12 -genkey -v -storepass android -keystore ~/.android/upload-key-helloworld.jks -keysize 2048 -dname "cn=Upload Key" -alias upload-key -validity 10000
+      $ ~/Library/Caches/org.beeware.briefcase/tools/java17/Contents/Home/bin/keytool -keyalg RSA -deststoretype pkcs12 -genkey -v -storepass android -keystore ~/.android/upload-key-helloworld.jks -keysize 2048 -dname "cn=Upload Key" -alias upload-key -validity 10000
 
   .. group-tab:: Linux
 
     .. code-block:: console
 
       $ mkdir -p ~/.android
-      $ ~/.cache/briefcase/tools/java/bin/keytool -keyalg RSA -deststoretype pkcs12 -genkey -v -storepass android -keystore ~/.android/upload-key-helloworld.jks -keysize 2048 -dname "cn=Upload Key" -alias upload-key -validity 10000
+      $ ~/.cache/briefcase/tools/java17/bin/keytool -keyalg RSA -deststoretype pkcs12 -genkey -v -storepass android -keystore ~/.android/upload-key-helloworld.jks -keysize 2048 -dname "cn=Upload Key" -alias upload-key -validity 10000
 
   .. group-tab:: Windows (cmd)
 

--- a/docs/how-to/publishing/android.rst
+++ b/docs/how-to/publishing/android.rst
@@ -81,7 +81,7 @@ name.
 
     .. code-block:: console
 
-      $ ~/Library/Caches/org.beeware.briefcase/tools/java/Contents/Home/bin/jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/upload-key-helloworld.jks "dist/Hello World-1.0.0.aab" upload-key -storepass android
+      $ ~/Library/Caches/org.beeware.briefcase/tools/java17/Contents/Home/bin/jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/upload-key-helloworld.jks "dist/Hello World-1.0.0.aab" upload-key -storepass android
          adding: META-INF/MANIFEST.MF
          adding: META-INF/UPLOAD-K.SF
          adding: META-INF/UPLOAD-K.RSA
@@ -106,7 +106,7 @@ name.
 
     .. code-block:: console
 
-      $ ~/.cache/briefcase/tools/java/bin/jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/upload-key-helloworld.jks "dist/Hello World-1.0.0.aab" upload-key -storepass android
+      $ ~/.cache/briefcase/tools/java17/bin/jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/upload-key-helloworld.jks "dist/Hello World-1.0.0.aab" upload-key -storepass android
          adding: META-INF/MANIFEST.MF
          adding: META-INF/UPLOAD-K.SF
          adding: META-INF/UPLOAD-K.RSA


### PR DESCRIPTION
In the process of publishing an update of TravelTips, I noticed that the path provided for the Java tools like `keystore` and `jarsigner` referred to a historical path. This PR updates those docs.
 
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
