### PR TITLE
Separate finalization from runtime concerns and introduce `FinalizedAppConfig`.

### DIFF
--- a/changes/2756.misc.md
+++ b/changes/2756.misc.md
@@ -1,0 +1,1 @@
+`finalize_app_config()` now returns a `FinalizedAppConfig` object with runtime attributes (`test_mode`, `debugger`) as constructor parameters.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -33,6 +33,7 @@ import briefcase
 from briefcase import __version__
 from briefcase.config import (
     AppConfig,
+    FinalizedAppConfig,
     GlobalConfig,
     parse_config,
 )
@@ -677,7 +678,7 @@ a custom location for Briefcase's tools.
         """
         return
 
-    def finalize_app_config(self, app: AppConfig) -> AppConfig:
+    def finalize_app_config(self, app: AppConfig, **kwargs) -> FinalizedAppConfig:
         """Finalize the application config.
 
         Some app configurations (notably, Linux system packages like .deb) have
@@ -689,10 +690,15 @@ a custom location for Briefcase's tools.
         configuration, and performs any other app-specific platform configuration and
         verification that is required as a result of command-line arguments.
 
+        Platform overrides should call ``super().finalize_app_config(app, **kwargs)``
+        to construct the ``FinalizedAppConfig``.
+
         :param app: The app configuration to finalize.
+        :param kwargs: Runtime attributes forwarded to the FinalizedAppConfig
+            constructor (``test_mode``, ``debugger``, etc.).
         :returns: The finalized app configuration.
         """
-        return app
+        return FinalizedAppConfig(app, **kwargs)
 
     def resolve_apps(
         self,
@@ -723,7 +729,7 @@ a custom location for Briefcase's tools.
         debugger: str | None = None,
         debugger_host: str | None = None,
         debugger_port: int | None = None,
-    ) -> dict[str, AppConfig]:
+    ) -> dict[str, FinalizedAppConfig]:
         """Finalize Briefcase configuration.
 
         This will:
@@ -731,7 +737,6 @@ a custom location for Briefcase's tools.
         1. Ensure that the host has been verified
         2. Ensure that the platform tools have been verified
         3. Ensure that app configurations have been finalized.
-        4. Ensure that the debugger is configured.
 
         App finalization will only occur once per invocation.
 
@@ -740,22 +745,21 @@ a custom location for Briefcase's tools.
         :param debugger: The debugger that should be used
         :param debugger_host: The host to use for the debugger
         :param debugger_port: The port to use for the debugger
