### PR TITLE
Limit line length in `src/briefcase` comments (ruff E501)

### DIFF
--- a/changes/2526.misc.rst
+++ b/changes/2526.misc.rst
@@ -1,0 +1,1 @@
+Comments in ``src/briefcase`` now have a maximum line length of 88 characters (ruff rule ``E501``).

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -1090,20 +1090,21 @@ Did you run Briefcase in a project directory that contains {filename.name!r}?"""
                         self.tools.shutil.rmtree(cached_template)
                     raise
                 except self.tools.git.exc.GitError as e:
-                    # The clone failed; to make sure the repo is in a clean state, clean up
-                    # any partial remnants of this initial clone.
+                    # The clone failed; to make sure the repo is in a clean state,
+                    # clean up any partial remnants of this initial clone.
                     # If we're getting a GitError, we know the directory must exist.
                     self.tools.shutil.rmtree(cached_template)
                     git_fatal_message = re.findall(
                         r"(?<=fatal: ).*?$", e.stderr, flags=re.DOTALL
                     )
                     if git_fatal_message:
-                        # GitError captures stderr with single quotes. Because the regex above
-                        # takes everything after git's "fatal" message, we need to strip that final single quote.
+                        # GitError captures stderr with single quotes. Because the regex
+                        # above takes everything after git's "fatal" message, we need to
+                        # strip that final single quote.
                         hint = git_fatal_message[0].rstrip("'").strip()
 
-                        # git is inconsistent with capitalisation of the first word of the message
-                        # and about periods at the end of the message.
+                        # git is inconsistent with capitalization of the first word of
+                        # the message and about periods at the end of the message.
                         hint = f"{hint[0].upper()}{hint[1:]}{'' if hint[-1] == '.' else '.'}"
                     else:
                         hint = (
@@ -1197,9 +1198,11 @@ Did you run Briefcase in a project directory that contains {filename.name!r}?"""
                 no_input=True,
                 output_dir=str(output_path),
                 checkout=branch,
-                # Use a copy to prevent changes propagating among tests while test suite is running
+                # Use a copy to prevent changes propagating among tests
+                # while the test suite is running
                 extra_context=extra_context.copy(),
-                # Store replay data in the Briefcase template cache instead of ~/.cookiecutter_replay
+                # Store replay data in the Briefcase template cache
+                # instead of ~/.cookiecutter_replay
                 default_config={"replay_dir": str(self.template_cache_path(".replay"))},
             )
         except subprocess.CalledProcessError as e:
