### PR TITLE
Adds `--no-wait` to macOS notarization process

### DIFF
--- a/changes/2888.feature.md
+++ b/changes/2888.feature.md
@@ -1,0 +1,1 @@
+The macOS ``package`` command now accepts a ``--no-wait`` option that submits an app for notarization without waiting for the notarization to complete. The submission can be finalized later by re-running ``briefcase package``.

--- a/docs/en/reference/platforms/macOS/index.md
+++ b/docs/en/reference/platforms/macOS/index.md
@@ -101,6 +101,10 @@ Do not sign the installer. This option can be useful during development and test
 
 Do not submit the application for notarization. By default, apps will be submitted for notarization unless they have been signed with an ad-hoc signing identity.
 
+### `--no-wait`
+
+Submit the application for notarization, but do not wait for notarization to complete. The submission can be finalized later by re-running the `briefcase package` command.
+
 ### `--resume <submission ID>`
 
 Apple's notarization server can take a long time to respond - in some cases, hours. When you submit an app for notarization, the console output of the `package` command will provide you with a submission ID. If the notarization process is interrupted for any reason (including user intervention), you can use this submission ID with the `--resume` option to resume the notarization process for an app.

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1122,7 +1122,7 @@ class macOSPackageMixin(macOSSigningMixin):
         :param identity: The code signing used to notarize the app.
         :param installer_identity: The signing identity to use when signing the
             installer. Optional unless the packaging format is ``pkg``.
-        :param wait: If ``True``, wait for notarization to complete. If ``False``,
+        :param wait: If `True`, wait for notarization to complete. If `False`,
             submit the app and return without finalizing.
         """
         # Determine the arguments that would be needed to reproduce this notarization
@@ -1143,8 +1143,9 @@ class macOSPackageMixin(macOSSigningMixin):
 
         if not wait:
             self.console.info(
-                "The submission has been sent. You'll need to run briefcase "
-                "package at some point in the future to finalize the notarization."
+                f"{app.formal_name} as been submitted to Apple for notarization. "
+                "You'll need to run briefcase package at some point in the future "
+                "to finalize the notarization."
             )
         else:
             self.console.warning("""
@@ -1161,7 +1162,6 @@ resume it.
                 app,
                 identity=notarization_identity,
                 submission_id=submission_id,
-                wait=wait,
             )
 
     def submit_notarization(self, app, identity: SigningIdentity) -> str:
@@ -1338,7 +1338,7 @@ password:
         :param app: The app to notarize.
         :param identity: The code signing identity to use.
         :param submission_id: The submission ID of the notarization task to finalize.
-        :param wait: If ``True``, poll until notarization completes. If ``False``,
+        :param wait: If `True`, poll until notarization completes. If `False`,
             check the status once and raise an error if it is not yet complete.
         """
         try:
@@ -1395,8 +1395,9 @@ password:
                                     "Apple has not completed notarising the app; "
                                     "try again later"
                                 ) from e
-                            # Try again in 10 seconds.
-                            time.sleep(10)
+                            else:
+                                # Try again in 10 seconds.
+                                time.sleep(10)
                         else:
                             self.tools.subprocess.output_error(e)
                             raise BriefcaseCommandError(

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1012,7 +1012,7 @@ class macOSPackageMixin(macOSSigningMixin):
             action="store_const",
             const=False,
             default=True,
-            help="Submit for notarization but don't wait for notarization to complete",
+            help="Don't wait for notarization; submit and check status once, then exit",
         )
 
     def verify_tools(self):
@@ -1161,6 +1161,7 @@ resume it.
                 app,
                 identity=notarization_identity,
                 submission_id=submission_id,
+                wait=wait,
             )
 
     def submit_notarization(self, app, identity: SigningIdentity) -> str:

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1113,6 +1113,7 @@ class macOSPackageMixin(macOSSigningMixin):
         app: FinalizedAppConfig,
         identity: SigningIdentity,
         installer_identity: SigningIdentity | None = None,
+        wait: bool = True,
     ):
         """Submit a file for notarization, and wait for that notarization to be
         completed.
@@ -1121,6 +1122,8 @@ class macOSPackageMixin(macOSSigningMixin):
         :param identity: The code signing used to notarize the app.
         :param installer_identity: The signing identity to use when signing the
             installer. Optional unless the packaging format is ``pkg``.
+        :param wait: If ``True``, wait for notarization to complete. If ``False``,
+            submit the app and return without finalizing.
         """
         # Determine the arguments that would be needed to reproduce this notarization
         if installer_identity:
@@ -1138,7 +1141,13 @@ class macOSPackageMixin(macOSSigningMixin):
             installer_identity=installer_identity,
         )
 
-        self.console.warning("""
+        if not wait:
+            self.console.info(
+                "The submission has been sent. You'll need to run briefcase "
+                "package at some point in the future to finalize the notarization."
+            )
+        else:
+            self.console.warning("""
 Briefcase will now wait for Apple to approve the notarization request.
 This can take some time - in some cases, hours.
 
@@ -1148,11 +1157,11 @@ resume it.
 
 """)
 
