### PR TITLE
Add auto device selection for iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,8 @@ __pycache__/
 tests/apps/verify-*/
 logs/
 
-# AI tooling (SpecKit v0.8.0)
+# AI tooling
+.kilo/
 .opencode/
 .specify/scripts
 .specify/templates

--- a/changes/3031.feature.md
+++ b/changes/3031.feature.md
@@ -1,0 +1,1 @@
+`briefcase run iOS` now automatically selects a recent "entry level" iPhone simulator (e.g., an iPhone SE, or iPhone 16e) on the most recent available iOS version if `-d`/`--device` isn't provided. Use `-d auto` to request this behavior explicitly, or `-d` with no value to see the full list of available simulators as before.

--- a/docs/en/reference/platforms/iOS/xcode.md
+++ b/docs/en/reference/platforms/iOS/xcode.md
@@ -91,9 +91,9 @@ The following options can be provided at the command line when producing iOS pro
 
 ### run
 
-#### `-d <device>` / `--device <device>`
+#### `-d [<device>]` / `--device [<device>]`
 
-The device simulator to target. Can be either a UDID, a device name (e.g., `"iPhone 11"`), or a device name and OS version (`"iPhone 11::iOS 13.3"`).
+The device simulator to target. Can be either a UDID, a device name (e.g., `"iPhone 11"`), a device name and OS version (`"iPhone 11::iOS 13.3"`), or `auto`. `auto` is the default behavior; Briefcase will automatically select an "entry level" iPhone simulator (e.g., an iPhone SE, or iPhone 16e) on the most recent available iOS version. To see the full list of available simulators and select from that list, provide `-d`/`--device` with no value.
 
 ## Application configuration
 

--- a/src/briefcase/platforms/iOS/xcode.py
+++ b/src/briefcase/platforms/iOS/xcode.py
@@ -95,10 +95,17 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
             "-d",
             "--device",
             dest="udid",
+            nargs="?",
+            default="auto",
+            const=None,
             help=(
-                "The device to target; either a UDID, "
-                'a device name ("iPhone 11"), '
-                'or a device name and OS version ("iPhone 11::iOS 13.3")'
+                "The device to target; either a UDID, a device name "
+                '("iPhone 11"), a device name and OS version '
+                '("iPhone 11::iOS 13.3"), or "auto" (the default) to '
+                'automatically select a recent "SE-class" device on the '
+                "most recently released iOS version. Provide -d with no "
+                "value to select from the full list of available "
+                "simulators."
             ),
             required=False,
         )
@@ -106,7 +113,11 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
     def select_target_device(self, udid_or_device=None):
         """Select the target device to use for iOS builds.
 
-        Interrogates the system to get the list of available simulators
+        Interrogates the system to get the list of available simulators.
+
+        If the user has specified "auto", a recent "SE-class" iPhone simulator
+        is selected automatically, on the most recent iOS version, without
+        prompting.
 
         If there is only a single iOS version available, that version
         will be selected automatically.
@@ -115,12 +126,16 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
         automatically.
 
         If the user has specified a device at the command line, it will be
-        used in preference to any
+        used in preference to any of the above.
 
-        :param udid_or_device: The device to target. Can be a device UUID, a
-            device name ("iPhone 11"), or a device name and OS version
-            ("iPhone 11::13.3"). If ``None``, the user will be asked to select
-            a device at runtime.
+        :param udid_or_device: The device to target. Can be:
+            - `None` (default if -d/--device was specified with no value)
+            - The literal string `"auto"` (case-insensitive); automatically
+              select a recent "SE-class" simulator on the most recent
+              available iOS version, without prompting.
+            - A device UUID.
+            - A device name (e.g. `"iPhone 11"`).
+            - A device name and OS version (e.g. `"iPhone 11::iOS 13.3"`).
         :returns: A tuple containing the udid, iOS version, and device name
             for the selected device.
         """
@@ -147,8 +162,51 @@ class iOSXcodeMixin(iOSXcodePassiveMixin):
 
         except (ValueError, TypeError) as e:
             # Provided value wasn't a UDID.