@@ -1233,7 +1236,8 @@ Did you run Briefcase in a project directory that contains {filename.name!r}?"""
 
         extra_context = extra_context.copy()
         # Additional context that can be used for the Briefcase template pyproject.toml
-        # header to include the version of Briefcase as well as the source of the template.
+        # header to include the version of Briefcase as well as the source of the
+        # template.
         extra_context.update(
             {
                 "template_source": template,

--- a/src/briefcase/commands/build.py
+++ b/src/briefcase/commands/build.py
@@ -110,7 +110,8 @@ class BuildCommand(BaseCommand):
         **options,
     ) -> dict | None:
         # Has the user requested an invalid set of options?
-        # This can't be done with argparse, because it isn't a simple mutually exclusive group.
+        # This can't be done with argparse because it isn't
+        # a simple mutually exclusive group.
         if no_update:
             if update:
                 raise BriefcaseCommandError(

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -522,7 +522,8 @@ class ConvertCommand(NewCommand):
         intro = "What license do you want to use for this project's code? "
         default = None
 
-        # If there is license information in the pyproject.toml file, use that, otherwise check the license file
+        # If there is license information in the pyproject.toml file, use that,
+        # otherwise check the license file
         if "text" in self.pep621_data.get("license", {}):
             default = self.get_license_from_text(self.pep621_data["license"]["text"])
             default_source = "the PEP621 formatted pyproject.toml"
@@ -638,9 +639,10 @@ class ConvertCommand(NewCommand):
         if pyproject_file.exists():
             pep621_pyproject = pyproject_file.read_text(encoding="utf-8")
 
-            # The pyproject.toml file in the target directory has no briefcase keys, so it's
-            # safe to copy-paste the text, and that way also keep formatting and comments.
-            # We merge it this way to preserve comments in the original pyproject.toml file
+            # The pyproject.toml file in the target directory has no briefcase keys, so
+            # it's safe to copy-paste the text, and that way also keep formatting and
+            # comments. We merge it this way to preserve comments in the original
+            # pyproject.toml file
             briefcase_comment = "# content below this line added by briefcase convert"
             merged_pyproject = (
                 f"{pep621_pyproject}\n\n\n{briefcase_comment}\n{briefcase_pyproject}"

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -240,7 +240,8 @@ class CreateCommand(BaseCommand):
                 # Ensure the output format is in the case we expect
                 "format": self.output_format.lower(),
                 # Properties of the generating environment
-                # The full Python version string, including minor and dev/a/b/c suffixes (e.g., 3.11.0rc2)
+                # The full Python version string, including minor and dev/a/b/c suffixes
+                # (e.g., 3.11.0rc2)
                 "python_version": platform.python_version(),
                 # The host architecture
                 "host_arch": self.tools.host_arch,
@@ -938,8 +939,9 @@ class CreateCommand(BaseCommand):
         self.console.info("Generating application template...", prefix=app.app_name)
         self.generate_app_template(app=app)
 
-        # External apps (apps that define 'external_package_path') need the packaging metadata
-        # from the template, but not the app content, dependencies, support package etc.
+        # External apps (apps that define 'external_package_path') need the packaging
+        # metadata from the template, but not the app content, dependencies, support
+        # package, etc.
         if app.external_package_path:
             self.console.info("Removing generated app content...", prefix=app.app_name)
             self.tools.shutil.rmtree(self.bundle_package_path(app))

--- a/src/briefcase/commands/dev.py
+++ b/src/briefcase/commands/dev.py
@@ -21,13 +21,13 @@ class DevCommand(RunAppMixin, BaseCommand):
     output_format = ""
     description = "Run a Briefcase project in the dev environment."
 
-    # On macOS CoreFoundation/NSApplication will do its own independent parsing of argc/argv.
-    # This means that whatever we pass to the Python interpreter on start-up will also be
-    # visible to NSApplication which will interpret things like `-u` (used to make I/O
-    # unbuffered in CPython) as `-u [URL]` (a request to open a document by URL). This is,
-    # rather patently, Not Good.
-    # To avoid this causing unwanted hilarity, we use environment variables to configure the
-    # Python interpreter rather than command-line options.
+    # On macOS CoreFoundation/NSApplication will do its own independent parsing of
+    # argc/argv. This means that whatever we pass to the Python interpreter on start-up
+    # will also be visible to NSApplication which will interpret things like `-u` (used
+    # to make I/O unbuffered in CPython) as `-u [URL]` (a request to open a document by
+    # URL). This is, rather patently, Not Good.
+    # To avoid this causing unwanted hilarity, we use environment variables to configure
+    # the Python interpreter rather than command-line options.
     DEV_ENVIRONMENT: Mapping[str, str] = {
         # Equivalent of passing "-u"
         "PYTHONUNBUFFERED": "1",

--- a/src/briefcase/commands/run.py
+++ b/src/briefcase/commands/run.py
@@ -55,11 +55,12 @@ class LogFilter:
             if filtered is None:
                 return
 
-            # If there's a cleaned line, we can determine if it should be included in analysis
+            # If there's a cleaned line, we can determine if it should be
+            # included in analysis
             clean_line, included = filtered
         else:
             # If we don't perform cleaning, we assume all content is potentially
-            # Python, and should be included in analysis
+            # Python and should be included in analysis
             clean_line = line
             included = True
 

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -174,7 +174,8 @@ a single value should be provided.
         else:
             uti = None
 
-        # If an UTI is provided in LSItemContentTypes, that takes precedence over a MIME type
+        # If an UTI is provided in LSItemContentTypes,
+        # that takes precedence over a MIME type
         if is_uti_core_type(uti) or ((uti := mime_type_to_uti(mime_type)) is not None):
             macOS.setdefault("is_core_type", True)
             macOS.setdefault("LSItemContentTypes", [uti])

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -186,8 +186,9 @@ class Console:
         self.save_log = False
         # flag set by exceptions to skip writing the log; save_log takes precedence.
         self.skip_log = False
-        # Rich stacktraces of exceptions for logging to file.
-        # A list of tuples containing a label for the thread context, and the Trace object
+        # Rich stacktraces of exceptions for logging to a file.
+        # A list of tuples containing a label for the thread context,
+        # and the Trace object
         self.stacktraces: list[tuple[str, Trace]] = []
         # functions to run for additional logging if creating a logfile
         self.log_file_extras: list[Callable[[], object]] = []
@@ -511,13 +512,17 @@ class Console:
             f"Platform:        {platform.platform(aliased=True)}\n"
             "\n"
             f"Python exe:      {sys.executable}\n"
-            # replace line breaks with spaces (use chr(10) since '\n' isn't allowed in f-strings...)
+            # replace line breaks with spaces
+            # (use chr(10) since '\n' isn't allowed in f-strings...)
             f"Python version:  {sys.version.replace(chr(10), ' ')}\n"
             # sys.real_prefix was used in older versions of virtualenv.
-            # sys.base_prefix is always the python exe's original site-specific directory (e.g. /usr/local).
-            # sys.prefix is updated (from base_prefix's value) to the virtual env's site-specific directory.
+            # sys.base_prefix is always the python exe's original site-specific
+            #     directory (e.g. /usr/local).
+            # sys.prefix is updated (from base_prefix's value) to the virtual env's
+            #     site-specific directory.
             f"Virtual env:     {hasattr(sys, 'real_prefix') or sys.base_prefix != sys.prefix}\n"
-            # for conda, prefix and base_prefix are likely the same but contain a conda-meta dir.
+            # for conda, prefix and base_prefix are likely the same
+            # but contain a conda-meta dir.
             f"Conda env:       {(Path(sys.prefix) / 'conda-meta').exists()}\n"
             "\n"
             f"Briefcase:       {__version__}\n"
@@ -561,7 +566,7 @@ class Console:
         the NO_COLOR environment variable; alternatively, the derived color system for
         the terminal is influenced by attributes of the platform as well as FORCE_COLOR.
         """
