### PR TITLE
Normalize project name

### DIFF
--- a/changes/3011.bugfix.md
+++ b/changes/3011.bugfix.md
@@ -1,0 +1,2 @@
+The project name in a new or converted project now defaults to the app name instead of the formal name, and is validated using the same rules. A project's PEP 621 `name` is now used to populate the project name if one isn't explicitly provided, and an invalid legacy project name now produces a warning instead of being silently accepted.
+

--- a/changes/3011.bugfix.md
+++ b/changes/3011.bugfix.md
@@ -1,2 +1,1 @@
 The project name in a new or converted project now defaults to the app name instead of the formal name, and is validated using the same rules. A project's PEP 621 `name` is now used to populate the project name if one isn't explicitly provided, and an invalid legacy project name now produces a warning instead of being silently accepted.
-

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -564,7 +564,7 @@ class ConvertCommand(NewCommand):
             module_name, override_value=project_overrides.pop("test_source_dir", None)
         )
         project_name = self.input_project_name(
-            formal_name, override_value=project_overrides.pop("project_name", None)
+            app_name, override_value=project_overrides.pop("project_name", None)
         )
         description = self.input_description(
             override_value=project_overrides.pop("description", None)

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -359,7 +359,7 @@ class NewCommand(BaseCommand):
         )
 
         project_name = self.input_project_name(
-            formal_name, project_overrides.pop("project_name", None)
+            app_name, project_overrides.pop("project_name", None)
         )
 
         description = self.console.text_question(

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -281,6 +281,7 @@ class NewCommand(BaseCommand):
             ),
             description="Project Name",
             default=formal_name,
+            validator=self.validate_app_name,
             override_value=override_value,
         )
 

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 from build import BuildBackendException
 from build.util import project_wheel_metadata
 from packaging.licenses import InvalidLicenseExpression, canonicalize_license_expression
+from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
 if sys.version_info >= (3, 11):  # pragma: no-cover-if-lt-py311
@@ -1276,7 +1277,7 @@ def resolve_dynamic_pep621_config(base_path, dynamic, console):
         ) from e
 
 
-def merge_pep621_config(global_config, pep621_config):
+def merge_pep621_config(global_config, pep621_config,console):
     """Merge a PEP621 configuration into a Briefcase configuration."""
 
     if requires_python := pep621_config.get("requires-python"):
@@ -1304,6 +1305,21 @@ def merge_pep621_config(global_config, pep621_config):
     maybe_update("license-files", "license-files")
     maybe_update("url", "urls", "Homepage")
     maybe_update("version", "version")
+
+    # PEP621's `name` maps to Briefcase's `project_name`. A pre-existing
+    # (legacy) `project_name` in the Briefcase config takes priority, but its
+    # value is checked for PEP621 name compliance; if it isn't compliant, a
+    # warning is raised, since this may become an error in a future version
+    # of Briefcase.
+    if "project_name" in global_config:
+        legacy_name = global_config["project_name"]
+        if not is_valid_pep508_name(legacy_name):
+            console.warning(
+                f"{legacy_name!r} is not a valid PEP621 project name. "
+                "This will be an error in a future version of Briefcase."
+            )
+    elif name := pep621_config.get("name"):
+        global_config["project_name"] = canonicalize_name(name)
 
     # Use the details of the first author as the Briefcase author.
     if "author" not in global_config:
@@ -1376,16 +1392,15 @@ def parse_config(config_file: Path, platform, output_format, console):
     except KeyError as e:
         raise BriefcaseConfigError("No tool.briefcase section in pyproject.toml") from e
 
