### PR TITLE
Add validation for app description length

### DIFF
--- a/changes/2489.bugfix.rst
+++ b/changes/2489.bugfix.rst
@@ -1,0 +1,1 @@
+Fix truncated icon link when packaging on Windows

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -397,6 +397,14 @@ class AppConfig(BaseConfig):
 
         self.test_mode: bool = False
 
+        if len(self.description) > 80:
+            raise BriefcaseConfigError(
+                f"The app description is {len(self.description)} characters long.\n\n"
+                "Descriptions should be short.\n"
+                "Longer descriptions should use the 'long_description' field.\n"
+                "On some platforms, descriptions may be truncated to fit platform limitations.",
+            )
+
         if not is_valid_app_name(self.app_name):
             raise BriefcaseConfigError(
                 f"{self.app_name!r} is not a valid app name.\n\n"


### PR DESCRIPTION
This PR adds a warning message for descriptions over 80 chars this is due to an issue packaging on Windows where the icon was getting truncated.

This is part of 3 PRs to update both the Windows app template and VisualStudio template to truncate descriptions over 256 chars & add a warning to briefcase
https://github.com/beeware/briefcase-windows-VisualStudio-template/pull/68
https://github.com/beeware/briefcase-windows-app-template/pull/72

This resolves issue: #2465 

## PR Checklist:
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
