### PR TITLE
Require app name to be a valid python identifier

### DIFF
--- a/changes/2127.misc.md
+++ b/changes/2127.misc.md
@@ -1,0 +1,1 @@
+Disallow app names that are not valid Python identifiers.

--- a/docs/en/reference/configuration.md
+++ b/docs/en/reference/configuration.md
@@ -48,7 +48,7 @@ The base `[tool.briefcase]` section declares settings that project specific, or 
 
 Configuration options for a specific application.
 
-`<app name>` must adhere to a valid Python distribution name as specified in [PEP508](https://peps.python.org/pep-0508/#names). The app name must also *not* be a reserved word in Python, Java or JavaScript (i.e., app names like `switch` or `pass` would not be valid); and it may not include any of the [filenames prohibited by Windows](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions) (i.e., `CON`, `PRN`, or `LPT1`).
+`<app name>` (with all of its hyphens replaced with underscores) must be a valid Python identifier, and adhere to a valid Python distribution name as specified in [PEP508](https://peps.python.org/pep-0508/#names). The app name must also *not* be a reserved word in Python, Java or JavaScript (i.e., app names like `switch` or `pass` would not be valid); and it may not include any of the [filenames prohibited by Windows](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions) (i.e., `CON`, `PRN`, or `LPT1`).
 
 ### `[tool.briefcase.app.<app name>.<platform>]`
 

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -19,7 +19,7 @@ else:  # pragma: no-cover-if-gte-py311
     import tomli as tomllib
 
 from briefcase.bootstraps import EmptyBootstrap
-from briefcase.config import make_class_name, validate_url
+from briefcase.config import APP_NAME_SPEC, make_class_name, validate_url
 from briefcase.exceptions import BriefcaseCommandError
 
 
@@ -108,31 +108,40 @@ class ConvertCommand(NewCommand):
         """
         intro = (
             "We need a name that can serve as a machine-readable Python package name "
-            "for your application. This name must be PEP508-compliant - that means the "
-            "name may only contain letters, numbers, hyphens and underscores; it can't "
-            "contain spaces or punctuation, and it can't start with a hyphen or "
-            "underscore."
+            f"for your application. {APP_NAME_SPEC}"
         )
 
         default = "hello-world"
-        if (
-            "name" in self.pep621_data
-            and is_valid_app_name(self.pep621_data["name"])
-            and override_value is None
-        ):
-            app_name = canonicalize_name(self.pep621_data["name"])
+
+        project_name = self.pep621_data.get("name")
+        if project_name and is_valid_app_name(project_name) and override_value is None:
+            # Project name is usable as-is (e.g., "foobar", "foo-bar")
             self.console.divider(title="App name")
             self.console.prompt()
             self.console.prompt(
-                f"Using value from PEP621 formatted pyproject.toml {app_name!r}"
+                f"Using value from PEP621 formatted pyproject.toml {project_name!r}"
             )
-            return app_name
-
-        if is_valid_app_name(self.base_path.name):  # Directory name is normalised
-            default = canonicalize_name(self.base_path.name)
+            return project_name
+        elif project_name and is_valid_app_name(
+            canonicalized_name := canonicalize_name(project_name)
+        ):
+            # Canonicalized project name is valid
+            # (e.g., "test.name" -> "test-name", "test-app_name" -> "test-app-name")
+            intro += (
+                "\n\nBased on the project name from your PEP621 formatted "
+                f"pyproject.toml, we suggest an app name of '{canonicalized_name}', "
+                "but you can use another name if you want."
+            )
+            default = canonicalized_name
+        elif is_valid_app_name(
+            canonicalized_name := canonicalize_name(self.base_path.name)
+        ):
+            # Canonicalized project name isn't valid
+            # Fall back to canonicalized directory name
+            default = canonicalized_name
             intro += (
                 "\n\n"
-                f"Based on your PEP508 formatted directory name, we suggest an "
+                f"Based on your canonicalized directory name, we suggest an "
                 f"app name of '{default}', but you can use another name if you want."
             )
 

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -8,6 +8,8 @@ from importlib import metadata
 
 from briefcase.bootstraps import BaseGuiBootstrap
 from briefcase.config import (
+    APP_NAME_SPEC,
+    get_module_name,
     is_valid_app_name,
     is_valid_bundle_identifier,
     make_class_name,
@@ -170,12 +172,7 @@ class NewCommand(BaseCommand):
         if not is_valid_app_name(candidate):
             raise ValueError(
                 self.console.textwrap(
-                    f"{candidate!r} is not a valid app name.\n"
-                    "\n"
-                    "App names must not be reserved keywords such as 'and', 'for' and "
-                    "'while'. They must also be PEP508 compliant (i.e., they can only "
-                    "include letters, numbers, '-' and '_'; must start with a letter; "
-                    "and cannot end with '-' or '_')."
+                    f"{candidate!r} is not a valid app name.\n\n{APP_NAME_SPEC}"
                 )
             )
 
@@ -190,7 +187,7 @@ class NewCommand(BaseCommand):
         :param app_name: The app name
         :returns: The app's module name.
         """
-        return app_name.replace("-", "_")
+        return get_module_name(app_name)
 
     def validate_bundle(self, candidate):
         """Determine if the bundle identifier is valid.
@@ -312,10 +309,7 @@ class NewCommand(BaseCommand):
                 "Next, we need a name that can serve as a machine-readable Python "
                 "package name for your application.\n"
                 "\n"
-                "This name must be PEP508-compliant - that means the name may only "
-                "contain letters, numbers, hyphens and underscores; it can't contain "
-                "spaces or punctuation, and it can't start with a hyphen or "
-                "underscore.\n"
+                f"{APP_NAME_SPEC}\n"
                 "\n"
                 "Based on your formal name, we suggest an app name of "
                 f"{default_app_name!r}, but you can use another name if you want."

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -33,10 +33,18 @@ from .exceptions import BriefcaseConfigError, InvalidVersionError
 # https://github.com/pypa/packaging/blob/24.0/src/packaging/_tokenizer.py#L80
 PEP508_NAME_RE = re.compile(r"^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])$")
 
+APP_NAME_SPEC = (
+    "App names must not be reserved keywords such as 'and', 'for' and "
+    "'while'. They must also be valid Python identifiers when hyphens "
+    "are replaced by underscores, and PEP508 compliant (i.e., they can "
+    "only include letters, numbers, '-' and '_'; must start with a letter; "
+    "and cannot end with '-' or '_')."
+)
+
 
 def is_valid_pep508_name(app_name):
     """Determine if the name is valid by PEP508 rules."""
-    return PEP508_NAME_RE.match(app_name)
+    return PEP508_NAME_RE.fullmatch(app_name)
 
 
 def is_reserved_keyword(app_name):
@@ -44,8 +52,17 @@ def is_reserved_keyword(app_name):
     return keyword.iskeyword(app_name.lower()) or app_name.lower() in RESERVED_WORDS
 
 
+def get_module_name(app_name: str) -> str:
+    return app_name.replace("-", "_")
+
+
 def is_valid_app_name(app_name):
-    return not is_reserved_keyword(app_name) and is_valid_pep508_name(app_name)
+    module_name = get_module_name(app_name)
+    return (
+        not is_reserved_keyword(app_name)
+        and is_valid_pep508_name(module_name)
+        and module_name.isidentifier()
+    )
 
 
 def make_class_name(formal_name):
@@ -487,7 +504,7 @@ class AppConfig(BaseConfig):
         This is derived from the name, but:
         * all `-` have been replaced with `_`.
         """
-        return self.app_name.replace("-", "_")
+        return get_module_name(self.app_name)
 
     @property
     def bundle_name(self):
@@ -638,12 +655,7 @@ class DraftAppConfig(AppConfig):
 
         if not is_valid_app_name(self.app_name):
             raise BriefcaseConfigError(
-                f"{self.app_name!r} is not a valid app name."
-                f"\n\n"
-                "App names must not be reserved keywords such as 'and', 'for' and "
-                "'while'. They must also be PEP508 compliant (i.e., they can only "
-                "include letters, numbers, '-' and '_'; must start with a letter; "
-                "and cannot end with '-' or '_')."
+                f"{self.app_name!r} is not a valid app name.\n\n{APP_NAME_SPEC}"
             )
 
         if not is_valid_bundle_identifier(self.bundle_identifier):

--- a/tests/commands/convert/test_input_app_name.py
+++ b/tests/commands/convert/test_input_app_name.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from ...utils import NoMatchString, PartialMatchString
 
 
@@ -11,17 +13,24 @@ def test_override_is_used(convert_command):
     assert convert_command.input_app_name("OVERRIDE") == "OVERRIDE"
 
 
-def test_no_pep621_data(convert_command, monkeypatch):
+@pytest.mark.parametrize(
+    ("dir_name", "expected_suggestion"),
+    [
+        ("test-app-name", "test-app-name"),
+        ("test_app-name", "test-app-name"),
+    ],
+)
+def test_no_pep621_data(convert_command, monkeypatch, dir_name, expected_suggestion):
     """The app directory is used if there is no PEP621-name."""
     mock_text_question = MagicMock()
     monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
-    convert_command.base_path /= "test-app-name"
+    convert_command.base_path /= dir_name
     convert_command.input_app_name(None)
 
     mock_text_question.assert_called_once_with(
         intro=PartialMatchString(
-            "Based on your PEP508 formatted directory name, we suggest an app name of"
-            " 'test-app-name'"
+            "Based on your canonicalized directory name, we suggest an app name of"
+            f" '{expected_suggestion}'"
         ),
         description="App Name",
         default="test-app-name",
@@ -38,11 +47,26 @@ def test_valid_pep621_app_name(convert_command):
     assert convert_command.input_app_name(None) == "test-name"
 
 
-def test_pep621_name_is_canonicalized(convert_command):
+def test_pep621_name_is_canonicalized(convert_command, monkeypatch):
+    """The canonicalized version of the PEP621-name is used if the name is present and
+    is not valid, but its canonicalized version is."""
+    mock_text_question = MagicMock()
+    monkeypatch.setattr(convert_command.console, "text_question", mock_text_question)
     (convert_command.base_path / "pyproject.toml").write_text(
         '[project]\nname="test.name"', encoding="utf-8"
     )
-    assert convert_command.input_app_name(None) == "test-name"
+    convert_command.input_app_name(None)
+
+    mock_text_question.assert_called_once_with(
+        intro=PartialMatchString(
+            "Based on the project name from your PEP621 formatted pyproject.toml, "
+            "we suggest an app name of 'test-name'"
+        ),
+        description="App Name",
+        default="test-name",
+        validator=convert_command.validate_app_name,
+        override_value=None,
+    )
 
 
 def test_invalid_hint_app_name(convert_command, monkeypatch):
@@ -55,7 +79,7 @@ def test_invalid_hint_app_name(convert_command, monkeypatch):
 
     mock_text_question.assert_called_once_with(
         intro=NoMatchString(
-            "Based on your PEP508 formatted directory name, we suggest an app name of"
+            "Based on your canonicalized directory name, we suggest an app name of"
             " 'test-app-name'"
         ),
         description="App Name",
@@ -74,7 +98,7 @@ def test_hint_is_canonicalized(convert_command, monkeypatch):
 
     mock_text_question.assert_called_once_with(
         intro=PartialMatchString(
-            "Based on your PEP508 formatted directory name, we suggest an app name of"
+            "Based on your canonicalized directory name, we suggest an app name of"
             " 'test-app-name'"
         ),
         description="App Name",

--- a/tests/commands/new/test_validate_app_name.py
+++ b/tests/commands/new/test_validate_app_name.py
@@ -7,7 +7,6 @@ import pytest
         "helloworld",
         "helloWorld",
         "hello42world",
-        "42helloworld",  # ?? Are we sure this is correct?
         "hello_world",
         "hello-world",
     ],
@@ -36,6 +35,9 @@ def test_valid_app_name(new_command, name):
         "false",  # Python, Java and Javascript keyword (in different cases)
         "False",  # Python, Java and Javascript keyword (in different cases)
         "FALSE",  # Python, Java and Javascript keyword (in different cases)
+        "42helloworld",  # Not a python identifier
+        "helloworld_",  # trailing underscore
+        "helloworld-",  # trailing hyphen
     ],
 )
 def test_invalid_app_name(new_command, name, tmp_path):

--- a/tests/config/test_AppConfig.py
+++ b/tests/config/test_AppConfig.py
@@ -216,6 +216,7 @@ def test_valid_app_name(name):
         "myApp-",  # end hyphen
         "_myApp",  # initial underscore
         "myApp_",  # end underscore
+        "2myApp",  # leading digit
     ],
 )
 def test_invalid_app_name(name):

