### PR TITLE
Use `-any` tag suffix as an indicator of pure status.

### DIFF
--- a/changes/2753.bugfix.md
+++ b/changes/2753.bugfix.md
@@ -1,0 +1,1 @@
+On macOS, any wheel that doesn't contain a tag ending `-any` will now be identified as binary content that requires a merge. Previously, the `Root-Is-Purelib` wheel metadata was used to determine if a package was "pure"; this flag has proven to be unreliable under some circumstances.

--- a/src/briefcase/platforms/macOS/utils.py
+++ b/src/briefcase/platforms/macOS/utils.py
@@ -89,11 +89,14 @@ class AppPackagesMergeMixin(_MixinBase):
             # for the wheel.
             with (distinfo / "WHEEL").open("r", encoding="utf-8") as f:
                 wheel_data = email.message_from_string(f.read())
-                is_purelib = wheel_data.get("Root-Is-Purelib", "false") == "true"
                 tags = wheel_data.get_all("Tag")
 
-            # If the wheel is pure, it's not a binary package
-            if is_purelib:
+            # If the wheel is tagged `*-*-any`, it's not a binary package. We can't rely
+            # on Root-Is-Purelib in the wheel metadata. The flag isn't used correctly in
+            # some edge cases; and a library whose root is "pure" is allowed to contain
+            # `.data/platlib` content, which functionally renders it non-pure for our
+            # purposes.
+            if any(tag.endswith("-any") for tag in tags):
                 continue
 
             # If the tag ends with the universal tag, the binary package can be used on

--- a/tests/platforms/macOS/test_AppPackagesMergeMixin__find_binary_packages.py
+++ b/tests/platforms/macOS/test_AppPackagesMergeMixin__find_binary_packages.py
@@ -85,6 +85,14 @@ def test_find_binary_packages(dummy_command, tmp_path):
         version="3.4.11",
         tag=["macOS_11_x86_64", "macOS_11_universal2"],
     )
+    # A package that is tagged binary, but marked Root-Is-Purelib (#2753)
+    create_installed_package(
+        tmp_path / "app-packages",
+        "binary-pure-package",
+        version="4.5.1",
+        tag=["macOS_11_arm64"],
+        pure=True,
+    )
 
     binary_packages = dummy_command.find_binary_packages(
         tmp_path / "app-packages",
@@ -98,6 +106,7 @@ def test_find_binary_packages(dummy_command, tmp_path):
         ("binary-package-1", "3.4.5"),
         ("binary-package-2", "3.4.6"),
         ("multi-tagged-binary-package-3", "3.4.9"),
+        ("binary-pure-package", "4.5.1"),
     }
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -194,12 +194,15 @@ def distinfo_metadata(
     package: str = "dummy",
     version: str = "1.2.3",
     tag: str | list[str] = "py3-none-any",
+    pure: bool | None = None,
 ):
     """Generate the content for a distinfo folder.
 
     :param package: The name of the package.
     :param version: The version number of the package.
     :param tag: The packaging tag (or tags) for the package.
+    :param pure: Is the package explicitly pure? If None, defaults to the tag as an
+        indicator of purity.
     """
     content = []
 
@@ -220,7 +223,10 @@ def distinfo_metadata(
     wheel = EmailMessage()
     wheel["Wheel-Version"] = "1.0"
     wheel["Generator"] = "test-case"
-    wheel["Root-Is-Purelib"] = "true" if tag == "py3-none-any" else "false"
+    if pure is None:
+        wheel["Root-Is-Purelib"] = "true" if tag == "py3-none-any" else "false"
+    else:
+        wheel["Root-Is-Purelib"] = str(pure).lower()
     if isinstance(tag, str):
         wheel["Tag"] = tag
     else:
@@ -241,6 +247,7 @@ def installed_package_content(
     version="1.2.3",
     tag="py3-none-any",
     extra_content=None,
+    pure: bool | None = None,
 ):
     """Generate the content for an installed package.
 
@@ -250,6 +257,8 @@ def installed_package_content(
     :param tag: The installation tag for the package. Defaults to a pure python wheel.
     :param extra_content: Optional. A list of tuples of ``(path, content)`` that will be
         added to the wheel.
+    :param pure: Is the package explicitly pure? If None, defaults to
+        the tag as an indicator of purity.
     """
     return (
         [
@@ -257,7 +266,7 @@ def installed_package_content(
             (f"{package}/app.py", "# This is the app"),
         ]
         + (extra_content or [])
-        + distinfo_metadata(package=package, version=version, tag=tag)
+        + distinfo_metadata(package=package, version=version, tag=tag, pure=pure)
     )
 
 
@@ -267,6 +276,7 @@ def create_installed_package(
     version="1.2.3",
     tag="py3-none-any",
     extra_content=None,
+    pure: bool | None = None,
 ):
     """Write an installed package into a 'site-packages' folder.
 
@@ -277,12 +287,15 @@ def create_installed_package(
     :param extra_content: Optional. A list of tuples of ``(path, content)`` or
         ``(path, content, chmod)`` that will be added to the wheel. If ``chmod`` is
         not specified, default filesystem permissions will be used.
+    :param pure: Is the package explicitly pure? If None, defaults to
+        the tag as an indicator of purity.
     """
     for entry in installed_package_content(
         package=package,
         version=version,
         tag=tag,
         extra_content=extra_content,
+        pure=pure,
     ):
         try:
             filename, content, chmod = entry


### PR DESCRIPTION
Use the existence of a `-any` tag as evidence of a wheel being "pure", rather than the `Root-Is-Purelib` metadata tag.

`Root-Is-Purelib` isn't set consistency (or easily) by some build tools, and it's technically possible for a `Root-Is-Purelib` package to contain platform binaries in the `.data` folder. The existence of a `*-*-any` tag is a more reliable indicator.

Fixes #2753.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
