### PR TITLE
Document the interaction of MSIs and the registry.

### DIFF
--- a/changes/2554.doc.rst
+++ b/changes/2554.doc.rst
@@ -1,0 +1,1 @@
+The obligations of a "well behaved" MSI-packaged application in ensuring a clean registry have been documented.

--- a/docs/en/reference/platforms/windows/index.md
+++ b/docs/en/reference/platforms/windows/index.md
@@ -208,3 +208,13 @@ Using the `--adhoc-sign` option on Windows results in no signing being performed
 ### Tkinter is not available
 
 Briefcase uses the official [Python.org Windows Embeddable package](https://docs.python.org/3/using/windows.html#windows-embeddable) to provide Python binaries for the Windows app. This embeddable distribution is missing some standard library modules that would be part of a normal Python.org install - most notably `tkinter`. This is due to the difficulty in distributing the Tk libraries needed by Tkinter in a way that is compatible with the Windows embedded binary format.
+
+### Maintaining a clean registry with MSI installers
+
+If you are using an MSI installer, it is important to ensure that you leave installed artefacts in a "clean" state - especially if you are using a post-install or pre-uninstall script.
+
+The MSI installer format can be thought of as managing a database - the MSI file describes a "transaction" of files that will be installed; when an app is uninstalled, that transaction is reverted, and all the installed files are removed. The transaction is tracked using the system registry. In most simple cases, running an MSI uninstaller will remove all the registry keys that were added by the MSI installer. However, there are some cases where this will not happen.
+
+If you write files into the application folder, or you use a post-install or pre-uninstall script that modifies files in the application folder, you must ensure that everything that is installed by the MSI can be removed by the MSI on uninstallation. If the uninstallation process cannot remove files or directories that were originally added by the installer - either because the files have been removed, or because a folder isn't empty - then registry entries tied to that installer will remain in the registry after completion of the installation.
+
+For example, consider an installer that creates a `data` folder in the app, containing 2 files `a.dat` and `b.dat`. The MSI installer has a post-installation script that deletes `b.dat`, and adds `c.dat`. When the uninstallation process is executed, registry entries for `data/b.dat` and `data` will remain in the registry. A well-behaved app should *not* delete content that the MSI app installed; and it should not leave content in locations that would prevent the MSI from removing content that the MSI installed.


### PR DESCRIPTION
Fixes #2554.

Following from a bug report, clarify that it's important for apps installed by MSI to ensure that they don't impede the uninstall process, lest they result in stray registry entries.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
