### PR TITLE
Restore missing section heading.

### DIFF
--- a/changes/2600.misc.md
+++ b/changes/2600.misc.md
@@ -1,0 +1,1 @@
+A missing section heading was restored.

--- a/docs/en/reference/configuration.md
+++ b/docs/en/reference/configuration.md
@@ -220,6 +220,8 @@ A path, relative to the directory where the `pyproject.toml` file is located, to
 
 A longer description of the purpose of the application. This description can be multiple paragraphs, if necessary. The long description *must not* be a copy of the [`description`][], or include the [`description`][] as the first line of the [`long_description`][].
 
+#### `min_os_version`
+
 A string describing the minimum OS version that the generated app will support. This value is only used on platforms that have a clear mechanism for specifying OS version compatibility; on the platforms where it *is* used, the interpretation of the value is platform specific. Refer to individual platform guides for details on how the provided value is interpreted.
 
 #### `requirement_installer_args`


### PR DESCRIPTION
Fixes #2600 

Restores the missing `min_os_version` section heading. Not sure how that went missing, but it's an easy fix.

I've audited the remaining setting names; the only discrepancies I found are settings that have been added in newer versions.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
