### PR TITLE
SpecifierSet func

### DIFF
--- a/changes/2604.bugfix.md
+++ b/changes/2604.bugfix.md
@@ -1,1 +1,1 @@
-Briefcase now accepts PEP 440 requires-python version ranges (e.g., >=3.14,<4.0).gc
+Briefcase now accepts PEP 440 requires-python version ranges (e.g., >=3.14,<4.0).

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -27,7 +27,7 @@ from briefcase.debuggers import get_debugger, get_debuggers
 if sys.version_info >= (3, 11):  # pragma: no-cover-if-lt-py311
     import tomllib
 else:  # pragma: no-cover-if-gte-py311
-    import tomli as tomllib  # pragma: no cover:
+    import tomli as tomllib
 
 import briefcase
 from briefcase import __version__

--- a/tests/commands/base/test_verify_requires_python.py
+++ b/tests/commands/base/test_verify_requires_python.py
@@ -79,27 +79,24 @@ def test_requires_python_invalid_specifier(base_command, my_app):
         base_command.verify_required_python(my_app)
 
 
-@mock.patch("platform.python_version")
-def test_requires_python_met_specifier_set(python_version_mock, base_command, my_app):
-    python_version_mock.return_value = "3.14.0"
+def test_requires_python_met_specifier_set(monkeypatch, base_command, my_app):
+    monkeypatch.setattr(platform, "python_version", mock.Mock(return_value="3.14.0"))
 
     base_command.global_config = _get_global_config(requires_python=">=3.14,<4.0")
     base_command.verify_required_python(my_app)
 
 
-@mock.patch("platform.python_version")
-def test_requires_python_unmet_specifier_set(python_version_mock, base_command, my_app):
-    python_version_mock.return_value = "3.13.0"
+def test_requires_python_unmet_specifier_set(monkeypatch, base_command, my_app):
+    monkeypatch.setattr(platform, "python_version", mock.Mock(return_value="3.13.0"))
 
     base_command.global_config = _get_global_config(requires_python=">=3.14,<4.0")
     with pytest.raises(UnsupportedPythonVersion):
         base_command.verify_required_python(my_app)
 
 
-@mock.patch("platform.python_version")
-def test_requires_python_prerelease(python_version_mock, base_command, my_app):
-    """Verify that pre-release Python versions are included in matches."""
-    python_version_mock.return_value = "3.14.0a0"
+def test_requires_python_prerelease(monkeypatch, base_command, my_app):
+    """Pre-release Python versions are included in matches."""
+    monkeypatch.setattr(platform, "python_version", mock.Mock(return_value="3.14.0a0"))
 
     base_command.global_config = _get_global_config(requires_python=">=3.12")
     base_command.verify_required_python(my_app)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Use `SpecifierSet` (instead of `Specifier`) to validate `requires-python`, allowing comma-separated version ranges (e.g., `>=3.14,<4.0`). Added regression tests for specifier sets.
<!--- What problem does this change solve? -->
Fixes a `BriefcaseConfigError` when projects use common PEP 440 `requires-python` ranges in `pyproject.toml`.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #2604


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
