### PR TITLE
Resolve E501 (line too long) violations in tests/integrations

### DIFF
--- a/changes/2383.misc.md
+++ b/changes/2383.misc.md
@@ -1,0 +1,1 @@
+Resolved outstanding ``E501`` (line too long) lint violations in the ``tests/integrations`` test suite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,7 +301,6 @@ known-third-party = ["build"]
 # E501: line too long, to be fixed in future changes
 "tests/platforms/*" = ["E501"]
 
-
 [tool.rumdl]
 flavor = "mkdocs"
 include = ["**/*.md"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,8 +299,8 @@ known-third-party = ["build"]
 
 [tool.ruff.lint.per-file-ignores]
 # E501: line too long, to be fixed in future changes
-"tests/integrations/*" = ["E501"]
 "tests/platforms/*" = ["E501"]
+
 
 [tool.rumdl]
 flavor = "mkdocs"

--- a/tests/integrations/android_sdk/ADB/test_run.py
+++ b/tests/integrations/android_sdk/ADB/test_run.py
@@ -93,7 +93,7 @@ def test_older_sdk_error(mock_tools, adb):
     mock_tools.subprocess.check_output.return_value = "\n".join(
         [
             "Performing Push Install",
-            "C:/.../app-debug.apk: 1 file pushed, 0 skipped. 5.5 MB/s (33125287 bytes in 5.768s)",
+            "C:/.../app-debug.apk: 1 file pushed, 0 skipped. 5.5 MB/s (33125287 bytes in 5.768s)",  # noqa: E501
             "         pkg: /data/local/tmp/app-debug.apk",
             "Failure [INSTALL_FAILED_OLDER_SDK]",
         ]

--- a/tests/integrations/android_sdk/ADB/test_start_app.py
+++ b/tests/integrations/android_sdk/ADB/test_start_app.py
@@ -133,7 +133,10 @@ def test_unable_to_start(adb):
 
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"Unable to start com.example.sample.package/com.example.sample.activity on exampleDevice",
+        match=(
+            r"Unable to start com.example.sample.package/com.example.sample.activity "
+            r"on exampleDevice"
+        ),
     ):
         adb.start_app(
             "com.example.sample.package", "com.example.sample.activity", [], {}

--- a/tests/integrations/android_sdk/AndroidSDK/sdkmanager/emulator_only.out
+++ b/tests/integrations/android_sdk/AndroidSDK/sdkmanager/emulator_only.out
@@ -1,0 +1,4 @@
+Installed packages:
+  Path                                    | Version | Description                    | Location
+  -------                                 | ------- | -------                        | -------
+  emulator                                | 35.4.9  | Android Emulator               | emulator

--- a/tests/integrations/android_sdk/AndroidSDK/sdkmanager/system_image_and_emulator.out
+++ b/tests/integrations/android_sdk/AndroidSDK/sdkmanager/system_image_and_emulator.out
@@ -1,0 +1,5 @@
+Installed packages:
+  Path                                    | Version | Description                    | Location
+  -------                                 | ------- | -------                        | -------
+  system-images;android-31;default;x86_64 | 5       | Intel x86_64 Atom System Image | system-images/android-31/default/x86_64
+  emulator                                | 35.4.9  | Android Emulator               | emulator

--- a/tests/integrations/android_sdk/AndroidSDK/sdkmanager/system_image_only.out
+++ b/tests/integrations/android_sdk/AndroidSDK/sdkmanager/system_image_only.out
@@ -1,0 +1,4 @@
+Installed packages:
+  Path                                    | Version | Description                    | Location
+  -------                                 | ------- | -------                        | -------
+  system-images;android-31;default;x86_64 | 5       | Intel x86_64 Atom System Image | system-images/android-31/default/x86_64

--- a/tests/integrations/android_sdk/AndroidSDK/test_list_installed_images.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_list_installed_images.py
@@ -10,10 +10,10 @@ def test_list_installed_system_images(mock_tools, android_sdk):
 
     mock_tools.subprocess.check_output.return_value = (
         "Installed packages:\n"
-        "  Path                                    | Version | Description                    | Location\n"
-        "  -------                                 | ------- | -------                        | -------\n"
-        "  system-images;android-31;default;x86_64 | 5       | Intel x86_64 Atom System Image | system-images/android-31/default/x86_64\n"
-        "  emulator                                | 35.4.9  | Android Emulator               | emulator\n"
+        "  Path                                    | Version | Description                    | Location\n"  # noqa: E501
+        "  -------                                 | ------- | -------                        | -------\n"  # noqa: E501
+        "  system-images;android-31;default;x86_64 | 5       | Intel x86_64 Atom System Image | system-images/android-31/default/x86_64\n"  # noqa: E501
+        "  emulator                                | 35.4.9  | Android Emulator               | emulator\n"  # noqa: E501
     )
 
     result = android_sdk.list_installed_system_images()
@@ -29,9 +29,9 @@ def test_no_installed_system_images(mock_tools, android_sdk):
     """If no system images are installed, an empty set is returned."""
     mock_tools.subprocess.check_output.return_value = (
         "Installed packages:\n"
-        "  Path                                    | Version | Description                    | Location\n"
-        "  -------                                 | ------- | -------                        | -------\n"
-        "  emulator                                | 35.4.9  | Android Emulator               | emulator\n"
+        "  Path                                    | Version | Description                    | Location\n"  # noqa: E501
+        "  -------                                 | ------- | -------                        | -------\n"  # noqa: E501
+        "  emulator                                | 35.4.9  | Android Emulator               | emulator\n"  # noqa: E501
     )
 
     result = android_sdk.list_installed_system_images()

--- a/tests/integrations/android_sdk/AndroidSDK/test_list_installed_images.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_list_installed_images.py
@@ -7,8 +7,7 @@ from briefcase.exceptions import BriefcaseCommandError
 
 
 def sdkmanager_result(name):
-    """Load a sample sdkmanager --list_installed result file, and return the
-    content."""
+    """Load a sample sdkmanager --list_installed result file, and return the content."""
     samples = Path(__file__).parent / "sdkmanager"
     with (samples / (name + ".out")).open(encoding="utf-8") as sdkmanager_output_file:
         return sdkmanager_output_file.read()

--- a/tests/integrations/android_sdk/AndroidSDK/test_list_installed_images.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_list_installed_images.py
@@ -1,19 +1,24 @@
 import subprocess
+from pathlib import Path
 
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
 
 
+def sdkmanager_result(name):
+    """Load a sample sdkmanager --list_installed result file, and return the
+    content."""
+    samples = Path(__file__).parent / "sdkmanager"
+    with (samples / (name + ".out")).open(encoding="utf-8") as sdkmanager_output_file:
+        return sdkmanager_output_file.read()
+
+
 def test_list_installed_system_images(mock_tools, android_sdk):
     """Returns a set of installed system image package identifiers."""
 
-    mock_tools.subprocess.check_output.return_value = (
-        "Installed packages:\n"
-        "  Path                                    | Version | Description                    | Location\n"  # noqa: E501
-        "  -------                                 | ------- | -------                        | -------\n"  # noqa: E501
-        "  system-images;android-31;default;x86_64 | 5       | Intel x86_64 Atom System Image | system-images/android-31/default/x86_64\n"  # noqa: E501
-        "  emulator                                | 35.4.9  | Android Emulator               | emulator\n"  # noqa: E501
+    mock_tools.subprocess.check_output.return_value = sdkmanager_result(
+        "system_image_and_emulator"
     )
 
     result = android_sdk.list_installed_system_images()
@@ -27,12 +32,7 @@ def test_list_installed_system_images(mock_tools, android_sdk):
 
 def test_no_installed_system_images(mock_tools, android_sdk):
     """If no system images are installed, an empty set is returned."""
-    mock_tools.subprocess.check_output.return_value = (
-        "Installed packages:\n"
-        "  Path                                    | Version | Description                    | Location\n"  # noqa: E501
-        "  -------                                 | ------- | -------                        | -------\n"  # noqa: E501
-        "  emulator                                | 35.4.9  | Android Emulator               | emulator\n"  # noqa: E501
-    )
+    mock_tools.subprocess.check_output.return_value = sdkmanager_result("emulator_only")
 
     result = android_sdk.list_installed_system_images()
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_properties.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_properties.py
@@ -141,7 +141,10 @@ def test_bad_emulator_abi(mock_tools, android_sdk, host_os, host_arch):
 
     with pytest.raises(
         BriefcaseCommandError,
-        match=rf"The Android emulator does not currently support {host_os} {host_arch} hardware.",
+        match=(
+            rf"The Android emulator does not currently support {host_os} "
+            rf"{host_arch} hardware."
+        ),
     ):
         _ = android_sdk.emulator_abi
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_start_emulator.py
@@ -382,7 +382,8 @@ def test_emulator_fail_to_boot(mock_tools, android_sdk):
         "\n",  # gets in to emulator has_booted() if block
         "\n",  # enters has_booted() while loop
         "\n",  # one loop waiting for simulator to finish booting
-        "1\n",  # successful boot...except poll() will return non-None first raising failure
+        "1\n",  # successful boot...except poll() will return non-None
+        # first raising failure
     ]
 
     # poll() on the process returns failure during simulator boot

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
@@ -8,8 +8,7 @@ from briefcase.exceptions import BriefcaseCommandError
 
 
 def sdkmanager_result(name):
-    """Load a sample sdkmanager --list_installed result file, and return the
-    content."""
+    """Load a sample sdkmanager --list_installed result file, and return the content."""
     samples = Path(__file__).parent / "sdkmanager"
     with (samples / (name + ".out")).open(encoding="utf-8") as sdkmanager_output_file:
         return sdkmanager_output_file.read()

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
@@ -21,7 +21,10 @@ def test_unsupported_abi(mock_tools, android_sdk, host_os, host_arch):
 
     with pytest.raises(
         BriefcaseCommandError,
-        match=f"The Android emulator does not currently support {host_os} {host_arch} hardware",
+        match=(
+            f"The Android emulator does not currently support {host_os} "
+            f"{host_arch} hardware"
+        ),
     ):
         android_sdk.verify_system_image("system-images;android-31;default;x86_64")
 
@@ -84,9 +87,9 @@ def test_existing_system_image(mock_tools, android_sdk):
     # Mock sdkmanager reporting the system image as installed
     mock_tools.subprocess.check_output.return_value = (
         "Installed packages:\n"
-        "  Path                                    | Version | Description                    | Location\n"
-        "  -------                                 | ------- | -------                        | -------\n"
-        "  system-images;android-31;default;x86_64 | 5       | Intel x86_64 Atom System Image | system-images/android-31/default/x86_64\n"
+        "  Path                                    | Version | Description                    | Location\n"  # noqa: E501
+        "  -------                                 | ------- | -------                        | -------\n"  # noqa: E501
+        "  system-images;android-31;default;x86_64 | 5       | Intel x86_64 Atom System Image | system-images/android-31/default/x86_64\n"  # noqa: E501
     )
 
     # Verify the system image that we already have
@@ -130,7 +133,10 @@ def test_problem_downloading_system_image(mock_tools, android_sdk):
     # Attempt to verify the system image
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"Error while installing the 'system-images;android-31;default;x86_64' Android system image\.",
+        match=(
+            r"Error while installing the 'system-images;android-31;default;x86_64' "
+            r"Android system image\."
+        ),
     ):
         android_sdk.verify_system_image("system-images;android-31;default;x86_64")
 

--- a/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_verify_system_image.py
@@ -1,9 +1,18 @@
 import platform
+from pathlib import Path
 from subprocess import CalledProcessError
 
 import pytest
 
 from briefcase.exceptions import BriefcaseCommandError
+
+
+def sdkmanager_result(name):
+    """Load a sample sdkmanager --list_installed result file, and return the
+    content."""
+    samples = Path(__file__).parent / "sdkmanager"
+    with (samples / (name + ".out")).open(encoding="utf-8") as sdkmanager_output_file:
+        return sdkmanager_output_file.read()
 
 
 @pytest.mark.parametrize(
@@ -85,11 +94,8 @@ def test_existing_system_image(mock_tools, android_sdk):
     mock_tools.host_arch = "AMD64" if platform.system() == "Windows" else "x86_64"
 
     # Mock sdkmanager reporting the system image as installed
-    mock_tools.subprocess.check_output.return_value = (
-        "Installed packages:\n"
-        "  Path                                    | Version | Description                    | Location\n"  # noqa: E501
-        "  -------                                 | ------- | -------                        | -------\n"  # noqa: E501
-        "  system-images;android-31;default;x86_64 | 5       | Intel x86_64 Atom System Image | system-images/android-31/default/x86_64\n"  # noqa: E501
+    mock_tools.subprocess.check_output.return_value = sdkmanager_result(
+        "system_image_only"
     )
 
     # Verify the system image that we already have

--- a/tests/integrations/base/test_ToolCache.py
+++ b/tests/integrations/base/test_ToolCache.py
@@ -21,7 +21,8 @@ def test_toolcache_typing():
     """Tool typing for ToolCache is correct."""
     # Tools that are intentionally not annotated in ToolCache.
     tools_unannotated = {"cookiecutter"}
-    # Tool names to exclude from the dynamic annotation checks; they are manually checked.
+    # Tool names to exclude from the dynamic annotation checks; they are
+    # manually checked.
     tool_names_skip_dynamic_check = {
         "app_context",  # Tested by the Docker module
         "git",  # An external API, not a Briefcase Tool

--- a/tests/integrations/docker/conftest.py
+++ b/tests/integrations/docker/conftest.py
@@ -18,7 +18,8 @@ def mock_tools(mock_tools, tmp_path) -> ToolCache:
     # Mock stdlib subprocess module
     mock_tools.subprocess._subprocess = MagicMock(spec_set=subprocess)
 
-    # Reset `os` mock without `spec` so tests can run on Windows where os.getuid doesn't exist.
+    # Reset `os` mock without `spec` so tests can run on Windows
+    #  where os.getuid doesn't exist.
     mock_tools.os = MagicMock()
     # Mock user and group IDs for docker image
     mock_tools.os.getuid.return_value = "37"

--- a/tests/integrations/docker/docker_info/connection_refused.out
+++ b/tests/integrations/docker/docker_info/connection_refused.out
@@ -1,0 +1,6 @@
+
+Client:
+ Debug Mode: false
+Server:
+ERROR: Error response from daemon: dial unix docker.raw.sock: connect: connection refused
+errors pretty printing info

--- a/tests/integrations/docker/docker_info/daemon_not_running.out
+++ b/tests/integrations/docker/docker_info/daemon_not_running.out
@@ -1,0 +1,6 @@
+
+Client:
+ Debug Mode: false
+Server:
+ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+errors pretty printing info

--- a/tests/integrations/docker/docker_info/permission_denied.out
+++ b/tests/integrations/docker/docker_info/permission_denied.out
@@ -1,0 +1,7 @@
+
+Client:
+ Debug Mode: false
+Server:
+ERROR: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock:
+Get http://%2Fvar%2Frun%2Fdocker.sock/v1.40/info: dial unix /var/run/docker.sock: connect: permission denied
+errors pretty printing info

--- a/tests/integrations/docker/test_Docker__verify.py
+++ b/tests/integrations/docker/test_Docker__verify.py
@@ -23,8 +23,8 @@ DOCKER_VERIFICATION_CALLS = [
 
 
 def docker_info_result(name):
-    """Load a sample docker info result file from the sample directory, and return
-    the content."""
+    """Load a sample docker info result file from the sample directory, and return the
+    content."""
     samples = Path(__file__).parent / "docker_info"
     with (samples / (name + ".out")).open(encoding="utf-8") as docker_output_file:
         return docker_output_file.read()

--- a/tests/integrations/docker/test_Docker__verify.py
+++ b/tests/integrations/docker/test_Docker__verify.py
@@ -22,6 +22,14 @@ DOCKER_VERIFICATION_CALLS = [
 ]
 
 
+def docker_info_result(name):
+    """Load a sample docker info result file from the sample directory, and return
+    the content."""
+    samples = Path(__file__).parent / "docker_info"
+    with (samples / (name + ".out")).open(encoding="utf-8") as docker_output_file:
+        return docker_output_file.read()
+
+
 @pytest.fixture
 def mock_tools(mock_tools) -> ToolCache:
     mock_tools.subprocess = MagicMock(spec_set=Subprocess)
@@ -197,16 +205,7 @@ def test_docker_unknown_version(mock_tools, user_mapping_run_calls, capsys):
 
 def test_docker_exists_but_process_lacks_permission_to_use_it(mock_tools):
     """If the docker daemon isn't running, the check fails."""
-    error_message = (
-        "Client:\n"
-        " Debug Mode: false\n"
-        "Server:\n"
-        "ERROR: Got permission denied while trying to connect to the Docker "
-        "daemon socket at unix:///var/run/docker.sock:\n"
-        "Get http://%2Fvar%2Frun%2Fdocker.sock/v1.40/info: dial unix "
-        "/var/run/docker.sock: connect: permission denied\n"
-        "errors pretty printing info"
-    )
+    error_message = docker_info_result("permission_denied")
     mock_tools.subprocess.check_output.side_effect = [
         VALID_DOCKER_VERSION,
         subprocess.CalledProcessError(
@@ -225,22 +224,8 @@ def test_docker_exists_but_process_lacks_permission_to_use_it(mock_tools):
 @pytest.mark.parametrize(
     "error_message",
     [
-        (
-            "Client:\n"
-            " Debug Mode: false\n"
-            "Server:\n"
-            "ERROR: Error response from daemon: dial unix docker.raw.sock: "
-            "connect: connection refused\n"
-            "errors pretty printing info\n"
-        ),
-        (
-            "Client:\n"
-            " Debug Mode: false\n"
-            "Server:\n"
-            "ERROR: Cannot connect to the Docker daemon at "
-            "unix:///var/run/docker.sock. Is the docker daemon running?\n"
-            "errors pretty printing info"
-        ),
+        docker_info_result("connection_refused"),
+        docker_info_result("daemon_not_running"),
     ],
 )
 def test_docker_exists_but_is_not_running(error_message, mock_tools):

--- a/tests/integrations/docker/test_Docker__verify.py
+++ b/tests/integrations/docker/test_Docker__verify.py
@@ -197,16 +197,16 @@ def test_docker_unknown_version(mock_tools, user_mapping_run_calls, capsys):
 
 def test_docker_exists_but_process_lacks_permission_to_use_it(mock_tools):
     """If the docker daemon isn't running, the check fails."""
-    error_message = """
-Client:
- Debug Mode: false
-
-Server:
-ERROR: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock:
-
-Get http://%2Fvar%2Frun%2Fdocker.sock/v1.40/info: dial unix /var/run/docker.sock: connect: permission denied
-errors pretty printing info"""
-
+    error_message = (
+        "Client:\n"
+        " Debug Mode: false\n"
+        "Server:\n"
+        "ERROR: Got permission denied while trying to connect to the Docker "
+        "daemon socket at unix:///var/run/docker.sock:\n"
+        "Get http://%2Fvar%2Frun%2Fdocker.sock/v1.40/info: dial unix "
+        "/var/run/docker.sock: connect: permission denied\n"
+        "errors pretty printing info"
+    )
     mock_tools.subprocess.check_output.side_effect = [
         VALID_DOCKER_VERSION,
         subprocess.CalledProcessError(
@@ -225,21 +225,22 @@ errors pretty printing info"""
 @pytest.mark.parametrize(
     "error_message",
     [
-        """
-Client:
- Debug Mode: false
-
-Server:
-ERROR: Error response from daemon: dial unix docker.raw.sock: connect: connection refused
-errors pretty printing info
-""",  # this is the error shown on mac
-        """
-Client:
- Debug Mode: false
-
-Server:
-ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
-errors pretty printing info""",  # this is the error show on linux
+        (
+            "Client:\n"
+            " Debug Mode: false\n"
+            "Server:\n"
+            "ERROR: Error response from daemon: dial unix docker.raw.sock: "
+            "connect: connection refused\n"
+            "errors pretty printing info\n"
+        ),
+        (
+            "Client:\n"
+            " Debug Mode: false\n"
+            "Server:\n"
+            "ERROR: Cannot connect to the Docker daemon at "
+            "unix:///var/run/docker.sock. Is the docker daemon running?\n"
+            "errors pretty printing info"
+        ),
     ],
 )
 def test_docker_exists_but_is_not_running(error_message, mock_tools):
@@ -290,7 +291,10 @@ def test_buildx_plugin_not_installed(mock_tools):
 
     with pytest.raises(
         BriefcaseCommandError,
-        match="Docker is installed and available for use but the buildx plugin\nis not installed",
+        match=(
+            "Docker is installed and available for use but the buildx plugin\n"
+            "is not installed"
+        ),
     ):
         Docker.verify(mock_tools)
 

--- a/tests/integrations/docker/test_Docker__x11_passthrough.py
+++ b/tests/integrations/docker/test_Docker__x11_passthrough.py
@@ -111,7 +111,8 @@ def test_x11_is_display_tcp(
     ("is_socket_outcomes", "is_tcp_outcomes", "expected_display_num"),
     [
         ([False], [False], 50),
-        # Due to short-circuiting, only the first iterator is consumed if it returns False
+        # Due to short-circuiting, only the first iterator is consumed
+        #  if it returns False
         ([True, False], [False], 51),
         ([True, True, False, True, False], [False, False, False], 52),
         ([True] * 248 + [False, False], [True, False], 299),
@@ -365,9 +366,11 @@ def test_x11_write_xauth_success(mock_tools, tmp_path, sub_check_output_kw):
                     "-",
                 ],
                 input=(
-                    "ffff 0007 6a757069746572 0000  0012 4d49542d4d414749432d434f4f4b49452d31 "
+                    "ffff 0007 6a757069746572 0000  0012 4d49542d4d414749432d"
+                    "434f4f4b49452d31 "
                     "0010 fa4b61837675f1581427e0c937701439\n"
-                    "ffff 0007 6a757069746572 0000  0012 4d49542d4d414749432d434f4f4b49452d31 "
+                    "ffff 0007 6a757069746572 0000  0012 4d49542d4d414749432d"
+                    "434f4f4b49452d31 "
                     "0010 fa4b61837675f1581427e0c937701439"
                 ),
                 **sub_check_output_kw,
@@ -477,7 +480,9 @@ def test_x11_passthrough_missing_DISPLAY(mock_tools, DISPLAY):
     with (
         pytest.raises(
             BriefcaseCommandError,
-            match="The DISPLAY environment variable must be set to run an app in Docker",
+            match=(
+                "The DISPLAY environment variable must be set to run an app in Docker"
+            ),
         ),
         mock_tools.docker.x11_passthrough({}),
     ):
@@ -594,7 +599,8 @@ def test_x11_passthrough_xauth_fails(mock_tools, in_kwargs, out_kwargs, capsys):
     assert capsys.readouterr().out == (
         "An X11 authentication database could not be created for the display.\n"
         "\n"
-        "Briefcase will proceed, but if access to the display is rejected, this may be why.\n"
+        "Briefcase will proceed, but if access to the display is rejected, "
+        "this may be why.\n"
     )
 
 

--- a/tests/integrations/file/test_File__download.py
+++ b/tests/integrations/file/test_File__download.py
@@ -427,8 +427,9 @@ def test_connection_error(mock_tools):
     # Keep using the fixture though, so that it still gets cleaned up after the test
     mock_tools.httpx = mock.Mock(wraps=httpx)
 
-    # Failure leads to filename never being read, so the error message will use the full URL
-    # rather than the filename
+    # Failure leads to filename never being read, so the error message
+    # will use the full URL rather than the filename
+
     with pytest.raises(NetworkFailure, match=f"Unable to download {url}"):
         mock_tools.file.download(
             url=url,

--- a/tests/integrations/file/test_File__sorted_depth_first.py
+++ b/tests/integrations/file/test_File__sorted_depth_first.py
@@ -13,7 +13,8 @@ from ...utils import create_file
             ["foo/bar/a.txt", "foo/bar/c.txt", "foo/bar/b.txt"],
             ["foo/bar/c.txt", "foo/bar/b.txt", "foo/bar/a.txt"],
         ),
-        # Subfolders are sorted before files in that directory; but sorted lexically in themselves
+        # Subfolders are sorted before files in that directory;
+        # but sorted lexically in themselves
         (
             [
                 "foo/bar/b",

--- a/tests/integrations/flatpak/test_Flatpak__verify.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify.py
@@ -36,7 +36,10 @@ def test_flatpak_not_installed(mock_tools):
 
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"Briefcase requires the Flatpak toolchain, but it does not appear to be installed.",
+        match=(
+            r"Briefcase requires the Flatpak toolchain, but it does not appear "
+            r"to be installed."
+        ),
     ):
         Flatpak.verify(mock_tools)
 
@@ -98,7 +101,10 @@ def test_flatpak_builder_not_installed(mock_tools):
 
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"Briefcase requires the full Flatpak development toolchain, but flatpak-builder",
+        match=(
+            r"Briefcase requires the full Flatpak development toolchain, but "
+            r"flatpak-builder"
+        ),
     ):
         Flatpak.verify(mock_tools)
 

--- a/tests/integrations/flatpak/test_Flatpak__verify_repo.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_repo.py
@@ -41,7 +41,10 @@ def test_verify_repo_fail(flatpak):
 
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"Unable to add Flatpak repo https://example.com/flatpak with alias test-alias.",
+        match=(
+            r"Unable to add Flatpak repo https://example.com/flatpak with "
+            r"alias test-alias."
+        ),
     ):
         flatpak.verify_repo(
             repo_alias="test-alias",

--- a/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
+++ b/tests/integrations/flatpak/test_Flatpak__verify_runtime.py
@@ -49,7 +49,8 @@ def test_verify_runtime_fail(flatpak):
     with pytest.raises(
         BriefcaseCommandError,
         match=(
-            r"Unable to install Flatpak runtime org.beeware.flatpak.Platform/gothic/37.42 "
+            r"Unable to install Flatpak runtime "
+            r"org.beeware.flatpak.Platform/gothic/37.42 "
             r"and SDK org.beeware.flatpak.SDK/gothic/37.42 from repo test-alias."
         ),
     ):
@@ -63,7 +64,8 @@ def test_verify_runtime_fail(flatpak):
     with pytest.raises(
         BriefcaseCommandError,
         match=(
-            r"Unable to install Flatpak runtime org.beeware.flatpak.Platform/gothic/37.42 "
+            r"Unable to install Flatpak runtime "
+            r"org.beeware.flatpak.Platform/gothic/37.42 "
             r"and SDK org.beeware.flatpak.SDK/gothic/37.42 "
             r"and base org.beeware.flatpak.BaseApp/gothic/1.0 "
             r"from repo test-alias."

--- a/tests/integrations/git/test_Git__verify.py
+++ b/tests/integrations/git/test_Git__verify.py
@@ -76,6 +76,9 @@ def test_git_version_invalid(mock_tools, version, monkeypatch):
 
     with pytest.raises(
         BriefcaseCommandError,
-        match=f"At least Git v2.17.0 is required; however, v{'.'.join(map(str, version))} is installed.",
+        match=(
+            f"At least Git v2.17.0 is required; however, "
+            f"v{'.'.join(map(str, version))} is installed."
+        ),
     ):
         Git.verify(mock_tools)

--- a/tests/integrations/subprocess/conftest.py
+++ b/tests/integrations/subprocess/conftest.py
@@ -6,7 +6,8 @@ import pytest
 
 from briefcase.integrations.subprocess import Subprocess
 
-# hardcoded here since subprocess will only include these constants if Python is literally on Windows
+# hardcoded here since subprocess will only include these constants
+#  if Python is literally on Windows
 CREATE_NO_WINDOW = 0x8000000
 CREATE_NEW_PROCESS_GROUP = 0x200
 

--- a/tests/integrations/subprocess/test_PopenOutputStreamer.py
+++ b/tests/integrations/subprocess/test_PopenOutputStreamer.py
@@ -327,6 +327,7 @@ def test_filter_func_line_unexpected_error(streamer, capsys):
     # Exception
     assert capsys.readouterr().out == (
         "output line 1\n"
-        "Error while streaming output: RuntimeError: Like something totally went wrong\n"
+        "Error while streaming output: RuntimeError: Like something totally "
+        "went wrong\n"
     )
     # fmt: on

--- a/tests/integrations/visualstudio/test_VisualStudio__verify.py
+++ b/tests/integrations/visualstudio/test_VisualStudio__verify.py
@@ -9,11 +9,12 @@ import pytest
 from briefcase.exceptions import BriefcaseCommandError, UnsupportedHostError
 from briefcase.integrations.visualstudio import VisualStudio
 
-MSBUILD_OUTPUT = """Microsoft (R) Build Engine version 17.2.1+52cd2da31 for .NET Framework
-Copyright (C) Microsoft Corporation. All rights reserved.
-
-17.2.1.25201
-"""
+MSBUILD_OUTPUT = (
+    "Microsoft (R) Build Engine version 17.2.1+52cd2da31 for .NET "
+    "Framework\n"
+    "Copyright (C) Microsoft Corporation. All rights reserved.\n"
+    "17.2.1.25201\n"
+)
 
 
 @pytest.fixture
@@ -259,7 +260,10 @@ def test_vswhere_bad_executable(mock_tools, vswhere_path):
     # Verify the installation
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"Visual Studio appears to exist, but Briefcase can't retrieve installation metadata.",
+        match=(
+            r"Visual Studio appears to exist, but Briefcase can't retrieve "
+            r"installation metadata."
+        ),
     ):
         VisualStudio.verify(mock_tools)
 
@@ -287,7 +291,10 @@ def test_vswhere_bad_content(mock_tools, vswhere_path):
     # Verify the installation
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"Visual Studio appears to exist, but Briefcase can't retrieve installation metadata.",
+        match=(
+            r"Visual Studio appears to exist, but Briefcase can't retrieve "
+            r"installation metadata."
+        ),
     ):
         VisualStudio.verify(mock_tools)
 
@@ -307,16 +314,21 @@ def test_vswhere_bad_content(mock_tools, vswhere_path):
 def test_vswhere_non_list_content(mock_tools, vswhere_path):
     """If VSWhere can be executed, but the outermost content isn't a list, an error is
     raised."""
-    # MSBuild is not on the path, and vswhere returns JSON content, but not in the format expected
+    # MSBuild is not on the path, and vswhere returns JSON content, but not
+    # in the format expected
     mock_tools.subprocess.check_output.side_effect = [
         FileNotFoundError,  # MSBuild not on path
-        '{"problem": "JSON but not a list"}',  # vswhere returns JSON content, but not as a list.
+        '{"problem": "JSON but not a list"}',
+        # vswhere returns JSON content, but not as a list.
     ]
 
     # Verify the installation
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"Visual Studio appears to exist, but Briefcase can't retrieve installation metadata.",
+        match=(
+            r"Visual Studio appears to exist, but Briefcase can't retrieve "
+            r"installation metadata."
+        ),
     ):
         VisualStudio.verify(mock_tools)
 
@@ -336,7 +348,8 @@ def test_vswhere_non_list_content(mock_tools, vswhere_path):
 def test_vswhere_empty_list_content(mock_tools, vswhere_path):
     """If VSWhere can be executed, but the outermost content is an empty list, an error
     is raised."""
-    # MSBuild is not on the path, and vswhere returns JSON content, but not in the format expected
+    # MSBuild is not on the path, and vswhere returns JSON content, but not
+    # in the format expected
     mock_tools.subprocess.check_output.side_effect = [
         FileNotFoundError,  # MSBuild not on path
         "[]",  # vswhere returns empty list JSON content
@@ -345,7 +358,10 @@ def test_vswhere_empty_list_content(mock_tools, vswhere_path):
     # Verify the installation
     with pytest.raises(
         BriefcaseCommandError,
-        match=r"Visual Studio appears to exist, but Briefcase can't retrieve installation metadata.",
+        match=(
+            r"Visual Studio appears to exist, but Briefcase can't retrieve "
+            r"installation metadata."
+        ),
     ):
         VisualStudio.verify(mock_tools)
 
@@ -365,7 +381,8 @@ def test_vswhere_empty_list_content(mock_tools, vswhere_path):
 def test_vswhere_msbuild_not_installed(mock_tools, tmp_path, vswhere_path):
     """If VSWhere can be executed, but it doesn't point at an MSBuild executable, an
     error is raised."""
-    # MSBuild is not on the path; vswhere a valid location, but there's no MSBuild there.
+    # MSBuild is not on the path; vswhere a valid location, but there's no
+    #  MSBuild there.
     mock_tools.subprocess.check_output.side_effect = [
         FileNotFoundError,  # MSBuild not on path
         json.dumps(

--- a/tests/integrations/windows_sdk/test_WindowsSDK___verify_signtool.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK___verify_signtool.py
@@ -46,7 +46,8 @@ def test_winsdk_signtool_raises_oserror(windows_sdk, tmp_path):
     )
     windows_sdk.tools.subprocess.check_output.side_effect = OSError(
         14001,
-        " The application has failed to start because its side-by-side configuration is incorrect.",
+        " The application has failed to start because its side-by-side "
+        "configuration is incorrect.",
     )
 
     assert WindowsSDK._verify_signtool(windows_sdk) is False

--- a/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
+++ b/tests/integrations/windows_sdk/test_WindowsSDK__verify.py
@@ -41,7 +41,8 @@ def setup_winsdk_install(
     """Create a mock Windows SDK for the version and arch.
 
     :param base_path: base path to create the SDK in; should be pytest's tmp_path.
-    :param version: SDK version triple, e.g. 1.2.3. The created directory path will include
+    :param version: SDK version triple, e.g. 1.2.3. The created directory
+        path will include
         a servicing version of 0, e.g. base_path/win_sdk/1.2.3.0.
     :param arch: The architecture for the SDK, e.g. amd64 or arm64.
     :param skip_bins: Do not create mock binaries in `bin` directory.
@@ -158,7 +159,10 @@ def test_winsdk_invalid_env_vars(mock_tools, mock_winreg, tmp_path, monkeypatch)
     # Fail validation for missing install from env vars
     with pytest.raises(
         BriefcaseCommandError,
-        match="The 'WindowsSDKDir' and 'WindowsSDKVersion' environment variables do not point",
+        match=(
+            "The 'WindowsSDKDir' and 'WindowsSDKVersion' environment "
+            "variables do not point"
+        ),
     ):
         WindowsSDK.verify(mock_tools)
 
@@ -239,9 +243,12 @@ def test_winsdk_nonlatest_install_from_reg(
     expected_output = (
         "\n"
         "[Windows SDK] Finding Suitable Installation...\n"
-        f"Evaluating Registry SDK version '85.0.9.0' at {tmp_path / 'invalid' / 'win_sdk'}\n"
-        f"Evaluating Registry SDK version '85.0.8.0' at {tmp_path / 'win_sdk'}\n"
-        f"Using Windows SDK v85.0.8.0 at {tmp_path / 'win_sdk'}\n"
+        f"Evaluating Registry SDK version '85.0.9.0' at "
+        f"{tmp_path / 'invalid' / 'win_sdk'}\n"
+        f"Evaluating Registry SDK version '85.0.8.0' at "
+        f"{tmp_path / 'win_sdk'}\n"
+        f"Using Windows SDK v85.0.8.0 at "
+        f"{tmp_path / 'win_sdk'}\n"
     )
     assert capsys.readouterr().out == expected_output
 
@@ -255,11 +262,14 @@ def test_winsdk_nonlatest_install_from_reg(
     [
         # One invalid registry install; no additional installs
         ([("invalid_1", "85.0.1")], []),
-        # One invalid registry install with missing SDK version; no additional installs
+        # One invalid registry install with missing SDK version; no
+        # additional installs
         ([("invalid_1", "")], []),
-        # One invalid registry install but directory key lookup fails; no additional installs
+        # One invalid registry install but directory key lookup fails; no
+        # additional installs
         ([("invalid_1", "85.0.1"), (FileNotFoundError, "")], []),
-        # One invalid registry install but version key lookup fails; no additional installs
+        # One invalid registry install but version key lookup fails;
+        # no additional installs
         ([("invalid_1", "85.0.1"), ("invalid_1", FileNotFoundError)], []),
         # Multiple invalid registry installs; no additional installs
         ([("invalid_1", "85.0.1"), ("invalid_2", "85.0.2")], []),
@@ -384,9 +394,12 @@ def test_winsdk_valid_install_from_default_dir(
     expected_output = (
         "\n"
         "[Windows SDK] Finding Suitable Installation...\n"
-        f"Evaluating Default Bin SDK version '86.0.7.0' at {tmp_path / 'invalid' / 'win_sdk'}\n"
-        f"Evaluating Default Bin SDK version '86.0.8.0' at {tmp_path / 'win_sdk'}\n"
-        f"Using Windows SDK v86.0.8.0 at {tmp_path / 'win_sdk'}\n"
+        f"Evaluating Default Bin SDK version '86.0.7.0' at "
+        f"{tmp_path / 'invalid' / 'win_sdk'}\n"
+        f"Evaluating Default Bin SDK version '86.0.8.0' "
+        f"at {tmp_path / 'win_sdk'}\n"
+        f"Using Windows SDK v86.0.8.0 at "
+        f"{tmp_path / 'win_sdk'}\n"
     )
     assert capsys.readouterr().out == expected_output
 
@@ -437,7 +450,9 @@ def test_winsdk_invalid_install_from_default_dir(
     expected_output = (
         "\n"
         "[Windows SDK] Finding Suitable Installation...\n"
-        f"Evaluating Default Bin SDK version '87.0.7.0' at {tmp_path / 'invalid_1' / 'win_sdk'}\n"
-        f"Evaluating Default Bin SDK version '87.0.8.0' at {tmp_path / 'invalid_2' / 'win_sdk'}\n"
+        f"Evaluating Default Bin SDK version '87.0.7.0' at "
+        f"{tmp_path / 'invalid_1' / 'win_sdk'}\n"
+        f"Evaluating Default Bin SDK version '87.0.8.0' at "
+        f"{tmp_path / 'invalid_2' / 'win_sdk'}\n"
     )
     assert capsys.readouterr().out == expected_output

--- a/tests/integrations/xcode/test_ensure_xcode_is_installed.py
+++ b/tests/integrations/xcode/test_ensure_xcode_is_installed.py
@@ -226,8 +226,8 @@ def test_installed_extra_output(capsys, xcode, mock_tools):
         xcode + "\n",  # xcode-select -p
         "\n".join(
             [
-                "objc[86306]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libauthinstall.dylib (0x20d17ab90) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x1084b82c8). One of the two will be used. Which one is undefined."
-                "objc[86306]: Class AMSupportURLSession is implemented in both /usr/lib/libauthinstall.dylib (0x20d17abe0) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x1084b8318). One of the two will be used. Which one is undefined.",
+                "objc[86306]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libauthinstall.dylib (0x20d17ab90) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x1084b82c8). One of the two will be used. Which one is undefined."  # noqa: E501
+                "objc[86306]: Class AMSupportURLSession is implemented in both /usr/lib/libauthinstall.dylib (0x20d17abe0) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x1084b8318). One of the two will be used. Which one is undefined.",  # noqa: E501
                 "Xcode 13.2.1",
                 "Build version 13C100",
             ]

--- a/tests/integrations/xcode/test_get_identities.py
+++ b/tests/integrations/xcode/test_get_identities.py
@@ -70,7 +70,7 @@ def test_one_identity(mock_tools):
     )
 
     assert simulators == {
-        "38EBD6F8903EC63C238B04C1067833814CE47CA3": "Developer ID Application: Example Corporation Ltd (Z2K4383DLE)",
+        "38EBD6F8903EC63C238B04C1067833814CE47CA3": "Developer ID Application: Example Corporation Ltd (Z2K4383DLE)",  # noqa: E501
     }
 
 
@@ -88,9 +88,9 @@ def test_multiple_identities(mock_tools):
     )
 
     assert simulators == {
-        "38EBD6F8903EC63C238B04C1067833814CE47CA3": "Developer ID Application: Example Corporation Ltd (Z2K4383DLE)",
-        "11E77FB58F13F6108B38110D5D92233C58ED38C5": "iPhone Developer: Jane Smith (BXAH5H869S)",
-        "F8903EC63C238B04C1067833814CE47CA338EBD6": "Developer ID Application: Other Corporation Ltd (83DLZ2K43E)",
+        "38EBD6F8903EC63C238B04C1067833814CE47CA3": "Developer ID Application: Example Corporation Ltd (Z2K4383DLE)",  # noqa: E501
+        "11E77FB58F13F6108B38110D5D92233C58ED38C5": "iPhone Developer: Jane Smith (BXAH5H869S)",  # noqa: E501
+        "F8903EC63C238B04C1067833814CE47CA338EBD6": "Developer ID Application: Other Corporation Ltd (83DLZ2K43E)",  # noqa: E501
     }
 
 
@@ -108,7 +108,7 @@ def test_no_profile(mock_tools):
     )
 
     assert simulators == {
-        "38EBD6F8903EC63C238B04C1067833814CE47CA3": "Developer ID Application: Example Corporation Ltd (Z2K4383DLE)",
-        "11E77FB58F13F6108B38110D5D92233C58ED38C5": "iPhone Developer: Jane Smith (BXAH5H869S)",
-        "F8903EC63C238B04C1067833814CE47CA338EBD6": "Developer ID Application: Other Corporation Ltd (83DLZ2K43E)",
+        "38EBD6F8903EC63C238B04C1067833814CE47CA3": "Developer ID Application: Example Corporation Ltd (Z2K4383DLE)",  # noqa: E501
+        "11E77FB58F13F6108B38110D5D92233C58ED38C5": "iPhone Developer: Jane Smith (BXAH5H869S)",  # noqa: E501
+        "F8903EC63C238B04C1067833814CE47CA338EBD6": "Developer ID Application: Other Corporation Ltd (83DLZ2K43E)",  # noqa: E501
     }

--- a/tests/integrations/xcode/test_get_simulators.py
+++ b/tests/integrations/xcode/test_get_simulators.py
@@ -101,7 +101,7 @@ def test_single_iOS_runtime(mock_tools, simulator):
         "iOS 13.2": {
             "20C5B052-F47A-4816-8584-9F1500B50477": "iPad Pro (9.7-inch)",
             "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D": "iPhone 11",
-            "314E772A-8034-44B4-9B28-3EE80C958F0A": "iPad Pro (12.9-inch) (3rd generation)",
+            "314E772A-8034-44B4-9B28-3EE80C958F0A": "iPad Pro (12.9-inch) (3rd generation)",  # noqa: E501
             "36E4663B-A10F-470F-94E8-05C3DC692AC9": "iPad Pro (11-inch)",
             "5497F9B2-F4F3-454A-A9DD-993DF44EBB63": "iPhone 8 Plus",
             "939B1EF6-C25A-4056-B61F-20A2835E89D6": "iPad (7th generation)",
@@ -155,7 +155,7 @@ def test_multiple_iOS_runtime(mock_tools, simulator):
         "iOS 13.2": {
             "20C5B052-F47A-4816-8584-9F1500B50477": "iPad Pro (9.7-inch)",
             "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D": "iPhone 11",
-            "314E772A-8034-44B4-9B28-3EE80C958F0A": "iPad Pro (12.9-inch) (3rd generation)",
+            "314E772A-8034-44B4-9B28-3EE80C958F0A": "iPad Pro (12.9-inch) (3rd generation)",  # noqa: E501
             "36E4663B-A10F-470F-94E8-05C3DC692AC9": "iPad Pro (11-inch)",
             "5497F9B2-F4F3-454A-A9DD-993DF44EBB63": "iPhone 8 Plus",
             "939B1EF6-C25A-4056-B61F-20A2835E89D6": "iPad (7th generation)",
@@ -178,7 +178,7 @@ def test_multiple_iOS_runtime(mock_tools, simulator):
             "CC954566-F315-4692-A754-DECDF72967CD": "iPhone 5",
             "D7BBAD14-38FD-48F5-ACFD-B1193F829216": "iPhone 6",
             "DA9B9F49-A070-4FD7-A6BF-8F49DC72194E": "iPhone 6s Plus",
-            "E582FF8E-A5DC-4985-B6C8-8D6B1795DF62": "iPad Pro (12.9-inch) (2nd generation)",
+            "E582FF8E-A5DC-4985-B6C8-8D6B1795DF62": "iPad Pro (12.9-inch) (2nd generation)",  # noqa: E501
             "E956D6AE-29F5-4780-A02A-D3426B7B4018": "iPad Pro (12.9 inch)",
             "F9A6C462-9A4A-438A-B541-848F0E6DBE5A": "iPhone 6s",
         },
@@ -235,7 +235,7 @@ def test_alternate_format(mock_tools, simulator):
             "9F055949-5DF2-40D8-A955-A8517F213E24": "iPhone 8 Plus",
             "A1970E36-8906-48FF-8B3C-819A0A88D9D6": "iPhone 6 Plus",
             "A604E87D-B2BF-4190-B974-C29FC40A6F15": "iPhone 7 Plus",
-            "AAF12280-0DC2-472F-87C5-2F141A6F0C55": "iPad Pro (12.9-inch) (2nd generation)",
+            "AAF12280-0DC2-472F-87C5-2F141A6F0C55": "iPad Pro (12.9-inch) (2nd generation)",  # noqa: E501
             "AC8D34EB-F42D-4518-A09C-3C3AD7FCAC8C": "iPhone SE",
             "C4DE0942-3A85-4091-98CC-C4A90E2D07C3": "iPhone X",
             "C8E5AD6A-B7EB-480F-89E8-341FD45AAFFC": "iPad Air",
@@ -248,7 +248,7 @@ def test_alternate_format(mock_tools, simulator):
             "04325672-C35F-4E5E-BD08-EAC478B7165C": "iPhone XS",
             "28F0335D-1B4D-4493-A5C5-4E86E2916178": "iPhone 6",
             "28F16D36-8878-489F-A8CF-33E7037D252B": "iPad Pro (9.7-inch)",
-            "512E11C5-5654-4F10-98D7-F75C50DF5DB7": "iPad Pro (12.9-inch) (3rd generation)",
+            "512E11C5-5654-4F10-98D7-F75C50DF5DB7": "iPad Pro (12.9-inch) (3rd generation)",  # noqa: E501
             "53D7FAF6-83D7-415D-A3B4-20A9D8C37C44": "iPhone 5s",
             "5EF8EAA5-9D63-4F53-8896-57F9D59DECF9": "iPhone 6s",
             "61D96B3A-3747-41AC-92F7-2177E467A196": "iPad Pro (10.5-inch)",
@@ -266,7 +266,7 @@ def test_alternate_format(mock_tools, simulator):
             "D637BC6D-A53F-4E78-BDA7-FA0D59303350": "iPad Pro (11-inch)",
             "DC08D810-B9AD-4423-972E-3EE8949BC1F2": "iPad Air",
             "DEE6AF0E-596D-4713-8B57-8C77D45EED80": "iPad Air 2",
-            "F022D86A-E404-46C0-98B2-9AB63AD7008B": "iPad Pro (12.9-inch) (2nd generation)",
+            "F022D86A-E404-46C0-98B2-9AB63AD7008B": "iPad Pro (12.9-inch) (2nd generation)",  # noqa: E501
             "F7EF0E11-864C-42A2-8D80-4DBE78AFD86B": "iPhone 6 Plus",
         },
     }


### PR DESCRIPTION
Refs #2383

Fixed the E501 line-length stuff in tests/integrations and dropped the
exclusion for it in pyproject.toml. Leaving tests/platforms for someone
else.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: Claude Sonnet 5