--- a/tests/config/test_is_valid_app_name.py
+++ b/tests/config/test_is_valid_app_name.py
@@ -9,7 +9,6 @@ from briefcase.config import is_valid_app_name
         "helloworld",
         "helloWorld",
         "hello42world",
-        "42helloworld",
         "hello_world",
         "hello-world",
     ],
@@ -34,6 +33,7 @@ def test_is_valid_app_name(name):
         "main",
         "socket",
         "test",
+        "42helloworld",
         # ı, İ and K (i.e. 0x212a) are valid ASCII when made lowercase # noqa: RUF003
         # and as such are accepted by the official PEP 508 regex. They are rejected
         # here to ensure compliance with the regex that is used in practice.


### PR DESCRIPTION
<!--- Describe your changes in detail -->

This PR adds the requirement that app names with all hyphens replaced by underscores must be valid Python identifiers, since they are used to create modules. Currently, it is possible to create an app whose name is not a legal python identifier, which leads to issues running the app.

Also pull out the natural language rules for `app_name` into one constant, and pull out the "app name to module name" transformation into one function.

I kept the PEP 508 regex check because there are existing test cases that rely on it. For example these, which check that an app name ending in a hyphen or underscore is invalid: https://github.com/beeware/briefcase/blob/fb0d6ee631e75dfccdbf24d99feb20f9822c8ec8/tests/config/test_AppConfig.py#L216-L218
and these, which check that app names with nonstandard characters are invalid: https://github.com/beeware/briefcase/blob/fb0d6ee631e75dfccdbf24d99feb20f9822c8ec8/tests/config/test_is_valid_app_name.py#L37-L42


