### PR TITLE
Correct path handling with requirements installer args.

### DIFF
--- a/changes/2965.misc.md
+++ b/changes/2965.misc.md
@@ -1,0 +1,1 @@
+An error with handling of paths in requirement arguments was resolved.

--- a/src/briefcase/commands/create.py
+++ b/src/briefcase/commands/create.py
@@ -561,7 +561,8 @@ class CreateCommand(BaseCommand):
 
             if requirement_installer_args_path:
                 pip_args = "\n".join(
-                    self.tools.file.resolve_relative_args(
+                    str(arg)
+                    for arg in self.tools.file.resolve_relative_args(
                         app.requirement_installer_args,
                         self.base_path,
                     )

--- a/tests/commands/create/test_install_app_requirements.py
+++ b/tests/commands/create/test_install_app_requirements.py
@@ -719,7 +719,14 @@ def test_app_requirements_requirement_installer_args_with_template_support(
 ):
     """If an app has requirement install args, a requirements file is still written, and
     requirement installer args file is written if the template supports it."""
-    myapp.requirement_installer_args = ["--no-cache", "-f", "wheels with space"]
+    (create_command.base_path / "packages").mkdir(exist_ok=True)
+    myapp.requirement_installer_args = [
+        "--no-cache",
+        "--extra-index-url",
+        "./packages",
+        "-f",
+        "wheels with space",
+    ]
     myapp.requires = ["my-favourite-package"]
 
     # Install requirements into the bundle
@@ -733,7 +740,16 @@ def test_app_requirements_requirement_installer_args_with_template_support(
     assert app_requirement_installer_args_path.exists()
     assert (
         app_requirement_installer_args_path.read_text(encoding="utf-8")
-        == "--no-cache\n-f\nwheels with space\n"
+        == "\n".join(
+            [
+                "--no-cache",
+                "--extra-index-url",
+                str(create_command.base_path / "packages"),
+                "-f",
+                "wheels with space",
+            ]
+        )
+        + "\n"
     )
 
     # Original app definitions haven't changed


### PR DESCRIPTION
#2956 modified the handling of path expansion when writing requirements files, changing the return type of argument processing tool to a Path, rather than a string.

This caused [CI failures in Toga running Testbed](https://github.com/beeware/toga/actions/runs/30309449567/job/90125970661?pr=4598) because the extra install arguments couldn't be handled.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
