### PR TITLE
Add helper for formatting long warning messages

### DIFF
--- a/changes/2563.misc.md
+++ b/changes/2563.misc.md
@@ -1,1 +1,1 @@
-``Warning_banner`` method added to ``Console`` class.
+An internal helper to display warning banners was added.

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -251,64 +251,68 @@ class Console:
         return self._log_impl.export_text()
 
     @staticmethod
-    def _dedent_and_wrap(text, wrap_width, is_title=False):
-        """Dedent text, split text into paragraphs and wrap each paragraph to lines of
-        the specified width."""
+    def _dedent_and_wrap(text, wrap_width, border=0):
+        """Dedent text, split text into paragraphs and wrap to a width.
 
+        If a border is specified, that border width will be preserved on the left *and
+        right* of the text. The right hand side won't be printed, but it will be
+        accommodated in any line wrapping.
+
+        Text that is already indented relative to the rest of the text will have that
+        indentation preserved.
+
+        If text is indented, it will *not* undergo line breaks on spaces and hyphens, on
+        the assumption that it will be an environment variable or command line.
+        """
         # Dedent and remove common leading empty lines
         text = textwrap.dedent(text).strip("\n")
-
-        # Add a warning prefix for title
-        if is_title:
-            text = f"WARNING: {text.strip()}"
 
         # Split text into text lines
         input_lines = text.split("\n")
 
-        # create paragraphs from lines
+        # Create paragraphs from lines. Use "None" for a paragraph break.
+        # Preserve any line that starts with spaces as-is. Any other line
+        # is accumulated into the last paragraph
         paragraphs = []
         for line in input_lines:
-            # add empty paragraph
             if not line:
+                # Preserve an empty line as a paragraph break
                 paragraphs.append(None)
-                continue
-
-            # calc relative indentation; always zero for title
-            rel_indent = 0 if is_title else len(line) - len(line.lstrip())
-
-            # add new paragraph
-            # if it first, if last empty or have relative indentation
-            if any((not paragraphs, rel_indent)) or not paragraphs[-1]:
-                # add new paragraph
-                paragraphs.append([line.strip(), rel_indent])
-
-            # append line to last paragraph
+            elif line[0] == " ":
+                # If the line starts with indentation, preserve it
+                paragraphs.append(line.rstrip())
+            elif not (paragraphs and paragraphs[-1] and paragraphs[-1][0] != " "):
+                # This is either the first paragraph, or the current last paragraph is
+                # either a paragraph break, or indented literal paragraph. This means
+                # the current line is the start of a new paragraph.
+                paragraphs.append(line.strip())
             else:
-                paragraphs[-1][0] += f" {line.strip()}"
+                # Accumulate onto the most recent paragraph.
+                paragraphs[-1] = f"{paragraphs[-1]} {line.strip()}"
 
         # Wrap each paragraph to lines
         output_lines = []
         for p in paragraphs:
-            # If the paragraph is not empty, wrap it to the specified width
             if p:
-                output_lines.extend(
-                    # add indent to each line in wrapping
-                    f"{' ' * p[-1]}{line}"
-                    for line in
-                    # wrapping paragraph to width minus rel indent
-                    textwrap.wrap(p[0], width=wrap_width - p[1])
-                )
-
-            # Otherwise, add an empty line
+                if p[0] == " ":
+                    # Preserve an indented line as a literal
+                    output_lines.append(f"{' ' * border}{p}")
+                else:
+                    # Break the paragraph into lines.
+                    output_lines.extend(
+                        f"{' ' * border}{line}"
+                        for line in textwrap.wrap(p, width=wrap_width - (border * 2))
+                    )
             else:
+                # Insert a paragraph break.
                 output_lines.append("")
