### PR TITLE
Miscellaneous improvements to MSI installers

### DIFF
--- a/changes/2781.feature.md
+++ b/changes/2781.feature.md
@@ -1,0 +1,1 @@
+MSI post-install scripts can now identify if they are running unattended.

--- a/changes/2781.feature.md
+++ b/changes/2781.feature.md
@@ -1,1 +1,1 @@
-MSI post-install scripts can now identify if they are running unattended.
+MSI post-install and pre-uninstall scripts can now identify if they are running unattended.

--- a/changes/2783.feature.md
+++ b/changes/2783.feature.md
@@ -1,0 +1,1 @@
+MSI installers now provide the user the ability to check disk space requirements prior to install.

--- a/changes/2789.feature.md
+++ b/changes/2789.feature.md
@@ -1,0 +1,1 @@
+Windows MSIs with a post-install or pre-uninstall script will no longer display a console window when running in quiet mode. Script output will be captured by the installer log.

--- a/docs/en/reference/platforms/windows/index.md
+++ b/docs/en/reference/platforms/windows/index.md
@@ -223,7 +223,10 @@ A Boolean describing the initial value of the option in the GUI. If not provided
 
 When an installer option is defined, the value of the option will be made available to the post-install or pre-uninstall script as an environment variable. For example, if you define an option with a name of `foo`, an environment variable of `OPTION_FOO` will be defined, with a value of 1 if the option has been selected by the user, and 0 if the option has not been selected.
 
-In the post-install script, the `ALLUSERS` environment variable will be set; its value will be 1 if the app has been installed for all users, or 0 if it has only been installed for the current user. The `INSTALLER_PATH` environment variable will be set to the path of the MSI file.
+In addition, the post-install script environment will have a number of variables set describing the conditions of the installation:
+* `ALLUSERS` will be set to 1 if the app has been installed for all users, or 0 if it has only been installed for the current user;
+* `INSTALLER_PATH` will be set to the path of the MSI file; and
+* `INSTALLER_UNATTENDED` will be set to 1 if the MSI has been installed in "quiet mode" (i.e., if the `/qn` option has been passed to `msiexec`).
 
 If a user uninstalls software by clicking "uninstall" through the Windows "Remove software" interface, the uninstall options will not be displayed to the user. The pre-uninstall script *will* be executed, but the uninstall options will assume their default values. The uninstall GUI is only displayed if the user re-runs the installer manually, or if the user specifies the "Modify" option in the Windows "Remove software" interface. This is a quirk of the Windows uninstall tooling.
 

--- a/docs/en/reference/platforms/windows/index.md
+++ b/docs/en/reference/platforms/windows/index.md
@@ -228,6 +228,8 @@ In addition, the post-install script environment will have a number of variables
 * `INSTALLER_PATH` will be set to the path of the MSI file; and
 * `INSTALLER_UNATTENDED` will be set to 1 if the MSI has been installed in "quiet mode" (i.e., if the `/qn` option has been passed to `msiexec`).
 
+The post-uninstall script will have the `INSTALLER_UNATTENDED` variable set.
+
 If a user uninstalls software by clicking "uninstall" through the Windows "Remove software" interface, the uninstall options will not be displayed to the user. The pre-uninstall script *will* be executed, but the uninstall options will assume their default values. The uninstall GUI is only displayed if the user re-runs the installer manually, or if the user specifies the "Modify" option in the Windows "Remove software" interface. This is a quirk of the Windows uninstall tooling.
 
 ## Platform quirks

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -615,6 +615,8 @@ class WindowsPackageCommand(PackageCommand):
                         self.tools.wix.ext_path("UI"),
                         "-ext",
                         self.tools.wix.ext_path("Netfx"),
+                        "-ext",
+                        self.tools.wix.ext_path("Util"),
                         "-arch",
                         self.vscode_platform.lower(),
                         f"{app.app_name}.wxs",

--- a/tests/integrations/wix/conftest.py
+++ b/tests/integrations/wix/conftest.py
@@ -19,6 +19,10 @@ WIX_NETFX_PATH = (
     "CFiles64/WixToolset/extensions/WixToolset.Netfx.wixext/5.0.2/wixext5/"
     "WixToolset.Netfx.wixext.dll"
 )
