### PR TITLE
Add change note for MSI wizard title changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,8 @@ __pycache__/
 tests/apps/verify-*/
 logs/
 
-# AI tooling (SpecKit v0.8.0)
+# AI tooling
+.kilo/
 .opencode/
 .specify/scripts
 .specify/templates

--- a/changes/3027.bugfix.md
+++ b/changes/3027.bugfix.md
@@ -1,0 +1,1 @@
+Windows MSI installers now uses "(App name) Installation" as the title for all pages of the installation wizard, and "(App name) Uninstallation" as the title for all pages of the uninstallation wizard.


### PR DESCRIPTION
Adds a changenote for the template change that normalises the wizard titles for installation and uninstallation.

Should not be merged until beeware/briefcase-windows-app-template#114 has been merged, and back ported to beeware/briefcase-windows-VisualStudio-template.

Fixes #3027.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
