### PR TITLE
Use helper for long warn messages in docker.py

### DIFF
--- a/changes/2559.misc.md
+++ b/changes/2559.misc.md
@@ -1,0 +1,1 @@
+Apply warning_banner method for long warning message on src/briefcase/integrations/docker.py file

--- a/src/briefcase/integrations/docker.py
+++ b/src/briefcase/integrations/docker.py
@@ -36,48 +36,6 @@ version {docker_version}. Visit:
 
 to download and install an updated version of Docker.
 """
-    UNKNOWN_DOCKER_VERSION_WARNING = """
-*************************************************************************
-** WARNING: Unable to determine the version of Docker                  **
-*************************************************************************
-
-    Briefcase will proceed, assuming everything is OK. If you
-    experience problems, this is almost certainly the cause of those
-    problems.
-
-    Please report this as a bug at:
-
-      https://github.com/beeware/briefcase/issues/new
-
-    In your report, please including the output from running:
-
-      $ docker --version
-
-    from the command prompt.
-
-*************************************************************************
-"""
-    DOCKER_INSTALLATION_STATUS_UNKNOWN_WARNING = """
-*************************************************************************
-** WARNING: Unable to determine if Docker is installed                 **
-*************************************************************************
-
-    Briefcase will proceed, assuming everything is OK. If you
-    experience problems, this is almost certainly the cause of those
-    problems.
-
-    Please report this as a bug at:
-
-      https://github.com/beeware/briefcase/issues/new
-
-    In your report, please including the output from running:
-
-      $ docker --version
-
-    from the command prompt.
-
-*************************************************************************
-"""
     DOCKER_NOT_INSTALLED_ERROR = """\
 Briefcase requires Docker, but it is not installed (or is not on your PATH).
 Visit:
@@ -187,9 +145,43 @@ See https://docs.docker.com/go/buildx/ to install the buildx plugin.
                     )
                 )
         except (InvalidVersion, IndexError):
-            tools.console.warning(cls.UNKNOWN_DOCKER_VERSION_WARNING)
+            tools.console.warning_banner(
+                "Unable to determine the version of Docker",
+                """
+                    Briefcase will proceed, assuming everything is OK. If you
+                    experience problems, this is almost certainly the cause of those
+                    problems.
+
+                    Please report this as a bug at:
+
+                        https://github.com/beeware/briefcase/issues/new
+
+                    In your report, please including the output from running:
+
+                        $ docker --version
+
+                    from the command prompt.
+                """,
+            )
         except subprocess.CalledProcessError:
-            tools.console.warning(cls.DOCKER_INSTALLATION_STATUS_UNKNOWN_WARNING)
+            tools.console.warning_banner(
+                "Unable to determine if Docker is installed",
+                """
+                    Briefcase will proceed, assuming everything is OK. If you
+                    experience problems, this is almost certainly the cause of those
+                    problems.
+
+                    Please report this as a bug at:
+
+                        https://github.com/beeware/briefcase/issues/new
+
+                    In your report, please including the output from running:
+
+                        $ docker --version
+
+                    from the command prompt.
+                """,
+            )
         except OSError as e:
             # Docker executable doesn't exist
             raise BriefcaseCommandError(

--- a/tests/integrations/docker/test_Docker__verify.py
+++ b/tests/integrations/docker/test_Docker__verify.py
@@ -148,7 +148,10 @@ def test_docker_failure(mock_tools, user_mapping_run_calls, capsys):
 
     # console output
     output = capsys.readouterr()
-    assert "** WARNING: Unable to determine if Docker is installed" in output.out
+    assert (
+        "**            WARNING: Unable to determine if Docker is installed"
+        in output.out
+    )
     assert output.err == ""
 
 
@@ -185,7 +188,10 @@ def test_docker_unknown_version(mock_tools, user_mapping_run_calls, capsys):
 
     # console output
     output = capsys.readouterr()
-    assert "** WARNING: Unable to determine the version of Docker" in output.out
+    assert (
+        "**             WARNING: Unable to determine the version of Docker"
+        in output.out
+    )
     assert output.err == ""
 
 


### PR DESCRIPTION
Applied tools.console.warning_banner method for docker

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Codebase is full of long (legacy) warning messages. Example:
```

    warning = [
        f"""
*******************************************************************************
** {"WARNING: '" + app_name + "' uses PEP 621 `license.text` format":73} **
*******************************************************************************

    Briefcase now uses PEP 639 format for license definitions.
"""
    ]
```
But now we have tools.console.warning_banner method method to make it a standard.

* Towards #2559

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
