### PR TITLE
docs: fix missing word in iOS publishing note

### DIFF
--- a/changes/2943.doc.md
+++ b/changes/2943.doc.md
@@ -1,0 +1,1 @@
+Fixed a missing word in the iOS publishing guide note.

--- a/docs/en/how-to/publishing/iOS.md
+++ b/docs/en/how-to/publishing/iOS.md
@@ -4,7 +4,7 @@ This guide will walk you through the process of publishing an app to the Apple A
 
 /// note | Note
 
-The Apple App Store makes frequent changes to the workflows and nomenclature associated with publishing apps. As a result, it's very difficult to keep a like this one up to date. If you spot any problems, [let us know](https://github.com/beeware/briefcase/issues/new?assignees=&labels=bug,documentation,apple&projects=&template=bug_report.yml).
+The Apple App Store makes frequent changes to the workflows and nomenclature associated with publishing apps. As a result, it's very difficult to keep a guide like this one up to date. If you spot any problems, [let us know](https://github.com/beeware/briefcase/issues/new?assignees=&labels=bug,documentation,apple&projects=&template=bug_report.yml).
 
 ///
 


### PR DESCRIPTION
## Changes
Fix a missing word in the iOS App Store publishing note so it matches the macOS and Android pages.

Fixes #2943.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Hermes Agent