-            # It must be a device or device+version
-            if udid_or_device and "::" in udid_or_device:
+            if udid_or_device and udid_or_device.lower() == "auto":
+                # No -d/--device value, or "-d auto": automatically select a
+                # recent "SE-class" device on the most recent iOS version,
+                # without prompting.
+                if not simulators:
+                    raise BriefcaseCommandError("No iOS simulators available.") from e
+
+                # simulators is keyed by iOS version tags of the form
+                # "iOS 15.5"; pick the tag with the highest version number.
+                iOS_tag = max(
+                    simulators,
+                    key=lambda tag: tuple(int(v) for v in tag.split()[-1].split(".")),
+                )
+                devices = simulators[iOS_tag]
+
+                matches = [
+                    (candidate_udid, name)
+                    for candidate_udid, name in devices.items()
+                    if name.startswith("iPhone SE ")
+                    or (name.startswith("iPhone ") and name.endswith("e"))
+                ]
+                if matches:
+                    # If multiple SE-class devices match, pick
+                    # deterministically (alphabetically last device name).
+                    udid, device = max(matches, key=lambda item: item[1])
+                else:
+                    raise BriefcaseCommandError(
+                        "Unable to automatically select an iOS simulator; "
+                        'no "SE-class" iPhone simulator (e.g., an iPhone SE, '
+                        'or a similar "entry level" device) is available on '
+                        f"{iOS_tag}, and the choice is ambiguous.\n"
+                        "\n"
+                        "Specify a device explicitly with -d/--device, or use "
+                        "-d with no value to select from the full list of "
+                        "available simulators."
+                    ) from e
+
+                # iOS_tag will be of the form "iOS 15.5"
+                # Drop the "iOS" prefix when reporting the version.
+                iOS_version = iOS_tag.split(" ", 1)[-1]
+                self.console.info(
+                    f"Automatically selected {device} simulator on {iOS_tag}"
+                )
+                return udid, iOS_version, device
+            elif udid_or_device and "::" in udid_or_device:
                 # A device name::version.
                 device, iOS_tag = udid_or_device.split("::")
 
@@ -553,14 +611,16 @@ class iOSXcodeRunCommand(iOSXcodeMixin, RunCommand):
         app: FinalizedAppConfig,
         *,
         passthrough: list[str],
-        udid=None,
+        udid: str | None = None,
         **options,
     ) -> dict | None:
         """Start the application.
 
         :param app: The config object for the app
         :param passthrough: The list of arguments to pass to the app
-        :param udid: The device UDID to target. If ``None``, the user will
+        :param udid: The device UDID, name, or name::version to target. If
+            `"auto"`, a recent "SE-class" simulator on the most recent iOS
+            version will be selected automatically. If `None`, the user will
             be asked to select a device at runtime.
         """
         try:

--- a/tests/platforms/iOS/xcode/mixin/test_select_target_device.py
+++ b/tests/platforms/iOS/xcode/mixin/test_select_target_device.py
@@ -335,3 +335,130 @@ def test_no_devices_for_os(dummy_command):
 
     with pytest.raises(BriefcaseCommandError):
         dummy_command.select_target_device()
