### PR TITLE
Document desktop shortcut behavior as tri-state optional

### DIFF
--- a/changes/2914.feature.md
+++ b/changes/2914.feature.md
@@ -1,1 +1,1 @@
-MSI installers now have a toggle to create a desktop shortcut. The default choice is controlled by the `create_desktop_shortcut` configuration.
+MSI installers can now provide the option to create a desktop shortcut using the [`create_desktop_shortcut`][] option.

--- a/docs/en/reference/platforms/windows/index.md
+++ b/docs/en/reference/platforms/windows/index.md
@@ -204,7 +204,16 @@ However, if you need to override this default value, you can define [`version_tr
 
 ### `create_desktop_shortcut`
 
-Whether the installer should default to creating a desktop shortcut. Defaults to `False`.
+/// note | Only used for MSI packaging
+///
+
+Windows MSI installers are able to provide an option to the user to create a desktop shortcut to start the application.
+
+If this setting is set to `True`, the installer will include a checkbox, enabled by default. The user installing the app can then opt out of creating a desktop shortcut for the app.
+
+If this setting is set to `False`, the installer will include the checkbox, but it will be *disabled* by default. The user installing the app can then opt into creating a desktop shortcut for the app.
+
+If this setting is undefined, or set to an empty string, the installer will not include an option to create a shortcut, and no shortcut will be created.
 
 ## Installer/uninstaller options
 


### PR DESCRIPTION
Documents the change in the `create_desktop_shortcut` option to be tri-state, defaulting to "not enabled."

Refs beeware/briefcase-windows-app-template#108
Refs beeware/briefcase-windows-VisualStudio-template#114
Fixes #2950

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
