### PR TITLE
Update Webkit dependency definitions in the Toga Linux bootstraps

### DIFF
--- a/changes/3002.misc.md
+++ b/changes/3002.misc.md
@@ -1,0 +1,1 @@
+Toga bootstrap dependencies for Linux WebKit support were updated.

--- a/src/briefcase/bootstraps/toga.py
+++ b/src/briefcase/bootstraps/toga.py
@@ -77,7 +77,6 @@ system_runtime_requires = [
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-module",
     # Needed to provide WebKit2 at runtime
-    # Note: Debian 11 requires gir1.2-webkit2-4.0 instead
     # "gir1.2-webkit2-4.1",
 ]
 """
@@ -99,7 +98,7 @@ system_runtime_requires = [
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3",
     # Needed to provide WebKit2 at runtime
-    # "webkit2gtk3",
+    # "webkit2gtk4.1",
 ]
 """
 

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -88,7 +88,6 @@ system_runtime_requires = [
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3-module",
     # Needed to provide WebKit2 at runtime
-    # Note: Debian 11 requires gir1.2-webkit2-4.0 instead
     # "gir1.2-webkit2-4.1",
 ]
 """,
@@ -108,7 +107,7 @@ system_runtime_requires = [
     # Dependencies that GTK looks for at runtime
     "libcanberra-gtk3",
     # Needed to provide WebKit2 at runtime
-    # "webkit2gtk3",
+    # "webkit2gtk4.1",
 ]
 """,
         "pyproject_table_linux_system_suse": """\


### PR DESCRIPTION
Toga has listed the RHEL WebKit dependency as webkit2gtk4.1 for a while, but the Briefcase bootstrap has never been updated.

This also removes the reference to Debian 11, since we no longer support that release.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
