### PR TITLE
Refactor Java integration to use Console.warning_banner

### DIFF
--- a/changes/2559.misc.1.md
+++ b/changes/2559.misc.1.md
@@ -1,0 +1,1 @@
+Style Java integration warning banners consistently.

--- a/src/briefcase/integrations/java.py
+++ b/src/briefcase/integrations/java.py
@@ -105,7 +105,6 @@ class JDK(ManagedTool):
             return tools.java
 
         java = None
-        install_message = None
 
         if java_home := tools.os.environ.get("JAVA_HOME", ""):
             tools.console.debug("Evaluating JAVA_HOME...", prefix=cls.full_name)
@@ -115,95 +114,79 @@ class JDK(ManagedTool):
                 if version_str.split(".")[0] == cls.JDK_MAJOR_VER:
                     java = JDK(tools, java_home=Path(java_home))
                 else:
-                    install_message = f"""
-*************************************************************************
-** WARNING: JAVA_HOME does not point to a Java {cls.JDK_MAJOR_VER} JDK            **
-*************************************************************************
+                    tools.console.warning_banner(
+                        f"JAVA_HOME does not point to a Java {cls.JDK_MAJOR_VER} JDK",
+                        f"""
+                            Android requires a Java {cls.JDK_MAJOR_VER} JDK, but the
+                            location pointed to by the JAVA_HOME environment variable:
 
-    Android requires a Java {cls.JDK_MAJOR_VER} JDK, but the location pointed to by the
-    JAVA_HOME environment variable:
+                                {java_home}
 
-    {java_home}
+                            isn't a Java {cls.JDK_MAJOR_VER} JDK (it appears to be Java
+                            {version_str}).
 
-    isn't a Java {cls.JDK_MAJOR_VER} JDK (it appears to be Java {version_str}).
-
-    Briefcase will proceed using its own JDK instance.
-
-*************************************************************************
-"""
-
+                            Briefcase will proceed using its own JDK instance.
+                        """,
+                    )
             except OSError:
-                install_message = f"""
-*************************************************************************
-** WARNING: JAVA_HOME does not point to a JDK                          **
-*************************************************************************
+                tools.console.warning_banner(
+                    "JAVA_HOME does not point to a JDK",
+                    f"""
+                        The location pointed to by the JAVA_HOME environment variable:
 
-    The location pointed to by the JAVA_HOME environment variable:
+                            {java_home}
 
-    {java_home}
+                        does not appear to be a JDK. It may be a Java Runtime
+                        Environment.
 
-    does not appear to be a JDK. It may be a Java Runtime Environment.
+                        If JAVA_HOME is a JDK, ensure it is the root directory of the
+                        JDK instance such that $JAVA_HOME/bin/javac is a valid filepath.
 
-    If JAVA_HOME is a JDK, ensure it is the root directory of the JDK
-    instance such that $JAVA_HOME/bin/javac is a valid filepath.
-
-    Briefcase will proceed using its own JDK instance.
-
-*************************************************************************
-"""
-
+                        Briefcase will proceed using its own JDK instance.
+                    """,
+                )
             except subprocess.CalledProcessError:
-                install_message = f"""
-*************************************************************************
-** WARNING: Unable to invoke the Java compiler                         **
-*************************************************************************
+                tools.console.warning_banner(
+                    "Unable to invoke the Java compiler",
+                    f"""
+                        Briefcase received an unexpected error when trying to invoke
+                        javac, the Java compiler, at the location indicated by the
+                        JAVA_HOME environment variable.
 
-    Briefcase received an unexpected error when trying to invoke javac,
-    the Java compiler, at the location indicated by the JAVA_HOME
-    environment variable.
+                        Briefcase will continue by downloading and using its own JDK.
 
-    Briefcase will continue by downloading and using its own JDK.
+                        Please report this as a bug at:
 
-    Please report this as a bug at:
+                            https://github.com/beeware/briefcase/issues/new
 
-        https://github.com/beeware/briefcase/issues/new
+                        In your report, please including the output from running:
 
+                            {java_home}/bin/javac -version
 
-    In your report, please including the output from running:
-
-        {java_home}/bin/javac -version
-
-    from the command prompt.
-
-*************************************************************************
-"""
-
+                        from the command prompt.
+                    """,
+                )
             except IndexError:
-                install_message = f"""
-*************************************************************************
-** WARNING: Unable to determine the version of Java that is installed  **
-*************************************************************************
+                tools.console.warning_banner(
+                    "Unable to determine the version of Java that is installed",
+                    f"""
+                        Briefcase was unable to interpret the version information
+                        returned by the Java compiler at the location indicated by the
+                        JAVA_HOME environment variable.
 
-    Briefcase was unable to interpret the version information returned
-    by the Java compiler at the location indicated by the JAVA_HOME
-    environment variable.
+                        Briefcase will continue by downloading and using its own JDK.
 
-    Briefcase will continue by downloading and using its own JDK.
+                        Please report this as a bug at:
 
-    Please report this as a bug at:
+                            https://github.com/beeware/briefcase/issues/new
 
-        https://github.com/beeware/briefcase/issues/new
+                        In your report, please including the output from running:
 
+                            {java_home}/bin/javac -version
 
-    In your report, please including the output from running:
-
-        {java_home}/bin/javac -version
-
-    from the command prompt.
-
-*************************************************************************
-"""
-
+                        from the command prompt.
+                    """,
+                )
         # macOS has a helpful system utility to determine JAVA_HOME. Try it.
         elif tools.host_os == "Darwin":
             tools.console.debug(
@@ -227,10 +210,6 @@ class JDK(ManagedTool):
                     pass  # do not alert user if macOS found an unqualified JDK
 
         if java is None:
-            # Inform the user if the user-specified JDK wasn't valid
-            if install_message:
-                tools.console.warning(install_message)
-
             # Use the Briefcase JDK install
             java_home = tools.base_path / cls.JDK_INSTALL_DIR_NAME
 

--- a/tests/integrations/java/test_JDK__verify.py
+++ b/tests/integrations/java/test_JDK__verify.py
@@ -504,7 +504,7 @@ def test_successful_jdk_download(
     # Console output contains a warning about the bad JDK location
     output = capsys.readouterr()
     assert output.err == ""
-    assert "** WARNING: JAVA_HOME does not point to a Java 17 JDK" in output.out
+    assert "WARNING: JAVA_HOME does not point to a Java 17 JDK" in output.out
 
     # Download was invoked
     mock_tools.file.download.assert_called_with(


### PR DESCRIPTION
Use `Console.warning_banner` to abstract formatting away from `src/briefcase/integrations/java.py`. This helps maintain a consistent style and does not mess up indentation.

Warning banners will now centre titles (previously left aligned). Test case updated to match.

* Towards #2559.
* Similar to #2835

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted by: Claude Opus 4.7