### PR TITLE
docs: clarify iOS icon format and splash sizes

### DIFF
--- a/changes/2942.doc.md
+++ b/changes/2942.doc.md
@@ -1,0 +1,1 @@
+Clarified that iOS icons must be square and opaque, and that only the 640/1280/1920px sizes feed the splash screen.

--- a/docs/en/reference/platforms/iOS/xcode.md
+++ b/docs/en/reference/platforms/iOS/xcode.md
@@ -54,7 +54,9 @@ When generating an iOS project, Briefcase produces an Xcode project.
 
 ## Icon format
 
-iOS projects use `.png` format icons. An application must provide icons of the following sizes:
+iOS projects use `.png` format icons. Icons must be **square** and **opaque**. iOS applies a squircle mask to square icons so they match the rest of the home screen; if you provide a non-square icon, or a squircle with transparent padding, the transparent regions render as black borders/corners.
+
+An application must provide icons of the following sizes:
 
 * 20px
 * 29px
@@ -73,7 +75,7 @@ iOS projects use `.png` format icons. An application must provide icons of the f
 * 1280px
 * 1920px
 
-The icon will also be used to populate the splash screen. You can specify a background color for the splash screen using the `splash_background_color` configuration setting.
+Only the **640px**, **1280px**, and **1920px** icons are used to populate the splash screen. You can specify a background color for the splash screen using the `splash_background_color` configuration setting.
 
 iOS projects do not support installer images.
 


### PR DESCRIPTION
## Changes
Clarify the iOS Icon format section:
- Icons must be square and opaque; iOS applies a squircle mask, and transparent padding becomes black corners/borders.
- Only the 640px, 1280px and 1920px sizes feed the splash screen (not every listed size).

Refs #2942.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Hermes Agent