### PR TITLE
mitigate linux app break for toga 0.5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
   verify-projects:
     name: Verify project
     needs: [ package, unit-tests ]
-    uses: beeware/.github/.github/workflows/app-create-verify.yml@main
+    uses: rmartin16/.github-beeware/.github/workflows/app-create-verify.yml@build-app-debian-trixie
     with:
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -240,7 +240,7 @@ jobs:
   verify-apps:
     name: Build app
     needs: [ package, unit-tests ]
-    uses: beeware/.github/.github/workflows/app-build-verify.yml@main
+    uses: rmartin16/.github-beeware/.github/workflows/app-build-verify.yml@build-app-debian-trixie
     with:
       # Builds on Linux must use System Python; otherwise, fall back to version all GUI toolkits support
       python-version: ${{ startsWith(matrix.runner-os, 'ubuntu') && 'system' || '3.12' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
   verify-projects:
     name: Verify project
     needs: [ package, unit-tests ]
-    uses: rmartin16/.github-beeware/.github/workflows/app-create-verify.yml@build-app-debian-trixie
+    uses: beeware/.github/.github/workflows/app-create-verify.yml@main
     with:
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -240,7 +240,7 @@ jobs:
   verify-apps:
     name: Build app
     needs: [ package, unit-tests ]
-    uses: rmartin16/.github-beeware/.github/workflows/app-build-verify.yml@build-app-debian-trixie
+    uses: beeware/.github/.github/workflows/app-build-verify.yml@main
     with:
       # Builds on Linux must use System Python; otherwise, fall back to version all GUI toolkits support
       python-version: ${{ startsWith(matrix.runner-os, 'ubuntu') && 'system' || '3.12' }}

--- a/changes/2920.misc.md
+++ b/changes/2920.misc.md
@@ -1,0 +1,1 @@
+The Toga bootstrap was updated to mitigate incompatibilities with toga==0.5.5.

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -59,10 +59,8 @@ requires = [
         return """\
 requires = [
     "toga-gtk~=0.5.0",
-    # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
-    # isn't available on Debian 12/Ubuntu 22.04. If you don't need to support those (or
-    # older) releases, you can remove this version pin. See beeware/toga#3143.
-    "pygobject < 3.52.1",
+    # Toga now enforces minimum version 3.55.1 (see beeware/briefcase#2919)
+    "pygobject >= 3.55.1",
 ]
 """
 
@@ -71,21 +69,15 @@ requires = [
 system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",
-    # One of the following two packages are needed to compile PyGObject wheel. If you
-    # remove the pygobject pin in the requires list, you should also change to the
-    # version 2.0 of the girepository library. See beeware/toga#3143.
-    "libgirepository1.0-dev",
-    # "libgirepository-2.0-dev",
+    # Following enforcement of pygobject>=3.55.1, only libgirepository 2.0 is supported now
+    "libgirepository-2.0-dev",
 ]
 
 system_runtime_requires = [
     # Needed to provide GTK and its GI bindings
     "gir1.2-gtk-3.0",
-    # One of the following two packages are needed to use PyGObject at runtime. If you
-    # remove the pygobject pin in the requires list, you should also change to the
-    # version 2.0 of the girepository library. See beeware/toga#3143.
-    "libgirepository-1.0-1",
-    # "libgirepository-2.0-0",
+    # Following enforcement of pygobject>=3.55.1, only libgirepository 2.0 is supported now
+    "libgirepository-2.0-0",
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-module",
     # Needed to provide WebKit2 at runtime

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -69,14 +69,14 @@ requires = [
 system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",
-    # Following enforcement of pygobject>=3.55.1, only libgirepository 2.0 is supported now
+    # Following enforcement of pygobject>=3.55.1, only libgirepository 2.0 is supported
     "libgirepository-2.0-dev",
 ]
 
 system_runtime_requires = [
     # Needed to provide GTK and its GI bindings
     "gir1.2-gtk-3.0",
-    # Following enforcement of pygobject>=3.55.1, only libgirepository 2.0 is supported now
+    # Following enforcement of pygobject>=3.55.1, only libgirepository 2.0 is supported
     "libgirepository-2.0-0",
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-module",

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -80,14 +80,14 @@ requires = [
 system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",
-    # Following enforcement of pygobject>=3.55.1, only libgirepository 2.0 is supported now
+    # Following enforcement of pygobject>=3.55.1, only libgirepository 2.0 is supported
     "libgirepository-2.0-dev",
 ]
 
 system_runtime_requires = [
     # Needed to provide GTK and its GI bindings
     "gir1.2-gtk-3.0",
-    # Following enforcement of pygobject>=3.55.1, only libgirepository 2.0 is supported now
+    # Following enforcement of pygobject>=3.55.1, only libgirepository 2.0 is supported
     "libgirepository-2.0-0",
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-module",

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -72,31 +72,23 @@ requires = [
         "pyproject_table_linux": """\
 requires = [
     "toga-gtk~=0.5.0",
-    # PyGObject 3.52.1 enforces a requirement on libgirepository-2.0-dev. This library
-    # isn't available on Debian 12/Ubuntu 22.04. If you don't need to support those (or
-    # older) releases, you can remove this version pin. See beeware/toga#3143.
-    "pygobject < 3.52.1",
+    # Toga now enforces minimum version 3.55.1 (see beeware/briefcase#2919)
+    "pygobject >= 3.55.1",
 ]
 """,
         "pyproject_table_linux_system_debian": """\
 system_requires = [
     # Needed to compile pycairo wheel
     "libcairo2-dev",
-    # One of the following two packages are needed to compile PyGObject wheel. If you
-    # remove the pygobject pin in the requires list, you should also change to the
-    # version 2.0 of the girepository library. See beeware/toga#3143.
-    "libgirepository1.0-dev",
-    # "libgirepository-2.0-dev",
+    # Following enforcement of pygobject>=3.55.1, only libgirepository 2.0 is supported now
+    "libgirepository-2.0-dev",
 ]
 
 system_runtime_requires = [
     # Needed to provide GTK and its GI bindings
     "gir1.2-gtk-3.0",
-    # One of the following two packages are needed to use PyGObject at runtime. If you
-    # remove the pygobject pin in the requires list, you should also change to the
-    # version 2.0 of the girepository library. See beeware/toga#3143.
-    "libgirepository-1.0-1",
-    # "libgirepository-2.0-0",
+    # Following enforcement of pygobject>=3.55.1, only libgirepository 2.0 is supported now
+    "libgirepository-2.0-0",
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-module",
     # Needed to provide WebKit2 at runtime


### PR DESCRIPTION
## changes
- mitigate the consequences of https://github.com/beeware/briefcase/issues/2919 in at least Briefcase CI for now

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I will abide by the BeeWare Code of Conduct
- [X] I have read and have followed the **CONTRIBUTING.md** file
- [X] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: opus 4.8
