### PR TITLE
docs: restore Travel Tips Play Store link

### DIFF
--- a/docs/en/about/success.md
+++ b/docs/en/about/success.md
@@ -2,7 +2,7 @@
 
 Want to see examples of Briefcase in use? Here's some:
 
-- [Travel Tips](https://github.com/freakboy3742/traveltips) is an app in the [iOS App Store](https://apps.apple.com/au/app/travel-tips/id1336372310) that was packaged for distribution using Briefcase.
+- [Travel Tips](https://github.com/freakboy3742/traveltips) is an app in the [iOS App Store](https://apps.apple.com/au/app/travel-tips/id1336372310) and [Google Play Store](https://play.google.com/store/apps/details?id=com.keith_magee.traveltips) that was packaged for distribution using Briefcase.
 - [Mu](https://codewith.mu) is a simple code editor for beginner programmers. It uses Briefcase to prepare a macOS installer.
 - [Napari](https://napari.org/) is a multidimensional image viewer for python. It uses Briefcase to prepare bundled Windows, macOS, and Linux installers.
 - [Patent Toolkit](https://patenttk.com/) is a suite of tools for patent professionals. It uses Briefcase to prepare Windows and macOS builds.


### PR DESCRIPTION
## Summary
- restore the Travel Tips Google Play Store link on the success stories page
- use the exact Play Store URL and wording that existed before the temporary delisting removal

Fixes #2827.

## Testing
- `git diff --check`
- verified the restored Google Play URL matches the pre-removal revision referenced in the issue

## Notes
- I did not run `tox -e docs-lint` locally because `tox` is not installed in this environment; this change is limited to a one-line docs restoration in `docs/en/about/success.md`.