### PR TITLE
Add CI workflow to check PR template content.

### DIFF
--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -1,0 +1,10 @@
+name: PR Checklist
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check-pr-template:
+    name: Check PR template
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,4 +34,4 @@ We require that all new features have full user documentation. We have a [docume
 
 ### Pull Requests
 
-We have a [process for submitting a PR](https://briefcase.beeware.org/en/latest/how-to/contribute/how/submit-pr/) that all contributions must follow.
+We have a [process for submitting a PR](https://briefcase.beeware.org/en/latest/how-to/contribute/how/submit-pr/) that all contributions must follow. This includes the use of a [pull request template](https://github.com/beeware/.github/blob/main/.github/pull_request_template.md) that *all* pull requests must include and complete as appropriate.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Briefcase is part of the [BeeWare suite](https://beeware.org). You can talk to t
 - [Discord](https://beeware.org/bee/chat/)
 - The Briefcase [GitHub Discussions forum](https://github.com/beeware/briefcase/discussions)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 

--- a/changes/2852.misc.md
+++ b/changes/2852.misc.md
@@ -1,0 +1,1 @@
+A CI check for the PR template has been added.


### PR DESCRIPTION
Adds an automated PR template check to CI workflows.

Also corrects some minor linking issues found while creating the upstream .github PR.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
