### PR TITLE
Clarify debug docs requirement updates

### DIFF
--- a/changes/2621.doc.md
+++ b/changes/2621.doc.md
@@ -1,0 +1,1 @@
+Clarified that bundled app debug workflows need `-r` / `--update-requirements` when switching an existing app into debug mode.

--- a/docs/en/how-to/debugging/pdb.md
+++ b/docs/en/how-to/debugging/pdb.md
@@ -16,19 +16,19 @@ This is currently an **experimental feature** that is only supported on Windows,
 
 To debug a bundled app, add `breakpoint()` somewhere in your code where the debugger should halt.
 
-Your app must then be modified to include a bootstrap that will connect to the VS Code debugger. This is done by passing the `--debug pdb` option to `briefcase build`:
+Your app must then be modified to include a bootstrap that will connect to the debugger. This is done by passing the `--debug pdb` option to `briefcase build`:
 
 ```console
-$ briefcase build --debug pdb
+$ briefcase build -r --debug pdb
 ```
 
 To build a mobile app, include the platform name in the `build` command - for example:
 
 ```console
-$ briefcase build iOS --debug pdb
+$ briefcase build iOS -r --debug pdb
 ```
 
-This will build your app in debug mode, adding [`remote-pdb`](https://pypi.org/project/remote-pdb/), and a package that automatically starts `remote-pdb` on startup of your bundled app.
+The `-r` option ensures that the debugger support package is installed when switching an existing app into debug mode. This will build your app in debug mode, adding [`remote-pdb`](https://pypi.org/project/remote-pdb/), and a package that automatically starts `remote-pdb` on startup of your bundled app.
 
 You can then run your app in debug mode:
 

--- a/docs/en/how-to/debugging/vscode.md
+++ b/docs/en/how-to/debugging/vscode.md
@@ -47,16 +47,16 @@ This is currently an **experimental feature** that is only supported on Windows,
 To debug a bundled app, the app must be modified to include a bootstrap that will connect to the VS Code debugger. This is done by passing the `--debug debugpy` option to `briefcase build`:
 
 ```console
-$ briefcase build --debug debugpy
+$ briefcase build -r --debug debugpy
 ```
 
 To build a mobile app, include the platform name in the `build` command - for example:
 
 ```console
-$ briefcase build iOS --debug debugpy
+$ briefcase build iOS -r --debug debugpy
 ```
 
-This will build your app in debug mode and add [debugpy](https://code.visualstudio.com/docs/debugtest/debugging#_debug-console-repl), and a package that automatically starts `debugpy` at the startup of your bundled app.
+The `-r` option ensures that the debugger support package is installed when switching an existing app into debug mode. This will build your app in debug mode and add [debugpy](https://code.visualstudio.com/docs/debugtest/debugging#_debug-console-repl), and a package that automatically starts `debugpy` at the startup of your bundled app.
 
 Then, select "Open Configurations" from the "Run" menu, and add a new debug configuration to your `.vscode/launch.json` file:
 

--- a/docs/en/how-to/testing/x11passthrough.md
+++ b/docs/en/how-to/testing/x11passthrough.md
@@ -4,7 +4,7 @@ Briefcase can use Docker to build apps for Linux distributions other than the di
 
 # X Window System Background
 
-Linux distributions use either the [X Window System](https://www.x.org/) (sometimes called X or X11) or [Wayland](https://wayland.freedesktop.org/) to manage their graphical displays. X11 is the older of the two; Wayland maintains compatibility with the [X11 protocol](https://www.x.org/releases/X11R7.7/doc/xproto/x11protocol.html) for backwards compatibility.
+Linux distributions use either the [X Window System](https://www.x.org/releases/X11R7.7/) (sometimes called X or X11) or [Wayland](https://wayland.freedesktop.org/) to manage their graphical displays. X11 is the older of the two; Wayland maintains compatibility with the [X11 protocol](https://www.x.org/releases/X11R7.7/doc/xproto/x11protocol.html) for backwards compatibility.
 
 The X11 protocol operates in a client/server framework; any application that wishes to display a window or receive user input will send and receive commands with an X server.
 

--- a/docs/en/reference/commands/build.md
+++ b/docs/en/reference/commands/build.md
@@ -109,6 +109,6 @@ This is an **experimental** new feature, that is currently only supported on Win
 
 This option may slow down the app a little bit.
 
-If you have previously run the app in "normal" mode, you may need to pass `-r` / `--update-requirements` the first time you build in debug mode to ensure that the debugger is embedded in your bundled app.
+If you have previously run the app in "normal" mode, you must pass `-r` / `--update-requirements` the first time you build in debug mode to ensure that the debugger is embedded in your bundled app.
 
 The selected debugger in `build --debug <debugger>` has to match the selected debugger in `run --debug <debugger>`.

--- a/docs/en/reference/commands/run.md
+++ b/docs/en/reference/commands/run.md
@@ -113,6 +113,8 @@ This is an **experimental** new feature, that is currently only supported on Win
 
 The selected debugger in `run --debug <debugger>` has to match the selected debugger in `build --debug <debugger>`.
 
+If you have previously run the app in "normal" mode, first rebuild the app with `briefcase build -r --debug <debugger>`, or pass `-r` / `--update-requirements` to `briefcase run --debug <debugger>`, to ensure that the debugger is embedded in your bundled app.
+
 ## `--debugger-host <host>`
 
 Specifies the host of the socket connection for the debugger. This option is only used when the `--debug <debugger>` option is specified. The default value is `localhost`.


### PR DESCRIPTION
## Summary

- Update bundled PDB and VS Code debug workflows to include `-r` when building in debug mode.
- Clarify the build and run command references so existing normal-mode apps refresh requirements before debug mode.
- Add a documentation changelog fragment.
- Refresh a stale X.org reference in the X11 passthrough docs so URL lint can complete.

Closes #2621.

## Verification

- `rg -q "briefcase build -r --debug pdb" docs/en/how-to/debugging/pdb.md` failed before the docs change and passes after it.
- `rg -q "briefcase build -r --debug debugpy" docs/en/how-to/debugging/vscode.md` failed before the docs change and passes after it.
- `PATH=$PWD/venv/bin:$PATH SSL_CERT_FILE=$(venv/bin/python -m certifi) build_md_translations en`
- `PATH=$PWD/venv/bin:$PATH markdown-checker docs/en/how-to/debugging/pdb.md docs/en/how-to/debugging/vscode.md docs/en/reference/commands/build.md docs/en/reference/commands/run.md --func check_broken_paths`
- `PATH=$PWD/venv/bin:$PATH markdown-checker docs/en/how-to/debugging/pdb.md docs/en/how-to/debugging/vscode.md docs/en/reference/commands/build.md docs/en/reference/commands/run.md --func check_broken_urls --skip-urls-containing=https://github.com/beeware,https://github.com/astral-sh,https://github.com/freakboy3742,https://github.com/toml-lang,https://github.com/pypa,https://github.com/linuxdeploy,https://www.rfc-editor.org/rfc/`
- `PATH=$PWD/venv/bin:$PATH markdown-checker docs/en/how-to/testing/x11passthrough.md --func check_broken_urls --skip-urls-containing=https://github.com/beeware,https://github.com/astral-sh,https://github.com/freakboy3742,https://github.com/toml-lang,https://github.com/pypa,https://github.com/linuxdeploy,https://www.rfc-editor.org/rfc/`
- `git diff --check`

## AI-assisted work
This change was prepared with AI assistance and manually reviewed.
