### PR TITLE
Add auto device selection for Android.

### DIFF
--- a/changes/3031.feature.2.md
+++ b/changes/3031.feature.2.md
@@ -1,0 +1,1 @@
+`briefcase run android` now automatically selects a default Android emulator, creating an emulator if no default exists. Use `-d auto` to request this behavior explicitly, or `-d` with no value to see the full list of available simulators as before.

--- a/docs/en/reference/platforms/android/gradle.md
+++ b/docs/en/reference/platforms/android/gradle.md
@@ -124,7 +124,7 @@ The following options can be provided at the command line when producing Android
 
 ### run
 
-#### `-d <device>` / `--device <device>`
+#### `-d [<device>]` / `--device [<device>]`
 
 The device or emulator to target. Can be specified in one of the following forms:
 
@@ -146,7 +146,9 @@ The device or emulator to target. Can be specified in one of the following forms
 
     If no device type is specified, a default device with a default skin will be used. If no system image is specified, a default system image will be used. If a device type is specified, but no *skin* is specified, a "skinless" device will be created.
 
-If this option is not provided, Briefcase will ask whether you want to use an existing device, or create a new one.
+* `auto` to select a default emulator device. Briefcase will create an emulator based on a recent Android version if one does not exist.
+
+If this option is not provided, `auto` will be used. To see the full list of available devices and emulators (including the option to create a new emulator) and select from that list, provide `-d`/`--device` with no value.
 
 #### `--Xemulator=<value>`
 

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -197,11 +197,24 @@ class AndroidSDK(ManagedTool):
 
     @property
     def DEFAULT_DEVICE_SKIN(self) -> str:
+        # Skins are entirely cosmetic. In a CI environment, default to no skin.
+        if "CI" in os.environ:
+            return None
         return "pixel_7_pro"
 
     @property
+    def DEFAULT_ANDROID_SDK_LEVEL(self) -> int:
+        return 31
+
+    @property
     def DEFAULT_SYSTEM_IMAGE(self) -> str:
-        return f"system-images;android-31;default;{self.emulator_abi}"
+        sdk_level = self.DEFAULT_ANDROID_SDK_LEVEL
+        return f"system-images;android-{sdk_level};default;{self.emulator_abi}"
+
+    @property
+    def DEFAULT_AVD(self) -> str:
+        sdk_level = self.DEFAULT_ANDROID_SDK_LEVEL
+        return f"beePhone-{sdk_level}"
 
     @classmethod
     def sdk_path_from_env(cls, tools: ToolCache) -> tuple[str | None, str | None]:
