### PR TITLE
Ensure requirement_install_args is passed to macOS and iOS installs.

### DIFF
--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -10,4 +10,4 @@ permissions:
 jobs:
   check-pr-template:
     name: Check PR template
-    uses: beeware/.github/.github/workflows/pr-checklist.yml@04ef7a6aca716616670c1ce5232d4aa3061f5c5e  # main
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   pre-commit:
     name: Pre-commit checks
-    uses: beeware/.github/.github/workflows/pre-commit-run.yml@04ef7a6aca716616670c1ce5232d4aa3061f5c5e  # main
+    uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
     with:
       pre-commit-source: "--group pre-commit"
 
@@ -60,7 +60,7 @@ jobs:
 
   towncrier:
     name: Check towncrier
-    uses: beeware/.github/.github/workflows/towncrier-run.yml@04ef7a6aca716616670c1ce5232d4aa3061f5c5e  # main
+    uses: beeware/.github/.github/workflows/towncrier-run.yml@main
     permissions:
       contents: read
       pull-requests: write
@@ -79,7 +79,7 @@ jobs:
         - ""  # root briefcase package
         - "debugger"
         - "automation"
-    uses: beeware/.github/.github/workflows/python-package-create.yml@04ef7a6aca716616670c1ce5232d4aa3061f5c5e  # main
+    uses: beeware/.github/.github/workflows/python-package-create.yml@main
     with:
       build-subdirectory: ${{ matrix.subdir }}
       attest: ${{ inputs.attest-package }}
@@ -238,7 +238,7 @@ jobs:
   verify-projects:
     name: Verify project
     needs: [ package, unit-tests ]
-    uses: beeware/.github/.github/workflows/app-create-verify.yml@04ef7a6aca716616670c1ce5232d4aa3061f5c5e  # main
+    uses: beeware/.github/.github/workflows/app-create-verify.yml@main
     with:
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -251,7 +251,7 @@ jobs:
   verify-apps:
     name: Build app
     needs: [ package, unit-tests ]
-    uses: beeware/.github/.github/workflows/app-build-verify.yml@04ef7a6aca716616670c1ce5232d4aa3061f5c5e  # main
+    uses: beeware/.github/.github/workflows/app-build-verify.yml@main
     with:
       # Builds on Linux must use System Python; otherwise, fall back to version all GUI toolkits support
       python-version: ${{ startsWith(matrix.runner-os, 'ubuntu') && 'system' || '3.12' }}

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -7,11 +7,12 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   changenote:
     name: Dependabot Change Note
-    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@04ef7a6aca716616670c1ce5232d4aa3061f5c5e  # main
+    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@main
     secrets:
       BRUTUS_PAT_TOKEN: ${{ secrets.BRUTUS_PAT_TOKEN }}
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
     name: Verify Docs Build
-    uses: beeware/.github/.github/workflows/docs-build-verify.yml@04ef7a6aca716616670c1ce5232d4aa3061f5c5e  # main
+    uses: beeware/.github/.github/workflows/docs-build-verify.yml@main
     secrets:
       RTD_API_TOKEN: ${{ secrets.RTD_API_TOKEN }}
     with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      # Allow BeeWare-provided actions to be unpinned. If an attacker is in a
