### PR TITLE
Document change to stub binary behavior.

### DIFF
--- a/changes/3013.bugfix.md
+++ b/changes/3013.bugfix.md
@@ -1,0 +1,1 @@
+When the Briefcase stub binary starts the Python interpreter, default Python signal handlers are now correctly installed. This means Briefcase-packaged apps will no longer terminate when sent a `SIGPIPE`, `SIGXFZ` or `SIGXFSZ` signal (matching the default behavior of a Python interpreter).


### PR DESCRIPTION
Fixes #3013.

There's no change in Briefcase itself; this is a changenote PR so that the changes to the templates and tagged stub binaries are recognised as a change.

CI has been run on the merged templates, which verifies the basic app startup behavior hasn't changed.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
