### PR TITLE
Add PySide6 Flatpak Kerberos module example

### DIFF
--- a/changes/2182.bugfix.md
+++ b/changes/2182.bugfix.md
@@ -1,0 +1,1 @@
+New PySide6 projects now include an optional Flatpak module snippet for the Kerberos libraries required by `QtWebEngineWidgets`.

--- a/src/briefcase/bootstraps/pyside6.py
+++ b/src/briefcase/bootstraps/pyside6.py
@@ -140,6 +140,22 @@ linuxdeploy_plugins = [
 flatpak_runtime = "org.kde.Platform"
 flatpak_runtime_version = "6.9"
 flatpak_sdk = "org.kde.Sdk"
+
+# PySide6.QtWebEngineWidgets requires Kerberos libraries that are not included
+# in the KDE Flatpak runtime. Uncomment this module to build them into the app.
+# modules_extra_content = '''
+#   - name: mit-krb5
+#     buildsystem: simple
+#     sources:
+#       - type: archive
+#         url: https://kerberos.org/dist/krb5/1.21/krb5-1.21.3.tar.gz
+#         sha256: b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35
+#     build-commands:
+#       - cd src && autoreconf -i
+#       - cd src && ./configure --prefix=/app --disable-static --enable-shared
+#       - cd src && make -j$(nproc)
+#       - cd src && make install
+# '''
 """
 
     def pyproject_table_windows(self):

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -464,6 +464,22 @@ linuxdeploy_plugins = [
 flatpak_runtime = "org.kde.Platform"
 flatpak_runtime_version = "6.9"
 flatpak_sdk = "org.kde.Sdk"
+
+# PySide6.QtWebEngineWidgets requires Kerberos libraries that are not included
+# in the KDE Flatpak runtime. Uncomment this module to build them into the app.
+# modules_extra_content = '''
+#   - name: mit-krb5
+#     buildsystem: simple
+#     sources:
+#       - type: archive
+#         url: https://kerberos.org/dist/krb5/1.21/krb5-1.21.3.tar.gz
+#         sha256: b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35
+#     build-commands:
+#       - cd src && autoreconf -i
+#       - cd src && ./configure --prefix=/app --disable-static --enable-shared
+#       - cd src && make -j$(nproc)
+#       - cd src && make install
+# '''
 """,
         "pyproject_table_windows": """\
 requires = [


### PR DESCRIPTION
PySide6 Flatpaks that import `QtWebEngineWidgets` need Kerberos libraries not provided by the KDE runtime. New PySide6 projects now include the issue's proven `mit-krb5` module recipe in their Flatpak configuration, commented out so projects that do not use WebEngine remain unchanged.

The generated bootstrap context is covered exactly, and a changelog fragment documents the user-facing option.

Fixes #2182

## Validation

- RED: `tox -e py312-fast -- tests/commands/new/test_build_gui_context.py::test_pyside6_bootstrap -q` failed because the generated Flatpak table lacked the module snippet.
- GREEN: `tox -e py312-fast -- tests/commands/new/test_build_gui_context.py -q` (6 passed)
- Scoped pre-commit hooks: checkers, docformatter, Ruff format/check, and codespell all passed
- `git diff --cached --check`

Python 3.12 was used because Python 3.13 is not installed on this Windows host; 3.12 is a supported Briefcase test environment.

## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: OpenAI Codex