### PR TITLE
Disable PySide6 CI testing for Windows ARM64.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,3 +269,6 @@ jobs:
           # Pygame hasn't published Windows ARM64 wheels
           - framework: "pygame"
             runner-os: "windows-11-arm"
+          # PySide6 is unstable on Windows ARM64 (see #2969)
+          - framework: "pyside6"
+            runner-os: "windows-11-arm"

--- a/changes/2969.misc.md
+++ b/changes/2969.misc.md
@@ -1,0 +1,1 @@
+CI testing of PySide on on Windows ARM64 was disabled.


### PR DESCRIPTION
In light of a persistent stability issue with Windows on ARM64 testing of PySide6, disable testing for now.

Refs #2969.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
