### PR TITLE
Add support for post-install scripts and installer resources on macOS PKG installers

### DIFF
--- a/changes/2561.feature.md
+++ b/changes/2561.feature.md
@@ -1,0 +1,1 @@
+macOS PKG installers can now include additional installer resources, configured with the ``installer_resources`` setting.

--- a/changes/2561.feature.md
+++ b/changes/2561.feature.md
@@ -1,1 +1,1 @@
-macOS PKG installers can now include additional installer resources, configured with the ``installer_resources`` setting.
+macOS PKG installers can now include additional installer resources, configured with the `installer_resources` setting.

--- a/changes/2865.feature.md
+++ b/changes/2865.feature.md
@@ -1,1 +1,1 @@
-macOS PKG installers can now run a post-install script, configured with the ``post_install_script`` setting.
+macOS PKG installers can now run a post-install script, configured with the `post_install_script` setting.

--- a/changes/2865.feature.md
+++ b/changes/2865.feature.md
@@ -1,0 +1,1 @@
+macOS PKG installers can now run a post-install script, configured with the ``post_install_script`` setting.

--- a/docs/en/reference/platforms/macOS/index.md
+++ b/docs/en/reference/platforms/macOS/index.md
@@ -167,7 +167,7 @@ The minimum macOS version that the app will support. This controls the value of 
 /// note | Only used for PKG packaging
 ///
 
-A path, relative to the project root, to a shell script that will be executed during installation, after the installer content has been unpacked. The script must be a valid macOS installer `postinstall` script (i.e., a script with an appropriate shebang line such as `#!/bin/sh`).
+A path, relative to the project root, to a shell script that will be executed during installation, after the installer content has been unpacked. The script must be a valid macOS shell script file with an appropriate shebang line (e.g., `#!/bin/sh`).
 
 For console apps, Briefcase provides a post-install script that creates a symbolic link to the app on the `PATH`; your script will be run *after* that link has been created.
 

--- a/docs/en/reference/platforms/macOS/index.md
+++ b/docs/en/reference/platforms/macOS/index.md
@@ -167,7 +167,7 @@ A path, relative to the project root, to a directory of additional resources to 
 
 These resources are part of the installer itself, they are used while the installer is running, and are not installed onto the target machine.
 
-DMG and ZIP "installers" do not carry resources, if you define `installer_resources` while using one of those formats, the setting will be ignored.
+DMG and ZIP "installers" do not carry resources. If you define `installer_resources` while using one of those formats, the setting will be ignored with a warning.
 
 ### `min_os_version`
 
@@ -182,7 +182,7 @@ A path, relative to the project root, to a shell script that will be executed du
 
 For console apps, Briefcase provides a post-install script that creates a symbolic link to the app on the `PATH`; your script will be run *after* that link has been created.
 
-DMG and ZIP "installers" cannot run scripts; if you define a `post_install_script` while using one of those formats, the setting will be ignored. There is no PKG analog for a pre-uninstall script.
+DMG and ZIP "installers" cannot run scripts. if you define a `post_install_script` while using one of those formats, the setting will be ignored with a warning. There is no PKG analog for a pre-uninstall script.
 
 ### `universal_build`
 

--- a/docs/en/reference/platforms/macOS/index.md
+++ b/docs/en/reference/platforms/macOS/index.md
@@ -158,6 +158,17 @@ will result in an `Info.plist` declaration of:
 
 Any Boolean or string value can be used for an `Info.plist` value.
 
+### `installer_resources`
+
+/// note | Only used for PKG packaging
+///
+
+A path, relative to the project root, to a directory of additional resources to include in the PKG installer. The contents of this directory are added alongside Briefcase's own installer resources (such as the welcome screen and license), and can be referenced by the installer's distribution definition.
+
+These resources are part of the installer itself, they are used while the installer is running, and are not installed onto the target machine.
+
+DMG and ZIP "installers" do not carry resources, if you define `installer_resources` while using one of those formats, the setting will be ignored.
+
 ### `min_os_version`
 
 The minimum macOS version that the app will support. This controls the value of `MACOSX_DEPLOYMENT_TARGET` used when building the app.

--- a/docs/en/reference/platforms/macOS/index.md
+++ b/docs/en/reference/platforms/macOS/index.md
@@ -162,6 +162,17 @@ Any Boolean or string value can be used for an `Info.plist` value.
 
 The minimum macOS version that the app will support. This controls the value of `MACOSX_DEPLOYMENT_TARGET` used when building the app.
 
