### PR TITLE
Correct build issues caused by vcs_versioning==2.0

### DIFF
--- a/automation/pyproject.toml
+++ b/automation/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     # keep versions in sync with ../pyproject.toml
     "setuptools==82.0.1",
-    "setuptools_scm==10.0.5",
+    "setuptools_scm==10.1.2",
     "setuptools_dynamic_dependencies @ git+https://github.com/beeware/setuptools_dynamic_dependencies",
 ]
 build-backend = "setuptools.build_meta"

--- a/changes/2902.misc.md
+++ b/changes/2902.misc.md
@@ -1,0 +1,1 @@
+Some issues with setuptools_scm configuration were resolved.

--- a/debugger/pyproject.toml
+++ b/debugger/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     # keep versions in sync with automation/pyproject.toml and ../pyproject.toml
     "setuptools==82.0.1",
-    "setuptools_scm==10.0.5",
+    "setuptools_scm==10.1.2",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     # keep versions in sync with automation/pyproject.toml
     "setuptools==82.0.1",
-    "setuptools_scm==10.0.5",
+    "setuptools_scm==10.1.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -111,7 +111,7 @@ pre-commit = [
 ]
 
 setuptools-scm = [
-    "setuptools_scm == 10.0.5",
+    "setuptools_scm==10.1.2",
 ]
 
 towncrier = [

--- a/src/briefcase/__init__.py
+++ b/src/briefcase/__init__.py
@@ -1,23 +1,7 @@
+from importlib.metadata import version
+
 __all__ = [
     "__version__",
 ]
 
-try:
-    # Read version from SCM metadata
-    # This will only exist in a development environment
-    from setuptools_scm import get_version
-
-    # Excluded from coverage because a pure test environment (such as the one
-    # used by tox in CI) won't have setuptools_scm.
-    # The tag_regex argument is needed as a workaround for setuptools_scm#1434
-    __version__ = get_version(
-        "../..", relative_to=__file__, tag_regex=None
-    )  # pragma: no cover
-except (ModuleNotFoundError, LookupError):  # pragma: no-cover-if-missing-setuptools_scm
-    # If setuptools_scm isn't in the environment, the call to import will fail.
-    # If it *is* in the environment, but the code isn't a git checkout (e.g.,
-    # it's been pip installed non-editable) the call to get_version() will fail.
-    # If either of these occurs, read version from the installer metadata.
-    from importlib.metadata import version
-
-    __version__ = version("briefcase")
+__version__ = version("briefcase")

--- a/src/briefcase/__init__.py
+++ b/src/briefcase/__init__.py
@@ -8,8 +8,11 @@ try:
     from setuptools_scm import get_version
 
     # Excluded from coverage because a pure test environment (such as the one
-    # used by tox in CI) won't have setuptools_scm
-    __version__ = get_version("../..", relative_to=__file__)  # pragma: no cover
+    # used by tox in CI) won't have setuptools_scm.
+    # The tag_regex argument is needed as a workaround for setuptools_scm#1434
+    __version__ = get_version(
+        "../..", relative_to=__file__, tag_regex=None
+    )  # pragma: no cover
 except (ModuleNotFoundError, LookupError):  # pragma: no-cover-if-missing-setuptools_scm
     # If setuptools_scm isn't in the environment, the call to import will fail.
     # If it *is* in the environment, but the code isn't a git checkout (e.g.,


### PR DESCRIPTION
Over the last 24 hours, vsc_versioning 2.0 has been released; this has caused problems with scm_versioning.

There's an underlying bug (pypa/setuptools-scm#1434). Based on the recommendation from the maintainers on that ticket, this simplifies version handling to always use importlib metadata. 

The direct call to get_version() may have been needed historically because importlib.metadata hadn't been fully formalized, but it isn't any more. The only consequence I can see is that an editable install won't necessarily show the *current* VCS version.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
