### PR TITLE
docs(how-to): add "How to run Briefcase" guide

### DIFF
--- a/changes/2884.doc.md
+++ b/changes/2884.doc.md
@@ -1,0 +1,1 @@
+Added a standalone "How to run Briefcase" guide covering pip, uvx, and pipx installation, plus FAQ entries linking to it.

--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -4,6 +4,7 @@
 
 - [Tutorial](tutorial/index.md)
 - [How-to guides](how-to/index.md)
+    - [How to run Briefcase](how-to/run-briefcase.md) - Install and invoke Briefcase as an end-user tool.
     - Obtaining a Code Signing identity
         - [Android](how-to/code-signing/android.md)
         - [macOS](how-to/code-signing/macOS.md)

--- a/docs/en/about/faq.md
+++ b/docs/en/about/faq.md
@@ -32,9 +32,17 @@ Yes! Briefcase uses `pip` to install third-party packages into your app bundle. 
 
 If the package is pure-Python (i.e., it does not contain a binary library), that's all you need to do.
 
-If the package contains a binary component, you'll need to ensure that a binary wheel is available for the platform you're targeting:
+If the package contains a binary component, you'll need to ensure that a binary wheel is available for the platform you are targeting:
 
 - **macOS, Linux, Windows**: Binary wheels are hosted on [PyPI](https://pypi.org).
 - **Android**: See the [Android platform documentation][android-third-party-packages].
 - **iOS**: See the [iOS platform documentation][ios-third-party-packages].
 - **Web**: Binary wheel support is currently limited to [those provided by the Pyodide project](https://pyodide.org/en/stable/usage/packages-in-pyodide.html).
+
+## How do I install and run Briefcase?
+
+See the [How to run Briefcase](../how-to/run-briefcase.md) how-to guide. Briefcase can be installed with `pip` into a virtual environment, or run ad-hoc with `uvx` or `pipx`.
+
+## Can I use uvx or pipx to run Briefcase?
+
+Yes. Both `uvx` and `pipx` create isolated environments for Briefcase so it does not clutter your system Python. See the [How to run Briefcase](../how-to/run-briefcase.md) guide for installation and usage details.

--- a/docs/en/how-to/index.md
+++ b/docs/en/how-to/index.md
@@ -2,7 +2,11 @@
 
 How-to guides are recipes that take the user through steps in key subjects. They are more advanced than tutorials and assume a lot more about what the user already knows than tutorials do, and unlike documents in the tutorial they can stand alone.
 
-## Obtaining a Code Signing identity { #obtain-code-signing-identity }
+## How to run Briefcase  { #run-briefcase }
+
+* [How to run Briefcase](run-briefcase.md) - Install and invoke Briefcase as an end-user tool, using `pip`, `uvx`, or `pipx`.
+
+## Obtaining a Code Signing identity  { #obtain-code-signing-identity }
 
 * [Android](code-signing/android.md) - One way to sign your app where the Google Play Store maintains the authoritative key for your app.
 * [macOS](code-signing/macOS.md) - How to generate a macOS code signing identity, which is required to distribute your application.

--- a/docs/en/how-to/run-briefcase.md
+++ b/docs/en/how-to/run-briefcase.md
@@ -1,0 +1,94 @@
+# How to run Briefcase  { #run-briefcase }
+
+This guide describes how to install and invoke Briefcase as an end-user tool, independent of the [Tutorial][] which walks through creating a full project.
+
+## Prerequisites
+
+Briefcase requires Python 3.10 or later.
+
+You should create and activate a virtual environment before installing Briefcase. If you are not familiar with virtual environments, see the [Python packaging user guide][venv-guide] for an introduction.
+
+## Default install
+
+1. Create and activate a virtual environment:
+
+   ```console
+   $ python -m venv ~/.venvs/briefcase
+   $ source ~/.venvs/briefcase/bin/activate
+   ```
+
+   On Windows, the activation command is:
+
+   ```console
+   C:\> %USERPROFILE%\.venvs\briefcase\Scripts\activate
+   ```
+
+2. Install Briefcase into the virtual environment:
+
+   ```console
+   (briefcase) $ python -m pip install briefcase
+   ```
+
+3. Verify the installation:
+
+   ```console
+   (briefcase) $ briefcase --version
+   ```
+
+4. Invoke Briefcase using any of the commands listed in the [Command reference][commands]:
+
+   ```console
+   (briefcase) $ briefcase new
+   ```
+
+## Using uvx
+
+[uvx][uvx] is a runner provided by the `uv` tool that executes a Python package in an isolated, temporary environment without requiring a manual virtual environment.
+
+1. Install `uv` following the [official instructions][uv-install].
+
+2. Run Briefcase without any global install:
+
+   ```console
+   $ uvx briefcase new
+   ```
+
+   Each invocation runs in a fresh environment, so Briefcase itself is not installed into your system Python or any project virtual environment.
+
+## Using pipx
+
+[pipx][pipx] installs Python CLI tools into isolated environments and exposes their commands on your `PATH` so they are available in every shell.
+
+1. Install `pipx` following the [official instructions][pipx-install].
+
+2. Install Briefcase:
+
+   ```console
+   $ pipx install briefcase
+   ```
+
+3. Invoke Briefcase from any shell:
+
+   ```console
+   $ briefcase new
+   ```
+
+   Unlike `uvx`, this does a one-time persistent install. Upgrade later with `pipx upgrade briefcase`.
+
+## Where to go next
+
+- Follow the [Tutorial][] to create a complete Briefcase project from scratch.
+- Browse the [Command reference][commands] for the full list of Briefcase commands.
+- See the [How-to guides index][how-to-index] for packaging, debugging, and publishing tasks.
+
+<!-- Standard reference link for pages that mention Briefcase-version metadata.
+(link target intentionally blank to be filled in by Sphinx; this anchor exists in faq.md) -->
+
+[ Tutorial ]: ../../tutorial/index.md
+[ commands ]: ../../reference/commands.md
+[ how-to-index ]: index.md
+[ venv-guide ]: https://packaging.python.org/en/latest/guides/installing-packages-from-pip/#creating-and-using-virtual-environments
+[ uvx ]: https://docs.astral.sh/uv/guides/tools/
+[ uv-install ]: https://docs.astral.sh/uv/getting-started/installation/
+[ pipx ]: https://pipx.pypa.io/
+[ pipx-install ]: https://pipx.pypa.io/stable/installation/

--- a/docs/en/how-to/run-briefcase.md
+++ b/docs/en/how-to/run-briefcase.md
@@ -81,9 +81,6 @@ You should create and activate a virtual environment before installing Briefcase
 - Browse the [Command reference][commands] for the full list of Briefcase commands.
 - See the [How-to guides index][how-to-index] for packaging, debugging, and publishing tasks.
 
-<!-- Standard reference link for pages that mention Briefcase-version metadata.
-(link target intentionally blank to be filled in by Sphinx; this anchor exists in faq.md) -->
-
 [ Tutorial ]: ../../tutorial/index.md
 [ commands ]: ../../reference/commands.md
 [ how-to-index ]: index.md

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -135,6 +135,7 @@ PFX
 phablet
 PID
 PNG
+pipx
 PowerShell
 ppb
 PR
@@ -228,6 +229,7 @@ UTF
 UTI
 UTIs
 UTTypeConformsTo
+uvx
 vendored
 Ventura
 verbing


### PR DESCRIPTION
Adds a standalone "How to run Briefcase" how-to guide as the first entry in the How-to index, covering:

- Default `pip` install into a virtual environment
- `uvx briefcase` for ad-hoc runs
- `pipx install briefcase` for persistent isolated install

Also adds two FAQ entries ("How do I install and run Briefcase?" and "Can I use uvx or pipx to run Briefcase?") that link to the new guide.

Fixes #2884

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Hermes Agent