### PR TITLE
Use helper function for formatting error banner in config.py

### DIFF
--- a/changes/+2559-config.misc.md
+++ b/changes/+2559-config.misc.md
@@ -1,0 +1,1 @@
+The warning banner helper was used in the configuration file.

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -855,7 +855,7 @@ def _normalize_pep639_license_config(
     if raw_license_files is None:
         raw_license_files = []
 
-    # Ensure `licence` is an SPDX expression
+    # Ensure `license` is an SPDX expression
     try:
         spdx_id = canonicalize_license_expression(raw_license)
     except InvalidLicenseExpression:
@@ -1000,7 +1000,7 @@ def _normalize_pep621_license_file_config(
         spdx_note = (
             "A license SPDX expression could not be identified from the "
             "license file. The license has been set to "
-            "'LicenseRef-UnknownLicense'"
+            "'LicenseRef-UnknownLicense'."
         )
 
     # Warn and finalize PEP 621 license.file coercion. Use `license_files` rather than
@@ -1012,7 +1012,7 @@ def _normalize_pep621_license_file_config(
 
             PEP 639 requires the definition of both `license` and
             `license-files`. The value for `license.file` will be used to
-            populate the PEP 639 `licence-files` setting.
+            populate the PEP 639 `license-files` setting.
 
             {spdx_note}
 

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -939,8 +939,7 @@ def _normalize_pep621_license_text_config(
             "cause problems packaging for some platforms."
         )
 
-    # Warn and finalize PEP 621 license.text coercion. Use `license_files` rather than
-    # `license-files` so it's a valid attribute name.
+    # Warn and finalize PEP 621 license.text coercion.
     console.warning_banner(
         f"'{app_name}' uses PEP 621 `license.text` format",
         f"""

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -903,65 +903,62 @@ def _normalize_pep621_license_text_config(
     # Attempt to identify the SPDX expression from the text content.
     spdx_id = get_license_from_text(license_text)
 
-    warning = [
-        f"""
-*******************************************************************************
-** {"WARNING: '" + app_name + "' uses PEP 621 `license.text` format":73} **
-*******************************************************************************
-
-    Briefcase now uses PEP 639 format for license definitions.
-"""
-    ]
     if spdx_id is not None:
         # SPDX identifiable.
         license = spdx_id
-        warning.append(f"""
-    PEP 639 requires the definition of both `license` and `license-files`,
-    and `license` must be a valid SPDX expression. The current value for
-    `license.text` seems to define a SPDX license of '{spdx_id}'.
-""")
+        spdx_note = (
+            "PEP 639 requires the definition of both `license` and "
+            "`license-files`, and `license` must be a valid SPDX expression. "
+            "The current value for `license.text` seems to define a SPDX "
+            f"license of '{spdx_id}'."
+        )
     else:
         # SPDX not identifiable.
         spdx_id = "<SPDX expression>"
         license = "LicenseRef-UnknownLicense"
-        warning.append(f"""
-    PEP 639 requires the definition of both `license` and `license-files`.
-    Briefcase cannot determine the current license for '{app_name}' based
-    on the value of `license.text`. A value of 'LicenseRef-UnknownLicense'
-    will be used.
-""")
+        spdx_note = (
+            "PEP 639 requires the definition of both `license` and "
+            "`license-files`. Briefcase cannot determine the current license "
+            f"for '{app_name}' based on the value of `license.text`. A value of "
+            "'LicenseRef-UnknownLicense' will be used."
+        )
 
     # Write the license text to a file under the build directory so it can
     # be referenced as a real path in license-files.
     tmp_license_file = _write_temp_license(base_path, app_name, license_text)
     if tmp_license_file:
         license_files = [tmp_license_file]
-        warning.append("""
-    The contents of `license.text` will be used as the contents of the
-    license file. This may not be correct, and should be verified.
-""")
+        file_note = (
+            "The contents of `license.text` will be used as the contents of "
+            "the license file. This may not be correct, and should be verified."
+        )
     else:
         license_files = []
-        warning.append("""
-    Your project will not have a value for `license-files`. This will
-    cause problems packaging for some platforms.
-""")
-
-    warning.append(f"""
-    Update your configuration to put the full license text in a file and use
-    PEP 639 format for the license definition:
-
-        license = "{spdx_id}"
-        license-files = ["LICENSE"]
-
-    You should not release your project without resolving this warning.
-
-*******************************************************************************
-""")
+        file_note = (
+            "Your project will not have a value for `license-files`. This will "
+            "cause problems packaging for some platforms."
+        )
 
     # Warn and finalize PEP 621 license.text coercion. Use `license_files` rather than
     # `license-files` so it's a valid attribute name.
-    console.warning("".join(warning))
+    console.warning_banner(
+        f"'{app_name}' uses PEP 621 `license.text` format",
+        f"""
+            Briefcase now uses PEP 639 format for license definitions.
+
+            {spdx_note}
+
+            {file_note}
+
+            Update your configuration to put the full license text in a file
+            and use PEP 639 format for the license definition:
+
+                license = "{spdx_id}"
+                license-files = ["LICENSE"]
+
+            You should not release your project without resolving this warning.
+        """,
+    )
     config["license"] = license
     config["license_files"] = license_files
 
@@ -992,47 +989,41 @@ def _normalize_pep621_license_file_config(
     license_text = license_path.read_text(encoding="utf-8")
     spdx_id = get_license_from_text(license_text)
 
-    warning = [
-        f"""
-*******************************************************************************
-** {"WARNING: '" + app_name + "' uses PEP 621 `license.file` format":73} **
-*******************************************************************************
-
-    Briefcase now uses PEP 639 format for license definitions.
-
-    PEP 639 requires the definition of both `license` and `license-files`.
-    The value for `license.file` will be used to populate the PEP 639
-    `licence-files` setting.
-"""
-    ]
     if spdx_id is not None:
         license = spdx_id
         # License is valid SPDX
-        warning.append(f"""
-    The license has been identified as '{spdx_id}'.
-""")
+        spdx_note = f"The license has been identified as '{spdx_id}'."
     else:
         # Can't identify SPDX for license
         license = "<SPDX expression>"
         spdx_id = "LicenseRef-UnknownLicense"
-        warning.append("""
-    A license SPDX expression could not be identified from the license file.
-    The license has been set to 'LicenseRef-UnknownLicense'
-    """)
+        spdx_note = (
+            "A license SPDX expression could not be identified from the "
+            "license file. The license has been set to "
+            "'LicenseRef-UnknownLicense'"
+        )
 
-    warning.append(f"""
-    Update your configuration to use PEP 639 format:
-
-        license = "{license}"
-        license-files = ["{license_file}"]
-
-    You should not release your project without resolving this warning.
-
-*******************************************************************************
-""")
     # Warn and finalize PEP 621 license.file coercion. Use `license_files` rather than
     # `license-files` so it's a valid attribute name.
-    console.warning("".join(warning))
+    console.warning_banner(
+        f"'{app_name}' uses PEP 621 `license.file` format",
+        f"""
+            Briefcase now uses PEP 639 format for license definitions.
+
+            PEP 639 requires the definition of both `license` and
+            `license-files`. The value for `license.file` will be used to
+            populate the PEP 639 `licence-files` setting.
+
+            {spdx_note}
+
+            Update your configuration to use PEP 639 format:
+
+                license = "{license}"
+                license-files = ["{license_file}"]
+
+            You should not release your project without resolving this warning.
+        """,
+    )
     config["license"] = spdx_id
     config["license_files"] = [license_file]
 
@@ -1062,65 +1053,62 @@ def _normalize_pre_pep621_license_config(
     # Attempt to identify the SPDX expression from the text content.
     spdx_id = get_license_from_text(license_text)
 
-    warning = [
-        f"""
-*******************************************************************************
-** {"WARNING: '" + app_name + "' uses pre-PEP 621 `license` format":73} **
-*******************************************************************************
-
-    Briefcase now uses PEP 639 format for license definitions.
-"""
-    ]
     if spdx_id is not None:
         # SPDX identifiable.
         license = spdx_id
-        warning.append(f"""
-    PEP 639 requires the definition of both `license` and `license-files`,
-    and `license` must be a valid SPDX expression. The current value for
-    `license` seems to define a SPDX license of '{spdx_id}'.
-""")
+        spdx_note = (
+            "PEP 639 requires the definition of both `license` and "
+            "`license-files`, and `license` must be a valid SPDX expression. "
+            "The current value for `license` seems to define a SPDX license "
+            f"of '{spdx_id}'."
+        )
     else:
         # SPDX not identifiable.
         spdx_id = "<SPDX expression>"
         license = "LicenseRef-UnknownLicense"
-        warning.append(f"""
-    PEP 639 requires the definition of both `license` and `license-files`.
-    Briefcase cannot determine the current license for '{app_name}' based
-    on the value of `license`. A value of 'LicenseRef-UnknownLicense' will
-    be used.
-""")
+        spdx_note = (
+            "PEP 639 requires the definition of both `license` and "
+            "`license-files`. Briefcase cannot determine the current license "
+            f"for '{app_name}' based on the value of `license`. A value of "
+            "'LicenseRef-UnknownLicense' will be used."
+        )
 
     # Write the license text to a file under the build directory so it can
     # be referenced as a real path in license-files.
     tmp_license_file = _write_temp_license(base_path, app_name, license_text)
     if tmp_license_file:
         license_files = [tmp_license_file]
-        warning.append("""
-    The contents of `license` will be used as the contents of the license
-    file. This may not be correct, and should be verified.
-""")
+        file_note = (
+            "The contents of `license` will be used as the contents of the "
+            "license file. This may not be correct, and should be verified."
+        )
     else:
         license_files = []
-        warning.append("""
-    Your project will not have a value for `license-files`. This will
-    cause problems packaging for some platforms.
-""")
-
-    warning.append(f"""
-    Update your configuration to put the full license text in a file and use
-    PEP 639 format for the license definition:
-
-        license = "{spdx_id}"
-        license-files = ["LICENSE"]
-
-    You should not release your project without resolving this warning.
-
-*******************************************************************************
-""")
+        file_note = (
+            "Your project will not have a value for `license-files`. This will "
+            "cause problems packaging for some platforms."
+        )
 
     # Warn and finalize pre-PEP 621 license coercion. Use `license_files` rather than
     # `license-files` so it's a valid attribute name.
-    console.warning("".join(warning))
+    console.warning_banner(
+        f"'{app_name}' uses pre-PEP 621 `license` format",
+        f"""
+            Briefcase now uses PEP 639 format for license definitions.
+
+            {spdx_note}
+
+            {file_note}
+
+            Update your configuration to put the full license text in a file
+            and use PEP 639 format for the license definition:
+
+                license = "{spdx_id}"
+                license-files = ["LICENSE"]
+
+            You should not release your project without resolving this warning.
+        """,
+    )
     config["license"] = license
     config["license_files"] = license_files
 

--- a/tests/config/test_parse_config.py
+++ b/tests/config/test_parse_config.py
@@ -104,7 +104,7 @@ def test_single_minimal_app(tmp_path):
     }
 
     # No warnings
-    console.warning.assert_not_called()
+    console.warning_banner.assert_not_called()
 
 
 def test_multiple_minimal_apps(tmp_path):
@@ -151,7 +151,7 @@ def test_multiple_minimal_apps(tmp_path):
     }
 
     # No warnings
-    console.warning.assert_not_called()
+    console.warning_banner.assert_not_called()
 
 
 def test_platform_override(tmp_path):
@@ -890,7 +890,7 @@ def test_license_pep639_empty_list(tmp_path):
 
     assert apps["my_app"]["license"] == "MIT"
     assert apps["my_app"]["license_files"] == []
-    console.warning.assert_not_called()
+    console.warning_banner.assert_not_called()
 
 
 def test_license_pep639_invalid_spdx_with_files(tmp_path):
@@ -951,7 +951,7 @@ def test_license_pep639_spdx_without_files(config, tmp_path):
 
     assert apps["my_app"]["license"] == "MIT"
     assert apps["my_app"]["license_files"] == []
-    console.warning.assert_not_called()
+    console.warning_banner.assert_not_called()
 
 
 def test_license_pep639_missing_file(tmp_path):
@@ -1006,7 +1006,7 @@ def test_license_pep639_valid(tmp_path):
 
     assert apps["my_app"]["license"] == "MIT AND BSD-3-Clause"
     assert apps["my_app"]["license_files"] == ["LICENSE", "LICENSE-other"]
-    console.warning.assert_not_called()
+    console.warning_banner.assert_not_called()
 
 
 def test_license_pep639_normalized(tmp_path):
@@ -1034,7 +1034,7 @@ def test_license_pep639_normalized(tmp_path):
 
     assert apps["my_app"]["license"] == "MIT"
     assert apps["my_app"]["license_files"] == ["LICENSE"]
-    console.warning.assert_not_called()
+    console.warning_banner.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -1078,8 +1078,8 @@ def test_license_pep621_text_spdx(config, tmp_path):
     assert not license_text_file.exists()
 
     # One warning hinting an identified license
-    console.warning.assert_called_once()
-    warning_text = console.warning.call_args[0][0]
+    console.warning_banner.assert_called_once()
+    warning_text = "\n".join(console.warning_banner.call_args[0])
     assert "uses PEP 621 `license.text` format" in warning_text
     assert "may not be correct, and should be verified." not in warning_text
     assert "LicenseRef-UnknownLicense" not in warning_text
@@ -1114,8 +1114,8 @@ def test_license_pep621_text_non_spdx(tmp_path):
     assert not license_text_file.exists()
 
     # One warning hinting an unknown license
-    console.warning.assert_called_once()
-    warning_text = console.warning.call_args[0][0]
+    console.warning_banner.assert_called_once()
+    warning_text = "\n".join(console.warning_banner.call_args[0])
     assert "uses PEP 621 `license.text` format" in warning_text
     assert "may not be correct, and should be verified." not in warning_text
     assert "LicenseRef-UnknownLicense" in warning_text
@@ -1154,8 +1154,8 @@ def test_license_pep621_text_non_spdx_multiline(tmp_path):
     )
 
     # One warning hinting an unknown license
-    console.warning.assert_called_once()
-    warning_text = console.warning.call_args[0][0]
+    console.warning_banner.assert_called_once()
+    warning_text = "\n".join(console.warning_banner.call_args[0])
     assert "uses PEP 621 `license.text` format" in warning_text
     assert "may not be correct, and should be verified." in warning_text
     assert "LicenseRef-UnknownLicense" in warning_text
@@ -1225,8 +1225,8 @@ of this software and associated documentation files (the "Software"), ...
     assert apps["my_app"]["license_files"] == ["LICENSE"]
 
     # One warning hinting a known license
-    console.warning.assert_called_once()
-    warning_text = console.warning.call_args[0][0]
+    console.warning_banner.assert_called_once()
+    warning_text = "\n".join(console.warning_banner.call_args[0])
     assert "uses PEP 621 `license.file` format" in warning_text
     assert "may not be correct, and should be verified." not in warning_text
     assert "LicenseRef-UnknownLicense" not in warning_text
@@ -1260,8 +1260,8 @@ def test_license_pep621_file_unknown_spdx(tmp_path):
     assert apps["my_app"]["license_files"] == ["LICENSE"]
 
     # One warning hinting an unknown license
-    console.warning.assert_called_once()
-    warning_text = console.warning.call_args[0][0]
+    console.warning_banner.assert_called_once()
+    warning_text = "\n".join(console.warning_banner.call_args[0])
     assert "uses PEP 621 `license.file` format" in warning_text
     assert "may not be correct, and should be verified." not in warning_text
     assert "LicenseRef-UnknownLicense" in warning_text
@@ -1348,8 +1348,8 @@ def test_license_text_spdx(config, tmp_path):
     assert not license_text_file.exists()
 
     # One warning hinting a known license
-    console.warning.assert_called_once()
-    warning_text = console.warning.call_args[0][0]
+    console.warning_banner.assert_called_once()
+    warning_text = "\n".join(console.warning_banner.call_args[0])
     assert "uses pre-PEP 621 `license` format" in warning_text
     assert "may not be correct, and should be verified." not in warning_text
     assert "LicenseRef-UnknownLicense" not in warning_text
@@ -1392,8 +1392,8 @@ def test_license_text_non_spdx(tmp_path):
     assert not license_text_file.exists()
 
     # One warning hinting an unknown license
-    console.warning.assert_called_once()
-    warning_text = console.warning.call_args[0][0]
+    console.warning_banner.assert_called_once()
+    warning_text = "\n".join(console.warning_banner.call_args[0])
     assert "uses pre-PEP 621 `license` format" in warning_text
     assert "may not be correct, and should be verified." not in warning_text
     assert "LicenseRef-UnknownLicense" in warning_text
@@ -1440,8 +1440,8 @@ def test_license_text_non_spdx_multiline(tmp_path):
     )
 
     # One warning hinting an unknown license
-    console.warning.assert_called_once()
-    warning_text = console.warning.call_args[0][0]
+    console.warning_banner.assert_called_once()
+    warning_text = "\n".join(console.warning_banner.call_args[0])
     assert "uses pre-PEP 621 `license` format" in warning_text
     assert "may not be correct, and should be verified." in warning_text
     assert "LicenseRef-UnknownLicense" in warning_text


### PR DESCRIPTION
Fixes: https://github.com/beeware/briefcase/issues/2559

**Description:**

https://github.com/beeware/briefcase/pull/2563 added the `warning_banner` helper function. 
This is the last file on the checklist still not using the new function. The three license deprecation warnings in `config.py` were still using the hand formatted asterisk box and joining a list of message fragments before calling `console.warning()`:
  - `_normalize_pep621_license_text_config`
  - `_normalize_pep621_license_file_config`
  - `_normalize_pre_pep621_license_config`

All three are now using the `console.warning_banner` helper function.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by:  Claude Opus 4.8