-        self.finalize_notarization(
-            app,
-            identity=notarization_identity,
-            submission_id=submission_id,
-        )
+            self.finalize_notarization(
+                app,
+                identity=notarization_identity,
+                submission_id=submission_id,
+            )
 
     def submit_notarization(self, app, identity: SigningIdentity) -> str:
         """Submit a file for notarization, returning the ID of the notarizatzion task.
@@ -1573,6 +1582,7 @@ password:
                 app,
                 notarize_app=notarize_app,
                 identity=identity,
+                wait=wait,
             )
 
         elif app.packaging_format == "pkg":
@@ -1592,6 +1602,7 @@ password:
                 notarize_app=notarize_app,
                 identity=identity,
                 installer_identity=installer_identity,
+                wait=wait,
             )
 
         else:  # Default packaging format is DMG
@@ -1599,6 +1610,7 @@ password:
                 app,
                 notarize_app=notarize_app,
                 identity=identity,
+                wait=wait,
             )
 
     def package_zip(
@@ -1606,6 +1618,7 @@ password:
         app: FinalizedAppConfig,
         notarize_app: bool,
         identity: SigningIdentity,
+        wait: bool = True,
     ):
         """Package an .app bundle in a zip file.
 
@@ -1619,7 +1632,7 @@ password:
                 f"Notarizing app using team ID {identity.team_id}...",
                 prefix=app.app_name,
             )
-            self.notarize(app, identity=identity)
+            self.notarize(app, identity=identity, wait=wait)
         else:
             self.finalize_package_zip(app)
 
@@ -1637,6 +1650,7 @@ password:
         notarize_app: bool,
         identity: SigningIdentity,
         installer_identity: SigningIdentity | None,
+        wait: bool = True,
     ):
         """Package the app as an installer."""
         dist_path: Path = self.distribution_path(app)
@@ -1754,6 +1768,7 @@ password:
                 app,
                 identity=identity,
                 installer_identity=installer_identity,
+                wait=wait,
             )
 
     def package_dmg(
@@ -1761,6 +1776,7 @@ password:
         app: FinalizedAppConfig,
         notarize_app: bool,
         identity: SigningIdentity,
+        wait: bool = True,
     ):
         """Package an app as a DMG installer."""
         dist_path: Path = self.distribution_path(app)
@@ -1830,4 +1846,4 @@ password:
                 f"Notarizing DMG with team ID {identity.team_id}...",
                 prefix=app.app_name,
             )
-            self.notarize(app, identity=identity)
+            self.notarize(app, identity=identity, wait=wait)

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1006,6 +1006,14 @@ class macOSPackageMixin(macOSSigningMixin):
             help="The notarization submission ID to resume",
             required=False,
         )
+        parser.add_argument(
+            "--no-wait",
+            dest="wait",
+            action="store_const",
+            const=False,
+            default=True,
+            help="Submit for notarization but don't wait for notarization to complete",
+        )
 
     def verify_tools(self):
         # Require the Xcode command line tools.
@@ -1310,6 +1318,7 @@ password:
         app: FinalizedAppConfig,
         identity: SigningIdentity,
         submission_id: str,
+        wait: bool = True,
     ):
         """Finalize a notarization task.
 
@@ -1319,9 +1328,16 @@ password:
         :param app: The app to notarize.
         :param identity: The code signing identity to use.
         :param submission_id: The submission ID of the notarization task to finalize.
+        :param wait: If ``True``, poll until notarization completes. If ``False``,
+            check the status once and raise an error if it is not yet complete.
         """
         try:
-            with self.console.wait_bar("Waiting for notarization acceptance..."):
+            label = (
+                "Waiting for notarization acceptance..."
+                if wait
+                else "Checking notarization status..."
+            )
+            with self.console.wait_bar(label):
                 accepted = False
                 while not accepted:
                     try:
@@ -1363,7 +1379,13 @@ password:
                             # Error code 69 (nice) indicates the server can't give a log
                             # response for the provided submission ID. We've already
                             # validated that it's a valid submission ID, so that means
-                            # notarization isn't complete yet. Try again in 10 seconds.
+                            # notarization isn't complete yet.
+                            if not wait:
+                                raise BriefcaseCommandError(
+                                    "Apple has not completed notarising the app; "
+                                    "try again later"
+                                ) from e
+                            # Try again in 10 seconds.
                             time.sleep(10)
                         else:
                             self.tools.subprocess.output_error(e)
@@ -1408,6 +1430,7 @@ password:
         sign_installer=True,
         installer_identity=None,
         submission_id=None,
