### PR TITLE
Add a release note for security issue.

### DIFF
--- a/changes/2759.bugfix.rst
+++ b/changes/2759.bugfix.rst
@@ -1,0 +1,1 @@
+(CVE-2026-33430) When a Windows MSI is installed for All Users, the installation folder no longer inherits the permissions of the parent folder. The fix for this issue has been backported to the templates for Briefcase v0.4.1, v0.4.0 and v0.3.26.


### PR DESCRIPTION
Adds a release note for the issue announced as [CVE-2026-33430](https://github.com/advisories/GHSA-r3r2-35v9-v238)

Actual fix is entirely in templates; see #2759 for details.

Fixes #2759. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
