### PR TITLE
Finalize changes related to migrating static web config to the GUI toolkit

### DIFF
--- a/changes/2337.feature.rst
+++ b/changes/2337.feature.rst
@@ -1,0 +1,1 @@
+Briefcase's web backend now gives full control of the Pyscript and GUI toolkit configuration to the Python packages that are installed in the app.

--- a/changes/2442.feature.rst
+++ b/changes/2442.feature.rst
@@ -1,1 +1,0 @@
-Update Briefcase’s build system to support GUI toolkit-owned pyscript/backend configuration and insertion content.

--- a/docs/reference/platforms/web/static.rst
+++ b/docs/reference/platforms/web/static.rst
@@ -209,12 +209,12 @@ directory which must use this naming convention:
 Where:
 
 * The target file path is specified in relation to the project root directory appears as
-  ``<target-file>`` (e.g., ``index.html`` or ``static/css/briefcase.css``).
+  ``<target-file>`` (e.g., ``index.html`` or ``static/css/style.css``).
 * The tilde (``~``) character separates the target path from the slot name.
 
 For example, a package named ``mypackage`` could include the following files as inserts:
 
 * ``mypackage/deploy/inserts/index.html~head`` - Inserts into the ``head`` slot of
   ``index.html`` in the root of the deployment directory
