### PR TITLE
Fix #2477: Escape paths in tox.ini

### DIFF
--- a/changes/2477.bugfix.rst
+++ b/changes/2477.bugfix.rst
@@ -1,0 +1,1 @@
+The docs checks in tox now work if there are spaces in the path.

--- a/tox.ini
+++ b/tox.ini
@@ -95,8 +95,8 @@ deps =
     -r {tox_root}/requirements-docs.txt
 extras = docs
 commands =
-    !lint-!all-!live : python -m sphinx {[docs]sphinx_args} {posargs} --builder html {[docs]docs_dir} {[docs]build_dir}{/}html
-    lint : python -m sphinx {[docs]sphinx_args} {posargs} --builder spelling {[docs]docs_dir} {[docs]build_dir}{/}spell
-    lint : python -m sphinx {[docs]sphinx_args} {posargs} --builder linkcheck {[docs]docs_dir} {[docs]build_dir}{/}links
-    all  : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html {[docs]docs_dir} {[docs]build_dir}{/}html
-    live : sphinx-autobuild {[docs]sphinx_args} {posargs} --builder html {[docs]docs_dir} {[docs]build_dir}{/}live
+    !lint-!all-!live : python -m sphinx {[docs]sphinx_args} {posargs} --builder html "{[docs]docs_dir}" "{[docs]build_dir}{/}html"
+    lint : python -m sphinx {[docs]sphinx_args} {posargs} --builder spelling "{[docs]docs_dir}" "{[docs]build_dir}{/}spell"
+    lint : python -m sphinx {[docs]sphinx_args} {posargs} --builder linkcheck "{[docs]docs_dir}" "{[docs]build_dir}{/}links"
+    all  : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html "{[docs]docs_dir}" "{[docs]build_dir}{/}html"
+    live : sphinx-autobuild {[docs]sphinx_args} {posargs} --builder html "{[docs]docs_dir}" "{[docs]build_dir}{/}live"


### PR DESCRIPTION
The `docs` tasks in `tox.ini` currently fail if there are spaces in the path to the briefcase repo (e.g. `.../brief case/`).

Caveat: If there are double quotes in the path, this will fail (e.g. `.../brief"case/`).

Fixes #2477

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
