### PR TITLE
Verify Flatpak base is installed

### DIFF
--- a/changes/2905.bugfix.md
+++ b/changes/2905.bugfix.md
@@ -1,1 +1,1 @@
-Verify used Flatpak base is installed.
+If a Linux Flatpak project specifies the use of a base image, Briefcase now verifies that base is installed and available.

--- a/changes/2905.bugfix.md
+++ b/changes/2905.bugfix.md
@@ -1,0 +1,1 @@
+Verify used Flatpak base is installed.

--- a/src/briefcase/integrations/flatpak.py
+++ b/src/briefcase/integrations/flatpak.py
@@ -168,13 +168,17 @@ You must install both flatpak and flatpak-builder.
         runtime: str,
         runtime_version: str,
         sdk: str,
+        base: str | None = None,
+        base_version: str | None = None,
     ):
-        """Verify that a specific Flatpak runtime and SDK are available.
+        """Verify that a specific Flatpak runtime, SDK and base are available.
 
         :param repo_alias: The alias of the repo where the runtime and SDK are stored.
         :param runtime: The identifier of the Flatpak runtime
         :param runtime_version: The version of the Flatpak runtime
         :param sdk: The Flatpak SDK
+        :param base: (Optional) The Flatpak base
+        :param base_version: The version of the Flatpak base if specified
         """
         try:
             self.tools.subprocess.run(
@@ -187,6 +191,7 @@ You must install both flatpak and flatpak-builder.
                     f"{runtime}/{self.tools.host_arch}/{runtime_version}",
                     f"{sdk}/{self.tools.host_arch}/{runtime_version}",
                 ]
+                + ([f"{base}/{self.tools.host_arch}/{base_version}"] if base else [])
                 + (["--verbose"] if self.tools.console.is_deep_debug else []),
                 check=True,
                 # flatpak install uses many animations that cannot be disabled
@@ -197,7 +202,12 @@ You must install both flatpak and flatpak-builder.
                 f"Unable to install "
                 f"Flatpak runtime {runtime}/{self.tools.host_arch}/{runtime_version} "
                 f"and SDK {sdk}/{self.tools.host_arch}/{runtime_version} "
-                f"from repo {repo_alias}."
+                + (
+                    f"and base {base}/{self.tools.host_arch}/{base_version} "
+                    if base
+                    else ""
+                )
+                + f"from repo {repo_alias}."
             ) from e
 
     def build(self, bundle_identifier: str, app_name: str, path: Path):

--- a/src/briefcase/platforms/linux/flatpak.py
+++ b/src/briefcase/platforms/linux/flatpak.py
@@ -97,6 +97,21 @@ Your application configuration must provide values for
 `flatpak_sdk`, `flatpak_runtime`, and `flatpak_runtime_version`.
 """) from e
 
+    def flatpak_base(self, app):
+        return getattr(app, "flatpak_base", None)
+
+    def flatpak_base_version(self, app):
+        try:
+            return app.flatpak_base_version
+        except AttributeError as e:
+            if self.flatpak_base(app) is not None:
+                raise BriefcaseConfigError("""\
+The App specifies a Flatpak base without a version.
+
+Your application configuration must provide a value for `flatpak_base_version`
+if `flatpak_base` is defined.
+""") from e
+
 
 class LinuxFlatpakCreateCommand(LinuxFlatpakMixin, CreateCommand):
     description = "Create and populate a Linux Flatpak."
@@ -108,6 +123,8 @@ class LinuxFlatpakCreateCommand(LinuxFlatpakMixin, CreateCommand):
             "flatpak_runtime": self.flatpak_runtime(app),
             "flatpak_runtime_version": self.flatpak_runtime_version(app),
             "flatpak_sdk": self.flatpak_sdk(app),
+            "flatpak_base": self.flatpak_base(app),
+            "flatpak_base_version": self.flatpak_base_version(app),
         }
 
     def permissions_context(
@@ -185,6 +202,8 @@ class LinuxFlatpakBuildCommand(LinuxFlatpakMixin, BuildCommand):
             runtime=self.flatpak_runtime(app),
             runtime_version=self.flatpak_runtime_version(app),
             sdk=self.flatpak_sdk(app),
+            base=self.flatpak_base(app),
+            base_version=self.flatpak_base_version(app),
         )
 
         self.console.info("Building Flatpak...", prefix=app.app_name)

--- a/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
@@ -18,6 +18,8 @@ def test_verify_runtime(flatpak, tool_debug_mode):
         runtime="org.beeware.flatpak.Platform",
         runtime_version="37.42",
         sdk="org.beeware.flatpak.SDK",
+        base="org.beeware.flatpak.BaseApp",
+        base_version="1.0",
     )
 
     # The expected call was made
@@ -30,6 +32,7 @@ def test_verify_runtime(flatpak, tool_debug_mode):
             "test-alias",
             "org.beeware.flatpak.Platform/gothic/37.42",
             "org.beeware.flatpak.SDK/gothic/37.42",
+            "org.beeware.flatpak.BaseApp/gothic/1.0",
         ]
         + (["--verbose"] if tool_debug_mode else []),
         check=True,
@@ -55,4 +58,22 @@ def test_verify_runtime_fail(flatpak):
             runtime="org.beeware.flatpak.Platform",
             runtime_version="37.42",
             sdk="org.beeware.flatpak.SDK",