-        # no_color has precedence since color_system can be set even if color is disabled
+        # no_color has precedence: color_system can be set even if color is disabled
         if self._console_impl.no_color:
             return False
         else:
@@ -632,7 +637,8 @@ class Console:
             self._wait_bar.start()
             yield NotDeadYet(console=self)
         except BaseException as e:
-            # capture BaseException so message is left on the screen even if user sends CTRL+C
+            # capture BaseException so the message is left on the screen
+            # even if the user sends CTRL+C
             error_message = "aborted" if isinstance(e, KeyboardInterrupt) else "errored"
             self.print(
                 f"{message} {error_message}", markup=markup, show=show_outcome_message

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -292,8 +292,9 @@ class AndroidSDK(ManagedTool):
 """
                     )
             elif sdk.cmdline_tools_path.parent.exists():
-                # a cmdline-tools directory exists but the required version isn't installed.
-                # try to install the required version using the 'latest' version.
+                # a cmdline-tools directory exists,
+                # but the required version isn't installed.
+                # Try to install the required version using the 'latest' version.
                 if not sdk.install_cmdline_tools():
                     sdk = None
                     tools.console.warning(
@@ -412,8 +413,10 @@ class AndroidSDK(ManagedTool):
         # So, the unpacking process is:
         #
         #  1. Make a <sdk_path>/cmdline-tools folder
-        #  2. Unpack the zip file into that folder, creating <sdk_path>/cmdline-tools/cmdline-tools
-        #  3. Move <sdk_path>/cmdline-tools/cmdline-tools to <sdk_path>/cmdline-tools/<cmdline-tools version>
+        #  2. Unpack the zip file into that folder, creating
+        #      <sdk_path>/cmdline-tools/cmdline-tools
+        #  3. Move <sdk_path>/cmdline-tools/cmdline-tools to
+        #      <sdk_path>/cmdline-tools/<cmdline-tools version>
 
         with self.tools.console.wait_bar(
             f"Installing Android SDK Command-Line Tools {self.SDK_MANAGER_VER}..."
@@ -1474,9 +1477,10 @@ class ADB:
                 [self.tools.android_sdk.adb_path, "-s", self.device, *arguments],
                 quiet=quiet,
             )
-            # add returns status code 0 in the case of failure. The only tangible evidence
-            # of failure is the message "Failure [INSTALL_FAILED_OLDER_SDK]" in the,
-            # console output; so if that message exists in the output, raise an exception.
+            # add returns status code 0 in the case of failure.
+            # The only tangible evidence of failure is the message
+            # "Failure [INSTALL_FAILED_OLDER_SDK]" in the console output;
+            # so if that message exists in the output, raise an exception.
             if "Failure [INSTALL_FAILED_OLDER_SDK]" in output:
                 raise BriefcaseCommandError(
                     "Your device doesn't meet the minimum SDK requirements of this app."
@@ -1529,9 +1533,9 @@ class ADB:
         :returns: `None` on success; raises an exception on failure.
         """
         try:
-            # `am start` also accepts string array extras, but we pass the arguments as a
-            # single JSON string, because JSON deals with edge cases like whitespace and
-            # escaping in a reliable and well-documented way.
+            # `am start` also accepts string array extras, but we pass the arguments as
+            # a single JSON string, because JSON deals with edge cases like whitespace
+            # and escaping in a reliable and well-documented way.
             output = self.run(
                 "shell",
                 "am",
@@ -1718,11 +1722,11 @@ Activity class not found while starting app.
         :returns: The PID of the given app as a string, or None if it isn't
         running.
         """
-        # The pidof command is available since API level 24. The level 23 emulator image also
-        # includes it, but it doesn't work correctly (it returns all processes).
+        # The pidof command is available since API level 24. The level 23 emulator image
+        # also includes it, but it doesn't work correctly (it returns all processes).
         try:
-            # Exit status is unreliable: some devices (e.g. Nexus 4) return 0 even when no
-            # process was found.
+            # Exit status is unreliable: some devices (e.g. Nexus 4) return 0
+            # even when no process was found.
             return self.run("shell", "pidof", "-s", package, **kwargs).strip() or None
         except subprocess.CalledProcessError:
             return None

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -770,7 +770,8 @@ Briefcase will proceed, but if access to the display is rejected, this may be wh
         xauth_file_path.unlink(missing_ok=True)
         xauth_file_path.touch()
 
-        # Create a xauth database for the target display using the current display's cookie
+        # Create an xauth database for the target display
+        # using the current display's cookie
         try:
             self.tools.subprocess.check_output(
                 [

--- a/src/briefcase/integrations/file.py
+++ b/src/briefcase/integrations/file.py
@@ -199,9 +199,9 @@ class File(Tool):
                         url=url, status_code=response.status_code
                     )
 
-                # The initial URL might (read: will) go through URL redirects, so
-                # we need the *final* response. We look at either the `Content-Disposition`
-                # header, or the final URL, to extract the cache filename.
+                # The initial URL might go through URL redirects, so we need the *final*
+                # response. We look at either the `Content-Disposition` header or the
+                # final URL to extract the cache filename.
                 cache_full_name = response.url.path
                 header_value = response.headers.get("Content-Disposition")
                 if header_value:
@@ -233,10 +233,11 @@ class File(Tool):
                 description = filename.name if filename else url
 
             if isinstance(e, httpx.TooManyRedirects):
-                # httpx, unlike requests, will not follow redirects indefinitely, and defaults to
-                # 20 redirects before calling it quits. If the download attempt exceeds 20 redirects,
-                # Briefcase probably needs to re-evaluate the URLs it is using for that download
-                # and ideally find a starting point that won't have so many redirects.
+                # httpx, unlike requests, will not follow redirects indefinitely and
+                # defaults to 20 redirects before calling it quits. If the download
+                # attempt exceeds 20 redirects, Briefcase probably needs to re-evaluate
+                # the URLs it is using for that download and ideally find a starting
+                # point that won't have so many redirects.
                 hint = "exceeded redirects when downloading the file.\n\nPlease report this as a bug to Briefcase."
             elif isinstance(e, httpx.DecodingError):
                 hint = "the server sent a malformed response."

--- a/src/briefcase/integrations/flatpak.py
+++ b/src/briefcase/integrations/flatpak.py
@@ -270,7 +270,8 @@ flatpak run {bundle_identifier}
         flatpak_run_cmd.extend([] if args is None else args)
 
         if self.tools.console.is_deep_debug:
-            # Must come before bundle identifier; otherwise, it's passed as an arg to app
+            # Must come before bundle identifier;
+            # otherwise, it's passed as an arg to app
             flatpak_run_cmd.insert(2, "--verbose")
 
         if stream_output:

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -301,8 +301,8 @@ Delete {jdk_zip_path} and run briefcase again.
             jdk_zip_path.unlink()  # Zip file no longer needed once unpacked.
 
             # The tarball will unpack into <briefcase data dir>/tools/jdk-17.0.X+7
-            # (or whatever name matches the current release).
-            # We turn this into <briefcase data dir>/tools/java so we have a consistent name.
+            # (or whatever name matches the current release). We turn this
+            # into <briefcase data dir>/tools/java so we have a consistent name.
             java_unpack_path = (
                 self.tools.base_path / f"jdk-{self.JDK_RELEASE}+{self.JDK_BUILD}"
             )

--- a/src/briefcase/integrations/windows_sdk.py
+++ b/src/briefcase/integrations/windows_sdk.py
@@ -176,8 +176,9 @@ WindowsSDKVersion: {environ_sdk_version}
         try:
             sdk.tools.subprocess.check_output([sdk.signtool_exe, "-?"])
         except (OSError, subprocess.CalledProcessError):
-            # Windows can raise OSError when it cannot run signtool. This can happen
-            # when an old version of the SDK is installed and only signtool is installed.
+            # Windows can raise OSError when it cannot run signtool.
+            # This can happen when an old version of the SDK is installed
+            # and only signtool is installed.
             return False
 
         return True

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -108,12 +108,12 @@ class GradleMixin:
         # Gradle may install the emulator via the dependency chain build-tools > tools >
         # emulator. (The `tools` package only shows up in sdkmanager if you pass
         # `--include_obsolete`.) However, the old sdkmanager built into Android Gradle
-        # plugin 4.2 doesn't know about macOS on ARM, so it'll install an x86_64 emulator
-        # which won't work with ARM system images.
+        # plugin 4.2 doesn't know about macOS on ARM, so it'll install an x86_64
+        # emulator which won't work with ARM system images.
         #
         # Work around this by pre-installing the emulator with our own sdkmanager before
-        # running Gradle. For simplicity, we do this on all platforms, since the user will
-        # almost certainly want an emulator soon enough.
+        # running Gradle. For simplicity, we do this on all platforms, since the user
+        # will almost certainly want an emulator soon enough.
         self.tools.android_sdk.verify_emulator()
 
         gradlew = "gradlew.bat" if self.tools.host_os == "Windows" else "gradlew"
@@ -219,7 +219,7 @@ class GradleCreateCommand(GradleMixin, CreateCommand):
         return {
             "version_code": version_code,
             "safe_formal_name": safe_formal_name(app.formal_name),
-            # Extract test packages, to enable features like test discovery and assertion
+            # Extract test packages to enable features like test discovery and assertion
             # rewriting.
             "extract_packages": ", ".join(
                 f'"{name}"'
@@ -275,7 +275,8 @@ class GradleCreateCommand(GradleMixin, CreateCommand):
         if x_permissions["photo_library"]:
             permissions["android.permission.READ_MEDIA_VISUAL_USER_SELECTED"] = True
 
-        # Override any permission and entitlement definitions with the platform specific definitions
+        # Override any permission and entitlement definitions
+        # with the platform-specific definitions
         permissions.update(app.permission)
         features.update(getattr(app, "feature", {}))
 

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -341,7 +341,7 @@ class iOSXcodeCreateCommand(iOSXcodePassiveMixin, CreateCommand):
             ) from None
         except FileNotFoundError:
             # If a plist file couldn't be found, it's an old-style support package;
-            # Determine the min iOS version from the VERSIONS file in the support package.
+            # Determine min. iOS version from the VERSIONS file in the support package
             versions = dict(
                 [part.strip() for part in line.split(": ", 1)]
                 for line in (

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -199,7 +199,7 @@ class macOSCreateMixin(AppPackagesMergeMixin):
             support_min_version = info_plist.get("MinimumOSVersion", "11.0")
         except FileNotFoundError:
             # If a plist file couldn't be found, it's an old-style support package;
-            # Determine the min macOS version from the VERSIONS file in the support package.
+            # Determine min. macOS version from the VERSIONS file in the support package
             versions = dict(
                 [part.strip() for part in line.split(": ", 1)]
                 for line in (
@@ -273,7 +273,7 @@ macOS version of {macOS_min_version} is not available.
                 universal_suffix="_universal2",
             )
 
-            # Now install dependencies for the architecture that isn't the host architecture.
+            # Install dependencies for the architecture that isn't the host architecture
             other_arch = {
                 "arm64": "x86_64",
                 "x86_64": "arm64",
@@ -320,19 +320,19 @@ in the macOS configuration section of your pyproject.toml.
             else:
                 self.console.info("All packages are pure Python, or universal.")
 
-            # If given the option of a single architecture binary or a universal2 binary,
-            # pip will install the single platform binary. However, a common situation on
-            # macOS is for there to be an x86_64 binary and a universal2 binary. This means
-            # you only get a universal2 binary in the "other" install pass. This then causes
-            # problems with merging, because the "other" binary contains a copy of the
-            # architecture that the "host" platform provides.
+            # If given the option of a single architecture binary or a universal2
+            # binary, pip will install the single platform binary. However, a common
+            # situation on macOS is for there to be an x86_64 binary and a universal2
+            # binary. This means you only get a universal2 binary in the "other" install
+            # pass. This then causes problems with merging, because the "other" binary
+            # contains a copy of the architecture that the "host" platform provides.
             #
-            # To avoid this - ensure that the libraries in the app packages for the "other"
-            # arch are all thin.
+            # To avoid this - ensure that the libraries in the app packages for the
+            # "other" arch are all thin.
             #
-            # This doesn't matter if it happens the other way around - if the "host" arch
-            # installs a universal binary, then the "other" arch won't be asked to install
-            # a binary at all.
+            # This doesn't matter if it happens the other way around - if the "host"
+            # arch installs a universal binary, then the "other" arch won't be asked to
+            # install a binary at all.
             self.thin_app_packages(other_app_packages_path, arch=other_arch)
 
             # Merge the binaries
@@ -397,7 +397,8 @@ in the macOS configuration section of your pyproject.toml.
             info["NSPhotoLibraryUsageDescription"] = cross_platform["photo_library"]
             entitlements["com.apple.security.personal-information.photo_library"] = True
 
-        # Override any info and entitlement definitions with the platform specific definitions
+        # Override any info and entitlement definitions
+        # with the platform-specific definitions
         info.update(getattr(app, "info", {}))
         entitlements.update(getattr(app, "entitlement", {}))
 
@@ -478,7 +479,7 @@ class macOSRunMixin:
                     **sub_kwargs,
                 )
             except subprocess.CalledProcessError:
-                # The command line app *could* returns an error code, which is entirely legal.
+                # The command line app *could* return an error code, which is legal.
                 # Ignore any subprocess error here.
                 pass
 

--- a/src/briefcase/platforms/macOS/app.py
+++ b/src/briefcase/platforms/macOS/app.py
@@ -122,8 +122,8 @@ class macOSAppBuildCommand(
 
         if not getattr(app, "universal_build", True):
             with self.console.wait_bar("Ensuring stub binary is thin..."):
-                # The stub binary is universal by default. If we're building a non-universal app,
-                # we can strip the binary to remove the unused slice. This occurs before the
+                # The stub binary is universal by default. If we're building a
+                # non-universal app, we can strip the binary to remove the unused slice.
                 self.ensure_thin_binary(
                     self.binary_executable_path(app),
                     arch=self.tools.host_arch,

--- a/src/briefcase/platforms/macOS/filters.py
+++ b/src/briefcase/platforms/macOS/filters.py
@@ -56,8 +56,8 @@ class XcodeBuildFilter:
         r"set via user default \(DVTEnableCoreDevice=disabled\)"
     )
 
-    # Xcode 14 generates the following warning when there is a passcode protected device
-    # attached to your computer, even if you're not doing anything to target that device:
+    # Xcode 14 generates the following warning when there is a passcode-protected device
+    # attached to your computer, even if you're not doing anything to target it:
     # ---------------------------------------------------------------------
     # 2023-09-27 08:38:11.865 xcodebuild[41087:25901835]  DTDKRemoteDeviceConnection:
     #   Failed to start remote service "com.apple.mobile.notification_proxy" on device.

--- a/src/briefcase/platforms/macOS/utils.py
+++ b/src/briefcase/platforms/macOS/utils.py
@@ -53,9 +53,10 @@ def sha256_file_digest(path: Path) -> str:
 
 
 class AppPackagesMergeMixin:
-    # A mixin containing the utilities to merge independent platform-specific app_packages folders
-    # into a single "fat" app_packages folder. This is currently only used by macOS, but it *could*
-    # be required on iOS if they ever re-introduce multiple on-device architectures.
+    # A mixin containing the utilities to merge independent platform-specific
+    # app_packages folders into a single "fat" app_packages folder.
+    # This is currently only used by macOS, but it *could* be required on iOS
+    # if they ever re-introduce multiple on-device architectures.
 
     def find_binary_packages(
         self,
@@ -83,8 +84,8 @@ class AppPackagesMergeMixin:
             if is_purelib:
                 continue
 
-            # If the tag ends with the universal tag, the binary package can be used on all
-            # targets, and doesn't need additional processing.
+            # If the tag ends with the universal tag, the binary package can be used on
+            # all targets and doesn't need additional processing.
             if universal_suffix and tag.endswith(universal_suffix):
                 continue
 
@@ -257,12 +258,12 @@ class AppPackagesMergeMixin:
                         target_path.mkdir(exist_ok=True)
                     else:
                         if is_mach_o_binary(source_path):
-                            # Dynamic libraries need to be merged; do this in a second pass.
+                            # Dynamic libraries need to be merged in a second pass
                             dylibs.add(relative_path)
                         elif target_path.exists():
-                            # The file already exists. Check for differences; if there are any
-                            # differences outside `dist-info` or `__pycache__` folders, warn
-                            # the user.
+                            # The file already exists. Check for differences; if there
+                            # are any differences outside `dist-info` or `__pycache__`
+                            # folders, warn the user.
                             digest = sha256_file_digest(source_path)
                             if digests[relative_path] != digest and not (
                                 relative_path.parent.name == "__pycache__"

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -314,7 +314,7 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
             )
             return
 
-        # Preserve any '~' that might exist in the target path by splitting from the right
+        # Preserve any '~' that might exist in the target path
         target, insert = rel_inside.rsplit("~", 1)
         self.console.info(f"    {path}: Adding {insert} insert for {target}")
 
@@ -410,7 +410,8 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
                 # Gather implementation from config.toml
                 implementation = config_data.get("implementation", None)
 
-                # Currently, only pyscript is supported. Warn if another implementation is found,
+                # Currently, only pyscript is supported.
+                # Warn if another implementation is found,
                 # but fail safe to using pyscript with a warning.
                 if implementation is None:
                     self.console.warning(

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -43,7 +43,8 @@ class WindowsMixin:
             raise UnsupportedHostError(
                 f"Windows applications cannot be built on an {self.tools.host_arch} machine."
             )
-        # 64bit Python is required to ensure 64bit wheels are installed/created for the app
+        # 64bit Python is required to ensure 64bit wheels are installed/created
+        # for the app
         if self.tools.is_32bit_python:
             raise UnsupportedHostError(
                 """\

--- a/src/briefcase/platforms/windows/app.py
+++ b/src/briefcase/platforms/windows/app.py
@@ -74,7 +74,7 @@ class WindowsAppBuildCommand(WindowsAppMixin, BuildCommand):
 
         if hasattr(self.tools, "windows_sdk"):
             # If an app has been packaged and code signed previously, then the digital
-            # signature on the app binary needs to be removed before re-building the app.
+            # signature on the app binary must be removed before re-building the app.
             # It is not safe to use RCEdit on signed binaries since it corrupts them.
             with self.console.wait_bar(
                 "Removing any digital signatures from stub app..."
@@ -115,9 +115,8 @@ Recreating the app layout may also help resolve this issue:
                         "--set-version-string",
                         "CompanyName",
                         app.author,
-                        # Although "FileDescription" sounds like it should be a... description,
-                        # this is the label that appears as a grouping in the Task Manager
-                        # when the application runs.
+                        # "FileDescription" is the label that appears as a grouping
+                        # in the Task Manager when the application runs.
                         "--set-version-string",
                         "FileDescription",
                         app.formal_name,


### PR DESCRIPTION
Issue #2383 requests to resolve [ruff rule E501](https://docs.astral.sh/ruff/rules/line-too-long/) by limiting all lines to 88 characters (and probably adding some `noqa` comments).

I'd like to split it into multiple PRs because it is a large task and the resolutions might trigger some (justified) discussions around style preferences.

This PR only addresses the **comments** in `src/briefcase`, which reduces the number of violations from 520 to 446. Please let me know what you think, and if you are interested in more PRs like this.

(I started with comments because I assume these fixes are less controversial than actual code changes.)

Refs #2383 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
