### PR TITLE
chore(deps): add cooldown to all Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,3 @@
-
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -8,6 +7,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -16,6 +17,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "automation"
@@ -24,6 +27,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "debugger"
@@ -32,6 +37,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
@@ -40,3 +47,5 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7

--- a/changes/2938.misc.md
+++ b/changes/2938.misc.md
@@ -1,0 +1,1 @@
+Dependabot now applies a 7-day cooldown to updates, preventing more than one PR per ecosystem per week.


### PR DESCRIPTION
Adds a 7-day cooldown to all Dependabot package ecosystems. This matches the standard beeware template and stops Dependabot from spamming update PRs every day.

Closes #2935

## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file