### PR TITLE
Add 7-day cooldown to all dependabot update entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -16,6 +18,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "automation"
@@ -24,6 +28,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "debugger"
@@ -32,6 +38,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
@@ -40,3 +48,5 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7

--- a/changes/2960.misc.md
+++ b/changes/2960.misc.md
@@ -1,0 +1,1 @@
+Added 7-day cooldown to all Dependabot update entries in `.github/dependabot.yml`.


### PR DESCRIPTION
## Description

Adds a 7-day cooldown period to all Dependabot update entries in `.github/dependabot.yml`.

## What problem does this change solve?

Without an explicit cooldown, Dependabot will create PRs for new package versions immediately upon release. This creates a supply chain attack vector — a malicious package could be merged before the community has time to identify it.

## Changes

- Added `cooldown: default-days: 7` to all 5 package ecosystem entries (github-actions, pip x3, pre-commit)
- Follows the pattern already established in `beeware/.github` dependabot config
- No functional change to build, test, or runtime behavior

Fixes #2935

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: Claude Code