### PR TITLE
Improve Android "install failed" messages

### DIFF
--- a/changes/1362.bugfix.md
+++ b/changes/1362.bugfix.md
@@ -1,0 +1,3 @@
+Installing an APK now gives a specific, actionable error message when
+it fails because the existing app was signed with a different key, or
+because a newer version is already installed on the device.

--- a/src/briefcase/console.py
+++ b/src/briefcase/console.py
@@ -252,7 +252,7 @@ class Console:
         return self._log_impl.export_text()
 
     @staticmethod
-    def _dedent_and_wrap(text, wrap_width, border=0):
+    def dedent_and_wrap(text, wrap_width=80, border=0):
         """Dedent text, split text into paragraphs and wrap to a width.
 
         If a border is specified, that border width will be preserved on the left *and
@@ -336,7 +336,7 @@ class Console:
 
         if title:
             # Remove 6 from the width to allow for "** " and " **" wrappers
-            title_lines = Console._dedent_and_wrap(f"WARNING: {title}", width - 6)
+            title_lines = Console.dedent_and_wrap(f"WARNING: {title}", width - 6)
 
             # Center each line of the title and add to the box
             for line in title_lines:
@@ -346,7 +346,7 @@ class Console:
             lines_array.append(BORDER_LINE)
 
         if message:
-            msg_lines = Console._dedent_and_wrap(message, width, border=2)
+            msg_lines = Console.dedent_and_wrap(message, width, border=2)
 
             lines_array.extend(["", *msg_lines, "", BORDER_LINE, ""])
 

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1481,18 +1481,45 @@ class ADB:
                 raise InvalidDeviceError("device id", self.device) from e
             raise
 
-    def install_apk(self, apk_path: str | Path):
+    def install_apk(self, apk_path: str | Path, package: str):
         """Install an APK file on an Android device.
 
         :param apk_path: The path of the Android APK file to install.