-    # Merge the PEP621 configuration (if it exists)
-    try:
-        pep621_config = pyproject["project"]
-        if dynamic := pep621_config.pop("dynamic", []):
-            pep621_config.update(
-                resolve_dynamic_pep621_config(base_path, dynamic, console)
-            )
-        merge_pep621_config(global_config, pep621_config)
-    except KeyError:
-        pass
+    # Merge the PEP621 configuration (if it exists). Even without a PEP621
+    # `[project]` table, the merge step still checks any legacy
+    # `project_name` for PEP621 compliance.
+    pep621_config = pyproject.get("project", {})
+    if dynamic := pep621_config.pop("dynamic", []):
+        pep621_config.update(
+            resolve_dynamic_pep621_config(base_path, dynamic, console)
+        )
+    merge_pep621_config(global_config, pep621_config, console)
 
     # For consistent results, sort the platforms and formats
     all_platforms = sorted(get_platforms().keys())

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -1277,7 +1277,7 @@ def resolve_dynamic_pep621_config(base_path, dynamic, console):
         ) from e
 
 
-def merge_pep621_config(global_config, pep621_config,console):
+def merge_pep621_config(global_config, pep621_config, console):
     """Merge a PEP621 configuration into a Briefcase configuration."""
 
     if requires_python := pep621_config.get("requires-python"):
@@ -1397,9 +1397,7 @@ def parse_config(config_file: Path, platform, output_format, console):
     # `project_name` for PEP621 compliance.
     pep621_config = pyproject.get("project", {})
     if dynamic := pep621_config.pop("dynamic", []):
-        pep621_config.update(
-            resolve_dynamic_pep621_config(base_path, dynamic, console)
-        )
+        pep621_config.update(resolve_dynamic_pep621_config(base_path, dynamic, console))
     merge_pep621_config(global_config, pep621_config, console)
 
     # For consistent results, sort the platforms and formats

--- a/tests/commands/convert/test_build_app_context.py
+++ b/tests/commands/convert/test_build_app_context.py
@@ -59,4 +59,3 @@ def test_project_name_defaults_to_app_name(convert_command, monkeypatch):
     }
     convert_command.build_app_context(overrides.copy())
     mock_input_project_name.assert_called_once_with("custom-app", override_value=None)
-    

--- a/tests/commands/convert/test_build_app_context.py
+++ b/tests/commands/convert/test_build_app_context.py
@@ -1,3 +1,6 @@
+from unittest.mock import MagicMock
+
+
 def test_overrides_are_used(convert_command):
     (convert_command.base_path / "src/app_name").mkdir(parents=True)
     (convert_command.base_path / "src/app_name/__main__.py").write_text(
@@ -28,3 +31,34 @@ def test_overrides_are_used(convert_command):
     assert "leftover" not in out
 
     assert override_input == {"leftover": "leftover"}
+
+
+def test_project_name_defaults_to_app_name(convert_command, monkeypatch):
+    """If no project_name override is given, the project name defaults to the
+    app name, not the formal name."""
+    (convert_command.base_path / "src/custom_app").mkdir(parents=True)
+    (convert_command.base_path / "src/custom_app/__main__.py").write_text(
+        "", encoding="utf-8"
+    )
+
+    mock_input_project_name = MagicMock(return_value="mocked-project-name")
+    monkeypatch.setattr(convert_command, "input_project_name", mock_input_project_name)
+
+    overrides = {
+        "app_name": "custom-app",
+        "formal_name": "Custom Formal Name",
+        "source_dir": "src/custom_app",
+        "test_source_dir": "tests",
+        "description": "description",
+        "url": "https://url.com",
+        "bundle": "com.bundle",
+        "author": "author",
+        "author_email": "author_email",
+        "license": "Other",
+        "app_type": "GUI",
+    }
+    convert_command.build_app_context(overrides.copy())
+
+    mock_input_project_name.assert_called_once_with(
+        "custom-app", override_value=None
+    )

--- a/tests/commands/convert/test_build_app_context.py
+++ b/tests/commands/convert/test_build_app_context.py
@@ -59,3 +59,4 @@ def test_project_name_defaults_to_app_name(convert_command, monkeypatch):
     }
     convert_command.build_app_context(overrides.copy())
     mock_input_project_name.assert_called_once_with("custom-app", override_value=None)
+    