-        # Return the list of lines
+
         return output_lines
 
     def warning_banner(
         self,
-        title: str,
-        message: str,
+        title: str | None = None,
+        message: str | None = None,
         width: int = 80,
     ) -> str:
         """The title or message can be provided as a single or as multiline string. Any
@@ -324,52 +328,24 @@ class Console:
         :param width: The total width of the box in characters. Defaults to 80.
         :return: The formatted message enclosed in a bordered box.
         """
+        BORDER_LINE = "*" * width
+        lines_array = ["", BORDER_LINE]
 
-        # character to use for the box border
-        border_char = "*"
-
-        # If message and title are both empty rase ValueError
-        if not any((message, title)):
-            raise ValueError("Message or title must be provided")
-        # If width is not an integer, raise TypeError
-        if not isinstance(width, int):
-            raise TypeError("Width must be an integer")
-
-        # Create border line
-        border_line = border_char * width
-        # create lines array with opening line of the box
-        lines_array = [border_line]
-
-        # if title exists, format title in the box
         if title:
-            # title must be a string
-            if not isinstance(title, str):
-                raise TypeError("Title must be a string")
+            # Remove 6 from the width to allow for "** " and " **" wrappers
+            title_lines = self._dedent_and_wrap(f"WARNING: {title}", width - 6)
 
-            # get title wrapped to lines
-            title_lines = self._dedent_and_wrap(title, width - 6, True)
-
-            # center each line of the title and add to the box
+            # Center each line of the title and add to the box
             for line in title_lines:
-                line = line.center(width - 4)
-                lines_array.append(f"{border_char * 2}{line}{border_char * 2}")
+                line = line.center(width - 6)
+                lines_array.append(f"** {line} **")
 
-            # closing line of title in the box
-            lines_array.append(border_line)
+            lines_array.append(BORDER_LINE)
 
-        # If message is not empty, add it to the box
         if message:
-            # message must be a string
-            if not isinstance(message, str):
-                raise TypeError("Message must be a string")
-            # get message wrapped to lines
-            msg_lines = self._dedent_and_wrap(message, width)
+            msg_lines = self._dedent_and_wrap(message, width, border=2)
 
-            # add message lines to the box
-            lines_array.extend(msg_lines)
-
-            # closing line of message
-            lines_array.append(border_line)
+            lines_array.extend(["", *msg_lines, "", BORDER_LINE, ""])
 
         # merge lines into a single string and send warning to console
         self.warning("\n".join(lines_array))

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -205,13 +205,13 @@ class AndroidSDK(ManagedTool):
         if android_home:
             if android_sdk_root and android_sdk_root != android_home:
                 tools.console.warning_banner(
-                    title="ANDROID_HOME and ANDROID_SDK_ROOT are inconsistent",
-                    message=f"""
+                    "ANDROID_HOME and ANDROID_SDK_ROOT are inconsistent",
+                    f"""
                         The ANDROID_HOME and ANDROID_SDK_ROOT environment variables
                         are set to different paths:
 
-                            ANDROID_HOME:     {android_home}
-                            ANDROID_SDK_ROOT: {android_sdk_root}
+                          ANDROID_HOME:     {android_home}
+                          ANDROID_SDK_ROOT: {android_sdk_root}
 
                         Briefcase will ignore ANDROID_SDK_ROOT and only use the path
                         specified by ANDROID_HOME.
@@ -294,13 +294,12 @@ class AndroidSDK(ManagedTool):
                         f"""
                             The Android SDK specified by {sdk_source_env} at:
 
-                            {sdk_root_env}
+                              {sdk_root_env}
 
-                            does not contain Command-Line Tools
-                            version {cls.SDK_MANAGER_VER}.
-                            Briefcase requires this version to be installed to use
-                            an external Android SDK.
-                            Use Android Studio's SDK Manager to install it.
+                            does not contain Command-Line Tools version
+                            {cls.SDK_MANAGER_VER}. Briefcase requires this version to be
+                            installed to use an external Android SDK. Use Android
+                            Studio's SDK Manager to install it.
 
                             Briefcase will proceed using its own SDK instance.
                         """,
@@ -312,15 +311,15 @@ class AndroidSDK(ManagedTool):
                         The location pointed to by the {sdk_source_env} environment
                         variable:
 
-                        {sdk_root_env}
+                          {sdk_root_env}
 
-                        doesn't appear to contain an Android SDK with
-                        the Command-line Tools installed.
+                        doesn't appear to contain an Android SDK with the Command-line
+                        Tools installed.
 
-                        If {sdk_source_env} is an Android SDK, ensure it is
-                        the root directory of the Android SDK instance such that
+                        If {sdk_source_env} is an Android SDK, ensure it is the root
+                        directory of the Android SDK instance such that:
 
-                        ${sdk_source_env}{os.sep}{sdk.sdkmanager_path.relative_to(sdk.root_path)}
+                            ${sdk_source_env}{os.sep}{sdk.sdkmanager_path.relative_to(sdk.root_path)}
 
                         is a valid filepath.
 
@@ -498,8 +497,8 @@ its output for errors.
             )
         except (OSError, subprocess.CalledProcessError) as e:
             self.tools.console.debug(str(e))