+### `post_install_script`
+
+/// note | Only used for PKG packaging
+///
+
+A path, relative to the project root, to a shell script that will be executed during installation, after the installer content has been unpacked. The script must be a valid macOS installer `postinstall` script (i.e., a script with an appropriate shebang line such as `#!/bin/sh`).
+
+For console apps, Briefcase provides a post-install script that creates a symbolic link to the app on the `PATH`; your script will be run *after* that link has been created.
+
+DMG and ZIP "installers" cannot run scripts; if you define a `post_install_script` while using one of those formats, the setting will be ignored. There is no PKG analog for a pre-uninstall script.
+
 ### `universal_build`
 
 A Boolean, indicating whether Briefcase should build a universal app (i.e, an app that can target both x86_64 and ARM64). Defaults to `true`; if `false`, the binary will only be executable on the host platform on which it was built - i.e., if you build on an x86_64 machine, you will produce an x86_65 binary; if you build on an ARM64 machine, you will produce an ARM64 binary.

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1826,20 +1826,22 @@ password:
         # Console apps always have a post-install script (it symlinks the binary onto
         # the PATH); any app can also configure its own. If a custom script is
         # configured, assemble a dedicated scripts directory for it.
-        scripts_path = installer_path / "scripts"
         if post_install := getattr(app, "post_install_script", None):
             with self.console.wait_bar("Installing post-install script..."):
                 scripts_path = self.build_pkg_scripts(app, installer_path)
+        else:
+            scripts_path = installer_path / "scripts"
 
         if app.console_app or post_install:
             install_args += ["--scripts", scripts_path]
 
         # Assemble the installer resources. If the user has supplied additional
         # resources, overlay them onto the templated resources in a clean directory.
-        resources_path = installer_path / "resources"
         if getattr(app, "installer_resources", None):
             with self.console.wait_bar("Installing additional installer resources..."):
                 resources_path = self.build_pkg_resources(app, installer_path)
+        else:
+            resources_path = installer_path / "resources"
 
         with self.console.wait_bar("Building app package..."):
             installer_packages_path = installer_path / "packages"

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1049,20 +1049,33 @@ class macOSPackageMixin(macOSSigningMixin):
     def verify_app(self, app):
         super().verify_app(app)
         self.verify_app_packaging_format(app)
-        self.verify_install_scripts(app)
+        self.verify_packaging_options(app)
 
-    def verify_install_scripts(self, app):
-        """Verify the post-install and pre-uninstall script configuration.
+    def verify_packaging_options(self, app):
+        """Verify the macOS-specific packaging configuration.
+
+        Only PKG installers can run a post-install script or carry extra installer
+        resources, and there's no PKG equivalent of a pre-uninstall script. Warn about
+        any setting that won't be used, and check that configured paths exist.
 
         :param app: The config object for the app
         """
         post_install = getattr(app, "post_install_script", None)
         pre_uninstall = getattr(app, "pre_uninstall_script", None)
+        installer_resources = getattr(app, "installer_resources", None)
 
         if app.packaging_format == "pkg":
             if post_install and not (self.base_path / post_install).is_file():
                 raise BriefcaseCommandError(
                     f"Couldn't find post-install script {post_install}."
+                )
+            if (
+                installer_resources
+                and not (self.base_path / installer_resources).is_dir()
+            ):
+                raise BriefcaseCommandError(
+                    "Couldn't find installer resources directory "
+                    f"{installer_resources}."
                 )
             if pre_uninstall:
                 self.console.warning(
@@ -1083,6 +1096,12 @@ class macOSPackageMixin(macOSSigningMixin):
                     f"macOS {installer} installers do not support pre-uninstall "
                     f"scripts; the pre_uninstall_script setting "
                     f"({pre_uninstall}) will be ignored."
+                )
+            if installer_resources:
+                self.console.warning(
+                    f"macOS {installer} installers do not support additional "
+                    f"resources; the installer_resources setting "
+                    f"({installer_resources}) will be ignored."
                 )
 
     def can_resume(self, app, submission_id=None, **options):
@@ -1716,6 +1735,33 @@ password:
 
         return scripts_path
 
+    def build_pkg_resources(
+        self, app: FinalizedAppConfig, installer_path: Path
+    ) -> Path:
+        """Assemble the resources directory passed to `productbuild --resources`.
+
+        Starts from the templated installer resources (welcome screen and license),
+        then overlays the user-provided `installer_resources` directory. The directory
+        is rebuilt from scratch each time, so resources from a previous build aren't
+        retained.
+
+        :param app: The config object for the app
+        :param installer_path: The path to the installer bundle
+        :returns: The resources directory to pass to productbuild
+        """
+        resources_path = installer_path / "final_resources"
+
+        # Start from a clean directory so resources from a previous build don't leak in.
+        self.tools.shutil.rmtree(resources_path, ignore_errors=True)
+        self.tools.shutil.copytree(installer_path / "resources", resources_path)
+        self.tools.shutil.copytree(
+            self.base_path / app.installer_resources,
+            resources_path,
+            dirs_exist_ok=True,
+        )
+
+        return resources_path
+
     def package_pkg(
         self,
         app: FinalizedAppConfig,
@@ -1795,6 +1841,13 @@ password:
         if app.console_app or post_install:
             install_args += ["--scripts", scripts_path]
 
+        # Assemble the installer resources. If the user has supplied additional
+        # resources, overlay them onto the templated resources in a clean directory.
+        resources_path = installer_path / "resources"
+        if getattr(app, "installer_resources", None):
+            with self.console.wait_bar("Installing additional installer resources..."):
+                resources_path = self.build_pkg_resources(app, installer_path)
+
         with self.console.wait_bar("Building app package..."):
             installer_packages_path = installer_path / "packages"
             if installer_packages_path.exists():
@@ -1829,7 +1882,7 @@ password:
                     "--package-path",
                     installer_path / "packages",
                     "--resources",
-                    installer_path / "resources",
+                    resources_path,
                     *signing_options,
                     dist_path,
                 ],

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1712,7 +1712,7 @@ password:
         :param installer_path: The path to the installer bundle
         :returns: The scripts directory to pass to pkgbuild
         """