+        wait=True,
         **kwargs,
     ):
         """Package an app bundle.
@@ -1427,6 +1450,8 @@ password:
         :param installer_identity: The signing identity to use when signing the
             installer. Ignored unless the packaging format is ``pkg``.
         :param submission_id: The submission ID of the notarization task to resume.
+        :param wait: Should briefcase wait for notarization to complete?
+            Default: ``True``.
         """
         # Confirm the project isn't currently on an iCloud synced drive.
         self.verify_not_on_icloud(app)
@@ -1503,6 +1528,7 @@ password:
                 app,
                 identity=notarization_identity,
                 submission_id=submission_id,
+                wait=wait,
             )
             return
 

--- a/tests/platforms/macOS/app/package/test_notarize.py
+++ b/tests/platforms/macOS/app/package/test_notarize.py
@@ -1308,3 +1308,49 @@ def test_interrupt_notarization(
 
     # Notarization was interrupted, so the marker is retained so it can be resumed.
     assert package_command.notarization_request_path(first_app_dmg).exists()
+
+
+def test_notarize_app_no_wait(
+    package_command,
+    first_app_zip,
+    sekrit_identity,
+    tmp_path,
+):
+    """With --no-wait, an app is submitted but notarization is not finalized."""
+    archive_path = tmp_path / "base_path/build/first-app/macos/app/First App.app.zip"
+
+    # Mock the creation of the ditto archive
+    package_command.ditto_archive = MagicMock()
+
+    # Mock the return values of subprocesses: only the submission is performed.
+    submission_id = str(uuid.uuid4())
+    package_command.tools.subprocess.parse_output.side_effect = [
+        # notarytool submit
+        {"id": submission_id},
+    ]
+
+    package_command.notarize(first_app_zip, identity=sekrit_identity, wait=False)
+
+    # Only the submission was made; notarization status was never checked.
+    assert package_command.tools.subprocess.parse_output.mock_calls == [
+        mock.call(
+            json_parser,
+            [
+                "xcrun",
+                "notarytool",
+                "submit",
+                archive_path,
+                "--keychain-profile",
+                "briefcase-macOS-DEADBEEF",
+                "--output-format",
+                "json",
+            ],
+            quiet=1,
+        ),
+    ]
+
+    # Notarization was not finalized, so nothing was stapled.
+    package_command.tools.subprocess.run.assert_not_called()
+
+    # The notarization request marker is left in place for a later resume.
+    assert package_command.notarization_request_path(first_app_zip).exists()

--- a/tests/platforms/macOS/app/package/test_package.py
+++ b/tests/platforms/macOS/app/package/test_package.py
@@ -72,6 +72,7 @@ def test_no_notarize_option(package_command):
         "packaging_format": None,
         "submission_id": None,
         "update": False,
+        "wait": True,
     }
     assert overrides == {}
 
@@ -91,6 +92,7 @@ def test_installer_identity_option(package_command):
         "packaging_format": None,
         "submission_id": None,
         "update": False,
+        "wait": True,
     }
     assert overrides == {}
 
@@ -108,6 +110,7 @@ def test_no_sign_installer(package_command):
         "packaging_format": None,
         "submission_id": None,
         "update": False,
+        "wait": True,
     }
     assert overrides == {}
 
@@ -125,6 +128,7 @@ def test_resume(package_command):
         "packaging_format": None,
         "submission_id": "cafe-beef-1234",
         "update": False,
+        "wait": True,
     }
     assert overrides == {}
 

