### PR TITLE
Allow for creating a "skinless" android emulator

### DIFF
--- a/changes/2788.feature.md
+++ b/changes/2788.feature.md
@@ -1,0 +1,1 @@
+It is now possible to create a "skinless" Android emulator by specifying a device type, but no skin, as part of a device specification.

--- a/docs/en/reference/platforms/android/gradle.md
+++ b/docs/en/reference/platforms/android/gradle.md
@@ -140,15 +140,11 @@ The device or emulator to target. Can be specified as:
 
   You may also specify:
 
+  * `device_type` (e.g., `pixel`) the type of device to emulate.
+  * `skin` (e.g., `pixel_3a`) - the skin to apply to the emulator.
+  * `system_image` (e.g., `system-images;android-31;default;arm64-v8a`) - the Android system image to use in the emulator.
 
-  * `device_type` (e.g., `pixel`) * the type of device to emulate
-  * `skin` (e.g., `pixel_3a`) * the skin to apply to the emulator
-  * `system_image` (e.g.,
-
-  `system-images;android-31;default;arm64-v8a`) * the Android system image to use in the emulator.
-
-  If any of these attributes are *not* specified, they will fall back to reasonable defaults.
-
+  If no device type is specified, a default device with a default skin will be used. If no system image is specified, a default system image will be used. If a device type is specified, but no *skin* is specified, a "skinless" device will be created.
 
 #### `--Xemulator=<value>`
 

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1175,13 +1175,15 @@ In future, you can specify this device by running:
         """
         if device_type is None:
             device_type = self.DEFAULT_DEVICE_TYPE
-        if skin is None:
             skin = self.DEFAULT_DEVICE_SKIN
         if system_image is None:
             system_image = self.DEFAULT_SYSTEM_IMAGE
 
         # Ensure the required skin is available.
-        self.verify_emulator_skin(skin)
+        if skin:
+            self.verify_emulator_skin(skin)
+        else:
+            self.tools.console.info("Creating an emulator with no skin")
 
         # Ensure the required system image is available.
         self.verify_system_image(system_image)
@@ -1215,19 +1217,23 @@ In future, you can specify this device by running:
                 raise BriefcaseCommandError("Unable to create Android emulator") from e
 
         with self.tools.console.wait_bar("Adding extra device configuration..."):
-            self.update_emulator_config(
-                avd,
-                {
-                    "avd.id": avd,
-                    "avd.name": avd,
-                    "disk.dataPartition.size": "4096M",
-                    "hw.keyboard": "yes",
-                    "skin.dynamic": "yes",
-                    "skin.name": skin,
-                    "skin.path": f"skins/{skin}",
-                    "showDeviceFrame": "yes",
-                },
-            )
+            avd_config = {
+                "avd.id": avd,
+                "avd.name": avd,
+                "disk.dataPartition.size": "4096M",
+                "hw.keyboard": "yes",
+                "showDeviceFrame": "yes",
+            }
+            if skin:
+                avd_config.update(
+                    {
+                        "skin.dynamic": "yes",
+                        "skin.name": skin,
+                        "skin.path": f"skins/{skin}",
+                    }
+                )
+
+            self.update_emulator_config(avd, avd_config)
 
     def avd_config(self, avd: str) -> dict[str, str]:
         """Obtain the AVD configuration as key-value pairs.

--- a/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
@@ -186,6 +186,82 @@ def test_create_emulator_with_defaults(
     assert "skin.name=pixel_7_pro" in config
 
 
+@pytest.mark.parametrize(
+    ("host_os", "host_arch", "emulator_abi"),
+    [
+        ("Darwin", "x86_64", "x86_64"),
+        ("Darwin", "arm64", "arm64-v8a"),
+        ("Windows", "AMD64", "x86_64"),
+        ("Linux", "x86_64", "x86_64"),
+        ("Linux", "aarch64", "arm64-v8a"),
+    ],
+)
+def test_create_emulator_with_defaults_no_skin(
+    mock_tools,
+    android_sdk,
+    tmp_path,
+    host_os,
+    host_arch,
+    emulator_abi,
+):
+    """A new emulator can be created using default properties."""
+    # This test validates everything going well on first run.
+    # This means the skin will be downloaded and unpacked.
+
+    # Mock the hardware and operating system to specific values
+    mock_tools.host_os = host_os
+    mock_tools.host_arch = host_arch
+
+    # Mock system image and skin verification
+    android_sdk.verify_system_image = MagicMock()
+    android_sdk.verify_emulator_skin = MagicMock()
+
+    # Mock the initial output of an AVD config file.
+    avd_config_path = tmp_path / "home/.android/avd/new-emulator.avd/config.ini"
+    avd_config_path.parent.mkdir(parents=True)
+    with avd_config_path.open("w", encoding="utf-8") as f:
+        f.write("hw.device.name=pixel\n")
+
+    # Create the emulator using default device, but no skin.
+    android_sdk._create_emulator(avd="new-emulator", device_type="pixel")
+
+    # The system image was verified
+    android_sdk.verify_system_image.assert_called_once_with(
+        f"system-images;android-31;default;{emulator_abi}"
+    )
+
+    # The emulator skin was not verified
+    android_sdk.verify_emulator_skin.assert_not_called()
+
+    # avdmanager was invoked
+    mock_tools.subprocess.check_output.assert_called_once_with(
+        [
+            android_sdk.avdmanager_path,
+            "--verbose",
+            "create",
+            "avd",
+            "--name",
+            "new-emulator",
+            "--abi",
+            emulator_abi,
+            "--package",
+            f"system-images;android-31;default;{emulator_abi}",
+            "--device",
+            "pixel",
+        ],
+        env={
+            **android_sdk.env,
+            "XDG_CONFIG_HOME": None,
+        },
+    )
+
+    # Emulator configuration file has been appended, but there are no skin details
+    with avd_config_path.open(encoding="utf-8") as f:
+        config = f.read().split("\n")
+    assert "hw.keyboard=yes" in config
+    assert "skin.name" not in config
+
+
 def test_create_failure(mock_tools, android_sdk):
     """If avdmanager fails, an error is raised."""
     # Mock system image and skin verification


### PR DESCRIPTION
We've recently seen a lot of rate limiting (HTTP 429) when downloading a skin for [Android CI builds](https://github.com/beeware/toga/actions/runs/24030637432/job/70078652391). Since a skin is purely cosmetic, it makes sense to provide an option to build a "skinless" build option.

This modifies the Android emulator creation process so that if you specify a device type, but no skin, a skinless device is created. (i.e., `briefcase run -d '{"device_type":"pixel"}'`). This will avoid the attempt to download the skin.

This only impacts the "explicit device syntax" format; a skin is still selected when you go through the "create new device" menu option.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