@@ -722,7 +735,7 @@ connection.
     def list_installed_system_images(self) -> set[str]:
         """Returns a set of installed system image package identifiers.
 
-        e.g., ``{"system-images;android-31;default;x86_64"}``
+        e.g., `{"system-images;android-31;default;x86_64"}`
         """
         try:
             output = self.tools.subprocess.check_output(
@@ -744,7 +757,7 @@ connection.
         """Verify that the required system image is installed.
 
         :param system_image: The SDKManager identifier for the system image (e.g.,
-            ``"system-images;android-31;default;x86_64"``)
+            `"system-images;android-31;default;x86_64"`)
         """
         # Look for the directory named as a system image.
         # If it exists, we already have the system image.
@@ -915,15 +928,16 @@ connection.
         be validated, and then automatically selected.
 
         :param device_or_avd: The device or AVD to target. Can be a physical
-            device id (a hex string), an emulator id (``emulator-5554``), or an
-            emulator AVD name (``@robotfriend``), or a JSON payload describing
-            the properties of an emulator that will be created (e.g.,
-            ``'{"avd":"beePhone","device_type":"pixel","skin":"pixel_3a","system_image":"system-images;android-31;default;arm64-v8a"}'``)
-            If ``None``, the user will be asked to select a device from the list
-            available.
-        :returns: A tuple containing ``(device, name, avd)``. ``avd`` will only
+            device id (a hex string), an emulator id (`emulator-5554`), or an
+            emulator AVD name (`@robotfriend`), a JSON payload describing the
+            properties of an emulator that will be created (e.g.,
+            `'{"avd":"beePhone","device_type":"pixel","skin":"pixel_3a","system_image":"system-images;android-31;default;arm64-v8a"}'`)
+            or `auto` to select an appropriate device automatically (creating
+            one if necessary). If `None`, the user will be asked to select a
+            device from the list available.
+        :returns: A tuple containing `(device, name, avd)`. `avd` will only
             be provided if an emulator with that AVD is not currently running.
-            If ``device`` is None, a new emulator should be created.
+            If `device` is None, a new emulator should be created.
         """
         # If the device_or_avd starts with "{", it's a definition for a new
         # emulator to be created.
@@ -994,9 +1008,26 @@ connection.
                 choices[f"@{avd}"] = name
                 device_index[f"@{avd}"] = name
 
-        # If a device or AVD has been provided, check it against the available
-        # device list.
-        if device_or_avd:
+        if device_or_avd == "auto":
+            default_avd = f"@{self.DEFAULT_AVD}"
+            try:
+                name = device_index[default_avd]
+            except KeyError:
+                # The default AVD doesn't exist; create it.
+                self._create_emulator(
+                    avd=self.DEFAULT_AVD,
+                    device_type=self.DEFAULT_DEVICE_TYPE,
+                    skin=self.DEFAULT_DEVICE_SKIN,
+                    system_image=self.DEFAULT_SYSTEM_IMAGE,
+                )
+                name = f"{default_avd} (emulator)"
+
+            device = running_avds.get(self.DEFAULT_AVD)
+            return device, name, self.DEFAULT_AVD
+
+        elif device_or_avd:
+            # If a device or AVD has been provided, check it against the available
+            # device list.
             try:
                 name = device_index[device_or_avd]
 
@@ -1434,7 +1465,7 @@ class ADB:
     def avd_name(self) -> str | None:
         """Get the AVD name for the device.
 
-        :returns: The AVD name for the device; or ``None`` if the device isn't
+        :returns: The AVD name for the device; or `None` if the device isn't
             an emulator
         """
         try:
@@ -1797,7 +1828,7 @@ Activity class not found while starting app.
         """Obtain the PID of a running app by package name.
 
         :param package: The package ID for the application (e.g.,
-            ``org.beeware.tutorial``)
+            `org.beeware.tutorial`)
         :returns: The PID of the given app as a string, or None if it isn't
         running.
         """

--- a/src/briefcase/integrations/android_sdk.py
+++ b/src/briefcase/integrations/android_sdk.py
@@ -1138,12 +1138,12 @@ In future, you can specify this device by running:
         # Get the list of existing emulators
         emulators = set(self.emulators())
 
-        default_avd = "beePhone"
+        default_avd = self.DEFAULT_AVD
         i = 1
         # Make sure the default name is unique
         while default_avd in emulators:
             i += 1
-            default_avd = f"beePhone{i}"
+            default_avd = f"{self.DEFAULT_AVD}-{i}"
 
         # Prompt for a device avd until a valid one is provided.
         avd = self.tools.console.text_question(

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -397,9 +397,15 @@ class GradleRunCommand(GradleMixin, RunCommand):
             "-d",
             "--device",
             dest="device_or_avd",
+            nargs="?",
+            default="auto",
+            const=None,
             help=(
                 "The device to target; either a device ID for a physical device, "
-                " or an AVD name ('@emulatorName') "
+                "or an AVD name ('@emulatorName'), or 'auto' (the default) to "
+                'automatically select a default "BeePhone" emulator (creating one '
+                "if necessary). Provide -d with no value to select from the full "
+                "list of available simulators."
             ),
             required=False,
         )
@@ -458,7 +464,7 @@ class GradleRunCommand(GradleMixin, RunCommand):
         self,
         app: FinalizedAppConfig,
         passthrough: list[str],
-        device_or_avd=None,
+        device_or_avd: str | None = None,
         extra_emulator_args=None,
         shutdown_on_exit=False,
         revoke_permissions: list[str] | None = None,
@@ -470,8 +476,9 @@ class GradleRunCommand(GradleMixin, RunCommand):
 
         :param app: The config object for the app
         :param passthrough: The list of arguments to pass to the app
-        :param device_or_avd: The device to target. If ``None``, the user will
-            be asked to re-run the command selecting a specific device.
+        :param device_or_avd: The device to target. If `None`, the user will
+            be asked to re-run the command selecting a specific device. If `"auto"`,
+            a default "beePhone" device will be selected (and created if necessary).
         :param extra_emulator_args: Any additional arguments to pass to the emulator.
         :param shutdown_on_exit: Should the emulator be shut down on exit?
         :param revoke_permissions: A list of permissions to revoke before launching

--- a/src/briefcase/platforms/android/gradle.py
+++ b/src/briefcase/platforms/android/gradle.py
@@ -403,9 +403,9 @@ class GradleRunCommand(GradleMixin, RunCommand):
             help=(
                 "The device to target; either a device ID for a physical device, "
                 "or an AVD name ('@emulatorName'), or 'auto' (the default) to "
-                'automatically select a default "BeePhone" emulator (creating one '
+                'automatically select a default "beePhone" emulator (creating one '
                 "if necessary). Provide -d with no value to select from the full "
-                "list of available simulators."
+                "list of available emulators, or to create one interactively."
             ),
             required=False,
         )

--- a/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test__create_emulator.py
@@ -315,7 +315,7 @@ def test_default_name(mock_tools, android_sdk, tmp_path):
     mock_tools.console.values = [""]
 
     # Mock the initial output of an AVD config file.
-    avd_config_path = tmp_path / "home/.android/avd/beePhone.avd/config.ini"
+    avd_config_path = tmp_path / "home/.android/avd/beePhone-31.avd/config.ini"
     avd_config_path.parent.mkdir(parents=True)
     with avd_config_path.open("w", encoding="utf-8") as f:
         f.write("hw.device.name=pixel\n")
@@ -324,7 +324,7 @@ def test_default_name(mock_tools, android_sdk, tmp_path):
     avd = android_sdk.create_emulator()
 
     # The expected device AVD was created.
-    assert avd == "beePhone"
+    assert avd == "beePhone-31"
 
 
 def test_default_name_with_collisions(mock_tools, android_sdk, tmp_path):
@@ -335,8 +335,10 @@ def test_default_name_with_collisions(mock_tools, android_sdk, tmp_path):
     # Create some existing emulators that will collide with the default name.
     android_sdk.emulators = MagicMock(
         return_value=[
-            "beePhone2",
+            "beePhone-31-2",
             "runningEmulator",
+            "beePhone-35",
+            "beePhone-31",
             "beePhone",
         ]
     )
@@ -344,7 +346,7 @@ def test_default_name_with_collisions(mock_tools, android_sdk, tmp_path):
     mock_tools.console.values = [""]
 
     # Mock the initial output of an AVD config file.
-    avd_config_path = tmp_path / "home/.android/avd/beePhone3.avd/config.ini"
+    avd_config_path = tmp_path / "home/.android/avd/beePhone-31-3.avd/config.ini"
     avd_config_path.parent.mkdir(parents=True)
     with avd_config_path.open("w", encoding="utf-8") as f:
         f.write("hw.device.name=pixel\n")
@@ -353,4 +355,4 @@ def test_default_name_with_collisions(mock_tools, android_sdk, tmp_path):
     avd = android_sdk.create_emulator()
 
     # The expected device AVD was created.
-    assert avd == "beePhone3"
+    assert avd == "beePhone-31-3"

--- a/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_create_emulator.py
@@ -100,7 +100,7 @@ def test_default_name(mock_tools, android_sdk, tmp_path):
     avd = android_sdk.create_emulator()
 
     # The expected device AVD was created.
-    assert avd == "beePhone"
+    assert avd == "beePhone-31"
 
 
 def test_default_name_with_collisions(mock_tools, android_sdk, tmp_path):
@@ -111,8 +111,10 @@ def test_default_name_with_collisions(mock_tools, android_sdk, tmp_path):
     # Create some existing emulators that will collide with the default name.
     android_sdk.emulators = MagicMock(
         return_value=[
-            "beePhone2",
+            "beePhone-31-2",
             "runningEmulator",
+            "beePhone-35",
+            "beePhone-31",
             "beePhone",
         ]
     )
@@ -125,4 +127,4 @@ def test_default_name_with_collisions(mock_tools, android_sdk, tmp_path):
     avd = android_sdk.create_emulator()
 
     # The expected device AVD was created.
-    assert avd == "beePhone3"
+    assert avd == "beePhone-31-3"

--- a/tests/integrations/android_sdk/AndroidSDK/test_properties.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_properties.py
@@ -155,3 +155,47 @@ def test_adb_for_device(mock_tools, android_sdk):
 
     assert adb.tools == mock_tools
     assert adb.device == "some-device"
+
+
+@pytest.mark.parametrize(
+    ("host_os", "host_arch", "emulator_abi"),
+    [
+        ("Darwin", "x86_64", "x86_64"),
+        ("Darwin", "arm64", "arm64-v8a"),
+        ("Windows", "AMD64", "x86_64"),
+        ("Linux", "x86_64", "x86_64"),
+        ("Linux", "aarch64", "arm64-v8a"),
+    ],
+)
+def test_default_system_image(
+    mock_tools,
+    android_sdk,
+    host_os,
+    host_arch,
+    emulator_abi,
+):
+    """The default system image takes default SDK and emulator ABI into account."""
+    # Mock the hardware and operating system
+    mock_tools.host_os = host_os
+    mock_tools.host_arch = host_arch
+
+    assert (
+        f"system-images;android-31;default;{emulator_abi}"
+        == android_sdk.DEFAULT_SYSTEM_IMAGE
+    )
+
+
+def test_default_skin(monkeypatch, android_sdk):
+    """The default skin is enabled under non-CI configurations."""
+    monkeypatch.delenv("CI", raising=False)
+
+    assert android_sdk.DEFAULT_DEVICE_SKIN == "pixel_7_pro"
+
+
+def test_default_skin_ci(monkeypatch, android_sdk):
+    """The default skin is disabled under CI configurations."""
+    # Ensure the test environment has no CI markers
+    # Explicitly set the test marker
+    monkeypatch.setenv("CI", "1")
+
+    assert android_sdk.DEFAULT_DEVICE_SKIN is None

--- a/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
+++ b/tests/integrations/android_sdk/AndroidSDK/test_select_target_device.py
@@ -144,6 +144,98 @@ def test_explicit_invalid_avd(mock_tools, android_sdk):
     assert mock_tools.console.prompts == []
 
 
+def test_auto_non_existent(mock_tools, android_sdk):
+    """If the user selects the auto device, and it doesn't exist, a device is
+    created."""
+    android_sdk._create_emulator = MagicMock()
+
+    # Select an auto device
+    device, name, avd = android_sdk.select_target_device("auto")
+
+    # Emulator was created
+    android_sdk._create_emulator.assert_called_once_with(
+        avd="beePhone-31",
+        device_type="pixel",
+        skin=android_sdk.DEFAULT_DEVICE_SKIN,
+        system_image=android_sdk.DEFAULT_SYSTEM_IMAGE,
+    )
+
+    # Emulator was created, so it is not running; so no device ID
+    assert device is None
+    assert name == "@beePhone-31 (emulator)"
+    assert avd == "beePhone-31"
+
+    # No input was requested
+    assert mock_tools.console.prompts == []
+
+
+def test_auto_existent(mock_tools, android_sdk):
+    """If the user selects the auto device, and it exists, the device is returned."""
+    android_sdk._create_emulator = MagicMock()
+
+    # Add a known beePhone-31 emulator
+    android_sdk.emulators = MagicMock(
+        return_value=[
+            "runningEmulator",
+            "idleEmulator",
+            "beePhone-31",
+        ]
+    )
+
+    # Select an auto device
+    device, name, avd = android_sdk.select_target_device("auto")
+
+    # Emulator pre-existed, so it won't be created
+    android_sdk._create_emulator.assert_not_called()
+
+    # Emulator is not running, so no device ID
+    assert device is None
+    assert name == "@beePhone-31 (emulator)"
+    assert avd == "beePhone-31"
+
+    # No input was requested
+    assert mock_tools.console.prompts == []
+
+
+def test_auto_running(mock_tools, android_sdk):
+    """If the user selects the auto device, and it is running, the device is
+    returned."""
+    android_sdk._create_emulator = MagicMock()
+
+    # Add a known beePhone-31 emulator that is running
+    android_sdk.emulators = MagicMock(
+        return_value=[
+            "runningEmulator",
+            "idleEmulator",
+            "beePhone-31",
+        ]
+    )
+
+    def mock_adb(device_id):
+        adb = MagicMock(spec_set=ADB)
+        if device_id == "emulator-5554":
+            adb.avd_name.return_value = "beePhone-31"
+        else:
+            adb.avd_name.return_value = None
+        return adb
+
+    android_sdk.adb = mock_adb
+
+    # Select an auto device
+    device, name, avd = android_sdk.select_target_device("auto")
+
+    # Emulator pre-existed, so it won't be created
+    android_sdk._create_emulator.assert_not_called()
+
+    # Emulator is running, so there is a device ID
+    assert device == "emulator-5554"
+    assert name == "@beePhone-31 (running emulator)"
+    assert avd == "beePhone-31"
+
+    # No input was requested
+    assert mock_tools.console.prompts == []
+
+
 def test_select_device(mock_tools, android_sdk, capsys):
     """If the user manually selects a physical device, details are returned."""
     # Mock the user input

--- a/tests/platforms/android/gradle/test_run.py
+++ b/tests/platforms/android/gradle/test_run.py
@@ -104,6 +104,33 @@ def test_device_option(run_command):
     assert overrides == {}
 
 
+def test_device_selection_option(run_command):
+    """The -d option with no argument can be parsed."""
+    options, overrides = run_command.parse_options(["-d"])
+
+    assert options == {
+        "device_or_avd": None,
+        "appname": None,
+        "update": False,
+        "update_requirements": False,
+        "update_resources": False,
+        "update_support": False,
+        "update_stub": False,
+        "no_update": False,
+        "test_mode": False,
+        "debugger": None,
+        "debugger_host": "localhost",
+        "debugger_port": 5678,
+        "passthrough": [],
+        "extra_emulator_args": None,
+        "shutdown_on_exit": False,
+        "revoke_permissions": None,
+        "forward_ports": None,
+        "reverse_ports": None,
+    }
+    assert overrides == {}
+
+
 def test_extra_emulator_args_option(run_command):
     """The -d option can be parsed."""
     options, overrides = run_command.parse_options(
@@ -111,7 +138,7 @@ def test_extra_emulator_args_option(run_command):
     )
 
     assert options == {
-        "device_or_avd": None,
+        "device_or_avd": "auto",
         "appname": None,
         "update": False,
         "update_requirements": False,
@@ -138,7 +165,7 @@ def test_shutdown_on_exit_option(run_command):
     options, overrides = run_command.parse_options(["--shutdown-on-exit"])
 
     assert options == {
-        "device_or_avd": None,
+        "device_or_avd": "auto",
         "appname": None,
         "update": False,
         "update_requirements": False,
@@ -170,7 +197,7 @@ def test_revoke_permission_option(run_command):
     )
 
     assert options == {
-        "device_or_avd": None,
+        "device_or_avd": "auto",
         "appname": None,
         "update": False,
         "update_requirements": False,
@@ -202,7 +229,7 @@ def test_forward_ports_option(run_command):
     )
 
     assert options == {
-        "device_or_avd": None,
+        "device_or_avd": "auto",
         "appname": None,
         "update": False,
         "update_requirements": False,
@@ -231,7 +258,7 @@ def test_reverse_ports_option(run_command):
     )
 
     assert options == {
-        "device_or_avd": None,
+        "device_or_avd": "auto",
         "appname": None,
         "update": False,
         "update_requirements": False,


### PR DESCRIPTION
A companion for #3031.

Adds automatic device selection (with creation, if needed) for Android. With this PR, `briefcase run android` will "just work", selecting an appropriate default emulator, creating that emulator if it doesn't already exist.

Also disables the use of skins if the code is running in a CI environment (if CI is set as an environment variable - which seems to be the defacto standard for identifying a CI environment).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