+        )
+
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=(
+            r"Unable to install Flatpak runtime org.beeware.flatpak.Platform/gothic/37.42 "
+            r"and SDK org.beeware.flatpak.SDK/gothic/37.42 "
+            r"and base org.beeware.flatpak.BaseApp/gothic/1.0 "
+            r"from repo test-alias."
+        ),
+    ):
+        flatpak.verify_runtime(
+            repo_alias="test-alias",
+            runtime="org.beeware.flatpak.Platform",
+            runtime_version="37.42",
+            sdk="org.beeware.flatpak.SDK",
+            base="org.beeware.flatpak.BaseApp",
+            base_version="1.0",
         )

--- a/tests/platforms/linux/flatpak/test_build.py
+++ b/tests/platforms/linux/flatpak/test_build.py
@@ -26,6 +26,8 @@ def test_build(build_command, first_app_config, tmp_path):
     first_app_config.flatpak_runtime = "org.beeware.Platform"
     first_app_config.flatpak_runtime_version = "37.42"
     first_app_config.flatpak_sdk = "org.beeware.SDK"
+    first_app_config.flatpak_base = "org.beeware.flatpak.BaseApp"
+    first_app_config.flatpak_base_version = "1.0"
 
     build_command.build_app(first_app_config)
 
@@ -41,6 +43,8 @@ def test_build(build_command, first_app_config, tmp_path):
         runtime="org.beeware.Platform",
         runtime_version="37.42",
         sdk="org.beeware.SDK",
+        base="org.beeware.flatpak.BaseApp",
+        base_version="1.0",
     )
 
     # The build is invoked
@@ -51,6 +55,30 @@ def test_build(build_command, first_app_config, tmp_path):
     )
 
 
+def test_missing_base_config(build_command, first_app_config):
+    """The build does not fail if an optional Flatpak base is not defined."""
+
+    build_command.tools.flatpak = MagicMock(spec_set=Flatpak)
+
+    first_app_config.flatpak_runtime_repo_url = "https://example.com/flatpak/repo"
+    first_app_config.flatpak_runtime_repo_alias = "custom-repo"
+
+    first_app_config.flatpak_runtime = "org.beeware.Platform"
+    first_app_config.flatpak_runtime_version = "37.42"
+    first_app_config.flatpak_sdk = "org.beeware.SDK"
+
+    build_command.build_app(first_app_config)
+
+    build_command.tools.flatpak.verify_runtime.assert_called_once_with(
+        repo_alias="custom-repo",
+        runtime="org.beeware.Platform",
+        runtime_version="37.42",
+        sdk="org.beeware.SDK",
+        base=None,
+        base_version=None,
+    )
+
+
 def test_missing_runtime_config(build_command, first_app_config):
     """The app build errors is a Flatpak runtime is not defined."""
     build_command.tools.flatpak = MagicMock(spec_set=Flatpak)
@@ -58,5 +86,25 @@ def test_missing_runtime_config(build_command, first_app_config):
     with pytest.raises(
         BriefcaseConfigError,
         match="Briefcase configuration error: The App does not specify the Flatpak runtime to use",
+    ):
+        build_command.build_app(first_app_config)
+
+
+def test_missing_base_version_config(build_command, first_app_config):
+    """The build fails if an optional Flatpak base is defined but without a version."""
+
+    build_command.tools.flatpak = MagicMock(spec_set=Flatpak)
+
+    first_app_config.flatpak_runtime_repo_url = "https://example.com/flatpak/repo"
+    first_app_config.flatpak_runtime_repo_alias = "custom-repo"
+
+    first_app_config.flatpak_runtime = "org.beeware.Platform"
+    first_app_config.flatpak_runtime_version = "37.42"
+    first_app_config.flatpak_sdk = "org.beeware.SDK"
+    first_app_config.flatpak_base = "org.beeware.flatpak.BaseApp"
+
+    with pytest.raises(
+        BriefcaseConfigError,
+        match=r"Briefcase configuration error: The App specifies a Flatpak base without a version.",
     ):
         build_command.build_app(first_app_config)

--- a/tests/platforms/linux/flatpak/test_create.py
+++ b/tests/platforms/linux/flatpak/test_create.py
@@ -33,11 +33,15 @@ def test_output_format_template_context(create_command, first_app_config):
     first_app_config.flatpak_runtime = "org.beeware.Platform"
     first_app_config.flatpak_runtime_version = "37.42"
     first_app_config.flatpak_sdk = "org.beeware.SDK"
+    first_app_config.flatpak_base = "org.beeware.flatpak.BaseApp"
+    first_app_config.flatpak_base_version = "1.0"
 
     assert create_command.output_format_template_context(first_app_config) == {
         "flatpak_runtime": "org.beeware.Platform",
         "flatpak_runtime_version": "37.42",
         "flatpak_sdk": "org.beeware.SDK",
+        "flatpak_base": "org.beeware.flatpak.BaseApp",
+        "flatpak_base_version": "1.0",
     }
 
 


### PR DESCRIPTION
If the optional `flatpak_base` option is set, Briefcase didn't ensure the base is installed before building the package, resulting in a flatpak-builder error.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
