### PR TITLE
Clarify iOS icon format section in docs

### DIFF
--- a/changes/2942.doc.md
+++ b/changes/2942.doc.md
@@ -1,1 +1,1 @@
-Clarified the iOS Icon format documentation to note that icons must be square, that iOS auto-masks app icons with rounded corners, that transparent areas render as black, that only 640px/1280px/1920px icons are used for the splash screen, and that splash screen images are not auto-masked.
+Requirements for iOS icon formats have been clarified.

--- a/changes/2942.doc.md
+++ b/changes/2942.doc.md
@@ -1,0 +1,1 @@
+Clarified the iOS Icon format documentation to note that icons must be square, that iOS auto-masks app icons with rounded corners, that transparent areas render as black, that only 640px/1280px/1920px icons are used for the splash screen, and that splash screen images are not auto-masked.

--- a/docs/en/reference/platforms/iOS/xcode.md
+++ b/docs/en/reference/platforms/iOS/xcode.md
@@ -68,12 +68,14 @@ iOS projects use `.png` format icons. An application must provide icons of the f
 * 152px
 * 167px
 * 180px
-* 640px
+* 640px (for splash screen)
 * 1024px
-* 1280px
-* 1920px
+* 1280px (for splash screen)
+* 1920px (for splash screen)
 
-The icon will also be used to populate the splash screen. You can specify a background color for the splash screen using the `splash_background_color` configuration setting.
+Icons must be square. iOS will automatically apply a mask with rounded corners (a "squircle") to app icons so they match the system icon shape. If you provide non-square icons or icons with transparent regions, the transparent areas will render as black on the device.
+
+The 640px, 1280px and 1920px icons will also be used to populate the splash screen. You can specify a background color for the splash screen using the `splash_background_color` configuration setting. Unlike app icons, splash screen images are *not* automatically masked by iOS — they will be displayed as-is. If you want a particular shape for your splash screen image (such as rounded corners), you must include that shape directly in the image file.
 
 iOS projects do not support installer images.
 

--- a/docs/en/reference/platforms/iOS/xcode.md
+++ b/docs/en/reference/platforms/iOS/xcode.md
@@ -75,7 +75,7 @@ iOS projects use `.png` format icons. An application must provide icons of the f
 
 Icons must be square. iOS will automatically apply a mask with rounded corners (a "squircle") to app icons so they match the system icon shape. If you provide non-square icons or icons with transparent regions, the transparent areas will render as black on the device.
 
-The 640px, 1280px and 1920px icons will also be used to populate the splash screen. You can specify a background color for the splash screen using the `splash_background_color` configuration setting. Unlike app icons, splash screen images are *not* automatically masked by iOS — they will be displayed as-is. If you want a particular shape for your splash screen image (such as rounded corners), you must include that shape directly in the image file.
+The 640px, 1280px and 1920px icons will also be used to populate the splash screen. Splash screen images are *not* automatically masked by iOS — they will be displayed as-is, with transparent areas showing the splash background color.
 
 iOS projects do not support installer images.
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -190,6 +190,7 @@ SHA
 SKU
 socat
 SPDX
+squircle
 SSL
 stylesheet
 subdirectories


### PR DESCRIPTION
Clarify the iOS Icon format docs: icons must be square (iOS auto-applies a squircle mask), transparent areas render as black, only 640/1280/1920px are for the splash screen, and splash images are not auto-masked.
Fixes #2942

## PR Checklist:
 - [x] I will abide by the BeeWare Code of Conduct
 - [x] I have read and have followed the **CONTRIBUTING.md** file
 - [x] This PR was generated or assisted using an AI tool
 Assisted-by: Claude Opus 4.6