### PR TITLE
Include return codes in run failure messages.

### DIFF
--- a/changes/2806.feature.md
+++ b/changes/2806.feature.md
@@ -1,0 +1,1 @@
+When an app fails to run or returns an error, the status code is now reported in the console.

--- a/src/briefcase/commands/run.py
+++ b/src/briefcase/commands/run.py
@@ -192,18 +192,27 @@ class RunAppMixin:
                             "Test suite didn't report a result."
                         )
                     else:
-                        self.console.error("Test suite failed!", prefix=app.app_name)
+                        self.console.error(
+                            f"Test suite failed! (return code {log_filter.returncode})",
+                            prefix=app.app_name,
+                        )
                         raise BriefcaseTestSuiteFailure()
             elif log_stream:
                 # If we're monitoring a log stream, and the log stream reported a
                 # non-zero exit code, surface that error to the user.
                 if log_filter.returncode is not None and log_filter.returncode != 0:
-                    raise BriefcaseCommandError(f"Problem running app {app.app_name}.")
+                    raise BriefcaseCommandError(
+                        f"Problem running app {app.app_name} "
+                        f"(log stream return code {log_filter.returncode})."
+                    )
             else:
                 # If we're monitoring an actual app (not just a log stream),
                 # and the app didn't exit cleanly, surface the error to the user.
-                if popen.poll() != 0:
-                    raise BriefcaseCommandError(f"Problem running app {app.app_name}.")
+                if (status_code := popen.poll()) != 0:
+                    raise BriefcaseCommandError(
+                        f"Problem running app {app.app_name} "
+                        f"(return code {status_code})."
+                    )
 
         except KeyboardInterrupt:
             pass  # Catch CTRL-C to exit normally

--- a/tests/commands/run/test__stream_app_logs.py
+++ b/tests/commands/run/test__stream_app_logs.py
@@ -119,7 +119,7 @@ def test_test_mode_success(run_command, first_app):
     assert filter_func.exit_filter.regex.pattern == LogFilter.DEFAULT_EXIT_REGEX
 
 
-def test_test_mode_failure(run_command, first_app):
+def test_test_mode_failure(run_command, first_app, capsys):
     """An app can be streamed in test mode, resulting in test failure."""
     first_app.test_mode = True
 
@@ -131,7 +131,7 @@ def test_test_mode_failure(run_command, first_app):
 
     # Mock effect of streaming the app resulting in a test suite success
     def mock_stream_output(label, popen_process, filter_func, **kwargs):
-        filter_func.returncode = 1
+        filter_func.returncode = 42
 
     run_command.tools.subprocess.stream_output.side_effect = mock_stream_output
 
@@ -160,6 +160,9 @@ def test_test_mode_failure(run_command, first_app):
     assert not filter_func.clean_output
     assert filter_func.clean_filter == clean_filter
     assert filter_func.exit_filter.regex.pattern == LogFilter.DEFAULT_EXIT_REGEX
+
+    # An error was written with the test suite failure code
+    assert "Test suite failed! (return code 42)" in capsys.readouterr().out
 
 
 def test_test_mode_no_result(run_command, first_app):
@@ -255,7 +258,7 @@ def test_test_mode_custom_filters(run_command, first_app):
 def test_run_app_failure(run_command, first_app):
     """If an app exits with a bad exit code, that is raised as an error."""
     popen = mock.MagicMock()
-    popen.returncode = 1
+    popen.poll = mock.MagicMock(return_value=42)
     clean_filter = mock.MagicMock()
     stop_func = mock.MagicMock()
     run_command.tools.subprocess.stream_output = mock.MagicMock()
@@ -263,7 +266,7 @@ def test_run_app_failure(run_command, first_app):
     # Streaming the app logs raises an error
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"Problem running app first.",
+        match=r"Problem running app first \(return code 42\)\.",
     ):
         run_command._stream_app_logs(
             first_app,
@@ -376,14 +379,14 @@ def test_run_app_log_stream_failure(run_command, first_app):
 
     # Mock effect of streaming the app resulting in a test suite success
     def mock_stream_output(label, popen_process, filter_func, **kwargs):
-        filter_func.returncode = 1
+        filter_func.returncode = 42
 
     run_command.tools.subprocess.stream_output.side_effect = mock_stream_output
 
     # Streaming the app logs causes a test suite failure
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"Problem running app first.",
+        match=r"Problem running app first \(log stream return code 42\)\.",
     ):
         run_command._stream_app_logs(
             first_app,


### PR DESCRIPTION
While trying to diagnose intermittent Windows testing failures, I wasn't able to get any insight into why the run was failing, because the return code of the executed process  wasn't being reported.

This PR adds the return code to run failure messages.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