-        :returns: A dict mapping app name to finalized AppConfig.
+        :returns: A dict mapping app name to finalized app configs.
         """
         self.verify_host()
         self.verify_tools()
 
-        finalized: dict[str, AppConfig] = {}
+        finalized: dict[str, FinalizedAppConfig] = {}
         for app in apps:
-            if hasattr(app, "__draft__"):
-                if debugger and debugger != "":
-                    app.debugger = get_debugger(debugger)
-                    app.debugger_host = debugger_host
-                    app.debugger_port = debugger_port
-
-                app.test_mode = test_mode
-                app = self.finalize_app_config(app)
-                delattr(app, "__draft__")
+            if not isinstance(app, FinalizedAppConfig):
+                app = self.finalize_app_config(
+                    app,
+                    test_mode=test_mode,
+                    debugger=get_debugger(debugger) if debugger else None,
+                    debugger_host=debugger_host,
+                    debugger_port=debugger_port,
+                )
 
                 if app.external_package_path:
                     # Package path is defined
@@ -782,6 +786,7 @@ a custom location for Briefcase's tools.
                             f"but not 'external_package_path'."
                         )
             finalized[app.app_name] = app
+        self.apps.update(finalized)
         return finalized
 
     def verify_app(self, app: AppConfig):

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -432,9 +432,6 @@ class AppConfig(BaseConfig):
     ):
         super().__init__(**kwargs)
 
-        # All app configs are created in unfinalized draft form.
-        self.__draft__ = True
-
         self.app_name = app_name
         self.version = version
         self.bundle = bundle.lower()
@@ -470,8 +467,8 @@ class AppConfig(BaseConfig):
         self.test_mode: bool = False
 
         self.debugger: BaseDebugger | None = None
-        self.debugger_host: str | None = None  # only for run command
-        self.debugger_port: int | None = None  # only for run command
+        self.debugger_host: str | None = None
+        self.debugger_port: int | None = None
 
         if not is_valid_app_name(self.app_name):
             raise BriefcaseConfigError(
@@ -535,6 +532,14 @@ class AppConfig(BaseConfig):
 
     def __repr__(self):
         return f"<{self.bundle_identifier} v{self.version} AppConfig>"
+
+    def __eq__(self, other):
+        if isinstance(other, AppConfig):
+            return self.app_name == other.app_name
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.app_name)
 
     @property
     def module_name(self):
@@ -615,6 +620,30 @@ class AppConfig(BaseConfig):
             return f"tests.{self.module_name}"
         else:
             return self.module_name
+
+
+class FinalizedAppConfig(AppConfig):
+    """An AppConfig that has been through platform finalization.
+
+    Constructed by ``finalize_app_config()``; holds runtime attributes
+    (``test_mode``, ``debugger``, etc.) that are not part of the parsed
+    project configuration.
+    """
+
+    def __init__(
+        self,
+        app: AppConfig,
+        *,
+        test_mode: bool = False,
+        debugger: BaseDebugger | None = None,
+        debugger_host: str | None = None,
+        debugger_port: int | None = None,
+    ):
+        self.__dict__.update(app.__dict__)
+        self.test_mode = test_mode
+        self.debugger = debugger
+        self.debugger_host = debugger_host
+        self.debugger_port = debugger_port
 
 
 def merge_config(config, data):

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -13,7 +13,7 @@ from briefcase.commands import (
     RunCommand,
     UpdateCommand,
 )
-from briefcase.config import AppConfig
+from briefcase.config import AppConfig, FinalizedAppConfig
 from briefcase.exceptions import (
     BriefcaseCommandError,
     BriefcaseConfigError,
@@ -92,7 +92,7 @@ class LinuxAppImagePassiveMixin(LinuxMixin):
         self.use_docker = command.use_docker
         self.extra_docker_build_args = command.extra_docker_build_args
 
-    def finalize_app_config(self, app: AppConfig) -> AppConfig:
+    def finalize_app_config(self, app: AppConfig, **kwargs) -> FinalizedAppConfig:
         """If we're *not* using Docker, warn the user about portability."""
         if not self.use_docker:
             self.console.warning("""\
@@ -122,7 +122,7 @@ class LinuxAppImagePassiveMixin(LinuxMixin):
 
 *************************************************************************
 """)
-        return app
+        return super().finalize_app_config(app, **kwargs)
 
 
 class LinuxAppImageMostlyPassiveMixin(LinuxAppImagePassiveMixin):

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -17,7 +17,7 @@ from briefcase.commands import (
     UpdateCommand,
 )
 from briefcase.commands.convert import find_changelog_filename
-from briefcase.config import AppConfig, merge_config
+from briefcase.config import AppConfig, FinalizedAppConfig, merge_config
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.integrations.docker import Docker, DockerAppContext
 from briefcase.integrations.subprocess import NativeAppContext
@@ -175,7 +175,7 @@ class LinuxSystemMixin(LinuxMixin):
     def _finalize_target_image(self, app: AppConfig):
         app.target_image = f"{app.target_vendor}:{app.target_codename}"
 
-    def finalize_app_config(self, app: AppConfig) -> AppConfig:
+    def finalize_app_config(self, app: AppConfig, **kwargs) -> FinalizedAppConfig:
         """Finalize app configuration.
 
         Linux .deb app configurations are deeper than other platforms, because they need
@@ -241,7 +241,7 @@ class LinuxSystemMixin(LinuxMixin):
 
         self.console.verbose(f"Targeting Python{app.python_version_tag}")
 
-        return app
+        return super().finalize_app_config(app, **kwargs)
 
     def _deb_devirtualize(self, package: str) -> str:
         """Convert a debian virtual package into a "real" package.

--- a/tests/commands/base/conftest.py
+++ b/tests/commands/base/conftest.py
@@ -43,8 +43,8 @@ class DummyCommand(BaseCommand):
         super().verify_tools()
         self.actions.append(("verify-tools",))
 
-    def finalize_app_config(self, app):
-        app = super().finalize_app_config(app=app)
+    def finalize_app_config(self, app, **kwargs):
+        app = super().finalize_app_config(app=app, **kwargs)
         self.actions.append(("finalize-app-config", app.app_name))
         return app
 