+      # position to exploit those action, they're probably able to exploit
+      # repositories directly; and it's significantly easier for our internal
+      # actions to automatically be the most recent versions.
+      policies:
+        beeware/*: ref-pin

--- a/changes/2978.misc.md
+++ b/changes/2978.misc.md
@@ -1,0 +1,1 @@
+Extra requirement arguments on macOS and iOS were corrected.

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -411,6 +411,7 @@ class iOSXcodeCreateCommand(iOSXcodePassiveMixin, CreateCommand):
                 allow_editable=False,
                 require_binary=self.require_binary_installs,
                 min_os_version=ios_min_version,
+                extra_installer_args=app.requirement_installer_args,
                 install_path=app_packages_path.parent / "app_packages.iphoneos",
                 install_hint=f"""
 
@@ -436,6 +437,7 @@ with Python {self.python_version_tag} and a minimum iOS version of {ios_min_vers
                 allow_editable=False,
                 require_binary=self.require_binary_installs,
                 min_os_version=ios_min_version,
+                extra_installer_args=app.requirement_installer_args,
                 install_path=app_packages_path.parent / "app_packages.iphonesimulator",
                 install_hint=f"""
 

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -280,6 +280,7 @@ class macOSCreateMixin(AppPackagesMergeMixin):
                 allow_editable=False,
                 require_binary=self.require_binary_installs,
                 min_os_version=macOS_min_version,
+                extra_installer_args=app.requirement_installer_args,
                 install_path=host_app_packages_path,
                 install_hint=f"""
 
@@ -331,6 +332,7 @@ is not available.
                         allow_editable=False,
                         require_binary=self.require_binary_installs,
                         min_os_version=macOS_min_version,
+                        extra_installer_args=app.requirement_installer_args,
                         install_path=other_app_packages_path,
                         install_hint=f"""
 

--- a/tests/platforms/iOS/xcode/test_create.py
+++ b/tests/platforms/iOS/xcode/test_create.py
@@ -107,6 +107,7 @@ def test_install_requirements(
     create_command.create_app_environment = mock.MagicMock(return_value=mock_sim_venv)
 
     first_app_generated.requires = ["something==1.2.3", "other>=2.3.4"]
+    first_app_generated.requirement_installer_args = ["-f", "./wheels"]
 
     create_command.install_app_requirements(first_app_generated, mock_venv)
 
@@ -119,6 +120,7 @@ def test_install_requirements(
         allow_editable=False,
         require_binary=True,
         min_os_version="12.0",
+        extra_installer_args=["-f", "./wheels"],
         install_path=bundle_path / "app_packages.iphoneos",
         install_hint=(
             "\n\n"
@@ -134,6 +136,7 @@ def test_install_requirements(
         allow_editable=False,
         require_binary=True,
         min_os_version="12.0",
+        extra_installer_args=["-f", "./wheels"],
         install_path=bundle_path / "app_packages.iphonesimulator",
         install_hint=(
             "\n\n"
@@ -202,6 +205,7 @@ def test_legacy_support_format(
         allow_editable=False,
         require_binary=True,
         min_os_version=version,
+        extra_installer_args=[],
         install_path=bundle_path / "app_packages.iphoneos",
         install_hint=mock.ANY,
     )
@@ -213,6 +217,7 @@ def test_legacy_support_format(
         allow_editable=False,
         require_binary=True,
         min_os_version=version,
+        extra_installer_args=[],
         install_path=bundle_path / "app_packages.iphonesimulator",
         install_hint=mock.ANY,
     )
@@ -248,6 +253,7 @@ def test_min_os_version(
         allow_editable=False,
         require_binary=True,
         min_os_version="15.2",
+        extra_installer_args=[],
         install_path=bundle_path / "app_packages.iphoneos",
         install_hint=mock.ANY,
     )
@@ -259,6 +265,7 @@ def test_min_os_version(
         allow_editable=False,
         require_binary=True,
         min_os_version="15.2",
+        extra_installer_args=[],
         install_path=bundle_path / "app_packages.iphonesimulator",
         install_hint=mock.ANY,
     )

--- a/tests/platforms/iOS/xcode/test_update.py
+++ b/tests/platforms/iOS/xcode/test_update.py
@@ -73,6 +73,7 @@ def test_install_requirements(
     update_command.create_app_environment = mock.MagicMock(return_value=mock_sim_venv)
 
     first_app_generated.requires = ["something==1.2.3", "other>=2.3.4"]
+    first_app_generated.requirement_installer_args = ["-f", "./wheels"]
 
     update_command.install_app_requirements(first_app_generated, mock_venv)
 
@@ -85,6 +86,7 @@ def test_install_requirements(
         allow_editable=False,
         require_binary=True,
         min_os_version="12.0",
+        extra_installer_args=["-f", "./wheels"],
         install_path=bundle_path / "app_packages.iphoneos",
         install_hint=mock.ANY,
     )
@@ -96,6 +98,7 @@ def test_install_requirements(
         allow_editable=False,
         require_binary=True,
         min_os_version="12.0",
+        extra_installer_args=["-f", "./wheels"],
         install_path=bundle_path / "app_packages.iphonesimulator",
         install_hint=mock.ANY,
     )

--- a/tests/platforms/macOS/app/test_create.py
+++ b/tests/platforms/macOS/app/test_create.py
@@ -396,6 +396,7 @@ def test_install_app_packages(
 
     create_command.tools.host_arch = host_arch
     first_app_templated.requires = ["first", "second==1.2.3", "third>=3.2.1"]
+    first_app_templated.requirement_installer_args = ["-f", "./wheels"]
 
     # Mock the result of finding the binary packages - 2 of the packages are binary;
     # the version on the loosely specified package doesn't match the lower bound.
@@ -431,6 +432,7 @@ def test_install_app_packages(
         allow_editable=False,
         require_binary=True,
         min_os_version="10.12",
+        extra_installer_args=["-f", "./wheels"],
         install_path=bundle_path / f"app_packages.{host_arch}",
         install_hint=(
             "\n\n"
@@ -448,6 +450,7 @@ def test_install_app_packages(
         allow_editable=False,
         require_binary=True,
         min_os_version="10.12",
+        extra_installer_args=["-f", "./wheels"],
         install_path=bundle_path / f"app_packages.{other_arch}",
         install_hint=(
             "\n\n"
@@ -559,6 +562,7 @@ def test_min_os_version(
         allow_editable=False,
         require_binary=True,
         min_os_version="13.2",
+        extra_installer_args=[],
         install_path=bundle_path / "app_packages.arm64",
         install_hint=mock.ANY,
     )
@@ -571,6 +575,7 @@ def test_min_os_version(
         allow_editable=False,
         require_binary=True,
         min_os_version="13.2",
+        extra_installer_args=[],
         install_path=bundle_path / "app_packages.x86_64",
         install_hint=mock.ANY,
     )
@@ -681,6 +686,7 @@ def test_default_min_os_version(
         allow_editable=False,
         require_binary=True,
         min_os_version="11.0",
+        extra_installer_args=[],
         install_path=bundle_path / "app_packages.arm64",
         install_hint=mock.ANY,
     )
@@ -693,6 +699,7 @@ def test_default_min_os_version(
         allow_editable=False,
         require_binary=True,
         min_os_version="11.0",
+        extra_installer_args=[],
         install_path=bundle_path / "app_packages.x86_64",
         install_hint=mock.ANY,
     )
@@ -794,6 +801,7 @@ def test_install_app_packages_no_binary(
         allow_editable=False,
         require_binary=True,
         min_os_version="10.12",
+        extra_installer_args=[],
         install_path=bundle_path / "app_packages.arm64",
         install_hint=mock.ANY,
     )
@@ -886,6 +894,7 @@ def test_install_app_packages_failure(
         allow_editable=False,
         require_binary=True,
         min_os_version="10.12",
+        extra_installer_args=[],
         install_path=bundle_path / "app_packages.arm64",
         install_hint=mock.ANY,
     )
@@ -898,6 +907,7 @@ def test_install_app_packages_failure(
         allow_editable=False,
         require_binary=True,
         min_os_version="10.12",
+        extra_installer_args=[],
         install_path=bundle_path / "app_packages.x86_64",
         install_hint=mock.ANY,
     )
@@ -960,6 +970,7 @@ def test_install_app_packages_non_universal(
         allow_editable=False,
         require_binary=True,
         min_os_version="10.12",
+        extra_installer_args=[],
         install_path=bundle_path / "First App.app/Contents/Resources/app_packages",
         install_hint=mock.ANY,
     )


### PR DESCRIPTION
#2967 refactored the use of app requirements to use virtual environments to install requirements. 

However, in doing this refactor, extra installer arguments were inadvertently omitted from the install process. This was observed as CI failures in Python-support-testbed (beeware/Python-support-testbed#192).

This ensures that the macOS and iOS invocations of requirements installs preserve the extra installer args.

Takes the opportunity to also switch back to rolling beeware/.github workflow pins, and to correct a permissions error with the dependabot changenote workflow.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
