### PR TITLE
Handle simctl install progress before JSON output

### DIFF
--- a/changes/780.bugfix.md
+++ b/changes/780.bugfix.md
@@ -1,0 +1,1 @@
+Ignore simulator installation progress emitted before `simctl` JSON so the first iOS run after installing or updating simulator runtimes can still discover available devices.

--- a/src/briefcase/integrations/xcode.py
+++ b/src/briefcase/integrations/xcode.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from briefcase.exceptions import BriefcaseCommandError, CommandOutputParseError
 from briefcase.integrations.base import Tool, ToolCache
-from briefcase.integrations.subprocess import json_parser
+from briefcase.integrations.subprocess import JsonT, json_parser
 
 
 class DeviceState(enum.Enum):
@@ -16,6 +16,21 @@ class DeviceState(enum.Enum):
     BOOTED = 1
     SHUTTING_DOWN = 10
     UNKNOWN = 99
+
+
+def simctl_json_parser(simctl_output: str) -> JsonT:
+    """Parse JSON output from ``simctl``.
+
+    On first use after installing or updating simulator runtimes, ``simctl`` can prefix
+    its JSON payload with installation progress output.
+
+    :param simctl_output: command output to parse as JSON
+    """
+    json_start = simctl_output.find("{")
+    if json_start > 0:
+        simctl_output = simctl_output[json_start:]
+
+    return json_parser(simctl_output)
 
 
 class Xcode(Tool):
@@ -427,7 +442,7 @@ and install the simulator.
 
     try:
         simctl_data = tools.subprocess.parse_output(
-            json_parser,
+            simctl_json_parser,
             ["xcrun", "simctl", "list", "-j"],
         )
 
@@ -479,7 +494,7 @@ def get_device_state(tools: ToolCache, udid: str) -> str:
     """
     try:
         simctl_data = tools.subprocess.parse_output(
-            json_parser,
+            simctl_json_parser,
             ["xcrun", "simctl", "list", "devices", "-j", udid],
         )
 

--- a/tests/integrations/xcode/test_get_simulators.py
+++ b/tests/integrations/xcode/test_get_simulators.py
@@ -71,6 +71,19 @@ def test_simctl_output_parse_error(mock_tools, simulator):
         get_simulators(mock_tools, "iOS", simulator_location=simulator)
 
 
+def test_simctl_install_progress_before_json(mock_tools, simulator):
+    """Installation progress before simctl JSON output can be ignored."""
+    mock_tools.subprocess.check_output.return_value = (
+        "Install Started\n"
+        "1%.........20.........40.........60.........80.........Install Succeeded\n"
+        f"{simctl_result('no-runtimes')}"
+    )
+
+    simulators = get_simulators(mock_tools, "iOS", simulator_location=simulator)
+
+    assert simulators == {}
+
+
 def test_no_runtimes(mock_tools, simulator):
     """If there are no runtimes available, no simulators will be found."""
     mock_tools.subprocess.check_output.return_value = simctl_result("no-runtimes")


### PR DESCRIPTION
## Summary
- tolerate the installation progress banner that `xcrun simctl list -j` can emit before its JSON payload on first use after simulator installation or update
- keep the recovery scoped to `simctl` parsing rather than loosening every JSON parser in Briefcase
- add regression coverage for the prefixed-output case and a changelog fragment for #780

## Validation
- Not run locally
- Relying on the repository's remote CI for verification.

Closes #780