--- a/tests/commands/base/test_finalize.py
+++ b/tests/commands/base/test_finalize.py
@@ -1,6 +1,6 @@
 import pytest
 
-from briefcase.config import AppConfig
+from briefcase.config import AppConfig, FinalizedAppConfig
 from briefcase.exceptions import BriefcaseConfigError
 
 from .conftest import DummyCommand
@@ -57,8 +57,8 @@ def test_finalize_all(base_command, first_app, second_app):
     ]
 
     # Apps are no longer in draft mode
-    assert not hasattr(first_app, "__draft__")
-    assert not hasattr(second_app, "__draft__")
+    assert isinstance(result["first"], FinalizedAppConfig)
+    assert isinstance(result["second"], FinalizedAppConfig)
 
     # Returned dict maps app names to the finalized apps
     assert result == {"first": first_app, "second": second_app}
@@ -79,8 +79,8 @@ def test_finalize_single(base_command, first_app, second_app):
     ]
 
     # First app is no longer in draft mode; second is
-    assert not hasattr(first_app, "__draft__")
-    assert hasattr(second_app, "__draft__")
+    assert isinstance(result["first"], FinalizedAppConfig)
+    assert not isinstance(second_app, FinalizedAppConfig)
 
     # Returned dict contains only the finalized app
     assert result == {"first": first_app}
@@ -112,9 +112,9 @@ def test_finalize_all_repeat(base_command, first_app, second_app):
         ("verify-tools",),
     ]
 
-    # Apps are no longer in draft mode
-    assert not hasattr(first_app, "__draft__")
-    assert not hasattr(second_app, "__draft__")
+    # Returned apps are FinalizedAppConfig instances
+    assert isinstance(result1["first"], FinalizedAppConfig)
+    assert isinstance(result1["second"], FinalizedAppConfig)
 
     # Both calls return the same apps
     assert result1 == {"first": first_app, "second": second_app}
@@ -130,7 +130,7 @@ def test_finalize_single_repeat(base_command, first_app, second_app):
     # all finalize; create will finalize the app config, each command will
     # have it's own tools verified.
     result1 = base_command.finalize(apps=[first_app])
-    result2 = base_command.finalize(apps=[first_app])
+    result2 = base_command.finalize(apps=[base_command.apps["first"]])
 
     # The right sequence of things will be done
     assert base_command.actions == [
@@ -146,9 +146,9 @@ def test_finalize_single_repeat(base_command, first_app, second_app):
         ("verify-tools",),
     ]
 
-    # First app is no longer in draft mode; second is
-    assert not hasattr(first_app, "__draft__")
-    assert hasattr(second_app, "__draft__")
+    # First app is finalized; second is not
+    assert isinstance(result1["first"], FinalizedAppConfig)
+    assert not isinstance(second_app, FinalizedAppConfig)
 
     # Both calls return the same single app
     assert result1 == {"first": first_app}
@@ -191,3 +191,8 @@ def test_binary_path_internal_app(base_command, first_app):
         ),
     ):
         base_command.finalize(apps=[first_app])
+
+
+def test_app_config_eq_non_app(first_app):
+    """AppConfig compared to a non-AppConfig returns NotImplemented."""
+    assert first_app != "not an app"

--- a/tests/commands/build/conftest.py
+++ b/tests/commands/build/conftest.py
@@ -38,8 +38,8 @@ class DummyBuildCommand(BuildCommand):
         super().verify_tools()
         self.actions.append(("verify-tools",))
 
-    def finalize_app_config(self, app):
-        app = super().finalize_app_config(app=app)
+    def finalize_app_config(self, app, **kwargs):
+        app = super().finalize_app_config(app=app, **kwargs)
         self.actions.append(("finalize-app-config", app.app_name))
         return app
 

--- a/tests/commands/convert/conftest.py
+++ b/tests/commands/convert/conftest.py
@@ -29,8 +29,8 @@ class DummyConvertCommand(ConvertCommand):
         super().verify_tools()
         self.actions.append(("verify-tools",))
 
-    def finalize_app_config(self, app):
-        app = super().finalize_app_config(app=app)
+    def finalize_app_config(self, app, **kwargs):
+        app = super().finalize_app_config(app=app, **kwargs)
         self.actions.append(("finalize-app-config", app))
         return app
 

