### PR TITLE
Fix invalid dict[str, ...] type annotations.

### DIFF
--- a/changes/2800.misc.md
+++ b/changes/2800.misc.md
@@ -1,0 +1,1 @@
+Replaced invalid ``dict[str, ...]`` annotations with ``dict[str, Any]`` in ``commands/base.py``, ``integrations/subprocess.py``, and ``integrations/docker.py``.

--- a/changes/2800.misc.md
+++ b/changes/2800.misc.md
@@ -1,1 +1,1 @@
-Replaced invalid ``dict[str, ...]`` annotations with ``dict[str, Any]`` in ``commands/base.py``, ``integrations/subprocess.py``, and ``integrations/docker.py``.
+Some typing references were corrected.

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -194,7 +194,7 @@ class BaseCommand(ABC):
             self.validate_locale()
 
         self.global_config = None
-        self._briefcase_toml: dict[AppConfig, dict[str, ...]] = {}
+        self._briefcase_toml: dict[AppConfig, dict[str, Any]] = {}
 
     @property
     def console(self):
@@ -504,7 +504,7 @@ a custom location for Briefcase's tools.
         else:
             return self.bundle_package_executable_path(app)
 
-    def briefcase_toml(self, app: FinalizedAppConfig) -> dict[str, ...]:
+    def briefcase_toml(self, app: FinalizedAppConfig) -> dict[str, Any]:
         """Load the ``briefcase.toml`` file provided by the app template.
 
         :param app: The config object for the app

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -8,6 +8,7 @@ import sys
 from collections.abc import Iterable, Mapping
 from functools import cache
 from pathlib import Path, PosixPath, PurePosixPath
+from typing import Any
 
 from packaging.version import InvalidVersion, Version
 
@@ -428,7 +429,7 @@ Delete this file and run Briefcase again.
         cwd: str | os.PathLike | None = None,
         add_hosts: Iterable[tuple[str, str]] | None = None,
         **subprocess_kwargs,
-    ) -> dict[str, ...]:  # pragma: no-cover-if-is-windows
+    ) -> dict[str, Any]:  # pragma: no-cover-if-is-windows
         """Convert arguments and environment into a Docker-compatible form.
 
         Converts an argument and environment specification into a form that can be used
@@ -522,8 +523,8 @@ Delete this file and run Briefcase again.
 
     @contextlib.contextmanager
     def x11_passthrough(
-        self, subprocess_kwargs: dict[str, ...]
-    ) -> dict[str, ...]:  # pragma: no-cover-if-is-windows
+        self, subprocess_kwargs: dict[str, Any]
+    ) -> dict[str, Any]:  # pragma: no-cover-if-is-windows
         """Manager to expose the host's X11 server to a container.
 
         This allows Docker containers to use the host's X11 server with the
@@ -945,7 +946,7 @@ class DockerAppContext(Tool):
                     ) from e
 
     @contextlib.contextmanager
-    def run_app_context(self, subprocess_kwargs: dict[str, ...]) -> dict[str, ...]:
+    def run_app_context(self, subprocess_kwargs: dict[str, Any]) -> dict[str, Any]:
         """Manager to run a Briefcase project app in a container.
 
         :returns: context manager to wrap the call to Popen/run/check_output()
@@ -979,7 +980,7 @@ class DockerAppContext(Tool):
 
     def _dockerize_args(
         self, args: SubprocessArgsT, **kwargs
-    ) -> dict[str, ...]:  # pragma: no-cover-if-is-windows
+    ) -> dict[str, Any]:  # pragma: no-cover-if-is-windows
         """App-specific wrapper for Docker.dockerize_args().
 
         Uses the app's dedicated Docker image to run the container.

--- a/src/briefcase/integrations/subprocess.py
+++ b/src/briefcase/integrations/subprocess.py
@@ -14,7 +14,7 @@ from collections.abc import Callable, Iterator, Mapping, Sequence
 from functools import wraps
 from pathlib import Path
 from subprocess import CompletedProcess
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import psutil
 
@@ -299,7 +299,7 @@ class Subprocess(Tool):
         # This is a no-op; the native subprocess environment is ready-to-use.
 
     @contextlib.contextmanager
-    def run_app_context(self, subprocess_kwargs: dict[str, ...]) -> dict[str, ...]:
+    def run_app_context(self, subprocess_kwargs: dict[str, Any]) -> dict[str, Any]:
         """A manager to wrap subprocess calls to run a Briefcase project app.
 
         :param subprocess_kwargs: initialized keyword arguments for subprocess calls


### PR DESCRIPTION
Replaced invalid `dict[str, ...]` annotations with `dict[str, Any]` as ellipsis `...` is not valid in a type expression. That clears 10 ty `invalid-type-form` diagnostics. Refs #2709

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
