### PR TITLE
Check for Python x86 Interpreter on Apple Silicon Mac

### DIFF
--- a/changes/2736.bugfix.md
+++ b/changes/2736.bugfix.md
@@ -1,1 +1,1 @@
-Briefcase will warn user if using an x86 Python interpreter on an Apple silicon machine
+Briefcase will now prevent the user from using an x86_64 Python interpreter on an Apple Silicon machine.

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -107,7 +107,6 @@ class macOSMixin(_MixinBase):
             )
 
         super().verify_tools()
-        return
 
     def is_icloud_synced(self, path: Path) -> bool:
         """Determine if a path is on an iCloud drive.

--- a/tests/platforms/macOS/test_macOSMixin_verify_tools.py
+++ b/tests/platforms/macOS/test_macOSMixin_verify_tools.py
@@ -6,11 +6,8 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError
 
 
-# test the verify_tools method of the macOSMixin class,
-# to ensure that it raises the expected error when running on Apple Silicon
-# with an x86_64 Python interpreter
-def test_verify_tools_on_macos(dummy_command):
-    """If you're on macOS, you can verify tools."""
+def test_verify_macos_cpu_arch(dummy_command):
+    """Running through Rosetta on macOS will raise an error."""
     # Create a Mock object for the platform module
     dummy_command.tools.platform = MagicMock(spec_set=platform)
 
@@ -20,9 +17,11 @@ def test_verify_tools_on_macos(dummy_command):
 
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"The Python interpreter that is being used to run Briefcase has been "
-        "compiled for x86_64, and is running in emulation mode on Apple "
-        "Silicon hardware. You must use a Python interpreter that has been "
-        "compiled for Apple Silicon, or is a Universal binary.",
+        match=(
+            r"The Python interpreter that is being used to run Briefcase has been "
+            r"compiled for x86_64, and is running in emulation mode on Apple "
+            r"Silicon hardware. You must use a Python interpreter that has been "
+            r"compiled for Apple Silicon, or is a Universal binary."
+        ),
     ):
         dummy_command.verify_tools()


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

This PR fixes #2736. 

The problem this PR solves:
- While following the [beeware tutorial](https://tutorial.beeware.org/tutorial/tutorial-5/iOS/), I was unable to launch the app from the iOS simulator from the briefcase command `briefcase run iOS`.
- Upon further research, it was determined that while porting my x86 mac to my current Apple Silicon mac, I ended up with a Python interpreter environment that claimed to be running on both x86 and Apple Silicon. 
- This caused the briefcase command line tools to call the wrong scripts (the one for x86), leading to the failure of the app launch from the iOS simulator.
- This PR solves the underlying problem in that now the briefcase command line tools will raise an error if it is trying to call the Python x86 interpreter while on an Apple Silicon machine.

Changes implemented offline (not in briefcase) and testing:
- Uninstalled all Python interpreters on my machine and reinstalled Python 3.13 from Homebrew.
- Re-created the beeware tutorial project with the newly installed Python 3.13 in the venv. 
Ran the briefcase command `briefcase run iOS` and saw the the app launch in the iOS simulator and successfully interacted with the app in the simulator.

Changes implemented in briefcase: 
- `changes/2736.bugfix.md` file: Change document
- `src/briefcase/platforms/macOS/__init__.py` file: Added a `verify_tools()` function in the `macOSMixin` class to check for an x86 Python interpreter running on Apple Silicon hardware
- `tests/platforms/macOS/test_macOSMixin_verify_tools.py` file: Add a unit test to test the `macOSMixin.verify_tools()` function.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
