### PR TITLE
Fix typing errors in console.py

### DIFF
--- a/changes/2845.misc.md
+++ b/changes/2845.misc.md
@@ -1,0 +1,1 @@
+Handle edge cases in the console more robustly.

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -514,17 +514,17 @@ class Console:
         :param label: An identifying label for the thread that has raised the
             stacktrace. Defaults to the main thread.
         """
-        _, exception, _ = sys.exc_info()
-        if exception is None:
+        exc_type, exc_value, exc_trace = sys.exc_info()
+        if exc_value is None:
             return
 
-        if isinstance(exception, BriefcaseError):
-            self.skip_log = exception.skip_logfile
+        if isinstance(exc_value, BriefcaseError):
+            self.skip_log = exc_value.skip_logfile
 
         trace = Traceback.extract(
-            type(exception),
-            exception,
-            exception.__traceback__,
+            exc_type,  # ty:ignore[invalid-argument-type]
+            exc_value,
+            exc_trace,
             show_locals=True,
         )
         self.stacktraces.append((label, trace))

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -9,12 +9,12 @@ import sys
 import textwrap
 import time
 import traceback
-from collections.abc import Callable, Collection, Iterable, Mapping
+from collections.abc import Callable, Generator, Iterable, Mapping, Sequence
 from contextlib import contextmanager
 from datetime import datetime
 from enum import IntEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from rich.console import Console as RichConsole
 from rich.control import strip_control_codes
@@ -31,7 +31,7 @@ from rich.traceback import Trace, Traceback
 
 from briefcase import __version__
 from briefcase.config import parse_boolean
-from briefcase.exceptions import InputDisabled
+from briefcase.exceptions import BriefcaseError, InputDisabled
 
 # Max width for printing to console; matches argparse's default width
 MAX_TEXT_WIDTH = max(min(shutil.get_terminal_size().columns, 80) - 2, 20)
@@ -69,8 +69,8 @@ class RichConsoleHighlighter(RegexHighlighter):
     consistent with a default HTML stylesheet, but otherwise renders content as-is.
     """
 
-    base_style = "repr."
-    highlights: Collection[str] = [
+    base_style: ClassVar[str] = "repr."
+    highlights: ClassVar[Sequence[str]] = [
         r"(?P<url>(file|https|http|ws|wss)://[-0-9a-zA-Z$_+!`(),.?/;:&=%#~]*)"
     ]
 
@@ -207,8 +207,9 @@ class Console:
         self.is_console_controlled = False
 
     def close(self):
-        self._dev_null.close()
-        self._dev_null = None
+        if self._dev_null:
+            self._dev_null.close()
+            self._dev_null = None
 
     def __del__(self):
         if self._dev_null:
@@ -314,7 +315,7 @@ class Console:
         title: str | None = None,
         message: str | None = None,
         width: int = 80,
-    ) -> str:
+    ) -> None:
         """The title or message can be provided as a single or as multiline string. Any
         common leading whitespace from each line will be removed.
 
@@ -326,7 +327,6 @@ class Console:
         :param title: The title of the box. If provided, appears centered at the top.
         :param message: The message to format inside the box.
         :param width: The total width of the box in characters. Defaults to 80.
-        :return: The formatted message enclosed in a bordered box.
         """
         BORDER_LINE = "*" * width
         lines_array = ["", BORDER_LINE]
@@ -514,13 +514,20 @@ class Console:
         :param label: An identifying label for the thread that has raised the
             stacktrace. Defaults to the main thread.
         """
-        exc_info = sys.exc_info()
-        try:
-            self.skip_log = exc_info[1].skip_logfile
-        except AttributeError:
-            pass
+        _, exception, _ = sys.exc_info()
+        if exception is None:
+            return
 
-        self.stacktraces.append((label, Traceback.extract(*exc_info, show_locals=True)))
+        if isinstance(exception, BriefcaseError):
+            self.skip_log = exception.skip_logfile
+
+        trace = Traceback.extract(
+            type(exception),
+            exception,
+            exception.__traceback__,
+            show_locals=True,
+        )
+        self.stacktraces.append((label, trace))
 
     def add_log_file_extra(self, func: Callable[[], object]):
         """Register a function to be called in the event that a log file is written.
@@ -662,7 +669,7 @@ class Console:
         should be specifically disabled in non-interactive sessions.
         """
         # `sys.__stdout__` is used because Rich captures and redirects `sys.stdout`
-        return os.isatty(sys.__stdout__.fileno())
+        return sys.__stdout__ is not None and os.isatty(sys.__stdout__.fileno())
 
     @property
     def is_color_enabled(self):
@@ -699,7 +706,7 @@ class Console:
         *,
         transient: bool = False,
         markup: bool = False,
-    ) -> NotDeadYet:
+    ) -> Generator[NotDeadYet]:
         """Activates the Wait Bar as a context manager.
 
         If the Wait Bar is already active, then its message is updated for the new
@@ -774,7 +781,9 @@ class Console:
         """
         # Preserve current console state
         is_output_controlled = self.is_console_controlled
-        is_wait_bar_running = self._wait_bar and self._wait_bar.live.is_started
+        is_wait_bar_running = (
+            self._wait_bar is not None and self._wait_bar.live.is_started
+        )
 
         # Stop any active dynamic console elements
         if is_wait_bar_running:
@@ -842,7 +851,7 @@ class Console:
 
         return input_value
 
-    def input_boolean(self, question: str, default: bool = False) -> bool:
+    def input_boolean(self, question: str, default: bool | None = False) -> bool:
         """Get a boolean input from user, in the form of y/n.
 
         The user might press "y" for true or "n" for false. If input is disabled,

--- a/tests/console/test_Log.py
+++ b/tests/console/test_Log.py
@@ -162,6 +162,19 @@ def test_capture_stacktrace_for_briefcaseerror(console, skip_logfile):
     assert console.skip_log is skip_logfile
 
 
+def test_capture_stacktrace_no_exception(console):
+    """capture_stacktrace is a no-op when there is no active exception."""
+    console.capture_stacktrace()
+
+    assert console.stacktraces == []
+
+
+def test_close_is_idempotent(console):
+    """Close() can be called more than once."""
+    console.close()
+    console.close()
+
+
 def test_save_log_to_file_do_not_log(console, command):
     """Nothing is done to save log if no command or --log wasn't passed."""
     console.save_log_to_file(command=None)


### PR DESCRIPTION
`src/briefcase/console.py` contained a few type errors according to `ty`. These have been fixed.

Behaviour changes:

- If `Console.close` is called more than once on the same instance, the method will do nothing instead of throwing an `AttributeError`.
- If the exception being captured by `Console.capture_stacktrace` has attribute `skip_logfile` yet is not a `BriefcaseError`, `skip_logfile` will be ignored. An alternative implementation more amiable to duck typing would be a `hasattr + isinstance` check.
- If `Console.capture_stacktrace` is called before an exception has been thrown, it will do nothing instead of throwing an `AttributeError` (due to implementation details of `rich` v15.0.0).
- If `sys.__stdout__ is None` then `Console.is_interactive` will return `False` instead of throwing a `AttributeError`.

I don't think these branches are taken under normal execution, so there should be no runtime impact. Corresponding tests have been added.

## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: Claude Opus 4.7
