### PR TITLE
Emit valid SPDX identifiers for the Proprietary and Other license options

### DIFF
--- a/changes/3016.bugfix.md
+++ b/changes/3016.bugfix.md
@@ -1,1 +1,1 @@
-The project wizard now generates a valid SPDX identifier for a project with a "Proprietary" license.
+The project wizard now generates a valid SPDX identifier for a project with a "Proprietary" or "Other" license.

--- a/changes/3016.bugfix.md
+++ b/changes/3016.bugfix.md
@@ -1,0 +1,5 @@
+The "Proprietary" license option in the new project wizard now emits the SPDX
+expression `LicenseRef-Proprietary`, which is a valid SPDX expression.
+Previously, the literal value `Proprietary` was written to the generated
+`pyproject.toml`, and any briefcase command then failed with a configuration
+error because it is not a valid SPDX expression.

--- a/changes/3016.bugfix.md
+++ b/changes/3016.bugfix.md
@@ -1,5 +1,1 @@
-The "Proprietary" license option in the new project wizard now emits the SPDX
-expression `LicenseRef-Proprietary`, which is a valid SPDX expression.
-Previously, the literal value `Proprietary` was written to the generated
-`pyproject.toml`, and any briefcase command then failed with a configuration
-error because it is not a valid SPDX expression.
+The project wizard now generates a valid SPDX identifier for a project with a "Proprietary" license.

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -501,22 +501,22 @@ class ConvertCommand(NewCommand):
         # otherwise check the license file
         if "text" in self.pep621_data.get("license", {}):
             default = get_license_from_text(
-                self.pep621_data["license"]["text"], default="Other"
+                self.pep621_data["license"]["text"], default="LicenseRef-Other"
             )
             default_source = "the PEP621 formatted pyproject.toml"
         elif "file" in self.pep621_data.get("license", {}):
             license_text = (
                 self.base_path / self.pep621_data["license"]["file"]
             ).read_text(encoding="utf-8")
-            default = get_license_from_text(license_text, default="Other")
+            default = get_license_from_text(license_text, default="LicenseRef-Other")
             default_source = "the license file"
         elif (self.base_path / "LICENSE").exists():
             license_text = (self.base_path / "LICENSE").read_text(encoding="utf-8")
-            default = get_license_from_text(license_text, default="Other")
+            default = get_license_from_text(license_text, default="LicenseRef-Other")
             default_source = "the license file"
         elif (self.base_path / "LICENCE").exists():
             license_text = (self.base_path / "LICENCE").read_text(encoding="utf-8")
-            default = get_license_from_text(license_text, default="Other")
+            default = get_license_from_text(license_text, default="LicenseRef-Other")
             default_source = "the license file"
         else:
             return None, intro

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -28,7 +28,7 @@ LICENSE_OPTIONS = {
     "GPL-2.0+": "GNU General Public License v2.0 or later (GPL-2.0+)",
     "GPL-3.0": "GNU General Public License v3.0 only (GPL-3.0)",
     "GPL-3.0+": "GNU General Public License v3.0 or later (GPL-3.0+)",
-    "Proprietary": "Proprietary",
+    "LicenseRef-Proprietary": "Proprietary",
     "Other": "Other",
 }
 DEFAULT_LICENSE = "BSD-3-Clause"

--- a/src/briefcase/commands/new.py
+++ b/src/briefcase/commands/new.py
@@ -29,7 +29,7 @@ LICENSE_OPTIONS = {
     "GPL-3.0": "GNU General Public License v3.0 only (GPL-3.0)",
     "GPL-3.0+": "GNU General Public License v3.0 or later (GPL-3.0+)",
     "LicenseRef-Proprietary": "Proprietary",
-    "Other": "Other",
+    "LicenseRef-Other": "Other",
 }
 DEFAULT_LICENSE = "BSD-3-Clause"
 

--- a/tests/commands/convert/test_build_app_context.py
+++ b/tests/commands/convert/test_build_app_context.py
@@ -14,7 +14,7 @@ def test_overrides_are_used(convert_command):
         "bundle": "com.bundle",
         "author": "author",
         "author_email": "author_email",
-        "license": "Other",
+        "license": "LicenseRef-Other",
         "app_type": "GUI",
         "leftover": "leftover",
     }

--- a/tests/commands/convert/test_input_license.py
+++ b/tests/commands/convert/test_input_license.py
@@ -181,4 +181,7 @@ def test_no_license_hint(convert_command, monkeypatch):
 
 
 def test_override_is_used(convert_command):
-    assert convert_command.input_license("Proprietary") == "Proprietary"
+    assert (
+        convert_command.input_license("LicenseRef-Proprietary")
+        == "LicenseRef-Proprietary"
+    )

--- a/tests/commands/convert/test_input_license.py
+++ b/tests/commands/convert/test_input_license.py
@@ -34,7 +34,7 @@ from ...utils import PartialMatchString
         ("version 3 of the GNU General Public License", "GPL-3.0"),
         ("GPLv3+", "GPL-3.0+"),
         ("either version 3 of the License", "GPL-3.0+"),
-        ("Some text", "Other"),
+        ("Some text", "LicenseRef-Other"),
     ],
 )
 def test_get_license_from_file(
@@ -93,7 +93,7 @@ def test_get_license_from_file(
         ("version 3 of the GNU General Public License", "GPL-3.0"),
         ("GPLv3+", "GPL-3.0+"),
         ("either version 3 of the License", "GPL-3.0+"),
-        ("Some text", "Other"),
+        ("Some text", "LicenseRef-Other"),
     ],
 )
 def test_get_license_from_pep621_license_file(
@@ -139,7 +139,7 @@ def test_get_license_from_pep621_license_file(
         ("GPLv2+", "GPL-2.0+"),
         ("GPLv3", "GPL-3.0"),
         ("GPLv3+", "GPL-3.0+"),
-        ("Some text", "Other"),
+        ("Some text", "LicenseRef-Other"),
     ],
 )
 def test_get_license_from_pyproject(


### PR DESCRIPTION
Problem:

- Selecting "Proprietary" in the new-project wizard writes `license = "Proprietary"` to the generated `pyproject.toml`, which is not a valid SPDX expression, so every briefcase command on the project fails configuration validation.
- While reviewing this PR, Russell identified that "Other" has the same problem: `license = "Other"` also fails SPDX validation.

Solution:

- `LICENSE_OPTIONS` now emits `LicenseRef-Proprietary` and `LicenseRef-Other` — the same `LicenseRef-*` convention briefcase already uses for `LicenseRef-UnknownLicense`.
- `briefcase convert`'s license-detection default was updated to match.

Result:

- `briefcase new -Q license=LicenseRef-Proprietary` (and `...=LicenseRef-Other`) generates a project whose license value passes PEP 639 validation; verified end-to-end with a paired template change.
- `tests/commands/new/` + `tests/commands/convert/`: 326 passed; ruff clean.

Fixes #3016

Paired template PR: beeware/briefcase-template#275

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Hermes Agent (Qwen3.8-Max) — changes reviewed and verified end-to-end by the operator
