### PR TITLE
Clarify first-time bundled debug setup

### DIFF
--- a/docs/en/how-to/debugging/pdb.md
+++ b/docs/en/how-to/debugging/pdb.md
@@ -16,16 +16,16 @@ This is currently an **experimental feature** that is only supported on Windows,
 
 To debug a bundled app, add `breakpoint()` somewhere in your code where the debugger should halt.
 
-Your app must then be modified to include a bootstrap that will connect to the VS Code debugger. This is done by passing the `--debug pdb` option to `briefcase build`:
+Your app must then be modified to include a bootstrap that will start the remote PDB debugger. If you are switching an existing bundled app into debug mode for the first time, include `-r` / `--update-requirements` so the debugger requirements are installed before the app is rebuilt. This is done by passing the `--debug pdb` option to `briefcase build`:
 
 ```console
-$ briefcase build --debug pdb
+$ briefcase build -r --debug pdb
 ```
 
 To build a mobile app, include the platform name in the `build` command - for example:
 
 ```console
-$ briefcase build iOS --debug pdb
+$ briefcase build iOS -r --debug pdb
 ```
 
 This will build your app in debug mode, adding [`remote-pdb`](https://pypi.org/project/remote-pdb/), and a package that automatically starts `remote-pdb` on startup of your bundled app.

--- a/docs/en/how-to/debugging/vscode.md
+++ b/docs/en/how-to/debugging/vscode.md
@@ -44,16 +44,16 @@ This is currently an **experimental feature** that is only supported on Windows,
 
 ///
 
-To debug a bundled app, the app must be modified to include a bootstrap that will connect to the VS Code debugger. This is done by passing the `--debug debugpy` option to `briefcase build`:
+To debug a bundled app, the app must be modified to include a bootstrap that will connect to the VS Code debugger. If you are switching an existing bundled app into debug mode for the first time, include `-r` / `--update-requirements` so the debugger requirements are installed before the app is rebuilt. This is done by passing the `--debug debugpy` option to `briefcase build`:
 
 ```console
-$ briefcase build --debug debugpy
+$ briefcase build -r --debug debugpy
 ```
 
 To build a mobile app, include the platform name in the `build` command - for example:
 
 ```console
-$ briefcase build iOS --debug debugpy
+$ briefcase build iOS -r --debug debugpy
 ```
 
 This will build your app in debug mode and add [debugpy](https://code.visualstudio.com/docs/debugtest/debugging#_debug-console-repl), and a package that automatically starts `debugpy` at the startup of your bundled app.

--- a/docs/en/reference/commands/run.md
+++ b/docs/en/reference/commands/run.md
@@ -113,6 +113,8 @@ This is an **experimental** new feature, that is currently only supported on Win
 
 The selected debugger in `run --debug <debugger>` has to match the selected debugger in `build --debug <debugger>`.
 
+If you have previously run the app in "normal" mode, you may need to pass `-r` / `--update-requirements` the first time you run in debug mode to ensure that the debugger is embedded in your bundled app before it is launched.
+
 ## `--debugger-host <host>`
 
 Specifies the host of the socket connection for the debugger. This option is only used when the `--debug <debugger>` option is specified. The default value is `localhost`.


### PR DESCRIPTION
## Summary
- update the bundled PDB and VS Code debug guides to show the first debug build with `-r`
- explain the first-time bundled debug requirement in the `run --debug` reference page
- fix the PDB guide wording so it refers to the remote PDB flow instead of VS Code

## Testing
- `git diff --check`
- `python3 -m tox -e docs-lint` *(fails locally: `No module named tox` in this environment)*

Fixes #2621.
