### PR TITLE
Optimize documentation linting strategy.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       attest: ${{ inputs.attest-package }}
 
   docs-lint:
+    name: Documentation linting
     needs: [ pre-commit ]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,38 @@ jobs:
       build-subdirectory: ${{ matrix.subdir }}
       attest: ${{ inputs.attest-package }}
 
+  docs-lint:
+    needs: [ pre-commit ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.X"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            .pre-commit-config.yaml
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get install aspell aspell-en
+
+      - name: Update pip
+        run: python -m pip install -U pip
+
+      - name: Install Tox
+        run: python -m pip install --group 'tox-uv'
+
+      - name: Perform lint checks
+        run: python -m tox -e docs-lint
+
   unit-tests:
     name: Unit tests
     needs: [ pre-commit, towncrier, package ]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,8 +17,6 @@ build:
     pre_install:
       - python -m pip install --upgrade pip
       - python -m pip install --group 'tox-uv'
-    pre_build:
-      - python -m tox -e docs-lint
     build:
       html:
         - python -m tox -e docs-$READTHEDOCS_LANGUAGE -- --output=$READTHEDOCS_OUTPUT/html/

--- a/changes/2713.misc.md
+++ b/changes/2713.misc.md
@@ -1,0 +1,1 @@
+The documentation linting strategy was improved.


### PR DESCRIPTION
Optimize the documentation linting strategy used by docs.

Instead of linting as part of RTD configuration, we lint as part of CI. This means future rebuilds of documentation don't re-validate links - which might have broken over time. 

Linting in CI means we guarantee links are valid then the documentation is written, but doesn't prevent future rebuilds from succeeding.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
