### PR TITLE
Reformat iOS `xcode.py` warning to use warning_banner

### DIFF
--- a/changes/+2559-xcode.misc.md
+++ b/changes/+2559-xcode.misc.md
@@ -1,0 +1,1 @@
+The warning banner helper was used in the iOS Xcode backend.

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -310,13 +310,15 @@ class Console:
 
         return output_lines
 
-    def warning_banner(
-        self,
+    @staticmethod
+    def format_warning_banner(
         title: str | None = None,
         message: str | None = None,
         width: int = 80,
-    ) -> None:
-        """The title or message can be provided as a single or as multiline string. Any
+    ) -> str:
+        """Format a warning banner and return it as a string.
+
+        The title or message can be provided as a single or as multiline string. Any
         common leading whitespace from each line will be removed.
 
         To separate text into paragraphs you can use:
@@ -327,13 +329,14 @@ class Console:
         :param title: The title of the box. If provided, appears centered at the top.
         :param message: The message to format inside the box.
         :param width: The total width of the box in characters. Defaults to 80.
+        :returns: The formatted warning banner as a string.
         """
         BORDER_LINE = "*" * width
         lines_array = ["", BORDER_LINE]
 
         if title:
             # Remove 6 from the width to allow for "** " and " **" wrappers
-            title_lines = self._dedent_and_wrap(f"WARNING: {title}", width - 6)
+            title_lines = Console._dedent_and_wrap(f"WARNING: {title}", width - 6)
 
             # Center each line of the title and add to the box
             for line in title_lines:
@@ -343,12 +346,25 @@ class Console:
             lines_array.append(BORDER_LINE)
 
         if message:
-            msg_lines = self._dedent_and_wrap(message, width, border=2)
+            msg_lines = Console._dedent_and_wrap(message, width, border=2)
 
             lines_array.extend(["", *msg_lines, "", BORDER_LINE, ""])
 
-        # merge lines into a single string and send warning to console
-        self.warning("\n".join(lines_array))
+        return "\n".join(lines_array)
+
+    def warning_banner(
+        self,
+        title: str | None = None,
+        message: str | None = None,
+        width: int = 80,
+    ) -> None:
+        """Format a warning banner and print it to the console.
+
+        :param title: The title of the box. If provided, appears centered at the top.
+        :param message: The message to format inside the box.
+        :param width: The total width of the box in characters. Defaults to 80.
+        """
+        self.warning(self.format_warning_banner(title, message, width))
 
     #################################################################
     # Logging controls

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -57,24 +57,22 @@ class iOSXcodePassiveMixin(iOSMixin):
     def distribution_path(self, app):
         # This path won't ever be *generated*, as distribution artefacts
         # can't be generated on iOS.
-        raise NoDistributionArtefact("""
-*************************************************************************
-** WARNING: No distributable artefact has been generated               **
-*************************************************************************
+        self.tools.console.warning_banner(
+            title="No distributable artefact has been generated",
+            message="""\
+                Briefcase has not generated a standalone iOS artefact, as iOS
+                apps must be published through Xcode.
 
-    Briefcase has not generated a standalone iOS artefact, as iOS apps
-    must be published through Xcode.
+                To open Xcode for your iOS project, run:
 
-    To open Xcode for your iOS project, run:
+                    briefcase open iOS
 
-        briefcase open iOS
+                and use Xcode's app distribution workflow described at:
 
-    and use Xcode's app distribution workflow described at:
-
-        https://briefcase.readthedocs.io/en/stable/reference/platforms/iOS/xcode.html#ios-deploy
-
-*************************************************************************
-""")
+                    https://briefcase.readthedocs.io/en/stable/reference/platforms/iOS/xcode.html#ios-deploy
+            """,
+        )
+        raise NoDistributionArtefact("")
 
 
 class iOSXcodeMixin(iOSXcodePassiveMixin):

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -19,6 +19,7 @@ from briefcase.commands import (
     UpdateCommand,
 )
 from briefcase.config import FinalizedAppConfig
+from briefcase.console import Console
 from briefcase.debuggers.base import AppPackagesPathMappings
 from briefcase.exceptions import (
     BriefcaseCommandError,
@@ -57,22 +58,23 @@ class iOSXcodePassiveMixin(iOSMixin):
     def distribution_path(self, app):
         # This path won't ever be *generated*, as distribution artefacts
         # can't be generated on iOS.
-        self.tools.console.warning_banner(
-            title="No distributable artefact has been generated",
-            message="""\
-                Briefcase has not generated a standalone iOS artefact, as iOS
-                apps must be published through Xcode.
+        raise NoDistributionArtefact(
+            Console.format_warning_banner(
+                title="No distributable artefact has been generated",
+                message="""\
+                    Briefcase has not generated a standalone iOS artefact, as
+                    iOS apps must be published through Xcode.
 
-                To open Xcode for your iOS project, run:
+                    To open Xcode for your iOS project, run:
 
-                    briefcase open iOS
+                        briefcase open iOS
 
-                and use Xcode's app distribution workflow described at:
+                    and use Xcode's app distribution workflow described at:
 
-                    https://briefcase.readthedocs.io/en/stable/reference/platforms/iOS/xcode.html#ios-deploy
-            """,
+                        https://briefcase.readthedocs.io/en/stable/reference/platforms/iOS/xcode.html#ios-deploy
+                """,
+            )
         )
-        raise NoDistributionArtefact("")
 
 
 class iOSXcodeMixin(iOSXcodePassiveMixin):

--- a/tests/platforms/iOS/xcode/test_mixin.py
+++ b/tests/platforms/iOS/xcode/test_mixin.py
@@ -32,12 +32,13 @@ def test_binary_path(create_command, first_app_config, tmp_path):
     )
 
 
-def test_distribution_path(create_command, first_app_config, tmp_path):
-    with pytest.raises(
-        NoDistributionArtefact,
-        match=r"WARNING: No distributable artefact has been generated",
-    ):
+def test_distribution_path(create_command, first_app_config, capsys, tmp_path):
+    with pytest.raises(NoDistributionArtefact):
         create_command.distribution_path(first_app_config)
+
+    output = capsys.readouterr().out
+    assert "WARNING: No distributable artefact has been generated" in output
+    assert "briefcase open iOS" in output
 
 
 def test_verify(create_command, monkeypatch):

--- a/tests/platforms/iOS/xcode/test_mixin.py
+++ b/tests/platforms/iOS/xcode/test_mixin.py
@@ -32,13 +32,12 @@ def test_binary_path(create_command, first_app_config, tmp_path):
     )
 
 
-def test_distribution_path(create_command, first_app_config, capsys, tmp_path):
-    with pytest.raises(NoDistributionArtefact):
+def test_distribution_path(create_command, first_app_config, tmp_path):
+    with pytest.raises(
+        NoDistributionArtefact,
+        match=r"WARNING: No distributable artefact has been generated",
+    ):
         create_command.distribution_path(first_app_config)
-
-    output = capsys.readouterr().out
-    assert "WARNING: No distributable artefact has been generated" in output
-    assert "briefcase open iOS" in output
 
 
 def test_verify(create_command, monkeypatch):


### PR DESCRIPTION
Fixes: #2559

**Description:** 

- `iOSXcodePassiveMixin.distribution_path()`: 
  - Replace hand formatted asterisk box with warning utility
  - raise error with empty message to prevent re-printing of the message

The hardcoded asterisk-box formatting was inconsistent with the rest of the codebase after #2563 introduced the `warning_banner()` helper.


## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: Claude Opus 4.8