--- a/tests/commands/convert/test_build_app_context.py
+++ b/tests/commands/convert/test_build_app_context.py
@@ -34,7 +34,8 @@ def test_overrides_are_used(convert_command):
 
 
 def test_project_name_defaults_to_app_name(convert_command, monkeypatch):
-    """If no project_name override is given, the project name defaults to the app name, not the formal name."""
+    """If no project_name override is given, the project name defaults to the app name,
+    not the formal name."""
     (convert_command.base_path / "src/custom_app").mkdir(parents=True)
     (convert_command.base_path / "src/custom_app/__main__.py").write_text(
         "", encoding="utf-8"
@@ -57,5 +58,4 @@ def test_project_name_defaults_to_app_name(convert_command, monkeypatch):
         "app_type": "GUI",
     }
     convert_command.build_app_context(overrides.copy())
-
     mock_input_project_name.assert_called_once_with("custom-app", override_value=None)

--- a/tests/commands/convert/test_build_app_context.py
+++ b/tests/commands/convert/test_build_app_context.py
@@ -34,8 +34,7 @@ def test_overrides_are_used(convert_command):
 
 
 def test_project_name_defaults_to_app_name(convert_command, monkeypatch):
-    """If no project_name override is given, the project name defaults to the
-    app name, not the formal name."""
+    """If no project_name override is given, the project name defaults to the app name, not the formal name."""
     (convert_command.base_path / "src/custom_app").mkdir(parents=True)
     (convert_command.base_path / "src/custom_app/__main__.py").write_text(
         "", encoding="utf-8"
@@ -59,6 +58,4 @@ def test_project_name_defaults_to_app_name(convert_command, monkeypatch):
     }
     convert_command.build_app_context(overrides.copy())
 
-    mock_input_project_name.assert_called_once_with(
-        "custom-app", override_value=None
-    )
+    mock_input_project_name.assert_called_once_with("custom-app", override_value=None)

--- a/tests/commands/new/test_build_app_context.py
+++ b/tests/commands/new/test_build_app_context.py
@@ -11,7 +11,7 @@ def test_question_sequence(new_command):
         "My Application",  # formal name
         "",  # app name - accept the default
         "org.beeware",  # bundle ID
-        "My Project",  # project name
+        "my-project",  # project name
         "Cool stuff",  # description
         "Grace Hopper",  # author
         "grace@navy.mil",  # author email
@@ -35,7 +35,7 @@ def test_question_sequence(new_command):
         "module_name": "myapplication",
         "source_dir": "src/myapplication",
         "test_source_dir": "tests",
-        "project_name": "My Project",
+        "project_name": "my-project",
         "url": "https://navy.mil/myapplication",
     }
 
@@ -51,7 +51,7 @@ def test_question_sequence_with_overrides(new_command):
             "formal_name": "My Override App",
             "app_name": "myoverrideapp",
             "bundle": "net.example",
-            "project_name": "My Override Project",
+            "project_name": "my-override-project",
             "description": "My override description",
             "author": "override, author",
             "author_email": "author@override.tld",
@@ -72,7 +72,7 @@ def test_question_sequence_with_overrides(new_command):
         "module_name": "myoverrideapp",
         "source_dir": "src/myoverrideapp",
         "test_source_dir": "tests",
-        "project_name": "My Override Project",
+        "project_name": "my-override-project",
         "url": "https://override.example.com",
     }
 
@@ -90,7 +90,7 @@ def test_question_sequence_with_bad_license_override(new_command):
             "formal_name": "My Override App",
             "app_name": "myoverrideapp",
             "bundle": "net.example",
-            "project_name": "My Override Project",
+            "project_name": "my-override-project",
             "description": "My override description",
             "author": "override, author",
             "author_email": "author@override.tld",
@@ -111,7 +111,7 @@ def test_question_sequence_with_bad_license_override(new_command):
         "module_name": "myoverrideapp",
         "source_dir": "src/myoverrideapp",
         "test_source_dir": "tests",
