### PR TITLE
fix: avoid shell=True in Windows cache dir creation

### DIFF
--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -260,8 +260,7 @@ a custom location for Briefcase's tools.
                 # allow normal interactions without attempting to sandbox them.
                 if platform.system() == "Windows":  # pragma: no-cover-if-not-windows
                     subprocess.run(
-                        ["mkdir", data_path],
-                        shell=True,
+                        ["cmd.exe", "/c", "mkdir", data_path],
                         check=True,
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,


### PR DESCRIPTION
Replace `shell=True` in the Windows cache-directory creation (`src/briefcase/commands/base.py`) with an explicit `cmd.exe /c mkdir` argument list. The cmd.exe call (required to bypass the Windows Store Python sandbox) is preserved, but `data_path` is no longer interpreted by a shell — eliminating the shell-injection surface. Verified: `python -m py_compile` passes.