### PR TITLE
Add install scope to Windows installer options

### DIFF
--- a/changes/2986.feature.md
+++ b/changes/2986.feature.md
@@ -1,0 +1,1 @@
+Windows MSI install and uninstall options can now be limited to current-user or all-users installs.

--- a/docs/en/reference/platforms/windows/index.md
+++ b/docs/en/reference/platforms/windows/index.md
@@ -219,7 +219,7 @@ If this setting is undefined, or set to an empty string, the installer will not 
 
 Windows MSI installers are able to present a panel of optional features to the user as part of the installation or uninstallation process. These features are binary flags which can then be used by a [post-install script][post_install_script] to perform additional installation behaviors, or by a [pre-uninstall script][pre_uninstall_script] to perform additional uninstallation behaviors.
 
-Installer and uninstaller options are defined using a TOML array of tables. Up to 4 installer options and 4 uninstaller options can be defined. Each option is in a group named `[[ toga.briefcase.app.<app name>.install_option ]]` or `[[ toga.briefcase.app.<app name>.uninstall_option ]]`, which must define the following keys:
+Installer and uninstaller options are defined using a TOML array of tables. Up to 4 installer options and 4 uninstaller options can be defined. Each option is in a group named `[[ tool.briefcase.app.<app name>.install_option ]]` or `[[ tool.briefcase.app.<app name>.uninstall_option ]]`, which must define the following keys:
 
 ### `install_option.name` / `uninstall_option.name`
 
@@ -236,6 +236,20 @@ A longer description of the purpose of the option, as a string.
 ### `install_option.default` / `uninstall_option.default`
 
 A Boolean describing the initial value of the option in the GUI. If not provided, defaults to `False`.
+
+### `install_option.system` / `uninstall_option.system`
+
+The install scope for which the option is relevant. The value can be:
+
+* `true` to display the option only when installing for all users;
+* `false` to display the option only when installing for the current user; or
+* `"both"` to display the option for both install scopes.
+
+If this setting is not defined, it defaults to `"both"`.
+
+The install scope is selected by the user during installation, or fixed by the [`system_installer`][] setting. The scope of an installed app is reused when displaying uninstall options.
+
+If an option is not displayed for the selected scope, its configured default value is still provided to the post-install or pre-uninstall script.
 
 ### Using options
 

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -338,6 +338,15 @@ def validate_install_options_config(config, opt_type, **others):
             # Options are booleans, and are False by default
             option["default"] = bool(config_item.get("default", False))
 
+            system = config_item.get("system", "both")
+            if not isinstance(system, bool) and system != "both":
+                raise BriefcaseConfigError(
+                    f"System setting for {opt_type} option {name!r} must be a "
+                    "boolean or 'both'."
+                )
+
+            option["system"] = system
+
     return options
 
 

--- a/tests/config/test_validate_install_options_config.py
+++ b/tests/config/test_validate_install_options_config.py
@@ -12,15 +12,17 @@ def option_config():
             "title": "First option",
             "description": "Do the first thing",
             "default": True,
+            "system": True,
         },
         {
             "name": "second",
             "title": "Second option",
             "description": "Do the second thing",
             "default": False,
+            "system": False,
         },
         # An option that is alphabetically second, but appears third,
-        # and has no explicit default.
+        # and has no explicit default or system scope.
         {
             "name": "default",
             "title": "Third option",
@@ -43,18 +45,48 @@ def test_install_options(option_config):
             "title": "First option",
             "description": "Do the first thing",
             "default": True,
+            "system": True,
         },
         "second": {
             "title": "Second option",
             "description": "Do the second thing",
             "default": False,
+            "system": False,
         },
         "default": {
             "title": "Third option",
             "description": "Do the third thing",
             "default": False,
+            "system": "both",
         },
     }
+
+
+@pytest.mark.parametrize(
+    "system",
+    [
+        None,
+        "user",
+        "system",
+        "Both",
+        0,
+        1,
+        [],
+        {},
+    ],
+)
+def test_invalid_system_scope(option_config, system):
+    """Install option system scopes must be booleans or ``"both"``."""
+    option_config[1]["system"] = system
+
+    with pytest.raises(
+        BriefcaseConfigError,
+        match=(
+            r"System setting for mystery option 'second' must be a boolean "
+            r"or 'both'\."
+        ),
+    ):
+        validate_install_options_config(option_config, "mystery")
 
 
 def test_missing_name(option_config):


### PR DESCRIPTION
Add support for limiting Windows MSI install and uninstall options to a specific install scope.

The new `system` setting accepts:

- `true` for options that apply only to all-users installations;
- `false` for options that apply only to current-user installations; and
- `"both"` for options that apply to either scope.

When the setting is omitted, it defaults to `"both"` to preserve the existing behavior. Invalid values are rejected during configuration validation.

This change includes configuration validation, automated tests, Windows platform documentation, and a change note. The corresponding Windows app template change uses this setting to filter controls in the MSI install and uninstall dialogs.

Companion template branch:
https://github.com/beeware/briefcase-windows-app-template/pull/113

Fixes #2986

## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: OpenAI Codex (GPT-5)