-        "project_name": "My Override Project",
+        "project_name": "my-override-project",
         "url": "https://override.example.com",
     }
 

--- a/tests/commands/new/test_build_app_context.py
+++ b/tests/commands/new/test_build_app_context.py
@@ -135,7 +135,7 @@ def test_question_sequence_with_no_user_input(new_command):
         "module_name": "helloworld",
         "source_dir": "src/helloworld",
         "test_source_dir": "tests",
-        "project_name": "Hello World",
+        "project_name": "helloworld",
         "url": "https://example.com/helloworld",
     }
 

--- a/tests/config/test_merge_pep621_config.py
+++ b/tests/config/test_merge_pep621_config.py
@@ -354,3 +354,13 @@ def test_test_dependencies_with_requires():
         "key": "value",
         "test_requires": ["dep1", "dep2", "first", "second"],
     }
+
+def test_valid_legacy_project_name_no_warning():
+    "A valid legacy project_name doesn't raise a warning"
+    briefcase_config = {"key": "value", "project_name": "valid-project-name"}
+    console = Mock()
+
+    merge_pep621_config(briefcase_config, {"name": "some-other-name"}, console)
+
+    assert briefcase_config["project_name"] == "valid-project-name"
+    console.warning.assert_not_called()

--- a/tests/config/test_merge_pep621_config.py
+++ b/tests/config/test_merge_pep621_config.py
@@ -7,7 +7,7 @@ def test_empty():
     "Merging a PEP621 config with no interesting keys causes no changes"
     briefcase_config = {"key": "value"}
 
-    merge_pep621_config(briefcase_config, {"other": "thingy"},Mock())
+    merge_pep621_config(briefcase_config, {"other": "thingy"}, Mock())
 
     assert briefcase_config == {"key": "value"}
 
@@ -25,7 +25,7 @@ def test_base_keys():
             "license": {"text": "BSD License"},
             "requires-python": ">=3.9",
         },
-        Mock()
+        Mock(),
     )
 
     assert briefcase_config == {
@@ -56,7 +56,7 @@ def test_base_keys_override():
             "urls": {"Homepage": "https://example.com"},
             "license": {"text": "GPL3"},
         },
-        Mock()
+        Mock(),
     )
 
     assert briefcase_config == {
@@ -77,7 +77,7 @@ def test_missing_subkeys():
         {
             "urls": {"Sponsorship": "https://example.com"},
         },
-        Mock()
+        Mock(),
     )
 
     assert briefcase_config == {"key": "value"}
@@ -93,7 +93,7 @@ def test_specified_license_file():
         {
             "license": {"file": "license.txt"},
         },
-        Mock()
+        Mock(),
     )
 
     assert briefcase_config == {"key": "value", "license": {"file": "license.txt"}}
@@ -103,11 +103,7 @@ def test_empty_authors():
     "If the author list is empty, no author is recorded"
     briefcase_config = {"key": "value"}
 
-    merge_pep621_config(
-        briefcase_config,
-        {"authors": []},
-        Mock()
-    )
+    merge_pep621_config(briefcase_config, {"authors": []}, Mock())
 
     assert briefcase_config == {
         "key": "value",
@@ -128,7 +124,7 @@ def test_single_author():
                 }
             ]
         },
-        Mock()
+        Mock(),
     )
 
     assert briefcase_config == {
@@ -156,7 +152,7 @@ def test_multiple_authors():
                 },
             ]
         },
-        Mock()
+        Mock(),
     )
 
     assert briefcase_config == {
@@ -179,7 +175,7 @@ def test_mising_author_name():
                 }
             ]
         },
-        Mock()
+        Mock(),
     )
 
     assert briefcase_config == {
@@ -201,7 +197,7 @@ def test_missing_author_email():
                 }
             ]
         },
-        Mock()
+        Mock(),
     )
 
     assert briefcase_config == {
@@ -224,7 +220,7 @@ def test_existing_author_name():
                 }
             ]
         },