Fixes #2127

## Testing

### `briefcase new`
`briefcase new` does not allow creating apps with invalid names:

```
(.venv) smcinnis@smcinnis-vm [~/pycon/sprints/new_test] >briefcase new -Q app_name=1hello --no-input

Using override value '1hello'

'1hello' is not a valid app name.

App names must not be reserved keywords such as 'and', 'for' and 'while'. They
must also be valid Python identifiers when hyphens are replaced by
underscores, and PEP508 compliant (i.e., they can only include letters,
numbers, '-' and '_'; must start with a letter; and cannot end with '-' or
'_').

Log saved to /home/smcinnis/pycon/sprints/new_test/logs/briefcase.2026_05_18-21_56_52.new.log
```

```
(.venv) smcinnis@smcinnis-vm [~/pycon/sprints/new_test] >briefcase new

Let's build a new Briefcase app!
...
App Name [helloworld]: 42world

Invalid value: '42world' is not a valid app name.

App names must not be reserved keywords such as 'and', 'for' and 'while'. They
must also be valid Python identifiers when hyphens are replaced by
underscores, and PEP508 compliant (i.e., they can only include letters,
numbers, '-' and '_'; must start with a letter; and cannot end with '-' or
'_').

App Name [helloworld]:
```


### `briefcase convert`

