### PR TITLE
Validate full bundle identifier in config

### DIFF
--- a/changes/2824.bugfix.md
+++ b/changes/2824.bugfix.md
@@ -1,1 +1,1 @@
-Bundle prefixes are now validated using the complete Bundle ID, including application name.  This more correctly validates identifiers.
+Bundle identifiers with 2 parts are no longer rejected by the validation process.

--- a/changes/2824.bugfix.md
+++ b/changes/2824.bugfix.md
@@ -1,0 +1,1 @@
+Bundle prefixes are now validated using the complete Bundle ID, including application name.  This more correctly validates identifiers.

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -646,11 +646,11 @@ class DraftAppConfig(AppConfig):
                 "and cannot end with '-' or '_')."
             )
 
-        if not is_valid_bundle_identifier(self.bundle):
+        if not is_valid_bundle_identifier(self.bundle_identifier):
             raise BriefcaseConfigError(
-                f"{self.bundle!r} is not a valid bundle identifier."
+                f"{self.bundle_identifier!r} is not a valid bundle identifier."
                 f"\n\n"
-                "The bundle should be a reversed domain name. It must contain at least "
+                "The bundle id should be a reversed domain name. It must contain at least "
                 "2 dot-separated sections; each section may only include letters, "
                 "numbers, and hyphens; and each section may not contain any reserved "
                 "words (like 'switch', or 'while')."

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -648,12 +648,13 @@ class DraftAppConfig(AppConfig):
 
         if not is_valid_bundle_identifier(self.bundle_identifier):
             raise BriefcaseConfigError(
-                f"{self.bundle_identifier!r} is not a valid bundle identifier."
-                f"\n\n"
-                "The bundle id should be a reversed domain name. It must contain at "
-                "least 2 dot-separated sections; each section may only include "
-                "letters, numbers, and hyphens; and each section may not contain any "
-                "reserved words (like 'switch', or 'while')."
+                f"{self.bundle!r} is not a valid bundle identifier.\n"
+                "\n"
+                "When the bundle is combined with an app name, it should form a "
+                "reversed domain name. The combined bundle identifier must "
+                "contain at least 2 dot-separated sections; each section may "
+                "only include letters, numbers, and hyphens; and each section "
+                "may not contain any reserved words (like 'switch', or 'while')."
             )
 
         for document_type_id, document_type in self.document_types.items():

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -650,10 +650,10 @@ class DraftAppConfig(AppConfig):
             raise BriefcaseConfigError(
                 f"{self.bundle_identifier!r} is not a valid bundle identifier."
                 f"\n\n"
-                "The bundle id should be a reversed domain name. It must contain at least "
-                "2 dot-separated sections; each section may only include letters, "
-                "numbers, and hyphens; and each section may not contain any reserved "
-                "words (like 'switch', or 'while')."
+                "The bundle id should be a reversed domain name. It must contain at "
+                "least 2 dot-separated sections; each section may only include "
+                "letters, numbers, and hyphens; and each section may not contain any "
+                "reserved words (like 'switch', or 'while')."
             )
 
         for document_type_id, document_type in self.document_types.items():

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -232,31 +232,35 @@ def test_invalid_app_name(name):
 
 
 @pytest.mark.parametrize(
-    "bundle",
+    ("bundle", "app_name", "bundle_identifier"),
     [
-        "is",
-        "home",
-        "com.example",
-        "com.example.more",
-        "com.example42.more",
-        "com.example-42.more",
+        ("is", "myapp", "is.myapp"),
+        ("home", "myapp", "home.myapp"),
+        ("home", "my-app", "home.my-app"),
+        ("home", "my_app", "home.my-app"),
+        ("com.example", "myapp", "com.example.myapp"),
+        ("com.example", "my-app", "com.example.my-app"),
+        ("com.example", "my_app", "com.example.my-app"),
+        ("com.example.more", "myapp", "com.example.more.myapp"),
+        ("com.example42.more", "myapp", "com.example42.more.myapp"),
+        ("com.example-42.more", "myapp", "com.example-42.more.myapp"),
     ],
 )
-def test_valid_bundle(bundle):
+def test_valid_bundle(bundle, app_name, bundle_identifier):
     try:
         config = DraftAppConfig(
-            app_name="myapp",
+            app_name=app_name,
             version="1.2.3",
             bundle=bundle,
             description="A simple app",
-            sources=["src/myapp"],
+            sources=[f"src/{app_name.replace('-', '_')}"],
             license="MIT",
             license_files=["LICENSE"],
         )
     except BriefcaseConfigError:
-        pytest.fail(f"{bundle} should be valid")
+        pytest.fail(f"{bundle_identifier} should be valid")
 
-    assert config.bundle_identifier == f"{bundle}.myapp"
+    assert config.bundle_identifier == bundle_identifier
 
 
 @pytest.mark.parametrize(

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -234,6 +234,8 @@ def test_invalid_app_name(name):
 @pytest.mark.parametrize(
     "bundle",
     [
+        "is",
+        "home",
         "com.example",
         "com.example.more",
         "com.example42.more",
@@ -242,7 +244,7 @@ def test_invalid_app_name(name):
 )
 def test_valid_bundle(bundle):
     try:
-        DraftAppConfig(
+        config = DraftAppConfig(
             app_name="myapp",
             version="1.2.3",
             bundle=bundle,
@@ -254,12 +256,13 @@ def test_valid_bundle(bundle):
     except BriefcaseConfigError:
         pytest.fail(f"{bundle} should be valid")
 
+    assert config.bundle_identifier == f"{bundle}.myapp"
+
 
 @pytest.mark.parametrize(
     "bundle",
     [
         "not a bundle!",  # Free text.
-        "home",  # Only one section.
         "com.hello_world",  # underscore
         "com.hello,world",  # comma
         "com.hello world!",  # exclamation point


### PR DESCRIPTION
Validate the full bundle id instead of just the bundle prefix.
This more correctly validates bundle ids, allowing single-dot ids.  Fixes #2824 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Opus 4.7 or perhaps Codex 5.5, I can't remember 
