### PR TITLE
Restore play store travel tips link

### DIFF
--- a/changes/2827.misc.md
+++ b/changes/2827.misc.md
@@ -1,0 +1,1 @@
+Restore the link to Travel Tips in the Play Store to the form that existed previously.

--- a/docs/en/about/success.md
+++ b/docs/en/about/success.md
@@ -2,7 +2,7 @@
 
 Want to see examples of Briefcase in use? Here's some:
 
-- [Travel Tips](https://github.com/freakboy3742/traveltips) is an app in the [iOS App Store](https://apps.apple.com/au/app/travel-tips/id1336372310) that was packaged for distribution using Briefcase.
+- [Travel Tips](https://github.com/freakboy3742/traveltips) is an app in the [iOS App Store](https://apps.apple.com/au/app/travel-tips/id1336372310) and [Google Play Store](https://play.google.com/store/apps/details?id=com.keith_magee.traveltips) that was packaged for distribution using Briefcase.
 - [Mu](https://codewith.mu) is a simple code editor for beginner programmers. It uses Briefcase to prepare a macOS installer.
 - [Napari](https://napari.org/) is a multidimensional image viewer for python. It uses Briefcase to prepare bundled Windows, macOS, and Linux installers.
 - [Patent Toolkit](https://patenttk.com/) is a suite of tools for patent professionals. It uses Briefcase to prepare Windows and macOS builds.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->

As part of the 0.4.2 release, it was necessary to [remove a reference to the Android Play Store for Travel Tips](https://github.com/beeware/briefcase/commit/5ca74889421f888dfbe44378ca9c5f6d6018a07a#diff-e6e2c46a855828cf573047959c03dd700f7db9e16c36894736aa09599f4d0fe6) due to a temporary delisting of the Travel Tips app. This PR restores the link since the delisting has now been resolved.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Fixes https://github.com/beeware/briefcase/issues/2827

## Testing

- Validated the link is not dead
- Validated the link in the live server (`tox -e docs-live`)
- Ran `tox -e docs-all` and `tox -e docs-lint`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I will abide by the BeeWare Code of Conduct
- [X] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