-* ``mypackage/deploy/inserts/static/css/briefcase.css~css`` - Inserts into the ``css``
-  slot of ``static/css/briefcase.css``
+* ``mypackage/deploy/inserts/static/css/style.css~css`` - Inserts into the ``css``
+  slot of ``static/css/style.css``

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -232,5 +232,4 @@ build_gradle_dependencies = [
 requires = [
     "toga-web~=0.5.0",
 ]
-style_framework = "Shoelace v2.3"
 """

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -76,12 +76,6 @@ class StaticWebMixin:
 class StaticWebCreateCommand(StaticWebMixin, CreateCommand):
     description = "Create and populate a static web project."
 
-    def output_format_template_context(self, app: AppConfig):
-        """Add style framework details to the app template."""
-        return {
-            "style_framework": getattr(app, "style_framework", "None"),
-        }
-
 
 class StaticWebUpdateCommand(StaticWebCreateCommand, UpdateCommand):
     description = "Update an existing static web project."
@@ -253,7 +247,7 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
         package_key: str,
         inserts: dict[str, dict[str, dict[str, str]]],
     ) -> None:
-        """Handle legacy CSS under /static/*.css and add to briefcase.css.
+        """Handle legacy CSS under /static/*.css and add to style.css.
 
         Emits a deprecation warning for every legacy CSS file discovered.
 
@@ -275,8 +269,8 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
         rel_inside = "/".join(path.parts[2:])
         contrib_key = f"{package_key} (legacy static CSS: {rel_inside})"
 
-        # Add CSS content to briefcase.css insert slot
-        target = "static/css/briefcase.css"
+        # Add CSS content to style.css insert slot
+        target = "static/css/style.css"
         insert = "css"
         pkg_map = inserts.setdefault(target, {}).setdefault(insert, {})
         if pkg_map.get(contrib_key):
@@ -335,7 +329,7 @@ class StaticWebBuildCommand(StaticWebMixin, BuildCommand):
         """Process a wheel to collect insert and style content.
 
         Scans the wheel for:
-        * Legacy CSS - .css files under /static/ added to briefcase.css.
+        * Legacy CSS - .css files under /static/ added to style.css.
         * Deploy inserts - files under /deploy/inserts/<target>~<insert>.
 
         :param wheelfile: Path to the wheel file.

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -239,7 +239,6 @@ build_gradle_dependencies = [
 requires = [
     "toga-web~=0.5.0",
 ]
-style_framework = "Shoelace v2.3"
 """,
     }
 

--- a/tests/platforms/web/static/conftest.py
+++ b/tests/platforms/web/static/conftest.py
@@ -43,9 +43,9 @@ app_requirements_path="requirements.txt"
 """,
     )
 
-    # Create the initial briefcase.css with CSS insert markers
+    # Create the initial style.css with CSS insert markers
     create_file(
-        bundle_path / "www/static/css/briefcase.css",
+        bundle_path / "www/static/css/style.css",
         """
 #pyconsole {
   display: None;

--- a/tests/platforms/web/static/test_build.py
+++ b/tests/platforms/web/static/test_build.py
@@ -202,8 +202,8 @@ existing-key-2 = 2
             + "\n"
         )
 
-    # briefcase.css has been appended
-    with (bundle_path / "www/static/css/briefcase.css").open(encoding="utf-8") as f:
+    # style.css has been appended
+    with (bundle_path / "www/static/css/style.css").open(encoding="utf-8") as f:
         assert (
             f.read()
             == "\n".join(
@@ -364,9 +364,9 @@ def test_build_app_missing_wheel_dir(build_command, first_app_generated, tmp_pat
     # Pyscript.toml has been written
     assert (bundle_path / "www/pyscript.toml").exists()
 
-    # briefcase.css has been appended
+    # style.css has been appended
     # (just check for existence; a full check is done in other tests)
-    assert (bundle_path / "www/static/css/briefcase.css").exists()
+    assert (bundle_path / "www/static/css/style.css").exists()
 
 
 def test_build_app_no_requirements(build_command, first_app_generated, tmp_path):
@@ -456,8 +456,8 @@ def test_build_app_no_requirements(build_command, first_app_generated, tmp_path)
             ],
         }
 
-    # briefcase.css has been appended
-    with (bundle_path / "www/static/css/briefcase.css").open(encoding="utf-8") as f:
+    # style.css has been appended
+    with (bundle_path / "www/static/css/style.css").open(encoding="utf-8") as f:
         assert (
             f.read()
             == "\n".join(

--- a/tests/platforms/web/static/test_build__handle_legacy_css.py
+++ b/tests/platforms/web/static/test_build__handle_legacy_css.py
@@ -35,7 +35,7 @@ def test_handle_legacy_css_warn_and_append(
             inserts=inserts,
         )
         # Pre-seed same contrib key to force append on second call
-        target_map = inserts.setdefault("static/css/briefcase.css", {}).setdefault(
+        target_map = inserts.setdefault("static/css/style.css", {}).setdefault(
             "css", {}
         )
         key = "pkg 1.0 (legacy static CSS: one.css)"
@@ -56,7 +56,7 @@ def test_handle_legacy_css_warn_and_append(
     )
 
     # Content appended
-    out = inserts["static/css/briefcase.css"]["css"][key]
+    out = inserts["static/css/style.css"]["css"][key]
     assert "h1 { x:1; }" in out
     assert "/*extra*/" in out
 

--- a/tests/platforms/web/static/test_build__process_wheel.py
+++ b/tests/platforms/web/static/test_build__process_wheel.py
@@ -46,9 +46,9 @@ def test_process_wheel(build_command, tmp_path):
     inserts = {}
     build_command._process_wheel(wheelfile=wheel_filename, inserts=inserts)
 
-    # Legacy CSS should be collected into the briefcase.css "css" insert slot
+    # Legacy CSS should be collected into the style.css "css" insert slot
     assert inserts == {
-        "static/css/briefcase.css": {
+        "static/css/style.css": {
             "css": {
                 "dummy 1.2.3 (legacy static CSS: first.css)": (
                     "span {\n  font-color: red;\n  font-size: larger\n}\n"
@@ -92,7 +92,7 @@ def test_process_wheel_deploy_inserts(build_command, tmp_path):
         extra_content=[
             ("dummy/deploy/inserts/index.html~header", "<script>alert('hi')</script>"),
             (
-                "dummy/deploy/inserts/static/css/briefcase.css~CSS",
+                "dummy/deploy/inserts/static/css/style.css~CSS",
                 "body { margin: 0; }",
             ),
         ],
@@ -108,9 +108,9 @@ def test_process_wheel_deploy_inserts(build_command, tmp_path):
     assert any("<script>" in v for v in contribs.values())
 
     # The CSS insert exists
-    assert "static/css/briefcase.css" in inserts
-    assert "CSS" in inserts["static/css/briefcase.css"]
-    css_contribs = inserts["static/css/briefcase.css"]["CSS"]
+    assert "static/css/style.css" in inserts
+    assert "CSS" in inserts["static/css/style.css"]
+    css_contribs = inserts["static/css/style.css"]["CSS"]
     assert any("body { margin: 0; }" in v for v in css_contribs.values())
 
 

--- a/tests/platforms/web/static/test_create.py
+++ b/tests/platforms/web/static/test_create.py
@@ -20,25 +20,3 @@ def test_unsupported_host_os(create_command, host_os):
 
     with pytest.raises(UnsupportedHostError, match="This command is not supported on"):
         create_command()
-
-
-def test_output_format_template_context_with_style_framework(
-    create_command, first_app_config
-):
-    """If the app defines a style framework, it is included in the template context."""
-    first_app_config.style_framework = "Souperstyler v1.2"
-
-    assert create_command.output_format_template_context(first_app_config) == {
-        "style_framework": "Souperstyler v1.2",
-    }
-
-
-def test_output_format_template_context_without_style_framework(
-    create_command,
-    first_app_config,
-):
-    """If the app doesn't define a style framework, the template context still has an
-    entry."""
-    assert create_command.output_format_template_context(first_app_config) == {
-        "style_framework": "None",
-    }

--- a/tests/platforms/web/static/test_package.py
+++ b/tests/platforms/web/static/test_package.py
@@ -38,7 +38,7 @@ def test_package_app(package_command, first_app_built, tmp_path):
             "index.html",
             "static/",
             "static/css/",
-            "static/css/briefcase.css",
+            "static/css/style.css",
             "static/wheels/",
             "static/wheels/dummy-1.2.3-py3-none-any.whl",
         ]


### PR DESCRIPTION
Finalise the changes related to migrating control of the static web GUI toolkit from Briefcase to the underlying GUI toolkit.

This involves 2 changes:
* Adopts a deployment-agnostic filename for the stylesheet (style.css, rather than briefcase.css)
* Removes the `style_toolkit` configuration item from the Toga bootstrap, as it's no longer needed

Fixes #2337.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
