### PR TITLE
Add workaround for inconsistent Github images.

### DIFF
--- a/changes/2971.misc.md
+++ b/changes/2971.misc.md
@@ -1,0 +1,1 @@
+Modifies a test to deal with Github's inconsistent Linux machine images.

--- a/tests/commands/base/test_paths.py
+++ b/tests/commands/base/test_paths.py
@@ -31,15 +31,18 @@ def test_path_is_realpath(dummy_console, tmp_path):
 def test_data_path_creation_failure(dummy_console, tmp_path, monkeypatch):
     """An error is raised if the data path cannot be created."""
 
-    def raise_calledprpcesserror(*a, **kw):
-        raise subprocess.CalledProcessError(returncode=1, cmd=["mkdir", str(data_path)])
+    if platform.system() == "Windows":
+        # On Windows, patch run(), since path creation is handled differently
+        def raise_calledprpcesserror(*a, **kw):
+            raise subprocess.CalledProcessError(returncode=1, cmd=["mkdir"])
 
-    # On Linux and macOS, use /etc/ to raise an OSError
-    data_path = Path("/etc/mydatadir")
+        monkeypatch.setattr(subprocess, "run", raise_calledprpcesserror)
+    else:
 
-    # Patch run() since it's apparently quite difficult to find a
-    # location in Windows that is guaranteed to throw an error...
-    monkeypatch.setattr(subprocess, "run", raise_calledprpcesserror)
+        def raise_oserror(*a, **kw):
+            raise OSError()
+
+        monkeypatch.setattr(os, "makedirs", raise_oserror)
 
     with pytest.raises(
         BriefcaseCommandError,
@@ -48,7 +51,7 @@ def test_data_path_creation_failure(dummy_console, tmp_path, monkeypatch):
             r" files:"
         ),
     ):
-        DummyCommand(console=dummy_console, data_path=data_path)
+        DummyCommand(console=dummy_console, data_path=Path("/etc/mydatadir"))
 
 
 def test_space_in_path(dummy_console, tmp_path):


### PR DESCRIPTION
We've had some CI failures today that appear to be caused by the fact that *some* GitHub Actions Linux machines have `/etc` writable. We've never seen it before, but it's happened twice today... so we might as well modify the test to be robust against that.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