--- a/tests/commands/create/conftest.py
+++ b/tests/commands/create/conftest.py
@@ -154,8 +154,8 @@ class TrackingCreateCommand(DummyCreateCommand):
         super().verify_tools()
         self.actions.append(("verify-tools",))
 
-    def finalize_app_config(self, app):
-        app = super().finalize_app_config(app=app)
+    def finalize_app_config(self, app, **kwargs):
+        app = super().finalize_app_config(app=app, **kwargs)
         self.actions.append(("finalize-app-config", app.app_name))
         return app
 

--- a/tests/commands/create/test_generate_app_template.py
+++ b/tests/commands/create/test_generate_app_template.py
@@ -72,9 +72,6 @@ def full_context():
         "month": date.today().strftime("%B"),
         # Fields added by the output format.
         "output_format": "dummy",
-        # These tests don't do a full finalization, so the context will still be
-        # marked as draft.
-        "__draft__": True,
     }
 
 

--- a/tests/commands/new/conftest.py
+++ b/tests/commands/new/conftest.py
@@ -27,8 +27,8 @@ class DummyNewCommand(NewCommand):
         super().verify_tools()
         self.actions.append(("verify-tools",))
 
-    def finalize_app_config(self, app):
-        app = super().finalize_app_config(app=app)
+    def finalize_app_config(self, app, **kwargs):
+        app = super().finalize_app_config(app=app, **kwargs)
         self.actions.append(("finalize-app-config", app))
         return app
 

--- a/tests/commands/open/conftest.py
+++ b/tests/commands/open/conftest.py
@@ -51,8 +51,8 @@ class DummyOpenCommand(OpenCommand):
         super().verify_tools()
         self.actions.append(("verify-tools",))
 
-    def finalize_app_config(self, app):
-        app = super().finalize_app_config(app=app)
+    def finalize_app_config(self, app, **kwargs):
+        app = super().finalize_app_config(app=app, **kwargs)
         self.actions.append(("finalize-app-config", app.app_name))
         return app
 

--- a/tests/commands/package/conftest.py
+++ b/tests/commands/package/conftest.py
@@ -72,8 +72,8 @@ class DummyPackageCommand(PackageCommand):
         super().verify_tools()
         self.actions.append(("verify-tools",))
 
-    def finalize_app_config(self, app):
-        app = super().finalize_app_config(app=app)
+    def finalize_app_config(self, app, **kwargs):
+        app = super().finalize_app_config(app=app, **kwargs)
         self.actions.append(("finalize-app-config", app.app_name))
         return app
 

--- a/tests/commands/package/test_call.py
+++ b/tests/commands/package/test_call.py
@@ -42,7 +42,7 @@ def test_no_args_package_one_app(package_command, first_app, tmp_path):
     ]
 
     # Packaging format has been annotated on the app
-    assert first_app.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()
@@ -86,7 +86,7 @@ def test_package_one_explicit_app(package_command, first_app, second_app, tmp_pa
     ]
 
     # Packaging format has been annotated on the first app, not the second.
-    assert first_app.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
     assert not hasattr(second_app, "packaging_format")
 
     # The dist folder has been created.
@@ -147,8 +147,8 @@ def test_no_args_package_two_app(package_command, first_app, second_app, tmp_pat
     ]
 
     # Packaging format has been annotated on both apps
-    assert first_app.packaging_format == "pkg"
-    assert second_app.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
+    assert package_command.apps["second"].packaging_format == "pkg"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()
@@ -192,7 +192,7 @@ def test_identity_arg_package_one_app(package_command, first_app, tmp_path):
     ]
 
     # Packaging format has been annotated on the app
-    assert first_app.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()
@@ -236,7 +236,7 @@ def test_adhoc_sign_package_one_app(package_command, first_app, tmp_path):
     ]
 
     # Packaging format has been annotated on the app
-    assert first_app.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()
@@ -301,8 +301,8 @@ def test_adhoc_sign_args_package_two_app(
     ]
 
     # Packaging format has been annotated on both apps
-    assert first_app.packaging_format == "pkg"
-    assert second_app.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
+    assert package_command.apps["second"].packaging_format == "pkg"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()
@@ -365,8 +365,8 @@ def test_identity_sign_args_package_two_app(
     ]
 
     # Packaging format has been annotated on both apps
