### PR TITLE
Issue #2559 Add helper for formatting long warning messages

### DIFF
--- a/src/briefcase/utils.py
+++ b/src/briefcase/utils.py
@@ -3,7 +3,7 @@ import textwrap
 
 def format_message_to_asterisk_box(
     message: str,
-    title=None,
+    title: str = "",
     width=80,
     border_char="*",
     padding=2,
@@ -22,6 +22,9 @@ def format_message_to_asterisk_box(
     Returns:
         str: The formatted message.
     """
+
+    if not message:
+        return ""
 
     # Create border line
     border_line = border_char * width
@@ -63,59 +66,3 @@ def format_message_to_asterisk_box(
 
     # merge lines into a single string and return
     return "\n".join(lines)
-
-
-if __name__ == "__main__":
-    name = "Anton"
-    issue_idx = 2559
-
-    source_msg = (
-        f"Hi there! My name is {name}, and I'm a Python developer.\n\n"
-        "This is my very first experience in open source development. "
-        "I like your project, and I'm excited to contribute to it."
-    )
-    source_title = (
-        f"INFO: I TRIED TO SOLVE THIS ISSUE #{issue_idx}. "
-        "IT SEEMED TO ME RATHER SIMPLE, "
-        "BUT I GOT VERY GOOD EXPERIENCE"
-    )
-
-    # Test with width 80: default
-    msg = format_message_to_asterisk_box(
-        source_msg,
-        title=source_title,
-    )
-    output_msg_width_80_default = (
-        "*" * 79
-        + """*
-**  INFO: I TRIED TO SOLVE THIS ISSUE #2559. IT SEEMED TO ME RATHER SIMPLE,   **
-**                       BUT I GOT VERY GOOD EXPERIENCE                       **
-********************************************************************************
-Hi there! My name is Anton, and I'm a Python developer.
-
-This is my very first experience in open source development. I like your
-project, and I'm excited to contribute to it.
-********************************************************************************"""
-    )
-    assert msg == output_msg_width_80_default
-
-    # Test with width 40: very narrow
-    msg = format_message_to_asterisk_box(
-        source_msg,
-        title=source_title,
-        width=40,
-    )
-    output_msg_width_40 = """****************************************
-**    INFO: I TRIED TO SOLVE THIS     **
-**    ISSUE #2559. IT SEEMED TO ME    **
-**   RATHER SIMPLE, BUT I GOT VERY    **
-**          GOOD EXPERIENCE           **
-****************************************
-Hi there! My name is Anton, and I'm a
-Python developer.
-
-This is my very first experience in open
-source development. I like your project,
-and I'm excited to contribute to it.
-****************************************"""
-    assert msg == output_msg_width_40

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,83 @@
+from briefcase.utils import format_message_to_asterisk_box
+
+name = "Anton"
+issue_idx = 2559
+
+source_msg = (
+    f"Hi there! My name is {name}, and I'm a Python developer.\n\n"
+    "This is my very first experience in open source development. "
+    "I like your project, and I'm excited to contribute to it."
+)
+source_title = (
+    f"INFO: I TRIED TO SOLVE THIS ISSUE #{issue_idx}. "
+    "IT SEEMED TO ME RATHER SIMPLE, "
+    "BUT I GOT VERY GOOD EXPERIENCE"
+)
+
+
+def test_format_message_to_asterisk_box_empty_string_title():
+    # Test with empty message and title
+    msg = format_message_to_asterisk_box("")
+
+    assert msg == ""
+
+
+def test_format_message_to_asterisk_box_width_80_default():
+    # Test with width 80: default
+    msg = format_message_to_asterisk_box(
+        source_msg,
+        title=source_title,
+    )
+    output_msg_width_80_default = (
+        "*" * 79
+        + """*
+**  INFO: I TRIED TO SOLVE THIS ISSUE #2559. IT SEEMED TO ME RATHER SIMPLE,   **
+**                       BUT I GOT VERY GOOD EXPERIENCE                       **
+********************************************************************************
+Hi there! My name is Anton, and I'm a Python developer.
+
+This is my very first experience in open source development. I like your
+project, and I'm excited to contribute to it.
+********************************************************************************"""
+    )
+    assert msg == output_msg_width_80_default
+
+
+def test_format_message_to_asterisk_box_width_40_default():
+    # Test with width 40: very narrow
+    msg = format_message_to_asterisk_box(
+        source_msg,
+        title=source_title,
+        width=40,
+    )
+    output_msg_width_40 = """****************************************
+**    INFO: I TRIED TO SOLVE THIS     **
+**    ISSUE #2559. IT SEEMED TO ME    **
+**   RATHER SIMPLE, BUT I GOT VERY    **
+**          GOOD EXPERIENCE           **
+****************************************
+Hi there! My name is Anton, and I'm a
+Python developer.
+
+This is my very first experience in open
+source development. I like your project,
+and I'm excited to contribute to it.
+****************************************"""
+    assert msg == output_msg_width_40
+
+
+def test_format_message_to_asterisk_box_empty_title():
+    # Test with width 80: default
+    msg = format_message_to_asterisk_box(
+        source_msg,
+    )
+    output_msg_width_80_default = (
+        "*" * 79
+        + """*
+Hi there! My name is Anton, and I'm a Python developer.
+
+This is my very first experience in open source development. I like your
+project, and I'm excited to contribute to it.
+********************************************************************************"""
+    )
+    assert msg == output_msg_width_80_default


### PR DESCRIPTION
I solved this issue by creation of the function "format_message_to_asterisk_box", that formatting message to asterisk box representation.

It takes this args:
        message (str): The message to format.
        title (str, optional): The title of the box. Defaults to None.
        width (int, optional): The width of the box. Defaults to 80.
        border_char (str, optional): The character to use for the border.
            Defaults to "*".
        padding (int, optional): The number of spaces to pad the border.
            Defaults to 2.

Also I added tests for it. Function it seems working good. 

But I was not sure in what file to put function. 
Now its location and tests by this paths:  
src/briefcase/utils.py
tests/test_utils.py

It is my very first attempt of contribution. Please don beat me hard)

I am waiting for your feedback.