`briefcase convert` provides a sane default and prompts for input if the project name is not valid, but it would be if it were canonicalized:
```
(.venv) smcinnis@smcinnis-vm [~/pycon/sprints/test/green-eggs] >grep name pyproject.toml 
name = "green.eggs"
(.venv) smcinnis@smcinnis-vm [~/pycon/sprints/test/green-eggs] >briefcase convert

Let's setup an existing project as a Briefcase app!


-- App Name ------------------------------------------------------------------

We need a name that can serve as a machine-readable Python package name for
your application. App names must not be reserved keywords such as 'and', 'for'
and 'while'. They must also be valid Python identifiers when hyphens are
replaced by underscores, and PEP508 compliant (i.e., they can only include
letters, numbers, '-' and '_'; must start with a letter; and cannot end with
'-' or '_').

Based on the project name from your PEP621 formatted pyproject.toml, we
suggest an app name of 'green-eggs', but you can use another name if you want.

App Name [green-eggs]: 
```

It falls back to the directory name if the canonicalized project name is not valid, but the canonicalized directory name is:
```
(.venv) smcinnis@smcinnis-vm [~/pycon/sprints/test/green-eggs] >grep name pyproject.toml 
name = "17green.eggs"
(.venv) smcinnis@smcinnis-vm [~/pycon/sprints/test/green-eggs] >briefcase convert

Let's setup an existing project as a Briefcase app!


-- App Name ------------------------------------------------------------------

We need a name that can serve as a machine-readable Python package name for
your application. App names must not be reserved keywords such as 'and', 'for'
and 'while'. They must also be valid Python identifiers when hyphens are
replaced by underscores, and PEP508 compliant (i.e., they can only include
letters, numbers, '-' and '_'; must start with a letter; and cannot end with
'-' or '_').

Based on your canonicalized directory name, we suggest an app name of 'green-
eggs', but you can use another name if you want.

App Name [green-eggs]: 
```

And it does not fall back to the directory if the canonicalized directory name is not valid:
```
(.venv) smcinnis@smcinnis-vm [~/pycon/sprints/test/17green-eggs] >briefcase convert

Let's setup an existing project as a Briefcase app!


-- App Name ------------------------------------------------------------------

We need a name that can serve as a machine-readable Python package name for
your application. App names must not be reserved keywords such as 'and', 'for'
and 'while'. They must also be valid Python identifiers when hyphens are
replaced by underscores, and PEP508 compliant (i.e., they can only include
letters, numbers, '-' and '_'; must start with a letter; and cannot end with
'-' or '_').

App Name [hello-world]:
```



## PR Checklist:
- [X] I will abide by the BeeWare Code of Conduct
- [X] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