-        scripts_path = installer_path / "pkg_scripts"
+        scripts_path = installer_path / "final_scripts"
 
         # Start from a clean copy of the templated scripts directory.
         self.tools.shutil.rmtree(scripts_path, ignore_errors=True)

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1703,35 +1703,28 @@ password:
     def build_pkg_scripts(self, app: FinalizedAppConfig, installer_path: Path) -> Path:
         """Assemble the scripts directory passed to `pkgbuild --scripts`.
 
-        pkgbuild runs the postinstall script in this directory after unpacking the app.
-        Console apps have one that symlinks the binary onto the PATH; the configured
-        post-install script is appended to it. For other apps, the configured script
-        becomes the postinstall script.
+        pkgbuild runs the templated postinstall script after unpacking the app; that
+        script invokes a sibling `_postinstall` script if one is present. The configured
+        post-install script is copied in under that name, so it runs as its own process
+        with its own interpreter. The directory is rebuilt from scratch each time.
 
         :param app: The config object for the app
         :param installer_path: The path to the installer bundle
         :returns: The scripts directory to pass to pkgbuild
         """
-        template_postinstall = installer_path / "scripts" / "postinstall"
         scripts_path = installer_path / "pkg_scripts"
-        postinstall = scripts_path / "postinstall"
 
-        if scripts_path.exists():
-            self.tools.shutil.rmtree(scripts_path)
-        scripts_path.mkdir(parents=True)
+        # Start from a clean copy of the templated scripts directory.
+        self.tools.shutil.rmtree(scripts_path, ignore_errors=True)
+        self.tools.shutil.copytree(installer_path / "scripts", scripts_path)
 
