### PR TITLE
Replaced dist-info tracking with venv creation tracking for dev command

### DIFF
--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -461,8 +461,8 @@ class StaticWebDevCommand(StaticWebMixin, DevCommand):
 
         :returns: Name for virtual environment directory
         """
-
-        return "dev-web"
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        return f"dev-web--{python_version}"
 
     def add_options(self, parser):
         super().add_options(parser)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
 
After #2420, an edge case was identified where running briefcase dev followed by briefcase dev web would cause the web dev command to skip dependency installation.
The issue occurs because both commands share the same source directory where the dist-info file is written. When briefcase dev runs first, it writes the dist-info file to the source. Then when briefcase dev web runs with its own isolated virtual environment, it sees the existing dist-info file and incorrectly assumes dependencies are already installed in its venv, even though they aren't.
This PR replaces the dist-info approach with venv-specific tracking:

Virtual environments now track a created attribute that's set when the venv is created or recreated
For non-isolated environments, a marker file (.venv-marker) is stored alongside the venv and contains the Python executable path
Dev venv names now include the Python version (e.g., dev-3.12, dev-3.12-web) to isolate environments across Python versions
Dependencies are installed when venv.created=True or when explicitly requested via --update-requirements

Since the marker is stored in the venv-specific directory rather than the shared source directory, each environment correctly tracks its own dependency installation status.
Refs #2334

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
