### PR TITLE
Single option selection default

### DIFF
--- a/changes/2856.feature.md
+++ b/changes/2856.feature.md
@@ -1,0 +1,1 @@
+When only a single option is available in a selection prompt, it is automatically selected as the default.

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -1073,6 +1073,8 @@ class Console:
         self.prompt()
 
         choices = [str(index) for index in range(1, len(ordered) + 1)]
+        if len(ordered) == 1:
+            default = "1"
         index = self.input_selection(
             prompt=f"{description} [{default}]: " if default else f"{description}: ",
             choices=choices,

--- a/tests/console/Console/test_selection_question.py
+++ b/tests/console/Console/test_selection_question.py
@@ -100,6 +100,25 @@ def test_selection_question_default(console, index, default):
     assert result == default
 
 
+def test_selection_question_single_option_default(console):
+    # Return an empty response when prompted as though the user press entered
+    console.values = [""]
+
+    options = {"first": "The first option"}
+
+    result = console.selection_question(
+        description="Test",
+        intro="This is a test",
+        options=options,
+    )
+
+    # Input is requested once
+    assert console.prompts == ["Test [1]: "]
+
+    # The default single option is returned
+    assert result == "first"
+
+
 def test_override_used(console, capsys):
     """The override is used if valid."""
     override_value = "value"


### PR DESCRIPTION
<!--- Describe your changes in detail -->
When only a single option is available in a selection prompt, it will be automatically selected as the default when the user presses enter.
<!--- What problem does this change solve? -->
Previously this would show an "Invalid Selection" warning and re-prompt the user.
From what I read, I believe this would be complementary to the user-defined defaults being worked on in #2279.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #2856 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Calude Sonnet 4.6