+
+
+@pytest.mark.parametrize(
+    "se_device",
+    [
+        "iPhone SE (3rd generation)",
+        "iPhone 16e",
+        "iPhone 17e",
+    ],
+)
+def test_auto_device(dummy_command, se_device):
+    """An SE-class device on the most recent iOS version is selected automatically."""
+    dummy_command.get_simulators.return_value = {
+        "iOS 16.4": {
+            "0BB80120-FA02-4597-A1BA-DB8CDE4F086D": "iPhone SE (3rd generation)",
+        },
+        "iOS 17.5": {
+            "C9A005C8-9468-47C5-8376-68A6E3408209": "iPhone 15 Pro",
+            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D": se_device,
+            "EEEBA06C-81F9-407C-885A-2261306DB2BE": "iPhone 15 Pro Max",
+        },
+    }
+
+    udid, iOS_version, device = dummy_command.select_target_device("auto")
+
+    assert udid == "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"
+    assert iOS_version == "17.5"
+    assert device == se_device
+
+    # No user input was solicited
+    assert dummy_command.console.prompts == []
+
+
+def test_auto_single_iOS_version(dummy_command):
+    """If there's only one iOS version, an SE device is selected."""
+    dummy_command.get_simulators.return_value = {
+        "iOS 18.1": {
+            "C9A005C8-9468-47C5-8376-68A6E3408209": "iPhone 16 Pro",
+            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D": "iPhone 16e",
+        },
+    }
+
+    udid, iOS_version, device = dummy_command.select_target_device("auto")
+
+    assert udid == "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"
+    assert iOS_version == "18.1"
+    assert device == "iPhone 16e"
+
+    # No user input was solicited
+    assert dummy_command.console.prompts == []
+
+
+def test_auto_multiple_se_class_matches_tie_break(dummy_command):
+    """If multiple SE-class devices match on the most recent iOS version, the
+    alphabetically-last device name is picked deterministically."""
+    dummy_command.get_simulators.return_value = {
+        "iOS 18.1": {
+            "0BB80120-FA02-4597-A1BA-DB8CDE4F086D": "iPhone 16e",
+            "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D": "iPhone SE (3rd generation)",
+        },
+    }
+
+    udid, iOS_version, device = dummy_command.select_target_device("auto")
+
+    # "iPhone SE (3rd generation)" sorts after "iPhone 16e" alphabetically.
+    assert udid == "2D3503A3-6EB9-4B37-9B17-C7EFEF2FA32D"
+    assert iOS_version == "18.1"
+    assert device == "iPhone SE (3rd generation)"
+
+    # No user input was solicited
+    assert dummy_command.console.prompts == []
+
+
+def test_auto_ignores_se_class_on_older_version(dummy_command):
+    """An SE-class device on an older iOS version is never selected, even if the most
+    recent version's choice is otherwise ambiguous."""
+    dummy_command.get_simulators.return_value = {
+        "iOS 16.4": {
+            "0BB80120-FA02-4597-A1BA-DB8CDE4F086D": "iPhone SE (3rd generation)",
+        },
+        "iOS 17.5": {
+            "C9A005C8-9468-47C5-8376-68A6E3408209": "iPhone 15 Pro",
+            "EEEBA06C-81F9-407C-885A-2261306DB2BE": "iPhone 15 Pro Max",
+        },
+    }
+
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r'Unable to automatically select an iOS simulator; no "SE-class"',
+    ):
+        dummy_command.select_target_device("auto")
+
+    # No user input was solicited
+    assert dummy_command.console.prompts == []
+
+
+def test_auto_raises_on_ambiguous_no_se_class_match(dummy_command):
+    """If the most recent iOS version has no SE-class match, the choice is ambiguous."""
+    dummy_command.get_simulators.return_value = {
+        "iOS 17.5": {
+            "C9A005C8-9468-47C5-8376-68A6E3408209": "iPhone 15 Pro",
+            "EEEBA06C-81F9-407C-885A-2261306DB2BE": "iPhone 15 Pro Max",
+        },
+    }
+
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r'Unable to automatically select an iOS simulator; no "SE-class"',
+    ):
+        dummy_command.select_target_device("auto")
+
+    # No user input was solicited
+    assert dummy_command.console.prompts == []
+
+
+def test_auto_raises_when_no_simulators(dummy_command):
+    """If there are no simulators available at all, auto-select raises an error."""
+    dummy_command.get_simulators.return_value = {}
+
+    with pytest.raises(
+        BriefcaseCommandError,
+        match=r"No iOS simulators available\.",
+    ):
+        dummy_command.select_target_device("auto")
+
+    # No user input was solicited
+    assert dummy_command.console.prompts == []


### PR DESCRIPTION
Modifies the behavior of the `-d`/`--device` flag on iOS so that `-d auto` will pick an appropriate "SE-class" device. `auto` is the default value, so `briefcase run iOS` will "just work". `briefcase run iOS -d` will force the interactive menu. `briefcase run iOS -d device_id` continues to work as before.

Fixes #3031.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Sonnet 5.