+WIX_UTIL_PATH = (
+    "CFiles64/WixToolset/extensions/WixToolset.Util.wixext/5.0.2/wixext5/"
+    "WixToolset.Util.wixext.dll"
+)
 
 
 @pytest.fixture

--- a/tests/platforms/windows/app/test_package.py
+++ b/tests/platforms/windows/app/test_package.py
@@ -11,7 +11,12 @@ from briefcase.integrations.windows_sdk import WindowsSDK
 from briefcase.integrations.wix import WiX
 from briefcase.platforms.windows.app import WindowsAppPackageCommand
 
-from ....integrations.wix.conftest import WIX_EXE_PATH, WIX_NETFX_PATH, WIX_UI_PATH
+from ....integrations.wix.conftest import (
+    WIX_EXE_PATH,
+    WIX_NETFX_PATH,
+    WIX_UI_PATH,
+    WIX_UTIL_PATH,
+)
 from ....utils import create_file
 
 
@@ -225,6 +230,8 @@ def test_package_msi(
                 tmp_path / "wix" / WIX_UI_PATH,
                 "-ext",
                 tmp_path / "wix" / WIX_NETFX_PATH,
+                "-ext",
+                tmp_path / "wix" / WIX_UTIL_PATH,
                 "-arch",
                 "x64",
                 "first-app.wxs",
@@ -360,6 +367,8 @@ def test_package_msi_with_codesigning(
                 tmp_path / "wix" / WIX_UI_PATH,
                 "-ext",
                 tmp_path / "wix" / WIX_NETFX_PATH,
+                "-ext",
+                tmp_path / "wix" / WIX_UTIL_PATH,
                 "-arch",
                 "x64",
                 "first-app.wxs",
@@ -544,6 +553,8 @@ def test_package_msi_failed_compile(package_command, first_app_config, tmp_path)
                 tmp_path / "wix" / WIX_UI_PATH,
                 "-ext",
                 tmp_path / "wix" / WIX_NETFX_PATH,
+                "-ext",
+                tmp_path / "wix" / WIX_UTIL_PATH,
                 "-arch",
                 "x64",
                 "first-app.wxs",
@@ -617,6 +628,8 @@ def test_package_msi_failed_signing_msi(package_command, first_app_config, tmp_p
                 tmp_path / "wix" / WIX_UI_PATH,
                 "-ext",
                 tmp_path / "wix" / WIX_NETFX_PATH,
+                "-ext",
+                tmp_path / "wix" / WIX_UTIL_PATH,
                 "-arch",
                 "x64",
                 "first-app.wxs",

--- a/tests/platforms/windows/visualstudio/test_package.py
+++ b/tests/platforms/windows/visualstudio/test_package.py
@@ -9,7 +9,12 @@ from briefcase.integrations.subprocess import Subprocess
 from briefcase.integrations.wix import WiX
 from briefcase.platforms.windows.visualstudio import WindowsVisualStudioPackageCommand
 
-from ....integrations.wix.conftest import WIX_EXE_PATH, WIX_NETFX_PATH, WIX_UI_PATH
+from ....integrations.wix.conftest import (
+    WIX_EXE_PATH,
+    WIX_NETFX_PATH,
+    WIX_UI_PATH,
+    WIX_UTIL_PATH,
+)
 
 
 @pytest.fixture
@@ -39,6 +44,8 @@ def test_package_msi(package_command, first_app_config, tmp_path):
                 tmp_path / "wix" / WIX_UI_PATH,
                 "-ext",
                 tmp_path / "wix" / WIX_NETFX_PATH,
+                "-ext",
+                tmp_path / "wix" / WIX_UTIL_PATH,
                 "-arch",
                 "x64",
                 "first-app.wxs",


### PR DESCRIPTION
Three improvements to MSI operation.

1. A `INSTALLER_UNATTENDED` environment variable is exposed to post-install and pre-uninstall scripts, allowing scripts to identify if they're running in quiet mode.
2. When running in quiet mode, post-install and pre-uninstall scripts no longer cause a console window to be displayed.
3. A disk space requirements tool has been added to the installer.

The bulk of the changes are actually in the MSI template, rather than Briefcase; this PR is mostly for change notes and documentation. The only exception is the inclusion of the `Util` WiX extension, which is needed for quiet mode script execution.

Fixes #2781 
Fixes #2783
Fixes #2789

Refs beeware/briefcase-windows-app-template#94
Refs beeware/briefcase-windows-VisualStudio-template#97

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
