### PR TITLE
Document MSI_PATH variable for post-install scripts.

### DIFF
--- a/changes/2637.feature.md
+++ b/changes/2637.feature.md
@@ -1,0 +1,1 @@
+Post-install scripts for MSI installers now expose an `MSI_PATH` environment variable.

--- a/changes/2637.feature.md
+++ b/changes/2637.feature.md
@@ -1,1 +1,1 @@
-Post-install scripts for MSI installers now expose an `MSI_PATH` environment variable.
+Post-install scripts for MSI installers now expose an `INSTALLER_PATH` environment variable.

--- a/docs/en/reference/platforms/windows/index.md
+++ b/docs/en/reference/platforms/windows/index.md
@@ -191,7 +191,7 @@ A Boolean describing the initial value of the option in the GUI. If not provided
 
 When an installer option is defined, the value of the option will be made available to the post-install or pre-uninstall script as an environment variable. For example, if you define an option with a name of `foo`, an environment variable of `OPTION_FOO` will be defined, with a value of 1 if the option has been selected by the user, and 0 if the option has not been selected.
 
-In the post-install script, the `ALLUSERS` environment variable will be set; its value will be 1 if the app has been installed for all users, or 0 if it has only been installed for the current user. The `MSI_PATH` environment variable will be set to the path of the MSI file.
+In the post-install script, the `ALLUSERS` environment variable will be set; its value will be 1 if the app has been installed for all users, or 0 if it has only been installed for the current user. The `INSTALLER_PATH` environment variable will be set to the path of the MSI file.
 
 If a user uninstalls software by clicking "uninstall" through the Windows "Remove software" interface, the uninstall options will not be displayed to the user. The pre-uninstall script *will* be executed, but the uninstall options will assume their default values. The uninstall GUI is only displayed if the user re-runs the installer manually, or if the user specifies the "Modify" option in the Windows "Remove software" interface. This is a quirk of the Windows uninstall tooling.
 

--- a/docs/en/reference/platforms/windows/index.md
+++ b/docs/en/reference/platforms/windows/index.md
@@ -191,7 +191,7 @@ A Boolean describing the initial value of the option in the GUI. If not provided
 
 When an installer option is defined, the value of the option will be made available to the post-install or pre-uninstall script as an environment variable. For example, if you define an option with a name of `foo`, an environment variable of `OPTION_FOO` will be defined, with a value of 1 if the option has been selected by the user, and 0 if the option has not been selected.
 
-In the post-install script, the `ALLUSERS` environment variable will also be set; its value will be 1 if the app has been installed for all users, or 0 if it has only been installed for the current user.
+In the post-install script, the `ALLUSERS` environment variable will be set; its value will be 1 if the app has been installed for all users, or 0 if it has only been installed for the current user. The `MSI_PATH` environment variable will be set to the path of the MSI file.
 
 If a user uninstalls software by clicking "uninstall" through the Windows "Remove software" interface, the uninstall options will not be displayed to the user. The pre-uninstall script *will* be executed, but the uninstall options will assume their default values. The uninstall GUI is only displayed if the user re-runs the installer manually, or if the user specifies the "Modify" option in the Windows "Remove software" interface. This is a quirk of the Windows uninstall tooling.
 


### PR DESCRIPTION
Adds documentation for the `MSI_PATH` environment variable being exposed into the post-install scripts for MSIs.

The actual fix is entirely in the templates; this PR documents the change.

Refs beeware/briefcase-windows-app-template#83
Refs beeware/briefcase-windows-VisualStudio-template#80
Fixes #2637

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