-        post_install = (self.base_path / app.post_install_script).read_text(
-            encoding="utf-8"
+        # Add the configured script as the `_postinstall` that the templated
+        # postinstall script invokes.
+        post_install = scripts_path / "_postinstall"
+        self.tools.shutil.copyfile(
+            self.base_path / app.post_install_script, post_install
         )
-        if app.console_app and template_postinstall.is_file():
-            # Append the configured script to the template's postinstall.
-            base = template_postinstall.read_text(encoding="utf-8").rstrip()
-            postinstall.write_text(f"{base}\n\n{post_install}", encoding="utf-8")
-        else:
-            postinstall.write_text(post_install, encoding="utf-8")
-
-        # pkgbuild requires the postinstall script to be executable.
-        self.tools.os.chmod(postinstall, 0o755)
+        self.tools.os.chmod(post_install, 0o755)
 
         return scripts_path
 

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1682,7 +1682,7 @@ password:
             self.ditto_archive(self.package_path(app), self.distribution_path(app))
 
     def build_pkg_scripts(self, app: FinalizedAppConfig, installer_path: Path) -> Path:
-        """Assemble the scripts directory passed to ``pkgbuild --scripts``.
+        """Assemble the scripts directory passed to `pkgbuild --scripts`.
 
         pkgbuild runs the postinstall script in this directory after unpacking the app.
         Console apps have one that symlinks the binary onto the PATH; the configured

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -1049,6 +1049,41 @@ class macOSPackageMixin(macOSSigningMixin):
     def verify_app(self, app):
         super().verify_app(app)
         self.verify_app_packaging_format(app)
+        self.verify_install_scripts(app)
+
+    def verify_install_scripts(self, app):
+        """Verify the post-install and pre-uninstall script configuration.
+
+        :param app: The config object for the app
+        """
+        post_install = getattr(app, "post_install_script", None)
+        pre_uninstall = getattr(app, "pre_uninstall_script", None)
+
+        if app.packaging_format == "pkg":
+            if post_install and not (self.base_path / post_install).is_file():
+                raise BriefcaseCommandError(
+                    f"Couldn't find post-install script {post_install}."
+                )
+            if pre_uninstall:
+                self.console.warning(
+                    "macOS PKG installers do not support pre-uninstall scripts; "
+                    f"the pre_uninstall_script setting ({pre_uninstall}) "
+                    "will be ignored."
+                )
+        else:
+            installer = app.packaging_format.upper()
+            if post_install:
+                self.console.warning(
+                    f"macOS {installer} installers do not support post-install "
+                    f"scripts; the post_install_script setting "
+                    f"({post_install}) will be ignored."
+                )
+            if pre_uninstall:
+                self.console.warning(
+                    f"macOS {installer} installers do not support pre-uninstall "
+                    f"scripts; the pre_uninstall_script setting "
+                    f"({pre_uninstall}) will be ignored."
+                )
 
     def can_resume(self, app, submission_id=None, **options):
         """Determine if notarization can be resumed.
@@ -1646,6 +1681,41 @@ password:
         ):
             self.ditto_archive(self.package_path(app), self.distribution_path(app))
 
+    def build_pkg_scripts(self, app: FinalizedAppConfig, installer_path: Path) -> Path:
+        """Assemble the scripts directory passed to ``pkgbuild --scripts``.
+
+        pkgbuild runs the postinstall script in this directory after unpacking the app.
+        Console apps have one that symlinks the binary onto the PATH; the configured
+        post-install script is appended to it. For other apps, the configured script
+        becomes the postinstall script.
+
+        :param app: The config object for the app
+        :param installer_path: The path to the installer bundle
+        :returns: The scripts directory to pass to pkgbuild
+        """
+        template_postinstall = installer_path / "scripts" / "postinstall"
+        scripts_path = installer_path / "pkg_scripts"
+        postinstall = scripts_path / "postinstall"
+
+        if scripts_path.exists():
+            self.tools.shutil.rmtree(scripts_path)
+        scripts_path.mkdir(parents=True)
+
+        post_install = (self.base_path / app.post_install_script).read_text(
+            encoding="utf-8"
+        )
+        if app.console_app and template_postinstall.is_file():
+            # Append the configured script to the template's postinstall.
+            base = template_postinstall.read_text(encoding="utf-8").rstrip()
+            postinstall.write_text(f"{base}\n\n{post_install}", encoding="utf-8")
+        else:
+            postinstall.write_text(post_install, encoding="utf-8")
+
+        # pkgbuild requires the postinstall script to be executable.
+        self.tools.os.chmod(postinstall, 0o755)
+
+        return scripts_path
+
     def package_pkg(
         self,
         app: FinalizedAppConfig,
@@ -1707,18 +1777,23 @@ password:
                 components_plist,
             )
 
-        # Console apps are installed in /Library/Formal Name, and include the
-        # post-install scripts. Normal apps are installed in /Applications, and don't
-        # include the scripts.
+        # Console apps are installed in /Library/Formal Name; normal apps are
+        # installed in /Applications.
         if app.console_app:
-            install_args = [
-                "--install-location",
-                f"/Library/{app.formal_name}",
-                "--scripts",
-                installer_path / "scripts",
-            ]
+            install_args = ["--install-location", f"/Library/{app.formal_name}"]
         else:
             install_args = ["--install-location", "/Applications"]
+
+        # Console apps always have a post-install script (it symlinks the binary onto
+        # the PATH); any app can also configure its own. If a custom script is
+        # configured, assemble a dedicated scripts directory for it.
+        scripts_path = installer_path / "scripts"
+        if post_install := getattr(app, "post_install_script", None):
+            with self.console.wait_bar("Installing post-install script..."):
+                scripts_path = self.build_pkg_scripts(app, installer_path)
+
+        if app.console_app or post_install:
+            install_args += ["--scripts", scripts_path]
 
         with self.console.wait_bar("Building app package..."):
             installer_packages_path = installer_path / "packages"

--- a/tests/platforms/macOS/app/package/test_package.py
+++ b/tests/platforms/macOS/app/package/test_package.py
@@ -59,6 +59,45 @@ def test_console_invalid_formats(
         package_command.verify_app(first_app_with_binaries)
 
 
+def test_post_install_script_missing(package_command, first_app_with_binaries):
+    """A configured post-install script that doesn't exist is an error."""
+    first_app_with_binaries.packaging_format = "pkg"
+    first_app_with_binaries.post_install_script = "scripts/missing.sh"
+
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r"Couldn't find post-install script scripts/missing\.sh",
+    ):
+        package_command.verify_app(first_app_with_binaries)
+
+
+@pytest.mark.parametrize(
+    ("packaging_format", "setting", "expected"),
+    [
+        ("pkg", "pre_uninstall_script", "PKG installers do not support pre-uninstall"),
+        ("dmg", "post_install_script", "DMG installers do not support post-install"),
+        ("dmg", "pre_uninstall_script", "DMG installers do not support pre-uninstall"),
+    ],
+)
+def test_install_script_warnings(
+    package_command,
+    first_app_with_binaries,
+    capsys,
+    packaging_format,
+    setting,
+    expected,
+):
+    """A script that won't be used is reported as ignored."""
+    first_app_with_binaries.packaging_format = packaging_format
+    setattr(first_app_with_binaries, setting, "scripts/x.sh")
+
+    package_command.verify_app(first_app_with_binaries)
+
+    output = " ".join(capsys.readouterr().out.split())
+    assert expected in output
+    assert "will be ignored" in output
+
+
 def test_no_notarize_option(package_command):
     """The --no-notarize option can be parsed."""
     options, overrides = package_command.parse_options(["--no-notarize"])

