### PR TITLE
Update link checking rules.

### DIFF
--- a/changes/2826.misc.md
+++ b/changes/2826.misc.md
@@ -1,0 +1,1 @@
+Link checking rules were updated.

--- a/tox.ini
+++ b/tox.ini
@@ -106,7 +106,9 @@ dependency_groups = docs
 commands =
     !lint-!all-!live-!en : build_md_translations {posargs} en
     lint : pyspelling
-    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-domains=https://www.firegiant.com,https://flathub.org,https://wunjo.online,https://www.x.org
+    # Github has aggressive rate limiters
+    # RFC-editor seems to block robots?
+    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-urls-containing=https://github.com/beeware,https://github.com/astral-sh,https://github.com/freakboy3742,https://github.com/toml-lang,https://github.com/pypa,https://github.com/linuxdeploy,https://www.rfc-editor.org/rfc/
     live : live_serve_en {posargs} --port=8039
     all : build_md_translations {posargs} en
     en : build_md_translations {posargs} en


### PR DESCRIPTION
A recent update to markdown checker added validation of Github rules, which triggers rate limiters. This PR tweaks the exclusion list to avoid those rate checkers.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
