### PR TITLE
Add resume handling cross-platform

### DIFF
--- a/changes/2887.feature.md
+++ b/changes/2887.feature.md
@@ -1,0 +1,1 @@
+The macOS notarization auto-resume workflow now allows for resuming the process with only the distribution artefact, usually the contents of the `dist` directory.

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -57,6 +57,27 @@ class PackageCommand(BaseCommand):
             # Ensure the dist folder exists.
             self.dist_path.mkdir(exist_ok=True)
 
+    def can_resume(self, app, **options):
+        """Determine if we can resume a packaging operation.
+
+        The default backend does not support resume; subclasses that support
+        resumable operations (e.g., notarization) should override this method.
+
+        :param app: The app being packaged
+        :returns: ``True`` if packaging can be resumed; ``False`` otherwise.
+        """
+        return False
+
+    def verify_resume_app(self, app, **options):
+        """Verify the app for a resumed packaging operation.
+
+        Called instead of :meth:`verify_app` when ``can_resume()`` returns
+        ``True``. The default implementation delegates to :meth:`verify_app`.
+
+        :param app: app configuration
+        """
+        self.verify_app(app)
+
     def package_app(self, app: FinalizedAppConfig, **options):
         """Package an application.
 
@@ -79,10 +100,15 @@ class PackageCommand(BaseCommand):
         :param update: Should the application be updated (and rebuilt) first?
         :param packaging_format: The format of the packaging artefact to create.
         """
-        template_file = self.bundle_path(app)
-        binary_file = self.binary_path(app)
+        # Annotate the packaging format onto the app so that distribution path
+        # resolution works correctly during the resume check.
+        app.packaging_format = packaging_format
 