--- a/tests/platforms/macOS/app/package/test_package.py
+++ b/tests/platforms/macOS/app/package/test_package.py
@@ -71,15 +71,28 @@ def test_post_install_script_missing(package_command, first_app_with_binaries):
         package_command.verify_app(first_app_with_binaries)
 
 
+def test_installer_resources_missing(package_command, first_app_with_binaries):
+    """A configured installer resources directory that doesn't exist is an error."""
+    first_app_with_binaries.packaging_format = "pkg"
+    first_app_with_binaries.installer_resources = "missing_dir"
+
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r"Couldn't find installer resources directory missing_dir",
+    ):
+        package_command.verify_app(first_app_with_binaries)
+
+
 @pytest.mark.parametrize(
     ("packaging_format", "setting", "expected"),
     [
         ("pkg", "pre_uninstall_script", "PKG installers do not support pre-uninstall"),
         ("dmg", "post_install_script", "DMG installers do not support post-install"),
         ("dmg", "pre_uninstall_script", "DMG installers do not support pre-uninstall"),
+        ("dmg", "installer_resources", "DMG installers do not support additional"),
     ],
 )
-def test_install_script_warnings(
+def test_install_option_warnings(
     package_command,
     first_app_with_binaries,
     capsys,
@@ -87,7 +100,7 @@ def test_install_script_warnings(
     setting,
     expected,
 ):
-    """A script that won't be used is reported as ignored."""
+    """A setting that won't be used is reported as ignored."""
     first_app_with_binaries.packaging_format = packaging_format
     setattr(first_app_with_binaries, setting, "scripts/x.sh")
 

--- a/tests/platforms/macOS/app/package/test_package_pkg.py
+++ b/tests/platforms/macOS/app/package/test_package_pkg.py
@@ -1,3 +1,4 @@
+import os
 import plistlib
 from unittest import mock
 
@@ -408,6 +409,75 @@ def test_console_app_adhoc_signed(
 
     # No notarization was performed
     package_command.notarize.assert_not_called()
+
+
+def test_gui_app_post_install_script(
+    package_command,
+    first_app_with_binaries,
+    tmp_path,
+):
+    """GUI app can include a custom post-install script in its PKG installer."""
+    first_app_with_binaries.packaging_format = "pkg"
+    first_app_with_binaries.post_install_script = "scripts/post_install.sh"
+
+    package_command.notarize = mock.Mock()
+    # Spy on chmod; the executable bit can't be checked via the file mode on Windows.
+    package_command.tools.os = mock.MagicMock(spec_set=os)
+    bundle_path = tmp_path / "base_path/build/first-app/macos/app"
+
+    create_file(
+        tmp_path / "base_path/scripts/post_install.sh",
+        "#!/bin/sh\necho 'Custom post-install'\n",
+    )
+    create_file(bundle_path / "installer/resources/LICENSE", "Original License")
+
+    package_command.package_app(first_app_with_binaries, adhoc_sign=True)
+
+    postinstall = bundle_path / "installer/pkg_scripts/postinstall"
+    assert postinstall.read_text(encoding="utf-8") == (
+        "#!/bin/sh\necho 'Custom post-install'\n"
+    )
+    # The postinstall script is made executable for pkgbuild.
+    package_command.tools.os.chmod.assert_called_once_with(postinstall, 0o755)
+
+    pkgbuild_args = package_command.tools.subprocess.run.mock_calls[0].args[0]
+    assert ["--scripts", bundle_path / "installer/pkg_scripts"] == pkgbuild_args[-3:-1]
+
+
+def test_console_app_post_install_script(
+    package_command,
+    first_app_with_binaries,
+    tmp_path,
+):
+    """A console app's custom post-install script is appended to the template's."""
+    first_app_with_binaries.packaging_format = "pkg"
+    first_app_with_binaries.console_app = True
+    first_app_with_binaries.post_install_script = "scripts/post_install.sh"
+
+    package_command.notarize = mock.Mock()
+    bundle_path = tmp_path / "base_path/build/first-app/macos/app"
+
+    template_postinstall = bundle_path / "installer/scripts/postinstall"
+    create_file(template_postinstall, "#!/bin/sh\necho symlink\n")
+    create_file(
+        tmp_path / "base_path/scripts/post_install.sh",
+        "#!/bin/sh\necho custom\n",
+    )
+
+    package_command.package_app(first_app_with_binaries, adhoc_sign=True)
+
+    postinstall = bundle_path / "installer/pkg_scripts/postinstall"
+    assert postinstall.read_text(encoding="utf-8") == (
+        "#!/bin/sh\necho symlink\n\n#!/bin/sh\necho custom\n"
+    )
+    assert (
+        template_postinstall.read_text(encoding="utf-8") == "#!/bin/sh\necho symlink\n"
+    )
+
+    package_command.package_app(first_app_with_binaries, adhoc_sign=True)
+    assert postinstall.read_text(encoding="utf-8") == (
+        "#!/bin/sh\necho symlink\n\n#!/bin/sh\necho custom\n"
+    )
 
 
 def test_no_license(

--- a/tests/platforms/macOS/app/package/test_package_pkg.py
+++ b/tests/platforms/macOS/app/package/test_package_pkg.py
@@ -480,6 +480,33 @@ def test_console_app_post_install_script(
     )
 
 
+def test_installer_resources(package_command, first_app_with_binaries, tmp_path):
+    """User installer resources are merged with the templated installer resources."""
+    first_app_with_binaries.packaging_format = "pkg"
+    first_app_with_binaries.installer_resources = "installer_extras"
+
+    package_command.notarize = mock.Mock()
+    bundle_path = tmp_path / "base_path/build/first-app/macos/app"
+
+    create_file(bundle_path / "installer/resources/welcome.html", "<html>")
+    create_file(bundle_path / "installer/final_resources/stale.txt", "stale")
+    create_file(tmp_path / "base_path/installer_extras/helper.dat", "payload")
+
+    package_command.package_app(first_app_with_binaries, adhoc_sign=True)
+
+    final = bundle_path / "installer/final_resources"
+    assert (final / "welcome.html").is_file()
+    assert (final / "LICENSE").read_text(encoding="utf-8") == (
+        "The Actual First App License"
+    )
+    assert (final / "helper.dat").read_text(encoding="utf-8") == "payload"
+    assert not (final / "stale.txt").exists()
+
+    productbuild_args = package_command.tools.subprocess.run.mock_calls[1].args[0]
+    idx = productbuild_args.index("--resources")
+    assert productbuild_args[idx + 1] == final
+
+
 def test_no_license(
     package_command,
     first_app_with_binaries,

--- a/tests/platforms/macOS/app/package/test_package_pkg.py
+++ b/tests/platforms/macOS/app/package/test_package_pkg.py
@@ -422,31 +422,56 @@ def test_post_install_script(package_command, first_app_with_binaries, tmp_path)
     bundle_path = tmp_path / "base_path/build/first-app/macos/app"
 
     # The templated scripts directory; its postinstall invokes `_postinstall`.
-    create_file(bundle_path / "installer/scripts/postinstall", "#!/bin/sh\nhook\n")
+    POSTINSTALL_BODY = "#!/bin/sh\nhook\n"
+    create_file(bundle_path / "installer/scripts/postinstall", POSTINSTALL_BODY)
     # The user's script keeps its own interpreter.
-    create_file(
-        tmp_path / "base_path/scripts/post_install.sh",
-        "#!/usr/bin/env python3\nprint('custom')\n",
-    )
+    USER_POSTINSTALL_BODY = "#!/usr/bin/env python3\nprint('custom')\n"
+    create_file(tmp_path / "base_path/scripts/post_install.sh", USER_POSTINSTALL_BODY)
 
     package_command.package_app(first_app_with_binaries, adhoc_sign=True)
 
-    pkg_scripts = bundle_path / "installer/pkg_scripts"
+    pkg_scripts = bundle_path / "installer/final_scripts"
     # The templated postinstall is carried over unchanged...
-    assert (pkg_scripts / "postinstall").read_text(
-        encoding="utf-8"
-    ) == "#!/bin/sh\nhook\n"
+    assert (pkg_scripts / "postinstall").read_text(encoding="utf-8") == POSTINSTALL_BODY
     # ...and the user's script is installed verbatim as an executable `_postinstall`.
     assert (pkg_scripts / "_postinstall").read_text(encoding="utf-8") == (
-        "#!/usr/bin/env python3\nprint('custom')\n"
+        USER_POSTINSTALL_BODY
     )
     package_command.tools.os.chmod.assert_called_once_with(
         pkg_scripts / "_postinstall", 0o755
     )
 
     # pkgbuild was given the generated scripts directory.
-    pkgbuild_args = package_command.tools.subprocess.run.mock_calls[0].args[0]
-    assert ["--scripts", pkg_scripts] == pkgbuild_args[-3:-1]
+    assert package_command.tools.subprocess.run.mock_calls == [
+        mock.call(
+            [
+                "pkgbuild",
+                "--root",
+                bundle_path / "installer/root",
+                "--component-plist",
+                bundle_path / "installer/components.plist",
+                "--install-location",
+                "/Applications",
+                "--scripts",
+                bundle_path / "installer/final_scripts",
+                bundle_path / "installer/packages/first-app.pkg",
+            ],
+            check=True,
+        ),
+        mock.call(
+            [
+                "productbuild",
+                "--distribution",
+                bundle_path / "installer/Distribution.xml",
+                "--package-path",
+                bundle_path / "installer/packages",
+                "--resources",
+                bundle_path / "installer/resources",
+                tmp_path / "base_path/dist/First App-0.0.1.pkg",
+            ],
+            check=True,
+        ),
+    ]
 
 
 def test_installer_resources(package_command, first_app_with_binaries, tmp_path):
@@ -471,9 +496,35 @@ def test_installer_resources(package_command, first_app_with_binaries, tmp_path)
     assert (final / "helper.dat").read_text(encoding="utf-8") == "payload"
     assert not (final / "stale.txt").exists()
 
-    productbuild_args = package_command.tools.subprocess.run.mock_calls[1].args[0]
-    idx = productbuild_args.index("--resources")
-    assert productbuild_args[idx + 1] == final
+    # The packaging calls got the custom resources directory
+    assert package_command.tools.subprocess.run.mock_calls == [
+        mock.call(
+            [
+                "pkgbuild",
+                "--root",
+                bundle_path / "installer/root",
+                "--component-plist",
+                bundle_path / "installer/components.plist",
+                "--install-location",
+                "/Applications",
+                bundle_path / "installer/packages/first-app.pkg",
+            ],
+            check=True,
+        ),
+        mock.call(
+            [
+                "productbuild",
+                "--distribution",
+                bundle_path / "installer/Distribution.xml",
+                "--package-path",
+                bundle_path / "installer/packages",
+                "--resources",
+                bundle_path / "installer/final_resources",
+                tmp_path / "base_path/dist/First App-0.0.1.pkg",
+            ],
+            check=True,
+        ),
+    ]
 
 
 def test_no_license(

--- a/tests/platforms/macOS/app/package/test_package_pkg.py
+++ b/tests/platforms/macOS/app/package/test_package_pkg.py
@@ -411,12 +411,8 @@ def test_console_app_adhoc_signed(
     package_command.notarize.assert_not_called()
 
 
-def test_gui_app_post_install_script(
-    package_command,
-    first_app_with_binaries,
-    tmp_path,
-):
-    """GUI app can include a custom post-install script in its PKG installer."""
+def test_post_install_script(package_command, first_app_with_binaries, tmp_path):
+    """A custom post-install script is installed as an executable `_postinstall`."""
     first_app_with_binaries.packaging_format = "pkg"
     first_app_with_binaries.post_install_script = "scripts/post_install.sh"
 
@@ -425,59 +421,32 @@ def test_gui_app_post_install_script(
     package_command.tools.os = mock.MagicMock(spec_set=os)
     bundle_path = tmp_path / "base_path/build/first-app/macos/app"
 
+    # The templated scripts directory; its postinstall invokes `_postinstall`.
+    create_file(bundle_path / "installer/scripts/postinstall", "#!/bin/sh\nhook\n")
+    # The user's script keeps its own interpreter.
     create_file(
         tmp_path / "base_path/scripts/post_install.sh",
-        "#!/bin/sh\necho 'Custom post-install'\n",
+        "#!/usr/bin/env python3\nprint('custom')\n",
     )
-    create_file(bundle_path / "installer/resources/LICENSE", "Original License")
 
     package_command.package_app(first_app_with_binaries, adhoc_sign=True)
 
-    postinstall = bundle_path / "installer/pkg_scripts/postinstall"
-    assert postinstall.read_text(encoding="utf-8") == (
-        "#!/bin/sh\necho 'Custom post-install'\n"
+    pkg_scripts = bundle_path / "installer/pkg_scripts"
+    # The templated postinstall is carried over unchanged...
+    assert (pkg_scripts / "postinstall").read_text(
+        encoding="utf-8"
+    ) == "#!/bin/sh\nhook\n"
+    # ...and the user's script is installed verbatim as an executable `_postinstall`.
+    assert (pkg_scripts / "_postinstall").read_text(encoding="utf-8") == (
+        "#!/usr/bin/env python3\nprint('custom')\n"
     )
-    # The postinstall script is made executable for pkgbuild.
-    package_command.tools.os.chmod.assert_called_once_with(postinstall, 0o755)
+    package_command.tools.os.chmod.assert_called_once_with(
+        pkg_scripts / "_postinstall", 0o755
+    )
 
+    # pkgbuild was given the generated scripts directory.
     pkgbuild_args = package_command.tools.subprocess.run.mock_calls[0].args[0]
-    assert ["--scripts", bundle_path / "installer/pkg_scripts"] == pkgbuild_args[-3:-1]
-
-
-def test_console_app_post_install_script(
-    package_command,
-    first_app_with_binaries,
-    tmp_path,
-):
-    """A console app's custom post-install script is appended to the template's."""
-    first_app_with_binaries.packaging_format = "pkg"
-    first_app_with_binaries.console_app = True
-    first_app_with_binaries.post_install_script = "scripts/post_install.sh"
-
-    package_command.notarize = mock.Mock()
-    bundle_path = tmp_path / "base_path/build/first-app/macos/app"
-
-    template_postinstall = bundle_path / "installer/scripts/postinstall"
-    create_file(template_postinstall, "#!/bin/sh\necho symlink\n")
-    create_file(
-        tmp_path / "base_path/scripts/post_install.sh",
-        "#!/bin/sh\necho custom\n",
-    )
-
-    package_command.package_app(first_app_with_binaries, adhoc_sign=True)
-
-    postinstall = bundle_path / "installer/pkg_scripts/postinstall"
-    assert postinstall.read_text(encoding="utf-8") == (
-        "#!/bin/sh\necho symlink\n\n#!/bin/sh\necho custom\n"
-    )
-    assert (
-        template_postinstall.read_text(encoding="utf-8") == "#!/bin/sh\necho symlink\n"
-    )
-
-    package_command.package_app(first_app_with_binaries, adhoc_sign=True)
-    assert postinstall.read_text(encoding="utf-8") == (
-        "#!/bin/sh\necho symlink\n\n#!/bin/sh\necho custom\n"
-    )
+    assert ["--scripts", pkg_scripts] == pkgbuild_args[-3:-1]
 
 
 def test_installer_resources(package_command, first_app_with_binaries, tmp_path):


### PR DESCRIPTION
PKG installers have always had the facility to run a post-install script, but Briefcase didn't expose it. This adds a `post_install_script` setting for macOS, matching the existing Windows MSI behaviour:

```toml
[tool.briefcase.app.myapp.macOS]
post_install_script = "scripts/post_install.sh"
```
  
The configured script is assembled into a dedicated scripts directory and passed to `pkgbuild --scripts`. The directory is rebuilt from scratch on every `package` run, so the template's own files are never mutated and re-packaging can't duplicate content.
  
As called out in the issue, scripts that an installer format can't use are now reported:
- a `pre_uninstall_script` on a PKG installer (there's no PKG equivalent) → warning;
- a `post_install_script` or `pre_uninstall_script` on a DMG/ZIP installer → warning;
- a `post_install_script` that doesn't exist on disk → error.

Fixes #2865, reported by me in #2561.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: Claude Code (Opus 4.8)
Disclosure: Tests and documentation in this PR were AI-generated.