### PR TITLE
Android sdk img verify

### DIFF
--- a/changes/1895.bugfix.md
+++ b/changes/1895.bugfix.md
@@ -1,0 +1,1 @@
+Android system image verification now uses ``sdkmanager --list_installed`` to confirm the image is fully installed, rather than only checking if the directory exists. If the image is not installed, it will be downloaded automatically.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -733,6 +733,27 @@ connection.
         except KeyError:
             self.tools.console.debug(f"Device {avd!r} doesn't define a skin.")
 
+    def list_installed_system_images(self) -> set[str]:
+        """Returns a set of installed system image package identifiers.
+
+        e.g., ``{"system-images;android-31;default;x86_64"}``
+        """
+        try:
+            output = self.tools.subprocess.check_output(
+                [self.sdkmanager_path, "--list_installed"],
+                env=self.env,
+            )
+        except subprocess.CalledProcessError as e:
+            raise BriefcaseCommandError(
+                "Unable to invoke the Android SDK manager"
+            ) from e
+
+        return {
+            line.split("|")[0].strip()
+            for line in output.splitlines()
+            if line.strip().startswith("system-images")
+        }
+
     def verify_system_image(self, system_image: str):
         """Verify that the required system image is installed.
 
@@ -766,13 +787,9 @@ connection.
 """
             )
 
-        # Convert the system image into a path where that system image
-        # would be expected, and see if the location exists.
-        system_image_path = self.root_path
-        for part in system_image_parts:
-            system_image_path = system_image_path / part
-
-        if system_image_path.exists():
+        # Use sdkmanager to verify the system image is fully installed,
+        # not just that the directory exists.
+        if system_image in self.list_installed_system_images():
             # Found the system image.
             return
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_list_installed_images.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_list_installed_images.py
@@ -1,0 +1,49 @@
+import subprocess
+
+import pytest
+
+from briefcase.exceptions import BriefcaseCommandError
+
+
+def test_list_installed_system_images(mock_tools, android_sdk):
+    """Returns a set of installed system image package identifiers."""
+
+    mock_tools.subprocess.check_output.return_value = (
+        "Installed packages:\n"
+        "  Path                                    | Version | Description                    | Location\n"
+        "  -------                                 | ------- | -------                        | -------\n"
+        "  system-images;android-31;default;x86_64 | 5       | Intel x86_64 Atom System Image | system-images/android-31/default/x86_64\n"
+        "  emulator                                | 35.4.9  | Android Emulator               | emulator\n"
+    )
+
+    result = android_sdk.list_installed_system_images()
+
+    assert result == {"system-images;android-31;default;x86_64"}
+    mock_tools.subprocess.check_output.assert_called_once_with(
+        [android_sdk.sdkmanager_path, "--list_installed"],
+        env=android_sdk.env,
+    )
+
+
+def test_no_installed_system_images(mock_tools, android_sdk):
+    """If no system images are installed, an empty set is returned."""
+    mock_tools.subprocess.check_output.return_value = (
+        "Installed packages:\n"
+        "  Path                                    | Version | Description                    | Location\n"
+        "  -------                                 | ------- | -------                        | -------\n"
+        "  emulator                                | 35.4.9  | Android Emulator               | emulator\n"
+    )
+
+    result = android_sdk.list_installed_system_images()
+
+    assert result == set()
+
+
+def test_list_installed_system_images_failure(mock_tools, android_sdk):
+    """If sdkmanager fails, an error is raised."""
+    mock_tools.subprocess.check_output.side_effect = subprocess.CalledProcessError(
+        1, ""
+    )
+
+    with pytest.raises(BriefcaseCommandError):
+        android_sdk.list_installed_system_images()

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
@@ -81,9 +81,12 @@ def test_existing_system_image(mock_tools, android_sdk):
     # Mock the host arch
     mock_tools.host_arch = "AMD64" if platform.system() == "Windows" else "x86_64"
 
-    # Mock the existence of a system image
-    (android_sdk.root_path / "system-images/android-31/default/x86_64").mkdir(
-        parents=True
+    # Mock sdkmanager reporting the system image as installed
+    mock_tools.subprocess.check_output.return_value = (
+        "Installed packages:\n"
+        "  Path                                    | Version | Description                    | Location\n"
+        "  -------                                 | ------- | -------                        | -------\n"
+        "  system-images;android-31;default;x86_64 | 5       | Intel x86_64 Atom System Image | system-images/android-31/default/x86_64\n"
     )
 
     # Verify the system image that we already have


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Adds a ``list_installed_system_images()`` utility method to ``AndroidSDK`` that invokes ``sdkmanager --list_installed`` and returns a set of installed system image package identifiers. Updates ``verify_system_image()`` to use this method instead of only checking if the system image directory exists.
<!--- What problem does this change solve? -->
Previously Briefcase verified a system image by checking if the expected directory existed. This check is not strong enough as the directory may exist wile the system image is incomplete or corrupted. This would cause a confusing error when either ``avdmanager`` or the emulator would try to use an incomplete system image.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #1895 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
