### PR TITLE
Add note on Liquid Glass quirks to docs

### DIFF
--- a/changes/2676.doc.md
+++ b/changes/2676.doc.md
@@ -1,1 +1,0 @@
-Added note on reverting Liquid Glass to docs

--- a/changes/2676.misc.md
+++ b/changes/2676.misc.md
@@ -1,0 +1,1 @@
+Details about reverting Liquid Glass styles were added.

--- a/docs/en/reference/platforms/macOS/index.md
+++ b/docs/en/reference/platforms/macOS/index.md
@@ -277,11 +277,14 @@ requirement_installer_args = ["--find-links", "<path-to-wheel-folder>"]
 
 to your `pyproject.toml`. This will instruct Briefcase to search that folder for compatible wheels during the installation process.
 
-### Liquid Glass (macOS 26 Tahoe) and PyQt6 / PySide6
+### Adapting to Liquid Glass (macOS 26 Tahoe)
 
-The Qt developers have been working hard on adopting [Liquid Glass using Qt native styles](https://www.qt.io/blog/qt-on-macos-26-tahoe). However, some bugs do remain. If you find that your application looks bad on macOS 26, you can enable compatibility mode and revert to the style of earlier macOS releases. In your `pyproject.toml` macOS section, you can enable the `UIDesignRequiresCompatibility` key:
+macOS 26 (Tahoe) introduced the "Liquid Glass" style to macOS apps. The stub executable used by Briefcase has been compiled with Liquid Glass styling enabled; however, at this time, most GUI toolkits (including [Toga](https://github.com/beeware/toga/issues/4188) and [Qt](https://www.qt.io/blog/qt-on-macos-26-tahoe)) are known to have some bugs with Liquid Glass adoption.
+
+If you find that your application looks bad on macOS 26, you can enable compatibility mode and revert to the style of earlier macOS releases. To enable compatibility mode, add the following to the macOS section of your `pyproject.toml` configuration:
 
 ```toml
-[tool.briefcase.app.<appname>.macOS]
 info."UIDesignRequiresCompatibility" = true
 ```
+
+Once you've made this change, re-run `briefcase create` for your application.


### PR DESCRIPTION
Some people (read me) might be running into problems that their PySide6 application suddenly looks terrible on macOS 26 with newer versions of Briefcase. It is because the latest binary GUI stub has been compiled with macOS 26 support and PySide6 has a lot of liquid glass UI bugs. As noted [here](https://www.qt.io/blog/qt-on-macos-26-tahoe) you can set the `UIDesignRequiresCompatibility` key to revert back to the style of previous macOS releases. This PR adds a note to the macOS-specific notes in the docs.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