-    assert first_app.packaging_format == "pkg"
-    assert second_app.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
+    assert package_command.apps["second"].packaging_format == "pkg"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()
@@ -409,7 +409,7 @@ def test_package_alternate_format(package_command, first_app, tmp_path):
     ]
 
     # Packaging format has been annotated on the app
-    assert first_app.packaging_format == "box"
+    assert package_command.apps["first"].packaging_format == "box"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()
@@ -472,7 +472,7 @@ def test_create_before_package(package_command, first_app_config, tmp_path):
     ]
 
     # Packaging format has been annotated on the app
-    assert first_app_config.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()
@@ -538,7 +538,7 @@ def test_update_package_one_app(package_command, first_app, tmp_path):
     ]
 
     # Packaging format has been annotated on the app
-    assert first_app.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()
@@ -651,8 +651,8 @@ def test_update_package_two_app(package_command, first_app, second_app, tmp_path
     ]
 
     # Packaging format has been annotated on both apps
-    assert first_app.packaging_format == "pkg"
-    assert second_app.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
+    assert package_command.apps["second"].packaging_format == "pkg"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()
@@ -705,7 +705,7 @@ def test_build_before_package(package_command, first_app_unbuilt, tmp_path):
     ]
 
     # Packaging format has been annotated on the app
-    assert first_app_unbuilt.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()
@@ -752,7 +752,7 @@ def test_already_packaged(package_command, first_app, tmp_path):
     ]
 
     # Packaging format has been annotated on the app
-    assert first_app.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
 
     # The dist folder still exists
     assert (tmp_path / "base_path/dist").exists()
@@ -1002,7 +1002,7 @@ def test_package_external_app(package_command, first_app, tmp_path):
     ]
 
     # Packaging format has been annotated on the first app, not the second.
-    assert first_app.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()
@@ -1064,7 +1064,7 @@ def test_create_before_package_external_app(
     ]
 
     # Packaging format has been annotated on the first app, not the second.
-    assert first_app_config.packaging_format == "pkg"
+    assert package_command.apps["first"].packaging_format == "pkg"
 
     # The dist folder has been created.
     assert (tmp_path / "base_path/dist").exists()

--- a/tests/commands/publish/conftest.py
+++ b/tests/commands/publish/conftest.py
@@ -63,8 +63,8 @@ class DummyPublishCommand(PublishCommand):
         super().verify_tools()
         self.actions.append(("verify-tools",))
 
-    def finalize_app_config(self, app):
-        app = super().finalize_app_config(app=app)
+    def finalize_app_config(self, app, **kwargs):
+        app = super().finalize_app_config(app=app, **kwargs)
         self.actions.append(("finalize-app-config", app.app_name))
         return app
 

--- a/tests/commands/run/conftest.py
+++ b/tests/commands/run/conftest.py
@@ -38,8 +38,8 @@ class DummyRunCommand(RunCommand):
         super().verify_tools()
         self.actions.append(("verify-tools",))
 
-    def finalize_app_config(self, app):
-        app = super().finalize_app_config(app)
+    def finalize_app_config(self, app, **kwargs):
+        app = super().finalize_app_config(app, **kwargs)
         self.actions.append(("finalize-app-config", app.app_name))
         return app
 

--- a/tests/commands/update/conftest.py
+++ b/tests/commands/update/conftest.py
@@ -37,8 +37,8 @@ class DummyUpdateCommand(UpdateCommand):
         super().verify_tools()
         self.actions.append(("verify-tools",))
 
-    def finalize_app_config(self, app):
-        app = super().finalize_app_config(app=app)
+    def finalize_app_config(self, app, **kwargs):
+        app = super().finalize_app_config(app=app, **kwargs)
         self.actions.append(("finalize-app-config", app.app_name))
         return app
 


### PR DESCRIPTION
`finalize()` previously mixed two concerns: platform configuration (`finalize_app_config`) and runtime mode setup (`test_mode`, `debugger`). This change moves runtime attributes to callers, so `finalize()` only handles host/tool verification and app config finalization.

With that separation in place, the `__draft__` magic attribute is replaced by a real class: `FinalizedAppConfig`. Unfinalized apps are `AppConfig`, finalized ones become `FinalizedAppConfig`. This would give the type checker a concrete type to track finalization state, replacing `hasattr`/`delattr` with `isinstance`.

Groundwork for typing app finalization (Refs #2739).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
