### PR TITLE
Introduce DraftAppConfig as the pre-finalization config type.

### DIFF
--- a/changes/2770.misc.md
+++ b/changes/2770.misc.md
@@ -1,0 +1,1 @@
+`AppConfig` is now a shared base class. `DraftAppConfig` holds parsed configuration; `FinalizedAppConfig` holds finalized configuration.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -33,6 +33,7 @@ import briefcase
 from briefcase import __version__
 from briefcase.config import (
     AppConfig,
+    DraftAppConfig,
     FinalizedAppConfig,
     GlobalConfig,
     parse_config,
@@ -678,7 +679,7 @@ a custom location for Briefcase's tools.
         """
         return
 
-    def finalize_app_config(self, app: AppConfig, **kwargs) -> FinalizedAppConfig:
+    def finalize_app_config(self, app: DraftAppConfig, **kwargs) -> FinalizedAppConfig:
         """Finalize the application config.
 
         Some app configurations (notably, Linux system packages like .deb) have
@@ -1125,7 +1126,7 @@ any compatibility problems, and then add the compatibility declaration.
                 # configuration options for the app.
                 app_config.update(overrides)
                 self.apps[app_name] = create_config(
-                    klass=AppConfig,
+                    klass=DraftAppConfig,
                     config=app_config,
                     msg=f"Configuration for '{app_name}'",
                 )

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -421,32 +421,171 @@ class GlobalConfig(BaseConfig):
 
 
 class AppConfig(BaseConfig):
+    """Base class for app configuration.
+
+    Not instantiated directly. Use ``DraftAppConfig`` for parsed project
+    configuration (pre-finalization) and ``FinalizedAppConfig`` for
+    finalized configuration (post-finalization).
+
+    Provides shared properties (``module_name``, ``bundle_name``, etc.)
+    and identity (``__eq__``/``__hash__`` based on ``app_name``).
+    """
+
+    app_name: str
+    version: Version
+    bundle: str
+    description: str
+    sources: list[str] | None
+    formal_name: str
+    url: str | None
+    author: str | None
+    author_email: str | None
+    requires: list[str] | None
+    icon: str | None
+    document_types: dict
+    permission: dict
+    template: str | None
+    template_branch: str | None
+    test_sources: list[str] | None
+    test_requires: list[str] | None
+    supported: bool
+    long_description: str | None
+    license: dict | None
+    license_files: list[str]
+    console_app: bool
+    requirement_installer_args: list[str]
+    external_package_path: str | None
+    external_package_executable_path: str | None
+    install_launcher: bool
+    install_options: dict
+    uninstall_options: dict
+
+    test_mode: bool
+    debugger: BaseDebugger | None
+    debugger_host: str | None
+    debugger_port: int | None
+
+    def __repr__(self):
+        return f"<{self.bundle_identifier} v{self.version} {type(self).__name__}>"
+
+    def __eq__(self, other):
+        if isinstance(other, AppConfig):
+            return self.app_name == other.app_name
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.app_name)
+
+    @property
+    def module_name(self):
+        """The module name for the app.
+
+        This is derived from the name, but:
+        * all `-` have been replaced with `_`.
+        """
+        return self.app_name.replace("-", "_")
+
+    @property
+    def bundle_name(self):
+        """The bundle name for the app.
+
+        This is derived from the app name, but:
+        * all `_` have been replaced with `-`.
+        """
+        return self.app_name.replace("_", "-").lower()
+
+    @property
+    def bundle_identifier(self):
+        """The bundle identifier for the app.
+
+        This is derived from the bundle and the bundle name, joined by a `.`.
+        """
+        return f"{self.bundle}.{self.bundle_name}"
+
+    @property
+    def class_name(self):
+        """The class name for the app.
+
+        This is derived from the formal name for the app.
+        """
+        return make_class_name(self.formal_name)
+
+    @property
+    def package_name(self):
+        """The bundle name of the app, with `-` replaced with `_` to create something
+        that can be used a namespace identifier on Python or Java, similar to
+        `module_name`."""
+        return self.bundle.replace("-", "_")
+
+    @property
+    def dist_info_name(self):
+        """The name of the .dist-info directory for the app."""
+        return f"{self.module_name}.dist-info"
+
+    def PYTHONPATH(self):
+        """The PYTHONPATH modifications needed to run this app."""
+        paths = []
+        sources = self.sources.copy() if self.sources else []
+        if self.test_mode and self.test_sources:
+            sources.extend(self.test_sources)
+
+        for source in sources:
+            path = "/".join(source.rsplit("/", 1)[:-1])
+            if path not in paths:
+                paths.append(path)
+        return paths
+
+    def all_sources(self) -> list[str]:
+        """Get all sources of the application that should be copied to the app.
+
+        :returns: The Path to the dist-info folder.
+        """
+        sources = self.sources.copy() if self.sources else []
+        if self.test_mode and self.test_sources:
+            sources.extend(self.test_sources)
+        return sources
+
+    def main_module(self):
+        """The path to the main module for the app.
+
+        In normal operation, this is ``app.module_name``; however,
+        in test mode, it is prefixed with ``tests.``.
+        """
+        if self.test_mode:
+            return f"tests.{self.module_name}"
+        else:
+            return self.module_name
+
+
+class DraftAppConfig(AppConfig):
+    """An AppConfig as parsed from ``pyproject.toml``, before finalization."""
+
     def __init__(
         self,
-        app_name,
-        version,
-        bundle,
-        description,
-        license=None,
-        license_files=None,
-        sources=None,
-        formal_name=None,
-        url=None,
-        author=None,
-        author_email=None,
-        requires=None,
-        icon=None,
-        document_type=None,
-        install_option=None,
-        uninstall_option=None,
-        permission=None,
-        template=None,
-        template_branch=None,
-        test_sources=None,
-        test_requires=None,
-        supported=True,
-        long_description=None,
-        console_app=False,
+        app_name: str,
+        version: str | Version,
+        bundle: str,
+        description: str,
+        license: dict | None = None,
+        license_files: list[str] | None = None,
+        sources: list[str] | None = None,
+        formal_name: str | None = None,
+        url: str | None = None,
+        author: str | None = None,
+        author_email: str | None = None,
+        requires: list[str] | None = None,
+        icon: str | None = None,
+        document_type: dict | None = None,
+        install_option: dict | None = None,
+        uninstall_option: dict | None = None,
+        permission: dict | None = None,
+        template: str | None = None,
+        template_branch: str | None = None,
+        test_sources: list[str] | None = None,
+        test_requires: list[str] | None = None,
+        supported: bool = True,
+        long_description: str | None = None,
+        console_app: bool = False,
         requirement_installer_args: list[str] | None = None,
         external_package_path: str | None = None,
         external_package_executable_path: str | None = None,
@@ -557,97 +696,6 @@ class AppConfig(BaseConfig):
                     f"package named {self.module_name!r}."
                 )
 
