### PR TITLE
Allow remote assembly loading in Windows ZIP packages

### DIFF
--- a/changes/1890.bugfix.md
+++ b/changes/1890.bugfix.md
@@ -1,1 +1,1 @@
-Windows ZIP packages now include an application configuration that permits .NET assemblies marked as originating from a remote source to load.
+Windows apps packaged as ZIP bundles are now safe from the "Mark of the Web".

--- a/changes/1890.bugfix.md
+++ b/changes/1890.bugfix.md
@@ -1,0 +1,1 @@
+Windows ZIP packages now include an application configuration that permits .NET assemblies marked as originating from a remote source to load.

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -27,6 +27,15 @@ else:
 
 DEFAULT_OUTPUT_FORMAT = "app"
 
+LOAD_FROM_REMOTE_SOURCES_CONFIG = """\
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <loadFromRemoteSources enabled="true"/>
+  </runtime>
+</configuration>
+"""
+
 
 def txt_to_rtf(txt: str | list[str]) -> str:
     """Convert plain text to a full RTF document.
@@ -678,3 +687,12 @@ class WindowsPackageCommand(PackageCommand):
                     archive.write(
                         file_path, zip_root / PurePath(file_path).relative_to(source)
                     )
+
+                executable_path = self.binary_path(app)
+                config_path = executable_path.with_name(
+                    f"{executable_path.name}.config"
+                )
+                archive.writestr(
+                    (zip_root / PurePath(config_path).relative_to(source)).as_posix(),
+                    LOAD_FROM_REMOTE_SOURCES_CONFIG,
+                )

--- a/tests/platforms/windows/app/test_package.py
+++ b/tests/platforms/windows/app/test_package.py
@@ -215,10 +215,8 @@ def test_package_msi(
 ):
     """A Windows app can be packaged as an MSI."""
 
-    package_command.package_app(
-        external_first_app if external else first_app_config,
-        **kwargs,
-    )
+    app = external_first_app if external else first_app_config
+    package_command.package_app(app, **kwargs)
 
     assert package_command.tools.subprocess.run.mock_calls == [
         # Compile MSI
@@ -246,6 +244,9 @@ def test_package_msi(
             cwd=tmp_path / "base_path/build/first-app/windows/app",
         ),
     ]
+    # The .NET remote source configuration is only included in ZIP packages.
+    executable_path = package_command.binary_path(app)
+    assert not executable_path.with_name(f"{executable_path.name}.config").exists()
 
 
 @pytest.mark.parametrize(
@@ -282,6 +283,8 @@ def test_package_zip(package_command_with_files, first_app_config, kwargs, tmp_p
         "app_packages/clr.py",
         "app_packages/toga_winforms/command.py",
     )
+    executable_path = package_command_with_files.binary_path(first_app_config)
+    remote_sources_config = f"{executable_path.name}.config"
 
     # The zip file exists
     assert archive_file.exists()
@@ -289,13 +292,24 @@ def test_package_zip(package_command_with_files, first_app_config, kwargs, tmp_p
     # Check content of zip file
     with ZipFile(archive_file) as archive:
         root = "First App-0.0.1/"
-        # All folders and files in zip are from source
+        expected_archive_members = (*source_folders_and_files, remote_sources_config)
+        # All folders and files in the ZIP are expected.
         for name in archive.namelist():
-            # name.removeprefix(f'{root}') will only work in Python > 3.8
-            assert name[len(root) :] in source_folders_and_files
-        # All files from source are in zip
-        for file in source_folders_and_files:
+            assert name[len(root) :] in expected_archive_members
+        # All expected files are in the ZIP.
+        for file in expected_archive_members:
             assert f"{root}{file}" in archive.namelist()
+        assert archive.read(f"{root}{remote_sources_config}").decode() == (
+            '<?xml version="1.0" encoding="utf-8"?>\n'
+            "<configuration>\n"
+            "  <runtime>\n"
+            '    <loadFromRemoteSources enabled="true"/>\n'
+            "  </runtime>\n"
+            "</configuration>\n"
+        )
+
+    # The generated configuration is written directly to the ZIP, not the source tree.
+    assert not executable_path.with_name(remote_sources_config).exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/platforms/windows/app/test_package.py
+++ b/tests/platforms/windows/app/test_package.py
@@ -266,6 +266,8 @@ def test_package_zip(package_command_with_files, first_app_config, kwargs, tmp_p
     assert package_command_with_files.tools.subprocess.run.mock_calls == []
 
     archive_file = tmp_path / "base_path/dist/First App-0.0.1.zip"
+    executable_path = package_command_with_files.binary_path(first_app_config)
+    remote_sources_config = f"{executable_path.name}.config"
     source_folders_and_files = (
         "app/",
         "app/first-app/",
@@ -282,9 +284,8 @@ def test_package_zip(package_command_with_files, first_app_config, kwargs, tmp_p
         "app/first-app-0.0.1.dist-info/top_level.txt",
         "app_packages/clr.py",
         "app_packages/toga_winforms/command.py",
+        remote_sources_config,
     )
-    executable_path = package_command_with_files.binary_path(first_app_config)
-    remote_sources_config = f"{executable_path.name}.config"
 
     # The zip file exists
     assert archive_file.exists()
@@ -292,13 +293,14 @@ def test_package_zip(package_command_with_files, first_app_config, kwargs, tmp_p
     # Check content of zip file
     with ZipFile(archive_file) as archive:
         root = "First App-0.0.1/"
-        expected_archive_members = (*source_folders_and_files, remote_sources_config)
         # All folders and files in the ZIP are expected.
         for name in archive.namelist():
-            assert name[len(root) :] in expected_archive_members
+            assert name[len(root) :] in source_folders_and_files
         # All expected files are in the ZIP.
-        for file in expected_archive_members:
+        for file in source_folders_and_files:
             assert f"{root}{file}" in archive.namelist()
+
+        # The remote source configuration file has the expected content.
         assert archive.read(f"{root}{remote_sources_config}").decode() == (
             '<?xml version="1.0" encoding="utf-8"?>\n'
             "<configuration>\n"


### PR DESCRIPTION
Fixes #1890.

Windows marks downloaded ZIP archives with Mark of the Web. This can prevent the
packaged app from loading remote assemblies such as `Python.Runtime.dll`.

ZIP packaging now injects an app-local `<executable>.exe.config` that enables
`loadFromRemoteSources`. The configuration is written directly into the archive,
so MSI packaging and the source tree are unchanged.

The Windows packaging tests cover the ZIP contents and verify the configuration
is not generated for MSI packages.

## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: OpenAI Codex (GPT-5.6)
