### PR TITLE
Document that the install directory is configurable.

### DIFF
--- a/docs/en/reference/platforms/windows/index.md
+++ b/docs/en/reference/platforms/windows/index.md
@@ -191,7 +191,7 @@ A Boolean describing the initial value of the option in the GUI. If not provided
 
 ### Using installer options
 
-When an installer option is defined, the value of the option will be made available to the post-install script as an environment variable. For example, if your installer defines an option with a name of `foo`, an environment variable of `OPTION_FOO` will be defined, with a value of 1 if the option has been selected by the user, and 0 if the option has not been selected. The `INSTALLDIR` and `ALLUSERS` environment variables will also be set. `INSTALLDIR` will be set to the location where the app has been installed; `ALLUSERS` its value will be 1 if the app has been installed for all users, or 0 if it has only been installed for the current user.
+When an installer option is defined, the value of the option will be made available to the post-install script as an environment variable. For example, if your installer defines an option with a name of `foo`, an environment variable of `OPTION_FOO` will be defined, with a value of 1 if the option has been selected by the user, and 0 if the option has not been selected. The `ALLUSERS` environment variable will also be set; its value will be 1 if the app has been installed for all users, or 0 if it has only been installed for the current user.
 
 ## Platform quirks
 


### PR DESCRIPTION
Documents the change in the MSI installers making the install directory configurable ~~, and the new environment variable exposed into the post-install script.~~

The actual change is entirely in templates:
* https://github.com/beeware/briefcase-windows-app-template/pull/78
* https://github.com/beeware/briefcase-windows-VisualStudio-template/pull/72

Fixes #2553

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