-    def __repr__(self):
-        return f"<{self.bundle_identifier} v{self.version} AppConfig>"
-
-    def __eq__(self, other):
-        if isinstance(other, AppConfig):
-            return self.app_name == other.app_name
-        return NotImplemented
-
-    def __hash__(self):
-        return hash(self.app_name)
-
-    @property
-    def module_name(self):
-        """The module name for the app.
-
-        This is derived from the name, but:
-        * all `-` have been replaced with `_`.
-        """
-        return self.app_name.replace("-", "_")
-
-    @property
-    def bundle_name(self):
-        """The bundle name for the app.
-
-        This is derived from the app name, but:
-        * all `_` have been replaced with `-`.
-        """
-        return self.app_name.replace("_", "-").lower()
-
-    @property
-    def bundle_identifier(self):
-        """The bundle identifier for the app.
-
-        This is derived from the bundle and the bundle name, joined by a `.`.
-        """
-        return f"{self.bundle}.{self.bundle_name}"
-
-    @property
-    def class_name(self):
-        """The class name for the app.
-
-        This is derived from the formal name for the app.
-        """
-        return make_class_name(self.formal_name)
-
-    @property
-    def package_name(self):
-        """The bundle name of the app, with `-` replaced with `_` to create something
-        that can be used a namespace identifier on Python or Java, similar to
-        `module_name`."""
-        return self.bundle.replace("-", "_")
-
-    @property
-    def dist_info_name(self):
-        """The name of the .dist-info directory for the app."""
-        return f"{self.module_name}.dist-info"
-
-    def PYTHONPATH(self):
-        """The PYTHONPATH modifications needed to run this app."""
-        paths = []
-        sources = self.sources.copy() if self.sources else []
-        if self.test_mode and self.test_sources:
-            sources.extend(self.test_sources)
-
-        for source in sources:
-            path = "/".join(source.rsplit("/", 1)[:-1])
-            if path not in paths:
-                paths.append(path)
-        return paths
-
-    def all_sources(self) -> list[str]:
-        """Get all sources of the application that should be copied to the app.
-
-        :returns: The Path to the dist-info folder.
-        """
-        sources = self.sources.copy() if self.sources else []
-        if self.test_mode and self.test_sources:
-            sources.extend(self.test_sources)
-        return sources
-
-    def main_module(self):
-        """The path to the main module for the app.
-
-        In normal operation, this is ``app.module_name``; however,
-        in test mode, it is prefixed with ``tests.``.
-        """
-        if self.test_mode:
-            return f"tests.{self.module_name}"
-        else:
-            return self.module_name
-
 
 class FinalizedAppConfig(AppConfig):
     """An AppConfig that has been through platform finalization.
@@ -659,7 +707,7 @@ class FinalizedAppConfig(AppConfig):
 
     def __init__(
         self,
-        app: AppConfig,
+        app: DraftAppConfig,
         *,
         test_mode: bool = False,
         debugger: BaseDebugger | None = None,

--- a/src/briefcase/platforms/linux/appimage.py
+++ b/src/briefcase/platforms/linux/appimage.py
@@ -13,7 +13,7 @@ from briefcase.commands import (
     RunCommand,
     UpdateCommand,
 )
-from briefcase.config import AppConfig, FinalizedAppConfig
+from briefcase.config import DraftAppConfig, FinalizedAppConfig
 from briefcase.exceptions import (
     BriefcaseCommandError,
     BriefcaseConfigError,
@@ -92,7 +92,7 @@ class LinuxAppImagePassiveMixin(LinuxMixin):
         self.use_docker = command.use_docker
         self.extra_docker_build_args = command.extra_docker_build_args
 
-    def finalize_app_config(self, app: AppConfig, **kwargs) -> FinalizedAppConfig:
+    def finalize_app_config(self, app: DraftAppConfig, **kwargs) -> FinalizedAppConfig:
         """If we're *not* using Docker, warn the user about portability."""
         if not self.use_docker:
             self.console.warning("""\

--- a/src/briefcase/platforms/linux/system.py
+++ b/src/briefcase/platforms/linux/system.py
@@ -17,7 +17,7 @@ from briefcase.commands import (
     UpdateCommand,
 )
 from briefcase.commands.convert import find_changelog_filename
-from briefcase.config import AppConfig, FinalizedAppConfig, merge_config
+from briefcase.config import AppConfig, DraftAppConfig, FinalizedAppConfig, merge_config
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.integrations.docker import Docker, DockerAppContext
 from briefcase.integrations.subprocess import NativeAppContext
@@ -175,7 +175,7 @@ class LinuxSystemMixin(LinuxMixin):
     def _finalize_target_image(self, app: AppConfig):
         app.target_image = f"{app.target_vendor}:{app.target_codename}"
 
-    def finalize_app_config(self, app: AppConfig, **kwargs) -> FinalizedAppConfig:
+    def finalize_app_config(self, app: DraftAppConfig, **kwargs) -> FinalizedAppConfig:
         """Finalize app configuration.
 
         Linux .deb app configurations are deeper than other platforms, because they need

--- a/tests/commands/base/conftest.py
+++ b/tests/commands/base/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from briefcase.commands.base import BaseCommand
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 
 
 class DummyCommand(BaseCommand):
@@ -118,7 +118,7 @@ def other_command(dummy_console, tmp_path):
 
 @pytest.fixture
 def my_app():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="my-app",
         formal_name="My App",
         bundle="com.example",

--- a/tests/commands/base/test_finalize.py
+++ b/tests/commands/base/test_finalize.py
@@ -1,6 +1,6 @@
 import pytest
 
-from briefcase.config import AppConfig, FinalizedAppConfig
+from briefcase.config import DraftAppConfig, FinalizedAppConfig
 from briefcase.exceptions import BriefcaseConfigError
 
 from .conftest import DummyCommand
@@ -8,7 +8,7 @@ from .conftest import DummyCommand
 
 @pytest.fixture
 def first_app():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="first",
         bundle="com.example",
         version="0.0.1",
@@ -19,7 +19,7 @@ def first_app():
 
 @pytest.fixture
 def second_app():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="second",
         bundle="com.example",
         version="0.0.2",

--- a/tests/commands/base/test_parse_config.py
+++ b/tests/commands/base/test_parse_config.py
@@ -99,7 +99,8 @@ def test_parse_config(base_command):
     # The first app will have all the base attributes required by an app,
     # defined in the config file.
     assert (
-        repr(base_command.apps["firstapp"]) == "<org.beeware.firstapp v1.2.3 AppConfig>"
+        repr(base_command.apps["firstapp"])
+        == "<org.beeware.firstapp v1.2.3 DraftAppConfig>"
     )
     assert base_command.apps["firstapp"].project_name == "Sample project"
     assert base_command.apps["firstapp"].app_name == "firstapp"
@@ -111,7 +112,7 @@ def test_parse_config(base_command):
     # value for `mystery`, and an `extra` value.
     assert (
         repr(base_command.apps["secondapp"])
-        == "<org.beeware.secondapp v1.2.3 AppConfig>"
+        == "<org.beeware.secondapp v1.2.3 DraftAppConfig>"
     )
     assert base_command.apps["secondapp"].project_name == "Sample project"
     assert base_command.apps["secondapp"].app_name == "secondapp"
@@ -165,7 +166,8 @@ def test_parse_config_with_overrides(base_command):
     # The first app will have all the base attributes required by an app,
     # defined in the config file, with the values from the overrides taking precedence.
     assert (
-        repr(base_command.apps["firstapp"]) == "<org.beeware.firstapp v2.3.4 AppConfig>"
+        repr(base_command.apps["firstapp"])
+        == "<org.beeware.firstapp v2.3.4 DraftAppConfig>"
     )
     assert base_command.apps["firstapp"].project_name == "Sample project"
     assert base_command.apps["firstapp"].app_name == "firstapp"
@@ -180,7 +182,7 @@ def test_parse_config_with_overrides(base_command):
     # is preserved.
     assert (
         repr(base_command.apps["secondapp"])
-        == "<org.beeware.secondapp v2.3.4 AppConfig>"
+        == "<org.beeware.secondapp v2.3.4 DraftAppConfig>"
     )
     assert base_command.apps["secondapp"].project_name == "Sample project"
     assert base_command.apps["secondapp"].app_name == "secondapp"

--- a/tests/commands/base/test_resolve_apps.py
+++ b/tests/commands/base/test_resolve_apps.py
@@ -1,12 +1,12 @@
 import pytest
 
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 from briefcase.exceptions import BriefcaseCommandError
 
 
 @pytest.fixture
 def first_app():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="first",
         bundle="com.example",
         version="0.0.1",
@@ -18,7 +18,7 @@ def first_app():
 
 @pytest.fixture
 def second_app():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="second",
         bundle="com.example",
         version="0.0.2",

--- a/tests/commands/build/conftest.py
+++ b/tests/commands/build/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 from briefcase.commands import BuildCommand
 from briefcase.commands.base import full_options
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 
 from ...utils import create_file
 
@@ -114,7 +114,7 @@ def build_command(dummy_console, tmp_path):
 
 @pytest.fixture
 def second_app_config():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="second",
         bundle="com.example",
         version="0.0.2",

--- a/tests/commands/create/conftest.py
+++ b/tests/commands/create/conftest.py
@@ -9,7 +9,7 @@ import tomli_w
 from cookiecutter.main import cookiecutter
 
 from briefcase.commands import CreateCommand
-from briefcase.config import AppConfig
+from briefcase.config import AppConfig, DraftAppConfig
 from briefcase.integrations.base import Tool
 from briefcase.integrations.subprocess import Subprocess
 
@@ -225,7 +225,7 @@ def tracking_create_command(
         git=mock_git,
         base_path=tmp_path / "base_path",
         apps={
-            "first": AppConfig(
+            "first": DraftAppConfig(
                 app_name="first",
                 bundle="com.example",
                 version="0.0.1",
@@ -233,7 +233,7 @@ def tracking_create_command(
                 sources=["src/first"],
                 license={"file": "LICENSE"},
             ),
-            "second": AppConfig(
+            "second": DraftAppConfig(
                 app_name="second",
                 bundle="com.example",
                 version="0.0.2",
@@ -247,7 +247,7 @@ def tracking_create_command(
 
 @pytest.fixture
 def myapp():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="my-app",
         formal_name="My App",
         bundle="com.example",

--- a/tests/commands/create/test_create_app.py
+++ b/tests/commands/create/test_create_app.py
@@ -1,6 +1,6 @@
 import pytest
 
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 from briefcase.exceptions import UnsupportedPlatform
 
 
@@ -166,7 +166,7 @@ def test_create_app_not_supported(tracking_create_command, tmp_path):
 
     with pytest.raises(UnsupportedPlatform):
         tracking_create_command.create_app(
-            AppConfig(
+            DraftAppConfig(
                 app_name="third",
                 bundle="com.example",
                 version="0.0.3",

--- a/tests/commands/create/test_install_app_resources.py
+++ b/tests/commands/create/test_install_app_resources.py
@@ -1,11 +1,11 @@
 from unittest import mock
 
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 
 
 def test_no_resources(create_command):
     """If the template defines no extra targets, none are installed."""
-    myapp = AppConfig(
+    myapp = DraftAppConfig(
         app_name="my-app",
         formal_name="My App",
         bundle="com.example",
@@ -30,7 +30,7 @@ def test_no_resources(create_command):
 
 def test_icon_target(create_command, tmp_path):
     """If the template defines an icon target, it will be installed."""
-    myapp = AppConfig(
+    myapp = DraftAppConfig(
         app_name="my-app",
         formal_name="My App",
         bundle="com.example",
@@ -97,7 +97,7 @@ def test_icon_target(create_command, tmp_path):
 
 def test_icon_variant_target(create_command, tmp_path):
     """If the template defines an icon target with variants, they will be installed."""
-    myapp = AppConfig(
+    myapp = DraftAppConfig(
         app_name="my-app",
         formal_name="My App",
         bundle="com.example",
@@ -185,7 +185,7 @@ def test_icon_variant_target(create_command, tmp_path):
 
 def test_splash_target(create_command, capsys):
     """If the template defines a splash target, a warning will be raised."""
-    myapp = AppConfig(
+    myapp = DraftAppConfig(
         app_name="my-app",
         formal_name="My App",
         bundle="com.example",
@@ -214,7 +214,7 @@ def test_splash_target(create_command, capsys):
 
 def test_splash_variant_target(create_command, capsys):
     """If the template defines a splash target with variants, a warning is raised."""
-    myapp = AppConfig(
+    myapp = DraftAppConfig(
         app_name="my-app",
         formal_name="My App",
         bundle="com.example",
@@ -246,7 +246,7 @@ def test_splash_variant_target(create_command, capsys):
 
 def test_doctype_icon_target(create_command, tmp_path):
     """If the template defines document types, their icons will be installed."""
-    myapp = AppConfig(
+    myapp = DraftAppConfig(
         app_name="my-app",
         formal_name="My App",
         bundle="com.example",

--- a/tests/commands/dev/conftest.py
+++ b/tests/commands/dev/conftest.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from briefcase.commands import DevCommand
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 from briefcase.integrations.subprocess import Subprocess
 
 
@@ -24,7 +24,7 @@ def first_app_uninstalled(tmp_path):
     with (tmp_path / "src/first/__init__.py").open("w", encoding="UTF-8") as f:
         f.write('print("Hello world")')
 
-    return AppConfig(
+    return DraftAppConfig(
         app_name="first",
         bundle="com.example",
         version="0.0.1",
@@ -52,7 +52,7 @@ def second_app(tmp_path):
     # Create the dist-info folder
     (tmp_path / "src/second.dist-info").mkdir(exist_ok=True)
 
-    return AppConfig(
+    return DraftAppConfig(
         app_name="second",
         bundle="com.example",
         version="0.0.2",
@@ -72,7 +72,7 @@ def third_app(tmp_path):
     # Create the dist-info folder
     (tmp_path / "src/third.dist-info").mkdir(exist_ok=True)
 
-    return AppConfig(
+    return DraftAppConfig(
         app_name="third",
         bundle="com.example",
         version="0.0.2",

--- a/tests/commands/open/conftest.py
+++ b/tests/commands/open/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 from briefcase.commands import OpenCommand
 from briefcase.commands.base import full_options
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 from briefcase.integrations.subprocess import Subprocess
 
 from ...utils import create_file
@@ -82,7 +82,7 @@ def open_command(dummy_console, tmp_path):
         console=dummy_console,
         base_path=tmp_path / "base_path",
         apps={
-            "first": AppConfig(
+            "first": DraftAppConfig(
                 app_name="first",
                 bundle="com.example",
                 version="0.0.1",
@@ -90,7 +90,7 @@ def open_command(dummy_console, tmp_path):
                 sources=["src/first"],
                 license={"file": "LICENSE"},
             ),
-            "second": AppConfig(
+            "second": DraftAppConfig(
                 app_name="second",
                 bundle="com.example",
                 version="0.0.2",

--- a/tests/commands/package/conftest.py
+++ b/tests/commands/package/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 from briefcase.commands import PackageCommand
 from briefcase.commands.base import full_options
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 
 from ...utils import create_file
 
@@ -127,7 +127,7 @@ def package_command(dummy_console, tmp_path):
 
 @pytest.fixture
 def first_app_config():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="first",
         bundle="com.example",
         version="0.0.1",
@@ -163,7 +163,7 @@ def first_app(first_app_unbuilt, tmp_path):
 
 @pytest.fixture
 def second_app_config():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="second",
         bundle="com.example",
         version="0.0.2",

--- a/tests/commands/publish/conftest.py
+++ b/tests/commands/publish/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from briefcase.channels.base import BasePublicationChannel
 from briefcase.commands import PublishCommand
 from briefcase.commands.base import full_options
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 
 from ...utils import create_file
 
@@ -123,7 +123,7 @@ def publish_command(dummy_console, tmp_path):
 
 @pytest.fixture
 def first_app_config():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="first",
         bundle="com.example",
         version="0.0.1",
@@ -178,7 +178,7 @@ def first_app(first_app_unpackaged, tmp_path):
 
 @pytest.fixture
 def second_app_config():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="second",
         bundle="com.example",
         version="0.0.2",

--- a/tests/commands/run/conftest.py
+++ b/tests/commands/run/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 from briefcase.commands import RunCommand
 from briefcase.commands.base import full_options
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 
 from ...utils import create_file
 
@@ -119,7 +119,7 @@ def run_command(dummy_console, tmp_path):
 
 @pytest.fixture
 def first_app_config():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="first",
         bundle="com.example",
         version="0.0.1",
@@ -162,7 +162,7 @@ def first_app(first_app_unbuild, tmp_path):
 
 @pytest.fixture
 def second_app_config():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="second",
         bundle="com.example",
         version="0.0.2",

--- a/tests/commands/update/conftest.py
+++ b/tests/commands/update/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from briefcase.commands import UpdateCommand
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 
 from ...utils import create_file
 
@@ -87,7 +87,7 @@ class DummyUpdateCommand(UpdateCommand):
 @pytest.fixture
 def first_app_config():
     """Populate skeleton app content for the first app."""
-    return AppConfig(
+    return DraftAppConfig(
         app_name="first",
         bundle="com.example",
         version="0.0.1",
@@ -115,7 +115,7 @@ def first_app(tmp_path, first_app_config):
 @pytest.fixture
 def second_app_config():
     """Populate skeleton app content for the second app."""
-    return AppConfig(
+    return DraftAppConfig(
         app_name="second",
         bundle="com.example",
         version="0.0.2",

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 from packaging.version import Version
 
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 from briefcase.exceptions import BriefcaseConfigError
 
 from .test_GlobalConfig import INVALID_VERSIONS, VALID_VERSIONS
@@ -11,7 +11,7 @@ from .test_GlobalConfig import INVALID_VERSIONS, VALID_VERSIONS
 
 def test_minimal_AppConfig():
     """A simple config can be defined."""
-    config = AppConfig(
+    config = DraftAppConfig(
         app_name="myapp",
         version="1.2.3",
         bundle="org.beeware",
@@ -49,12 +49,12 @@ def test_minimal_AppConfig():
     assert config.PYTHONPATH() == ["src", "somewhere/else", ""]
 
     # The object has a meaningful REPL
-    assert repr(config) == "<org.beeware.myapp v1.2.3 AppConfig>"
+    assert repr(config) == "<org.beeware.myapp v1.2.3 DraftAppConfig>"
 
 
 def test_minimal_external_AppConfig():
     """A simple config for an external app can be defined."""
-    config = AppConfig(
+    config = DraftAppConfig(
         app_name="myapp",
         version="1.2.3",
         bundle="org.beeware",
@@ -93,12 +93,12 @@ def test_minimal_external_AppConfig():
     assert config.PYTHONPATH() == []
 
     # The object has a meaningful REPL
-    assert repr(config) == "<org.beeware.myapp v1.2.3 AppConfig>"
+    assert repr(config) == "<org.beeware.myapp v1.2.3 DraftAppConfig>"
 
 
 def test_extra_attrs():
     """A config can contain attributes in addition to those required."""
-    config = AppConfig(
+    config = DraftAppConfig(
         app_name="myapp",
         formal_name="My App!",
         version="1.2.3",
@@ -192,7 +192,7 @@ def test_extra_attrs():
 )
 def test_valid_app_name(name):
     try:
-        AppConfig(
+        DraftAppConfig(
             app_name=name,
             version="1.2.3",
             bundle="org.beeware",
@@ -220,7 +220,7 @@ def test_valid_app_name(name):
 )
 def test_invalid_app_name(name):
     with pytest.raises(BriefcaseConfigError, match=r"is not a valid app name\."):
-        AppConfig(
+        DraftAppConfig(
             app_name=name,
             version="1.2.3",
             bundle="org.beeware",
@@ -242,7 +242,7 @@ def test_invalid_app_name(name):
 )
 def test_valid_bundle(bundle):
     try:
-        AppConfig(
+        DraftAppConfig(
             app_name="myapp",
             version="1.2.3",
             bundle=bundle,
@@ -269,7 +269,7 @@ def test_invalid_bundle_identifier(bundle):
     with pytest.raises(
         BriefcaseConfigError, match=r"is not a valid bundle identifier\."
     ):
-        AppConfig(
+        DraftAppConfig(
             app_name="myapp",
             version="1.2.3",
             bundle=bundle,
@@ -282,7 +282,7 @@ def test_invalid_bundle_identifier(bundle):
 
 @pytest.mark.parametrize(("input", "expected"), VALID_VERSIONS)
 def test_valid_app_version(input, expected):
-    config = AppConfig(
+    config = DraftAppConfig(
         app_name="myapp",
         version=input,
         bundle="org.beeware",
@@ -304,7 +304,7 @@ def test_invalid_app_version(input):
         BriefcaseConfigError,
         match=rf"Version number for 'myapp' \({input}\) is not valid\.",
     ):
-        AppConfig(
+        DraftAppConfig(
             app_name="myapp",
             version=input,
             bundle="org.beeware",
@@ -323,7 +323,7 @@ def test_invalid_app_version(input):
     ],
 )
 def test_module_name(name, module_name):
-    config = AppConfig(
+    config = DraftAppConfig(
         app_name=name,
         version="1.2.3",
         bundle="org.beeware",
@@ -344,7 +344,7 @@ def test_module_name(name, module_name):
     ],
 )
 def test_package_name(bundle, package_name):
-    config = AppConfig(
+    config = DraftAppConfig(
         app_name="myapp",
         version="1.2.3",
         bundle=bundle,
@@ -365,7 +365,7 @@ def test_package_name(bundle, package_name):
     ],
 )
 def test_dist_info_name(app_name, dist_info_name):
-    config = AppConfig(
+    config = DraftAppConfig(
         app_name=app_name,
         version="1.2.3",
         bundle="com.example",
@@ -386,7 +386,7 @@ def test_dist_info_name(app_name, dist_info_name):
     ],
 )
 def test_bundle_name(app_name, bundle_name):
-    config = AppConfig(
+    config = DraftAppConfig(
         app_name=app_name,
         version="1.2.3",
         bundle="com.example",
@@ -409,7 +409,7 @@ def test_bundle_name(app_name, bundle_name):
 def test_bundle_identifier(app_name, bundle_name):
     bundle = "com.example"
 
-    config = AppConfig(
+    config = DraftAppConfig(
         app_name=app_name,
         version="1.2.3",
         bundle=bundle,
@@ -435,7 +435,7 @@ def test_duplicated_source(sources):
     with pytest.raises(
         BriefcaseConfigError, match=r"contains duplicated package names\."
     ):
-        AppConfig(
+        DraftAppConfig(
             app_name="dupe",
             version="1.2.3",
             bundle="org.beeware",
@@ -450,7 +450,7 @@ def test_no_source_for_app():
     with pytest.raises(
         BriefcaseConfigError, match=r" does not include a package named 'my_app'\."
     ):
-        AppConfig(
+        DraftAppConfig(
             app_name="my-app",
             version="1.2.3",
             bundle="org.beeware",
@@ -474,7 +474,7 @@ def test_no_source_for_app():
     ],
 )
 def test_install_launcher(install_launcher, console_app, expected):
-    config = AppConfig(
+    config = DraftAppConfig(
         app_name="my-app",
         version="1.2.3",
         bundle="org.beeware",
@@ -496,7 +496,7 @@ def test_non_unique_uninstall_options():
             r"The name 'first' is already used as an install option."
         ),
     ):
-        AppConfig(
+        DraftAppConfig(
             app_name="myapp",
             version="1.2.3",
             bundle="org.beeware",
@@ -531,7 +531,7 @@ def test_non_unique_uninstall_options():
 
 def test_capitalization():
     """Capitalization is prohibited and normalized out in some properties."""
-    config = AppConfig(
+    config = DraftAppConfig(
         app_name="MyApp",
         version="1.2.3",
         bundle="Org.Beeware",
@@ -552,4 +552,4 @@ def test_capitalization():
     assert config.class_name == "MyApp"
 
     # The object has a meaningful REPL
-    assert repr(config) == "<org.beeware.myapp v1.2.3 AppConfig>"
+    assert repr(config) == "<org.beeware.myapp v1.2.3 DraftAppConfig>"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import ANY, MagicMock
 
 import pytest
 
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 
 from .utils import DummyConsole, create_file
 
@@ -93,7 +93,7 @@ def sub_stream_kw(sub_kw):
 @pytest.fixture
 def first_app_config(tmp_path):
     create_file(tmp_path / "base_path" / "LICENSE", "MIT License")
-    return AppConfig(
+    return DraftAppConfig(
         app_name="first",
         bundle="com.example",
         version="0.0.1",

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.file import File
 from briefcase.integrations.subprocess import Subprocess
@@ -45,7 +45,7 @@ def mock_tools(dummy_console, tmp_path) -> ToolCache:
 @pytest.fixture
 def first_app_config(tmp_path):
     create_file(tmp_path / "base_path" / "LICENSE", "MIT License")
-    return AppConfig(
+    return DraftAppConfig(
         app_name="first-app",
         project_name="First Project",
         formal_name="First App",

--- a/tests/integrations/docker/conftest.py
+++ b/tests/integrations/docker/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, call
 import pytest
 
 import briefcase
-from briefcase.config import AppConfig
+from briefcase.config import AppConfig, DraftAppConfig
 from briefcase.integrations.base import ToolCache
 from briefcase.integrations.docker import Docker, DockerAppContext
 
@@ -50,7 +50,7 @@ def mock_tools(mock_tools, tmp_path) -> ToolCache:
 @pytest.fixture
 def my_app(tmp_path) -> AppConfig:
     create_file(tmp_path / "base_path" / "LICENSE", "MIT License")
-    return AppConfig(
+    return DraftAppConfig(
         app_name="myapp",
         formal_name="My App",
         bundle="com.example",

--- a/tests/platforms/conftest.py
+++ b/tests/platforms/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 from briefcase.debuggers.base import (
     BaseDebugger,
     DebuggerConnectionMode,
@@ -12,7 +12,7 @@ from ..utils import create_file
 @pytest.fixture
 def first_app_config(tmp_path):
     create_file(tmp_path / "base_path" / "LICENSE", "The Actual First App License")
-    return AppConfig(
+    return DraftAppConfig(
         app_name="first-app",
         project_name="First Project",
         formal_name="First App",
@@ -32,7 +32,7 @@ def first_app_config(tmp_path):
 
 @pytest.fixture
 def uppercase_app_config():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="First-App",
         project_name="First Project",
         formal_name="First App",
@@ -46,7 +46,7 @@ def uppercase_app_config():
 
 @pytest.fixture
 def underscore_app_config():
-    return AppConfig(
+    return DraftAppConfig(
         app_name="first_app",
         project_name="First Project",
         formal_name="First App",

--- a/tests/platforms/linux/system/conftest.py
+++ b/tests/platforms/linux/system/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from briefcase.config import AppConfig
+from briefcase.config import DraftAppConfig
 from briefcase.platforms.linux.system import LinuxSystemCreateCommand
 
 from ....utils import create_file
@@ -64,7 +64,7 @@ def first_app(first_app_config, tmp_path):
 @pytest.fixture
 def underscore_app(tmp_path):
     """A fixture for an app with an underscore in the name, rolled out on disk."""
-    app_config = AppConfig(
+    app_config = DraftAppConfig(
         app_name="underscore_app",
         project_name="Underscore Project",
         formal_name="Underscore App",


### PR DESCRIPTION
- `AppConfig` becomes a shared base with properties and type annotations.
- `DraftAppConfig` gets the constructor previously on `AppConfig`.
- `FinalizedAppConfig` takes `DraftAppConfig` instead of `AppConfig`.
- `__repr__` distinguishes draft from finalized configs.

Groundwork for `LinuxSystemAppConfig` (Refs #2739).

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
