### PR TITLE
Rework monkey patching strategy for command line tests

### DIFF
--- a/changes/2685.misc.md
+++ b/changes/2685.misc.md
@@ -1,0 +1,1 @@
+The CI testing strategy for command line tests was modified to avoid mocking issues.


### PR DESCRIPTION
A recent combination of changes in the GitHub Actions and Platformdirs resulted in test failures under Windows when mocking a macOS environment for the purposes of command line testing.

This slightly changes the mocking strategy so that BRIEFCASE_HOME is also mocked. The location of the home directory isn't actually needed for command line testing.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