+        :param package: The package name that the Android APK will install.
         :returns: `None` on success; raises an exception on failure.
         """
         try:
             self.run("install", "-r", apk_path)
         except subprocess.CalledProcessError as e:
-            raise BriefcaseCommandError(
-                f"Unable to install APK {apk_path} on {self.device}"
-            ) from e
+            output = e.output or ""
+            if "INSTALL_FAILED_UPDATE_INCOMPATIBLE" in output:
+                raise BriefcaseCommandError(
+                    f"""\
+            Unable to install APK {apk_path} on {self.device}.
+
+            The app currently installed on the device was signed with a different key
+            than this APK (often because it was previously installed from a different
+            computer). To resolve this, uninstall the existing app, then try again:
+
+                $ adb -s {self.device} uninstall {package}
+            """
+                ) from e
+            elif "INSTALL_FAILED_VERSION_DOWNGRADE" in output:
+                raise BriefcaseCommandError(
+                    f"""\
+            Unable to install APK {apk_path} on {self.device}.
+
+            A newer version of this app is already installed, and Android won't install
+            an older version over it. To resolve this, uninstall the existing app, then
+            try again:
+
+                $ adb -s {self.device} uninstall {package}
+            """
+                ) from e
+            else:
+                raise BriefcaseCommandError(
+                    f"Unable to install APK {apk_path} on {self.device}"
+                ) from e
 
     def force_stop_app(self, package: str):
         """Force-stop an app, specified as a package name.

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1495,14 +1495,16 @@ class ADB:
             if "INSTALL_FAILED_UPDATE_INCOMPATIBLE" in output:
                 raise BriefcaseCommandError(
                     f"""\
-            Unable to install APK {apk_path} on {self.device}.
+            Unable to install APK {apk_path} on {self.device}
 
             The app currently installed on the device was signed with a different key
             than this APK (often because it was previously installed from a different
-            computer). To resolve this, uninstall the existing app, then try again:
+            computer). To resolve this, run the following command to uninstall the
+            existing app, then try again:
 
-                $ adb -s {self.device} uninstall {package}
-            """
+                $ "{self.tools.android_sdk.adb_path}" -s {self.device} """
+                    f"""uninstall {package}
+"""
                 ) from e
             elif "INSTALL_FAILED_VERSION_DOWNGRADE" in output:
                 raise BriefcaseCommandError(
@@ -1510,11 +1512,12 @@ class ADB:
             Unable to install APK {apk_path} on {self.device}.
 
             A newer version of this app is already installed, and Android won't install
-            an older version over it. To resolve this, uninstall the existing app, then
-            try again:
+            an older version over it. To resolve this, run the following command to
+            uninstall the existing app, then try again:
 
-                $ adb -s {self.device} uninstall {package}
-            """
+                $ "{self.tools.android_sdk.adb_path}" -s {self.device} """
+                    f"""uninstall {package}
+"""
                 ) from e
             else:
                 raise BriefcaseCommandError(

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pathlib import Path
 
 from briefcase.config import PEP508_NAME_RE
+from briefcase.console import Console
 from briefcase.exceptions import (
     BriefcaseCommandError,
     IncompatibleToolError,
@@ -1492,37 +1493,49 @@ class ADB:
             self.run("install", "-r", apk_path)
         except subprocess.CalledProcessError as e:
             output = e.output or ""
-            if "INSTALL_FAILED_UPDATE_INCOMPATIBLE" in output:
-                raise BriefcaseCommandError(
-                    f"""\
-            Unable to install APK {apk_path} on {self.device}
+            unable_to_install = f"Unable to install APK {apk_path} on {self.device}."
 
-            The app currently installed on the device was signed with a different key
-            than this APK (often because it was previously installed from a different
-            computer). To resolve this, run the following command to uninstall the
-            existing app, then try again:
+            remedy = "\n".join(
+                Console.dedent_and_wrap(
+                    f"""
+                    To resolve this, run the following command to uninstall the
+                    existing app, then try again:
 
-                $ "{self.tools.android_sdk.adb_path}" -s {self.device} """
+                        "{self.tools.android_sdk.adb_path}" -s {self.device} """
                     f"""uninstall {package}
-"""
+
+                    Warning: this will delete the app's existing data on the device.
+                    """
+                )
+            )
+
+            if "INSTALL_FAILED_UPDATE_INCOMPATIBLE" in output:
+                cause = "\n".join(
+                    Console.dedent_and_wrap(
+                        """
+                        The app currently installed on the device was signed with
+                        a different key than this APK (maybe because it was
+                        installed from a different computer).
+                        """
+                    )
+                )
+                raise BriefcaseCommandError(
+                    f"{unable_to_install}\n\n{cause}\n\n{remedy}"
                 ) from e
             elif "INSTALL_FAILED_VERSION_DOWNGRADE" in output:
+                cause = "\n".join(
+                    Console.dedent_and_wrap(
+                        """
+                        A newer version of this app is already installed, and
+                        Android won't install an older version over it.
+                        """
+                    )
+                )
                 raise BriefcaseCommandError(
-                    f"""\
-            Unable to install APK {apk_path} on {self.device}.
-
-            A newer version of this app is already installed, and Android won't install
-            an older version over it. To resolve this, run the following command to
-            uninstall the existing app, then try again:
-
-                $ "{self.tools.android_sdk.adb_path}" -s {self.device} """
-                    f"""uninstall {package}
-"""
+                    f"{unable_to_install}\n\n{cause}\n\n{remedy}"
                 ) from e
             else:
-                raise BriefcaseCommandError(
-                    f"Unable to install APK {apk_path} on {self.device}"
-                ) from e
+                raise BriefcaseCommandError(unable_to_install) from e
 
     def force_stop_app(self, package: str):
         """Force-stop an app, specified as a package name.

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -523,7 +523,7 @@ class GradleRunCommand(GradleMixin, RunCommand):
 
             # Install the latest APK file onto the device.
             with self.console.wait_bar("Installing new app version..."):
-                adb.install_apk(self.binary_path(app))
+                adb.install_apk(self.binary_path(app), package)
 
             if revoke_permissions:
                 # Revoke specified app permissions to ensure a reproducible

--- a/tests/integrations/android_sdk/ADB/test_install_apk.py
+++ b/tests/integrations/android_sdk/ADB/test_install_apk.py
@@ -12,7 +12,7 @@ def test_install_apk(adb, capsys):
     adb.run = MagicMock(return_value="example normal adb output")
 
     # Invoke install
-    adb.install_apk("example.apk")
+    adb.install_apk("example.apk", "com.example.helloworld")
 
     # Validate call parameters.
     adb.run.assert_called_once_with("install", "-r", "example.apk")
@@ -31,9 +31,44 @@ def test_install_failure(adb, capsys):
 
     # Invoke install
     with pytest.raises(BriefcaseCommandError):
-        adb.install_apk("example.apk")
+        adb.install_apk("example.apk", "com.example.helloworld")
 
     # Validate call parameters.
+    adb.run.assert_called_once_with("install", "-r", "example.apk")
+
+
+def test_install_failure_update_incompatible(adb, capsys):
+    """If install fails because of a signing key mismatch, a specific error is
+    raised."""
+    adb.run = MagicMock(
+        side_effect=subprocess.CalledProcessError(
+            returncode=1,
+            cmd="install",
+            output="Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE: signatures do not match]",
+        )
+    )
+
+    with pytest.raises(BriefcaseCommandError) as exc_info:
+        adb.install_apk("example.apk", "com.example.helloworld")
+    assert "uninstall com.example.helloworld" in str(exc_info.value)
+
+    adb.run.assert_called_once_with("install", "-r", "example.apk")
+
+
+def test_install_failure_version_downgrade(adb, capsys):
+    """If install fails because of a version downgrade, a specific error is raised."""
+    adb.run = MagicMock(
+        side_effect=subprocess.CalledProcessError(
+            returncode=1,
+            cmd="install",
+            output="Failure [INSTALL_FAILED_VERSION_DOWNGRADE]",
+        )
+    )
+
+    with pytest.raises(BriefcaseCommandError) as exc_info:
+        adb.install_apk("example.apk", "com.example.helloworld")
+    assert "uninstall com.example.helloworld" in str(exc_info.value)
+
     adb.run.assert_called_once_with("install", "-r", "example.apk")
 
 
@@ -44,7 +79,7 @@ def test_invalid_device(adb, capsys):
 
     # Invoke install
     with pytest.raises(InvalidDeviceError):
-        adb.install_apk("example.apk")
+        adb.install_apk("example.apk", "com.example.helloworld")
 
     # Validate call parameters.
     adb.run.assert_called_once_with("install", "-r", "example.apk")

--- a/tests/integrations/android_sdk/ADB/test_install_apk.py
+++ b/tests/integrations/android_sdk/ADB/test_install_apk.py
@@ -67,7 +67,7 @@ def test_install_failure_version_downgrade(adb, capsys):
 
     with pytest.raises(BriefcaseCommandError) as exc_info:
         adb.install_apk("example.apk", "com.example.helloworld")
-    assert "uninstall com.example.helloworld" in str(exc_info.value)
+    assert "newer version" in str(exc_info.value)
 
     adb.run.assert_called_once_with("install", "-r", "example.apk")
 

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -317,7 +317,8 @@ def test_run_existing_device(run_command, first_app_config):
 
     # The adb wrapper is invoked with the expected arguments
     run_command.tools.mock_adb.install_apk.assert_called_once_with(
-        run_command.binary_path(first_app_config)
+        run_command.binary_path(first_app_config),
+        f"{first_app_config.package_name}.{first_app_config.module_name}",
     )
     run_command.tools.mock_adb.force_stop_app.assert_called_once_with(
         f"{first_app_config.package_name}.{first_app_config.module_name}",
@@ -396,7 +397,8 @@ def test_run_with_passthrough(run_command, first_app_config):
 
     # The adb wrapper is invoked with the expected arguments
     run_command.tools.mock_adb.install_apk.assert_called_once_with(
-        run_command.binary_path(first_app_config)
+        run_command.binary_path(first_app_config),
+        f"{first_app_config.package_name}.{first_app_config.module_name}",
     )
     run_command.tools.mock_adb.force_stop_app.assert_called_once_with(
         f"{first_app_config.package_name}.{first_app_config.module_name}",
@@ -630,7 +632,8 @@ def test_run_created_emulator(run_command, first_app_config):
 
     # The adb wrapper is invoked with the expected arguments
     run_command.tools.mock_adb.install_apk.assert_called_once_with(
-        run_command.binary_path(first_app_config)
+        run_command.binary_path(first_app_config),
+        f"{first_app_config.package_name}.{first_app_config.module_name}",
     )
     run_command.tools.mock_adb.force_stop_app.assert_called_once_with(
         f"{first_app_config.package_name}.{first_app_config.module_name}",
@@ -692,7 +695,8 @@ def test_run_idle_device(run_command, first_app_config):
 
     # The adb wrapper is invoked with the expected arguments
     run_command.tools.mock_adb.install_apk.assert_called_once_with(
-        run_command.binary_path(first_app_config)
+        run_command.binary_path(first_app_config),
+        f"{first_app_config.package_name}.{first_app_config.module_name}",
     )
     run_command.tools.mock_adb.force_stop_app.assert_called_once_with(
         f"{first_app_config.package_name}.{first_app_config.module_name}",
@@ -794,7 +798,8 @@ def test_run_test_mode(run_command, first_app_config):
 
     # The adb wrapper is invoked with the expected arguments
     run_command.tools.mock_adb.install_apk.assert_called_once_with(
-        run_command.binary_path(first_app_config)
+        run_command.binary_path(first_app_config),
+        f"{first_app_config.package_name}.{first_app_config.module_name}",
     )
     run_command.tools.mock_adb.force_stop_app.assert_called_once_with(
         f"{first_app_config.package_name}.{first_app_config.module_name}",
@@ -868,7 +873,8 @@ def test_run_test_mode_with_passthrough(run_command, first_app_config):
 
     # The adb wrapper is invoked with the expected arguments
     run_command.tools.mock_adb.install_apk.assert_called_once_with(
-        run_command.binary_path(first_app_config)
+        run_command.binary_path(first_app_config),
+        f"{first_app_config.package_name}.{first_app_config.module_name}",
     )
     run_command.tools.mock_adb.force_stop_app.assert_called_once_with(
         f"{first_app_config.package_name}.{first_app_config.module_name}",
@@ -946,7 +952,8 @@ def test_run_test_mode_created_emulator(run_command, first_app_config):
 
     # The adb wrapper is invoked with the expected arguments
     run_command.tools.mock_adb.install_apk.assert_called_once_with(
-        run_command.binary_path(first_app_config)
+        run_command.binary_path(first_app_config),
+        f"{first_app_config.package_name}.{first_app_config.module_name}",
     )
     run_command.tools.mock_adb.force_stop_app.assert_called_once_with(
         f"{first_app_config.package_name}.{first_app_config.module_name}",
@@ -1055,7 +1062,8 @@ def test_run_debugger(run_command, first_app_config, tmp_path, debugger):
 
     # The adb wrapper is invoked with the expected arguments
     run_command.tools.mock_adb.install_apk.assert_called_once_with(
-        run_command.binary_path(first_app_config)
+        run_command.binary_path(first_app_config),
+        f"{first_app_config.package_name}.{first_app_config.module_name}",
     )
     run_command.tools.mock_adb.force_stop_app.assert_called_once_with(
         f"{first_app_config.package_name}.{first_app_config.module_name}",


### PR DESCRIPTION
<!--- Describe your changes in detail -->
The two known failure markers `UPDATE_INCOMPATIBLE` and `VERSION_DOWNGRADE` now present the user with an informative error message indicating the probable cause and include a suggested route for resolution. 
<!--- What problem does this change solve? -->
Previously, both failures produced the same generic 'Unable to install APK' message, giving users no indication of what went wrong or how to fix it.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Refs #1362 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Sonnet<!--name of tool; e.g., Claude Opus 4.5-->