--- a/tests/platforms/macOS/app/package/test_package.py
+++ b/tests/platforms/macOS/app/package/test_package.py
@@ -231,6 +231,7 @@ def test_package_app(
     package_command.notarize.assert_called_once_with(
         first_app_with_binaries,
         identity=sekrit_identity,
+        wait=True,
     )
 
     # The app doesn't specify an app icon or installer icon, so there's no

--- a/tests/platforms/macOS/app/package/test_package_dmg.py
+++ b/tests/platforms/macOS/app/package/test_package_dmg.py
@@ -352,6 +352,7 @@ def test_dmg_external_app(
     package_command.notarize.assert_called_once_with(
         external_first_app,
         identity=sekrit_identity,
+        wait=True,
     )
 
     # The app doesn't specify an app icon or installer icon, so there's no

--- a/tests/platforms/macOS/app/package/test_package_pkg.py
+++ b/tests/platforms/macOS/app/package/test_package_pkg.py
@@ -122,6 +122,7 @@ def test_gui_app(
         first_app_with_binaries,
         identity=sekrit_identity,
         installer_identity=sekrit_installer_identity,
+        wait=True,
     )
 
 
@@ -321,6 +322,7 @@ def test_console_app(
         first_app_with_binaries,
         identity=sekrit_identity,
         installer_identity=sekrit_installer_identity,
+        wait=True,
     )
 
 
@@ -520,6 +522,7 @@ def test_no_license(
         first_app_with_binaries,
         identity=sekrit_identity,
         installer_identity=sekrit_installer_identity,
+        wait=True,
     )
 
 
@@ -740,4 +743,5 @@ def test_external_app(
         external_first_app,
         identity=sekrit_identity,
         installer_identity=sekrit_installer_identity,
+        wait=True,
     )

--- a/tests/platforms/macOS/app/package/test_package_zip.py
+++ b/tests/platforms/macOS/app/package/test_package_zip.py
@@ -29,6 +29,7 @@ def test_package_zip(
     package_command.notarize.assert_called_once_with(
         first_app_with_binaries,
         identity=sekrit_identity,
+        wait=True,
     )
 
     # No dmg was built.
@@ -118,6 +119,7 @@ def test_external_app(
     package_command.notarize.assert_called_once_with(
         external_first_app,
         identity=sekrit_identity,
+        wait=True,
     )
 
     # No dmg was built.

--- a/tests/platforms/macOS/app/package/test_resume_notarization.py
+++ b/tests/platforms/macOS/app/package/test_resume_notarization.py
@@ -1,5 +1,6 @@
 import shutil
 import subprocess
+import time
 import uuid
 from pathlib import Path
 from unittest import mock
@@ -1595,3 +1596,103 @@ def test_notarization_rejected(
 
     # No staple attempt is made.
     package_command.tools.subprocess.run.assert_not_called()
+
+
+def test_resume_no_wait_incomplete(
+    package_command,
+    first_app_with_binaries,
+    sekrit_identity,
+    tmp_path,
+    sleep_zero,
+):
+    """Resuming with --no-wait errors if notarization is still pending."""
+    package_command.select_identity.return_value = sekrit_identity
+    package_command.ditto_archive = mock.MagicMock()
+
+    submission_id = str(uuid.uuid4())
+    package_command.tools.subprocess.parse_output.side_effect = [
+        # notarytool history returns the app's submission ID
+        {
+            "history": [
+                {
+                    "id": submission_id,
+                    "name": "First App.app.zip",
+                    "status": "In Progress",
+                },
+            ]
+        },
+        # notarytool log: still not ready.
+        subprocess.CalledProcessError(
+            returncode=69,
+            cmd=["xcrun", "notarytool", "log"],
+        ),
+    ]
+
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r"Apple has not completed notarising the app; try again later",
+    ):
+        package_command._package_app(
+            first_app_with_binaries,
+            update=False,
+            packaging_format="zip",
+            identity=sekrit_identity.id,
+            submission_id=submission_id,
+            wait=False,
+        )
+
+    # History + exactly one status check were made; no retry loop.
+    assert package_command.tools.subprocess.parse_output.call_count == 2
+    time.sleep.assert_not_called()
+
+
+def test_resume_no_wait_single_attempt(
+    package_command,
+    first_app_with_binaries,
+    sekrit_identity,
+    tmp_path,
+    sleep_zero,
+):
+    """Resuming with --no-wait checks notarization status exactly once."""
+    package_command.select_identity.return_value = sekrit_identity
+    package_command.ditto_archive = mock.MagicMock()
+
+    submission_id = str(uuid.uuid4())
+    package_command.tools.subprocess.parse_output.side_effect = [
+        # notarytool history returns the app's submission ID
+        {
+            "history": [
+                {
+                    "id": submission_id,
+                    "name": "First App.app.zip",
+                    "status": "Accepted",
+                },
+            ]
+        },
+        # notarytool log: accepted on the first (and only) check.
+        {"status": "Accepted"},
+    ]
+
+    package_command._package_app(
+        first_app_with_binaries,
+        update=False,
+        packaging_format="zip",
+        identity=sekrit_identity.id,
+        submission_id=submission_id,
+        wait=False,
+    )
+
+    # History + exactly one status check; no retry loop and no sleeping.
+    assert package_command.tools.subprocess.parse_output.call_count == 2
+    time.sleep.assert_not_called()
+
+    # Notarization succeeded, so the artefact was stapled.
+    package_command.tools.subprocess.run.assert_called_once_with(
+        [
+            "xcrun",
+            "stapler",
+            "staple",
+            tmp_path / "base_path/build/first-app/macos/app/First App.app",
+        ],
+        check=True,
+    )


### PR DESCRIPTION
The macOS `package` command now accepts `--no-wait`, which submits the app for notarisation, but does not wait for completion.

Fixes #2888

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] I will abide by the BeeWare Code of Conduct
 - [x] I have read and have followed the **CONTRIBUTING.md** file
 - [x] This PR was generated or assisted using an AI tool
 <!-- update or delete the next line to reflect your usage -->
 Assisted-by: Claude Code Sonnet 4.6, Opus 4.8