-            self.tools.console.warning_banner(
-                "", f"Failed to install cmdline-tools;{self.SDK_MANAGER_VER}"
+            self.tools.console.warning(
+                f"Failed to install cmdline-tools;{self.SDK_MANAGER_VER}"
             )
             return False
         return True
@@ -721,8 +720,7 @@ connection.
             self.tools.console.warning_banner(
                 "Unexpected emulator ABI",
                 f"""
-                    The system image {system_image!r}
-                    does not match the architecture of
+                    The system image {system_image!r} does not match the architecture of
                     this computer ({self.emulator_abi}).
 
                     Briefcase will proceed assuming the emulator is correctly
@@ -1286,15 +1284,15 @@ Review the emulator output above for:
 
 Ensure your Android SDK is up-to-date by running:
 
-    $ briefcase upgrade {AndroidSDK.name}
+  $ briefcase upgrade {AndroidSDK.name}
 
 To review Google's general troubleshooting steps for the emulator, visit:
 
-    https://developer.android.com/studio/run/emulator-troubleshooting
+  https://developer.android.com/studio/run/emulator-troubleshooting
 
 You can also start the emulator manually by running:
 
-    $ {emulator_command}
+  $ {emulator_command}
 """
 
         failed_startup_error_msg = f"{{prologue}}\n{general_error_msg}"

--- a/tests/console/Console/test_warning_banner.py
+++ b/tests/console/Console/test_warning_banner.py
@@ -1,248 +1,220 @@
 import pytest
 
-test_title = "ANDROID_HOME and ANDROID_SDK_ROOT are inconsistent"
-test_message = """
+TEST_TITLE = "ANDROID_HOME and ANDROID_SDK_ROOT are inconsistent"
+TEST_MESSAGE = """
     The ANDROID_HOME and ANDROID_SDK_ROOT environment variables
     are set to different paths:
 
-        ANDROID_HOME:     /briefcase/tests/console/Console/test_warning_banner.py
-        ANDROID_SDK_ROOT: /home/anton/briefcase/tests/console/Console/\
-test_warning_banner.py
+      ANDROID_HOME:     /briefcase/tests/console/Console/test_warning_banner.py
+      ANDROID_SDK_ROOT: /home/anton/briefcase/tests/console/Console/test_warning_banner.py
 
-     Briefcase will ignore ANDROID_SDK_ROOT and only use the path
+    Briefcase will ignore ANDROID_SDK_ROOT and only use the path
     specified by ANDROID_HOME.
 
     You should update your environment configuration to either
     not set ANDROID_SDK_ROOT, or set both environment variables
-    to the samepath.
-"""
+    to the same path.
+"""  # noqa: E501
 
 
 @pytest.mark.parametrize(
-    ("message", "title", "width", "expected"),
+    ("title", "message", "width", "expected"),
     [
         # Default width (80) with title and message
-        (
-            test_message,
-            test_title,
+        pytest.param(
+            TEST_TITLE,
+            TEST_MESSAGE,
             80,
-            """\
+            """
 ********************************************************************************
 **        WARNING: ANDROID_HOME and ANDROID_SDK_ROOT are inconsistent         **
 ********************************************************************************
-The ANDROID_HOME and ANDROID_SDK_ROOT environment variables are set to different
-paths:
+
+  The ANDROID_HOME and ANDROID_SDK_ROOT environment variables are set to
+  different paths:
 
     ANDROID_HOME:     /briefcase/tests/console/Console/test_warning_banner.py
-    ANDROID_SDK_ROOT:
-    /home/anton/briefcase/tests/console/Console/test_warning_banner.py
+    ANDROID_SDK_ROOT: /home/anton/briefcase/tests/console/Console/test_warning_banner.py
 
- Briefcase will ignore ANDROID_SDK_ROOT and only use the path specified by
- ANDROID_HOME.
+  Briefcase will ignore ANDROID_SDK_ROOT and only use the path specified by
+  ANDROID_HOME.
 
-You should update your environment configuration to either not set
-ANDROID_SDK_ROOT, or set both environment variables to the samepath.
+  You should update your environment configuration to either not set
+  ANDROID_SDK_ROOT, or set both environment variables to the same path.
+
 ********************************************************************************
 """,
+            id="80-char",
         ),
-        # Narrow width (40) with title and message
-        (
-            test_message,
-            test_title,
-            40,
-            """\
-****************************************
-**     WARNING: ANDROID_HOME and      **
-** ANDROID_SDK_ROOT are inconsistent  **
-****************************************
-The ANDROID_HOME and ANDROID_SDK_ROOT
-environment variables are set to
-different paths:
-
-    ANDROID_HOME:     /briefcase/tests/c
-    onsole/Console/test_warning_banner.p
-    y
-    ANDROID_SDK_ROOT: /home/anton/briefc
-    ase/tests/console/Console/test_warni
-    ng_banner.py
-
- Briefcase will ignore ANDROID_SDK_ROOT
- and only use the path specified by
- ANDROID_HOME.
-
-You should update your environment
-configuration to either not set
-ANDROID_SDK_ROOT, or set both
-environment variables to the samepath.
-****************************************
-""",
-        ),
-        # Default width (80) without title
-        (
-            test_message,
-            None,
-            80,
-            """\
-********************************************************************************
-The ANDROID_HOME and ANDROID_SDK_ROOT environment variables are set to different
-paths:
-
-    ANDROID_HOME:     /briefcase/tests/console/Console/test_warning_banner.py
-    ANDROID_SDK_ROOT:
-    /home/anton/briefcase/tests/console/Console/test_warning_banner.py
-
- Briefcase will ignore ANDROID_SDK_ROOT and only use the path specified by
- ANDROID_HOME.
-
-You should update your environment configuration to either not set
-ANDROID_SDK_ROOT, or set both environment variables to the samepath.
-********************************************************************************
-""",
-        ),
-        # Custom width (60) with title and message
-        (
-            test_message,
-            test_title,
+        # Wrap to 60 chars
+        pytest.param(
+            TEST_TITLE,
+            TEST_MESSAGE,
             60,
-            """\
+            """
 ************************************************************
 **     WARNING: ANDROID_HOME and ANDROID_SDK_ROOT are     **
 **                      inconsistent                      **
 ************************************************************
-The ANDROID_HOME and ANDROID_SDK_ROOT environment variables
-are set to different paths:
 
-    ANDROID_HOME:
-    /briefcase/tests/console/Console/test_warning_banner.py
-    ANDROID_SDK_ROOT: /home/anton/briefcase/tests/console/Co
-    nsole/test_warning_banner.py
+  The ANDROID_HOME and ANDROID_SDK_ROOT environment
+  variables are set to different paths:
 
- Briefcase will ignore ANDROID_SDK_ROOT and only use the
- path specified by ANDROID_HOME.
+    ANDROID_HOME:     /briefcase/tests/console/Console/test_warning_banner.py
+    ANDROID_SDK_ROOT: /home/anton/briefcase/tests/console/Console/test_warning_banner.py
 
-You should update your environment configuration to either
-not set ANDROID_SDK_ROOT, or set both environment variables
-to the samepath.
+  Briefcase will ignore ANDROID_SDK_ROOT and only use the
+  path specified by ANDROID_HOME.
+
+  You should update your environment configuration to
+  either not set ANDROID_SDK_ROOT, or set both environment
+  variables to the same path.
+
 ************************************************************
 """,
+            id="60-char",
         ),
-        # Very narrow width (30) with title and message
-        (
-            test_message,
-            test_title,
-            31,
-            # codespell: ignore
-            """\
-*******************************
-** WARNING: ANDROID_HOME and **
-**    ANDROID_SDK_ROOT are   **
-**        inconsistent       **
-*******************************
-The ANDROID_HOME and
-ANDROID_SDK_ROOT environment
-variables are set to different
-paths:
+        # Wrap to 120 chars
+        pytest.param(
+            TEST_TITLE,
+            TEST_MESSAGE,
+            120,
+            """
+************************************************************************************************************************
+**                            WARNING: ANDROID_HOME and ANDROID_SDK_ROOT are inconsistent                             **
+************************************************************************************************************************
 
-    ANDROID_HOME:     /briefcas
-    e/tests/console/Console/tes
-    t_warning_banner.py
-    ANDROID_SDK_ROOT: /home/ant
-    on/briefcase/tests/console/
-    Console/test_warning_banner
-    .py
+  The ANDROID_HOME and ANDROID_SDK_ROOT environment variables are set to different paths:
 
- Briefcase will ignore
- ANDROID_SDK_ROOT and only use
- the path specified by
- ANDROID_HOME.
+    ANDROID_HOME:     /briefcase/tests/console/Console/test_warning_banner.py
+    ANDROID_SDK_ROOT: /home/anton/briefcase/tests/console/Console/test_warning_banner.py
 
-You should update your
-environment configuration to
-either not set
-ANDROID_SDK_ROOT, or set both
-environment variables to the
-samepath.
-*******************************
-""",
+  Briefcase will ignore ANDROID_SDK_ROOT and only use the path specified by ANDROID_HOME.
+
+  You should update your environment configuration to either not set ANDROID_SDK_ROOT, or set both environment
+  variables to the same path.
+
+************************************************************************************************************************
+""",  # noqa: E501
+            id="120-char",
         ),
-        # Message with only title (empty message)
-        (
-            "",
-            test_title,
+        # Default width (80) without title
+        pytest.param(
+            None,
+            TEST_MESSAGE,
             80,
-            """\
+            """
+********************************************************************************
+
+  The ANDROID_HOME and ANDROID_SDK_ROOT environment variables are set to
+  different paths:
+
+    ANDROID_HOME:     /briefcase/tests/console/Console/test_warning_banner.py
+    ANDROID_SDK_ROOT: /home/anton/briefcase/tests/console/Console/test_warning_banner.py
+
+  Briefcase will ignore ANDROID_SDK_ROOT and only use the path specified by
+  ANDROID_HOME.
+
+  You should update your environment configuration to either not set
+  ANDROID_SDK_ROOT, or set both environment variables to the same path.
+
+********************************************************************************
+""",
+            id="no-title",
+        ),
+        pytest.param(
+            TEST_TITLE,
+            None,
+            80,
+            """
 ********************************************************************************
 **        WARNING: ANDROID_HOME and ANDROID_SDK_ROOT are inconsistent         **
 ********************************************************************************
 """,
-        ),
-        # Very short message with title
-        (
-            "Short message",
-            "Short title",
-            80,
-            """\
-********************************************************************************
-**                            WARNING: Short title                            **
-********************************************************************************
-Short message
-********************************************************************************
-""",
+            id="title-only",
         ),
         # Message and title lengths equal to box width
-        (
-            "Length of message is equal to box _width",
-            "Length of ......... width",
-            40,
-            """\
-****************************************
-** WARNING: Length of ......... width **
-****************************************
-Length of message is equal to box _width
-****************************************
+        pytest.param(
+            "Length of ............. width",
+            "Length of message is equal to box width.",
+            44,
+            """
+********************************************
+** WARNING: Length of ............. width **
+********************************************
+
+  Length of message is equal to box width.
+
+********************************************
 """,
+            id="exact-width",
         ),
-        # Message and title lengths longer +1 symbol to box width
-        (
-            "Length of message +is equal to box _width",
-            "Length of ......+... width",
+        pytest.param(
+            "Length+ of ............. width",
+            "Length+ of message is equal to box width.",
+            44,
+            """
+********************************************
+**   WARNING: Length+ of .............    **
+**                 width                  **
+********************************************
+
+  Length+ of message is equal to box
+  width.
+
+********************************************
+""",
+            id="1-char-wrap",
+        ),
+        pytest.param(
+            None,
+            """
+              Start text with literal
+
+            More text
+
+             - bullet point
+             - other bullet point
+
+
+            Text after two new lines.
+
+              A single literal.
+
+            Text following a literal, followed by a blank line.
+
+            """,
             40,
-            """\
+            """
 ****************************************
-**   WARNING: Length of ......+...    **
-**               width                **
-****************************************
-Length of message +is equal to box
-_width
+
+    Start text with literal
+
+  More text
+
+   - bullet point
+   - other bullet point
+
+
+  Text after two new lines.
+
+    A single literal.
+
+  Text following a literal, followed
+  by a blank line.
+
 ****************************************
 """,
+            id="line-breaks",
         ),
     ],
 )
-def test_warning_banner(console, message, title, width, expected, capsys):
+def test_warning_banner(console, title, message, width, expected, capsys):
     """Test warning_banner with various inputs."""
 
     # call the function
-    console.warning_banner(message=message, title=title, width=width)
+    console.warning_banner(title=title, message=message, width=width)
     # capture console output
     output = capsys.readouterr().out
 
     assert expected == output
-
-
-@pytest.mark.parametrize(
-    ("message", "title", "width", "expected_error"),
-    [
-        ("", "", 80, "Message or title must be provided"),
-        ("message", "title", "80", "Width must be an integer"),
-        (777, "title", 80, "Message must be a string"),
-        ("message", 777, 80, "Title must be a string"),
-    ],
-)
-def test_warning_banner_with_invalid_inputs(
-    console, message, title, width, expected_error
-):
-    """Test warning_banner with various invalid inputs."""
-
-    with pytest.raises((ValueError, TypeError), match=expected_error):
-        console.warning_banner(message=message, title=title, width=width)


### PR DESCRIPTION
* Fixes #2559

I solved Issue #2559 by creation the function "format_message_to_asterisk_box", that formatting message to asterisk box representation.

It takes this args:
message (str): The message to format.
title (str, optional): The title of the box. Defaults to None.
width (int, optional): The width of the box. Defaults to 80.
border_char (str, optional): The character to use for the border.
Defaults to "*".
padding (int, optional): The number of spaces to pad the border.
Defaults to 2.

Also I added tests for it. Function it seems working good.

But I was not sure in what file to put function.
Now its location and tests by this paths:
src/briefcase/utils.py
tests/test_utils.py

It is my very first attempt of contribution. Please don beat me hard)

I am waiting for your feedback.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