-        if app.external_package_path:
+        resume = self.can_resume(app, **options)
+
+        if resume:
+            state = None
+        elif app.external_package_path:
             if not self.supports_external_packaging:
                 raise BriefcaseCommandError(
                     f"Briefcase cannot package external {self.platform} apps "
@@ -99,36 +125,35 @@ class PackageCommand(BaseCommand):
             # packaging metadata is up-to-date. If the app has been packaged before,
             # it will be necessary to confirm deletion of the old folder.
             state = self.create_command(app, **options)
-        elif not template_file.exists():
-            state = self.create_command(app, **options)
-            state = self.build_command(app, **full_options(state, options))
-        elif update:
-            # If we're updating for packaging, update everything.
-            # This ensures everything in the packaged artefact is up to date,
-            # and is in a production state
-            state = self.update_command(
-                app,
-                update_resources=True,
-                update_requirements=True,
-                update_support=True,
-                **options,
-            )
-            state = self.build_command(app, **full_options(state, options))
-        elif not binary_file.exists():
-            state = self.build_command(app, **options)
         else:
-            state = None
+            template_file = self.bundle_path(app)
+            binary_file = self.binary_path(app)
 
-        # Annotate the packaging format onto the app
-        app.packaging_format = packaging_format
+            if not template_file.exists():
+                state = self.create_command(app, **options)
+                state = self.build_command(app, **full_options(state, options))
+            elif update:
+                # If we're updating for packaging, update everything.
+                # This ensures everything in the packaged artefact is up to date,
+                # and is in a production state
+                state = self.update_command(
+                    app,
+                    update_resources=True,
+                    update_requirements=True,
+                    update_support=True,
+                    **options,
+                )
+                state = self.build_command(app, **full_options(state, options))
+            elif not binary_file.exists():
+                state = self.build_command(app, **options)
+            else:
+                state = None
 
-        # Verify the app, which will do final confirmation that we can
-        # package in the requested format.
-        self.verify_app(app)
-
-        # Make sure the dist folder exists, and doesn't contain an existing artefact for
-        # this app.
-        self.clean_dist_folder(app, **options)
+        if resume:
+            self.verify_resume_app(app, **options)
+        else:
+            self.verify_app(app)
+            self.clean_dist_folder(app, **options)
 
         # Package the app
         state = self.package_app(app, **full_options(state, options))

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -72,11 +72,14 @@ class PackageCommand(BaseCommand):
         """Verify the app for a resumed packaging operation.
 
         Called instead of `verify_app` when `can_resume()` returns
-        `True`. The default implementation delegates to `verify_app`.
+        `True`. Verifies that tools are available and the required Python
+        version is present, but skips template and app-level checks that
+        were validated during the initial packaging pass.
 
         :param app: app configuration
         """
-        self.verify_app(app)  # pragma: no cover
+        self.verify_app_tools(app)
+        self.verify_required_python(app)
 
     def package_app(self, app: FinalizedAppConfig, **options):
         """Package an application.

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -76,7 +76,7 @@ class PackageCommand(BaseCommand):
 
         :param app: app configuration
         """
-        self.verify_app(app)
+        self.verify_app(app)  # pragma: no cover
 
     def package_app(self, app: FinalizedAppConfig, **options):
         """Package an application.

--- a/src/briefcase/commands/package.py
+++ b/src/briefcase/commands/package.py
@@ -64,15 +64,15 @@ class PackageCommand(BaseCommand):
         resumable operations (e.g., notarization) should override this method.
 
         :param app: The app being packaged
-        :returns: ``True`` if packaging can be resumed; ``False`` otherwise.
+        :returns: `True` if packaging can be resumed; `False` otherwise.
         """
         return False
 
     def verify_resume_app(self, app, **options):
         """Verify the app for a resumed packaging operation.
 
-        Called instead of :meth:`verify_app` when ``can_resume()`` returns
-        ``True``. The default implementation delegates to :meth:`verify_app`.
+        Called instead of `verify_app` when `can_resume()` returns
+        `True`. The default implementation delegates to `verify_app`.
 
         :param app: app configuration
         """

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1047,13 +1047,13 @@ class macOSPackageMixin(macOSSigningMixin):
 
         Checks for an explicit submission ID or a notarization request marker.
         If either exists, verifies that the notarization artefact is present.
-        Raises ``BriefcaseCommandError`` if the marker/submission ID exists but
+        Raises `BriefcaseCommandError` if the marker/submission ID exists but
         the artefact is missing.
 
         :param app: The app being packaged.
         :param submission_id: The notarization submission ID to resume (if any).
         :param options: Any additional arguments.
-        :returns: ``True`` if notarization can be resumed.
+        :returns: `True` if notarization can be resumed.
         """
         self.verify_app_packaging_format(app)
         if bool(submission_id) or self.notarization_request_path(app).exists():

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1022,9 +1022,12 @@ class macOSPackageMixin(macOSSigningMixin):
         # These are abstracted to enable testing without patching.
         self.dmgbuild = dmgbuild
 
-    def verify_app(self, app):
-        super().verify_app(app)
+    def verify_app_packaging_format(self, app):
+        """Set the default packaging format if not already set, and validate console app
+        format requirements.
 
+        :param app: The app being packaged.
+        """
         if app.console_app:
             if app.packaging_format is None:
                 app.packaging_format = "pkg"
@@ -1035,17 +1038,25 @@ class macOSPackageMixin(macOSSigningMixin):
         elif app.packaging_format is None:
             app.packaging_format = "dmg"
 
-    def clean_dist_folder(self, app, **options):
-        """Clean up any existing artefacts in the dist folder.
+    def verify_app(self, app):
+        super().verify_app(app)
+        self.verify_app_packaging_format(app)
 
-        If we are resuming a notarization session verify that the artefact exists, but
-        *do not* delete it.
+    def can_resume(self, app, submission_id=None, **options):
+        """Determine if notarization can be resumed.
+
+        Checks for an explicit submission ID or a notarization request marker.
+        If either exists, verifies that the notarization artefact is present.
+        Raises ``BriefcaseCommandError`` if the marker/submission ID exists but
+        the artefact is missing.
 
         :param app: The app being packaged.
-        :param submission_id: The notarization submission being resumed.
-        :param options: Any additional arguments passed to the package command.
+        :param submission_id: The notarization submission ID to resume (if any).
+        :param options: Any additional arguments.
+        :returns: ``True`` if notarization can be resumed.
         """
-        if options.get("submission_id") or self.notarization_request_path(app).exists():
+        self.verify_app_packaging_format(app)
+        if bool(submission_id) or self.notarization_request_path(app).exists():
             if not self.notarization_path(app).exists():
                 raise BriefcaseCommandError(
                     "Notarization cannot be resumed, as the notarization artefact "
@@ -1053,14 +1064,18 @@ class macOSPackageMixin(macOSSigningMixin):
                     f"({self.notarization_path(app).relative_to(self.base_path)}) "
                     "does not exist."
                 )
+            return True
+        return False
 
-            # If the packaging format is zip, the distribution artefact is created
-            # *after* completion of notarization. If there's an existing distribution
-            # artefact, it must be from a previous notarization/stapling attempt.
-            if app.packaging_format == "zip":
-                super().clean_dist_folder(app, **options)
-        else:
-            super().clean_dist_folder(app, **options)
+    def verify_resume_app(self, app, **options):
+        """Verify the app for a resumed notarization operation.
+
+        Only verifies that the required tools are available. Skips template and Python
+        version checks since those were validated during initial packaging.
+
+        :param app: app configuration
+        """
+        self.verify_app_tools(app)
 
     def ditto_archive(
         self,

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1067,16 +1067,6 @@ class macOSPackageMixin(macOSSigningMixin):
             return True
         return False
 
-    def verify_resume_app(self, app, **options):
-        """Verify the app for a resumed notarization operation.
-
-        Only verifies that the required tools are available. Skips template and Python
-        version checks since those were validated during initial packaging.
-
-        :param app: app configuration
-        """
-        self.verify_app_tools(app)
-
     def ditto_archive(
         self,
         app_filename: Path,

--- a/tests/platforms/macOS/app/package/test_resume_notarization.py
+++ b/tests/platforms/macOS/app/package/test_resume_notarization.py
@@ -11,13 +11,6 @@ from briefcase.integrations.subprocess import json_parser
 
 from .....utils import create_file
 
-RESUME_FORMATS = [
-    # (packaging_format, submission name in notarytool history, dist artefact, uses an installer identity)
-    pytest.param("zip", "First App.app.zip", None, False, id="app"),
-    pytest.param("dmg", "First App-0.0.1.dmg", "First App-0.0.1.dmg", False, id="dmg"),
-    pytest.param("pkg", "First App-0.0.1.pkg", "First App-0.0.1.pkg", True, id="pkg"),
-]
-
 
 def test_resume_notarize_app(
     package_command,
@@ -743,7 +736,15 @@ def test_resume_notarize_from_marker_explicit_identity(
 
 @pytest.mark.parametrize(
     ("packaging_format", "submission_name", "dist_artefact", "use_installer"),
-    RESUME_FORMATS,
+    [
+        pytest.param("zip", "First App.app.zip", None, False, id="app"),
+        pytest.param(
+            "dmg", "First App-0.0.1.dmg", "First App-0.0.1.dmg", False, id="dmg"
+        ),
+        pytest.param(
+            "pkg", "First App-0.0.1.pkg", "First App-0.0.1.pkg", True, id="pkg"
+        ),
+    ],
 )
 def test_resume_notarize_from_marker_rejected(
     package_command,

--- a/tests/platforms/macOS/app/package/test_resume_notarization.py
+++ b/tests/platforms/macOS/app/package/test_resume_notarization.py
@@ -1117,15 +1117,12 @@ def test_resume_notarize_app_dist_artefact_exists(
     )
 
     # As this is a .zip distribution, there's a finalization step to create the actual
-    # distribution artefact with ditto. This file won't actually be created though, as
-    # we're mocking ditto. However, as a result of resuming with a pre-existing
-    # distribution artefact, the pre-existing artefact will have been deleted.
+    # distribution artefact with ditto. The pre-existing artefact is preserved until
+    # ditto overwrites it.
     package_command.ditto_archive.assert_called_once_with(
         tmp_path / "base_path/build/first-app/macos/app/First App.app",
         tmp_path / "base_path/dist/First App-0.0.1.app.zip",
     )
-
-    assert not (tmp_path / "base_path/dist/First App-0.0.1.app.zip").exists()
 
 
 def test_resume_notarize_artefact_missing(

--- a/tests/platforms/macOS/app/package/test_resume_notarization.py
+++ b/tests/platforms/macOS/app/package/test_resume_notarization.py
@@ -432,8 +432,38 @@ def test_resume_notarize_pkg(
 
 
 @pytest.mark.parametrize(
-    ("packaging_format", "submission_name", "dist_artefact", "use_installer"),
-    RESUME_FORMATS,
+    (
+        "packaging_format",
+        "submission_name",
+        "dist_artefact",
+        "use_installer",
+        "delete_build",
+    ),
+    [
+        pytest.param("zip", "First App.app.zip", None, False, False, id="app"),
+        pytest.param(
+            "dmg", "First App-0.0.1.dmg", "First App-0.0.1.dmg", False, False, id="dmg"
+        ),
+        pytest.param(
+            "dmg",
+            "First App-0.0.1.dmg",
+            "First App-0.0.1.dmg",
+            False,
+            True,
+            id="dmg-build-deleted",
+        ),
+        pytest.param(
+            "pkg", "First App-0.0.1.pkg", "First App-0.0.1.pkg", True, False, id="pkg"
+        ),
+        pytest.param(
+            "pkg",
+            "First App-0.0.1.pkg",
+            "First App-0.0.1.pkg",
+            True,
+            True,
+            id="pkg-build-deleted",
+        ),
+    ],
 )
 def test_resume_notarize_from_marker(
     package_command,
@@ -446,10 +476,15 @@ def test_resume_notarize_from_marker(
     submission_name,
     dist_artefact,
     use_installer,
+    delete_build,
 ):
     """An interrupted notarization can be auto-resumed from its marker file."""
     # Set the packaging format, so the marker path can be determined.
     first_app_with_binaries.packaging_format = packaging_format
+
+    # Simulate a partially cleaned workspace by deleting the entire build directory.
+    if delete_build:
+        shutil.rmtree(tmp_path / "base_path/build")
 
     # Create a pre-existing distribution artefact. A .zip is built from the app via
     # ditto as part of finalization, so it doesn't need a pre-existing artefact.


### PR DESCRIPTION
`can_resume` returns `False` on all backends, except for the macOS override when applicable.

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] I will abide by the BeeWare Code of Conduct
 - [x] I have read and have followed the **CONTRIBUTING.md** file
 - [x] This PR was generated or assisted using an AI tool
 <!-- update or delete the next line to reflect your usage -->
 Assisted-by: Claude Code, Big Pickle
