### PR TITLE
Update use of macos-13 runner.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,8 +194,6 @@ jobs:
       python-version: ${{ startsWith(matrix.runner-os, 'ubuntu') && 'system' || '3.12' }}
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
-      xcode-version: ${{ matrix.xcode-version }}
-      ios-simulator: ${{ matrix.ios-simulator }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ "macos-13", "macos-latest", "windows-latest", "ubuntu-24.04" ]
+        platform: [ "macos-15-intel", "macos-latest", "windows-latest", "ubuntu-24.04" ]
         python-version: [ "3.10", "3.14" ]
         include:
           # Ensure the Python versions between min and max are tested
@@ -183,7 +183,7 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ "toga", "pyside6", "pygame", "console" ]
-        runner-os: [ "macos-13", "macos-latest", "ubuntu-24.04", "ubuntu-24.04-arm", "windows-latest" ]
+        runner-os: [ "macos-15-intel", "macos-latest", "ubuntu-24.04", "ubuntu-24.04-arm", "windows-latest" ]
 
   verify-apps:
     name: Build app
@@ -200,14 +200,4 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ "toga", "pyside6", "pygame", "console" ]
-        runner-os: [ "macos-13", "macos-15", "ubuntu-24.04", "ubuntu-24.04-arm", "windows-latest" ]
-        include:
-          - framework: "toga"
-            runner-os: "macos-15"
-            xcode-version: "16.4"
-            ios-simulator: "iPhone 16e::iOS 18.5"
-
-          # Default xcode handling works for macOS-13
-          - framework: "toga"
-            runner-os: "macos-13"
-            ios-simulator: "iPhone SE (3rd generation)"
+        runner-os: [ "macos-15-intel", "macos-15", "ubuntu-24.04", "ubuntu-24.04-arm", "windows-latest" ]

--- a/changes/2509.misc.rst
+++ b/changes/2509.misc.rst
@@ -1,1 +1,1 @@
-The deprecated macos-13 CI runner was replaced with the macos-15-intel runner.
+The deprecated macos-13 CI runner was replaced with macos-15-intel.

--- a/changes/2509.misc.rst
+++ b/changes/2509.misc.rst
@@ -1,0 +1,1 @@
+The deprecated macos-13 CI runner was replaced with the macos-15-intel runner.

--- a/docs/topics/access-packaging-metadata.rst
+++ b/docs/topics/access-packaging-metadata.rst
@@ -55,7 +55,7 @@ in your app's ``pyproject.toml`` configuration:
   * **Author-email** - :attr:`author_email`
 
 For example, the metadata for the app constructed by the `BeeWare Tutorial
-<https://docs.beeware.org/en/latest/tutorial/tutorial-1.html>`_ would
+<https://docs.beeware.org/en/latest/tutorial/tutorial-1/>`_ would
 contain::
 
     Metadata-Version: 2.1


### PR DESCRIPTION
The macOS-13 runner has been deprecated, and is being slowly browned out.

This also affords an opportunity to clean up some workarounds that were added in August as Github made big changes to their Xcode actions configuration.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
