### PR TITLE
Add links for platform-level docs

### DIFF
--- a/changes/2916.misc.md
+++ b/changes/2916.misc.md
@@ -1,0 +1,1 @@
+The platform docs matrix was updated to include direct links to the shared platform docs for Windows and macOS.

--- a/docs/en/reference/platforms/index.md
+++ b/docs/en/reference/platforms/index.md
@@ -109,7 +109,7 @@
 <td>{{ ci_tested }}</td>
 </tr>
 <tr>
-<td rowspan="2">macOS</td>
+<td rowspan="2"><a href="./macOS/">macOS</a></td>
 <td><a href="./macOS/app"><strong>.app bundle</strong></a></td>
 <td>{{ ci_tested }}</td>
 <td>{{ ci_tested }}</td>
@@ -147,7 +147,7 @@
 <td>{{ ci_tested }}</td>
 </tr>
 <tr>
-<td class="target-app-format-windows" rowspan="2">Windows</td>
+<td class="target-app-format-windows" rowspan="2"><a href="./windows/">Windows</a></td>
 <td><a href="./windows/app"><strong>Windows app</strong></a></td>
 <td></td>
 <td></td>

--- a/docs/en/reference/platforms/windows/visualstudio.md
+++ b/docs/en/reference/platforms/windows/visualstudio.md
@@ -71,11 +71,12 @@ Briefcase will auto-detect the location of your Visual Studio installation, prov
 When you install Visual Studio, there are many optional components. You should ensure that you have installed the following:
 
 - .NET Desktop Development
-  - All default packages
+    - All default packages
 - Desktop Development with C++
-  - All default packages
-  - C++/CLI support for v143 build tools
-  - MSVC v143 VS 2022 C++ ARM64/x64 build tools
+    - All default packages
+    - C++/CLI support for v143 build tools
+    - MSVC v143 VS 2022 C++ x64 build tools
+    - MSVC v143 VS 2022 C++ ARM64 build tools (if required)
 
 ## Application configuration
 

--- a/docs/en/reference/platforms/windows/visualstudio.md
+++ b/docs/en/reference/platforms/windows/visualstudio.md
@@ -75,8 +75,8 @@ When you install Visual Studio, there are many optional components. You should e
 - Desktop Development with C++
     - All default packages
     - C++/CLI support for v143 build tools
-    - MSVC v143 VS 2022 C++ x64 build tools
-    - MSVC v143 VS 2022 C++ ARM64 build tools (if required)
+    - MSVC v143 VS 2022 C++ x64 build tools (if using x86-64)
+    - MSVC v143 VS 2022 C++ ARM64 build tools (if using ARM64)
 
 ## Application configuration
 

--- a/docs/en/stylesheets/briefcase.css
+++ b/docs/en/stylesheets/briefcase.css
@@ -33,6 +33,12 @@ table.platform-support-table tbody tr td {
     padding: 0.05em 0 0.05em 0.25em;
 }
 
+table.platform-support-table thead tr th,
+table.platform-support-table tbody tr td,
+table.platform-support-table tbody tr td a {
+    word-break: normal;
+}
+
 table.platform-support-table tbody tr td.target-app-format-windows {
     padding-right: 0.2em;
 }

--- a/src/briefcase/integrations/visualstudio.py
+++ b/src/briefcase/integrations/visualstudio.py
@@ -18,7 +18,8 @@ class VisualStudio(Tool):
       - Default packages
     * Desktop Development with C++
       - Default packages; plus
-      - MSVC v143 VS 2022 C++ ARM64/x64 build tools
+      - MSVC v143 VS 2022 C++ x64 build tools (if using x86-64)
+      - MSVC v143 VS 2022 C++ ARM64 build tools (if using ARM64)
 """
 
     def __init__(


### PR DESCRIPTION
* Add links to the platform docs matrix directly to the macOS/Windows page, rather than needing to go via the format pages.
* Clarified the Visual Studio components that are required (since it wasn't clear that there are 2 different v143 tool sets)
* Corrected the markup of Visual Studio install requirements.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