-        Mock()
+        Mock(),
     )
 
     assert briefcase_config == {
@@ -248,7 +244,7 @@ def test_existing_author_email():
                 }
             ]
         },
-        Mock()
+        Mock(),
     )
 
     assert briefcase_config == {
@@ -262,11 +258,7 @@ def test_no_dependencies():
     "If there are no global dependencies, requires are used as is."
     briefcase_config = {"key": "value", "requires": ["first", "second"]}
 
-    merge_pep621_config(
-        briefcase_config,
-        {},
-        Mock()
-    )
+    merge_pep621_config(briefcase_config, {}, Mock())
 
     assert briefcase_config == {
         "key": "value",
@@ -278,11 +270,7 @@ def test_dependencies_without_requires():
     "If the global config doesn't specify requirements, dependencies are used as is"
     briefcase_config = {"key": "value"}
 
-    merge_pep621_config(
-        briefcase_config,
-        {"dependencies": ["dep1", "dep2"]},
-        Mock()
-    )
+    merge_pep621_config(briefcase_config, {"dependencies": ["dep1", "dep2"]}, Mock())
 
     assert briefcase_config == {
         "key": "value",
@@ -294,10 +282,7 @@ def test_dependencies_with_requires():
     "If the global config specify requirements, requires augments dependencies"
     briefcase_config = {"key": "value", "requires": ["first", "second"]}
 
-    merge_pep621_config(
-        briefcase_config,
-        {"dependencies": ["dep1", "dep2"]},Mock()
-    )
+    merge_pep621_config(briefcase_config, {"dependencies": ["dep1", "dep2"]}, Mock())
 
     assert briefcase_config == {
         "key": "value",
@@ -310,10 +295,7 @@ def test_no_test_dependencies():
     is."""
     briefcase_config = {"key": "value", "test_requires": ["first", "second"]}
 
-    merge_pep621_config(
-        briefcase_config,
-        {},Mock()
-    )
+    merge_pep621_config(briefcase_config, {}, Mock())
 
     assert briefcase_config == {
         "key": "value",
@@ -326,8 +308,7 @@ def test_optional_non_test_dependencies():
     briefcase_config = {"key": "value", "requires": ["first", "second"]}
 
     merge_pep621_config(
-        briefcase_config,
-        {"optional-dependencies": {"other": ["dep1", "dep2"]}},Mock()
+        briefcase_config, {"optional-dependencies": {"other": ["dep1", "dep2"]}}, Mock()
     )
 
     assert briefcase_config == {
@@ -342,8 +323,7 @@ def test_test_dependencies_without_requires():
     briefcase_config = {"key": "value"}
 
     merge_pep621_config(
-        briefcase_config,
-        {"optional-dependencies": {"test": ["dep1", "dep2"]}},Mock()
+        briefcase_config, {"optional-dependencies": {"test": ["dep1", "dep2"]}}, Mock()
     )
 
     assert briefcase_config == {
@@ -357,8 +337,7 @@ def test_test_dependencies_with_requires():
     briefcase_config = {"key": "value", "test_requires": ["first", "second"]}
 
     merge_pep621_config(
-        briefcase_config,
-        {"optional-dependencies": {"test": ["dep1", "dep2"]}},Mock()
+        briefcase_config, {"optional-dependencies": {"test": ["dep1", "dep2"]}}, Mock()
     )
 
     assert briefcase_config == {

--- a/tests/config/test_merge_pep621_config.py
+++ b/tests/config/test_merge_pep621_config.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from briefcase.config import merge_pep621_config
 
 
@@ -5,7 +7,7 @@ def test_empty():
     "Merging a PEP621 config with no interesting keys causes no changes"
     briefcase_config = {"key": "value"}
 
-    merge_pep621_config(briefcase_config, {"other": "thingy"})
+    merge_pep621_config(briefcase_config, {"other": "thingy"},Mock())
 
     assert briefcase_config == {"key": "value"}
 
@@ -23,6 +25,7 @@ def test_base_keys():
             "license": {"text": "BSD License"},
             "requires-python": ">=3.9",
         },
+        Mock()
     )
 
     assert briefcase_config == {
@@ -53,6 +56,7 @@ def test_base_keys_override():
             "urls": {"Homepage": "https://example.com"},
             "license": {"text": "GPL3"},
         },
+        Mock()
     )
 
     assert briefcase_config == {
@@ -73,6 +77,7 @@ def test_missing_subkeys():
         {
             "urls": {"Sponsorship": "https://example.com"},
         },
+        Mock()
     )
 
     assert briefcase_config == {"key": "value"}
@@ -88,6 +93,7 @@ def test_specified_license_file():
         {
             "license": {"file": "license.txt"},
         },
+        Mock()
     )
 
     assert briefcase_config == {"key": "value", "license": {"file": "license.txt"}}
@@ -100,6 +106,7 @@ def test_empty_authors():
     merge_pep621_config(
         briefcase_config,
         {"authors": []},
+        Mock()
     )
 
     assert briefcase_config == {
@@ -121,6 +128,7 @@ def test_single_author():
                 }
             ]
         },
+        Mock()
     )
 
     assert briefcase_config == {
@@ -148,6 +156,7 @@ def test_multiple_authors():
                 },
             ]
         },
+        Mock()
     )
 
     assert briefcase_config == {
@@ -170,6 +179,7 @@ def test_mising_author_name():
                 }
             ]
         },
+        Mock()
     )
 
     assert briefcase_config == {
@@ -191,6 +201,7 @@ def test_missing_author_email():
                 }
             ]
         },
+        Mock()
     )
 
     assert briefcase_config == {
@@ -213,6 +224,7 @@ def test_existing_author_name():
                 }
             ]
         },
+        Mock()
     )
 
     assert briefcase_config == {
@@ -236,6 +248,7 @@ def test_existing_author_email():
                 }
             ]
         },
+        Mock()
     )
 
     assert briefcase_config == {
@@ -252,6 +265,7 @@ def test_no_dependencies():
     merge_pep621_config(
         briefcase_config,
         {},
+        Mock()
     )
 
     assert briefcase_config == {
@@ -267,6 +281,7 @@ def test_dependencies_without_requires():
     merge_pep621_config(
         briefcase_config,
         {"dependencies": ["dep1", "dep2"]},
+        Mock()
     )
 
     assert briefcase_config == {
@@ -281,7 +296,7 @@ def test_dependencies_with_requires():
 
     merge_pep621_config(
         briefcase_config,
-        {"dependencies": ["dep1", "dep2"]},
+        {"dependencies": ["dep1", "dep2"]},Mock()
     )
 
     assert briefcase_config == {
@@ -297,7 +312,7 @@ def test_no_test_dependencies():
 
     merge_pep621_config(
         briefcase_config,
-        {},
+        {},Mock()
     )
 
     assert briefcase_config == {
@@ -312,7 +327,7 @@ def test_optional_non_test_dependencies():
 
     merge_pep621_config(
         briefcase_config,
-        {"optional-dependencies": {"other": ["dep1", "dep2"]}},
+        {"optional-dependencies": {"other": ["dep1", "dep2"]}},Mock()
     )
 
     assert briefcase_config == {
@@ -328,7 +343,7 @@ def test_test_dependencies_without_requires():
 
     merge_pep621_config(
         briefcase_config,
-        {"optional-dependencies": {"test": ["dep1", "dep2"]}},
+        {"optional-dependencies": {"test": ["dep1", "dep2"]}},Mock()
     )
 
     assert briefcase_config == {
@@ -343,7 +358,7 @@ def test_test_dependencies_with_requires():
 
     merge_pep621_config(
         briefcase_config,
-        {"optional-dependencies": {"test": ["dep1", "dep2"]}},
+        {"optional-dependencies": {"test": ["dep1", "dep2"]}},Mock()
     )
 
     assert briefcase_config == {

--- a/tests/config/test_merge_pep621_config.py
+++ b/tests/config/test_merge_pep621_config.py
@@ -355,6 +355,7 @@ def test_test_dependencies_with_requires():
         "test_requires": ["dep1", "dep2", "first", "second"],
     }
 
+
 def test_valid_legacy_project_name_no_warning():
     "A valid legacy project_name doesn't raise a warning"
     briefcase_config = {"key": "value", "project_name": "valid-project-name"}

--- a/tests/config/test_merge_pep621_config.py
+++ b/tests/config/test_merge_pep621_config.py
@@ -11,6 +11,7 @@ def test_empty():
 
     assert briefcase_config == {"key": "value"}
 
+
 def test_no_project_name_no_pep621_name():
     "If neither a legacy project_name nor a PEP621 name is present, nothing changes"
     briefcase_config = {"key": "value"}

--- a/tests/config/test_merge_pep621_config.py
+++ b/tests/config/test_merge_pep621_config.py
@@ -11,6 +11,15 @@ def test_empty():
 
     assert briefcase_config == {"key": "value"}
 
+def test_no_project_name_no_pep621_name():
+    "If neither a legacy project_name nor a PEP621 name is present, nothing changes"
+    briefcase_config = {"key": "value"}
+
+    merge_pep621_config(briefcase_config, {"other": "thingy"}, Mock())
+
+    assert briefcase_config == {"key": "value"}
+    assert "project_name" not in briefcase_config
+
 
 def test_base_keys():
     "If the PEP621 config provides keys, they are added"

--- a/tests/config/test_parse_config.py
+++ b/tests/config/test_parse_config.py
@@ -754,6 +754,37 @@ def test_pep_621_merge(tmp_path):
     }
 
 
+def test_invalid_legacy_project_name_warns(tmp_path):
+    """An invalid legacy project_name (not PEP621-compliant) raises a warning."""
+    config_file = create_file(
+        tmp_path / "pyproject.toml",
+        """
+        [tool.briefcase]
+        project_name = "My Invalid Project Name!"
+        bundle = "com.example"
+        license = "MIT"
+
+        [tool.briefcase.app.my_app]
+        """,
+    )
+
+    console = Mock()
+    _, apps = parse_config(
+        config_file,
+        platform="macOS",
+        output_format="app",
+        console=console,
+    )
+
+    # The invalid project_name is preserved as-is...
+    assert apps["my_app"]["project_name"] == "My Invalid Project Name!"
+    # ...but the user is warned that it isn't PEP621 compliant.
+    console.warning.assert_called_once()
+    warning_text = console.warning.call_args[0][0]
+    assert "My Invalid Project Name!" in warning_text
+    assert "not a valid PEP621 project name" in warning_text
+
+
 def test_long_description_warning(tmp_path):
     """A description longer than the recommended length raises a warning."""
     long_description = "This is a needlessly long app description " + ("x" * 50)
@@ -1515,6 +1546,7 @@ def test_pep621_empty_dynamic(monkeypatch, tmp_path):
         "license_files": [],
         "formal_name": "Awesome Application",
         "long_description": "The application is very awesome",
+        "project_name": "awesome",
     }
 
 
@@ -1587,6 +1619,7 @@ def test_pep621_dynamic(monkeypatch, tmp_path):
         "requires": ["toga>=0.5.3"],
         "url": "https://example.com/",
         "version": "1.2.3",
+        "project_name": "awesome",
     }
 
 


### PR DESCRIPTION
Fixes #3011

This PR normalizes how `project_name` is handled in Briefcase, per the issue:

1. In the `new` and `convert` wizards, the project name now defaults to
   the app name instead of the formal name, and is validated using the
   same rules as app name.

2. If a project defines a PEP 621 `name` in `[project]`, it's now used
   as the `project_name` (normalized), as part of the PEP 621 merge step.

3. If a legacy `project_name` is set in `[tool.briefcase]` and it isn't
   PEP 621 compliant, Briefcase now warns instead of erroring, since this
   may become an error in a future version.

Tests were added/updated to cover all three changes.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: Claude