### PR TITLE
Drop support for Python 3.10, add 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,18 +127,15 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ "macos-26-intel", "macos-26", "windows-2025", "ubuntu-24.04" ]
-        python-version: [ "3.10", "3.14" ]
+        python-version: [ "3.11", "3.15" ]
         include:
           # Ensure the Python versions between min and max are tested
-          - platform: "ubuntu-24.04"
-            python-version: "3.11"
           - platform: "ubuntu-24.04"
             python-version: "3.12"
           - platform: "ubuntu-24.04"
             python-version: "3.13"
-          # # Allow dev Python to fail without failing entire job
-          # - python-version: "3.15"
-          #   experimental: true
+          - platform: "ubuntu-24.04"
+            python-version: "3.14"
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -206,7 +203,7 @@ jobs:
       with:
         # Use minimum version of python for coverage to avoid phantom branches
         # https://github.com/nedbat/coveragepy/issues/1572#issuecomment-1522546425
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install Tox
       run: python -m pip install --group tox-uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,3 +267,6 @@ jobs:
           # PySide6 is unstable on Windows ARM64 (see #2969)
           - framework: "pyside6"
             runner-os: "windows-11-arm"
+          # PySide6 is unstable on macOS Intel (see #2969)
+          - framework: "pyside6"
+            runner-os: "macos-26-intel"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ jobs:
         run: |
           echo "VERSION=${GITHUB_REF_NAME#v}" | tee -a $GITHUB_ENV
 
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
+
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
       # remove toml extra once Python 3.10 is no longer supported
       additional_dependencies: ['.[toml]']
       args: ["--skip=CODE_OF_CONDUCT.md"]
-
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.29.0
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Briefcase converts Python projects into standalone native applications for macOS
 
 ## Quick Reference
 
-- **Language**: Python >= 3.10 (3.10–3.14 supported)
+- **Language**: Python >= 3.11 (3.11–3.15 supported)
 - **Docstrings**: Sphinx style with Markdown content
 - **Dev environment**: Python 3.13 virtualenv with `dev` dependency group
 - **License**: BSD-3-Clause
@@ -109,12 +109,11 @@ Do not make changes to AGENTS.md unless specifically directed to do so.
 
 ```python
 class macOSAppBuildCommand(
-    macOSAppMixin,          # format-specific paths/behavior
-    macOSSigningMixin,      # platform signing logic
+    macOSAppMixin,  # format-specific paths/behavior
+    macOSSigningMixin,  # platform signing logic
     AppPackagesMergeMixin,  # utility mixin
-    BuildCommand,           # base command from commands/
-):
-    ...
+    BuildCommand,  # base command from commands/
+): ...
 ```
 
 ### Platform module conventions
@@ -174,6 +173,7 @@ class DummyBuildCommand(BuildCommand):
     def build(self, app, **kwargs):
         self.actions.append(("build", app.app_name))
         return {}
+
 
 # Then assert exact action sequence:
 assert build_command.actions == [

--- a/changes/3035.feature.md
+++ b/changes/3035.feature.md
@@ -1,0 +1,1 @@
+Support for Python 3.15 was added.

--- a/changes/3035.removal.md
+++ b/changes/3035.removal.md
@@ -1,0 +1,1 @@
+Python 3.10 is no longer supported.

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -16,9 +16,9 @@ extra:
   project_name: briefcase
   package_name: briefcase
   formal_name: Briefcase
-  min_python_version: "3.10"  # The oldest supported Python version
-  min_python_version_tag: "310"  # The tag version of the minimum python version
-  recent_python_version: "3.13"  # The newest Python version known to work on all platforms
+  min_python_version: "3.11"  # The oldest supported Python version
+  min_python_version_tag: "311"  # The tag version of the minimum python version
+  recent_python_version: "3.15"  # The newest Python version known to work on all platforms
   docs_python_version: "3.13"  # The version of Python required to build the documentation
   contribution_guide_root: how-to/contribute
   social:

--- a/docs/en/about/faq.md
+++ b/docs/en/about/faq.md
@@ -2,7 +2,7 @@
 
 ## What versions of Python are supported?
 
-Python 3.11 or higher.
+Python {{ min_python_version }} or higher.
 
 ## What platforms does Briefcase support?
 

--- a/docs/en/about/faq.md
+++ b/docs/en/about/faq.md
@@ -2,7 +2,7 @@
 
 ## What versions of Python are supported?
 
-Python 3.10 or higher.
+Python 3.11 or higher.
 
 ## What platforms does Briefcase support?
 
@@ -23,7 +23,7 @@ Briefcase's platform support is built on a [plugin system][platform-interface], 
 Briefcase adds a [PEP566](https://peps.python.org/pep-0566/) metadata file when it installs your app's code. The metadata can be retrieved at runtime as described in the [Accessing Briefcase packaging metadata at runtime][access-packaging-metadata] how-to. You can determine if your app was packaged with Briefcase by testing for the existence of the `Briefcase-Version` tag:
 
 ```python
-in_briefcase = 'Briefcase-Version' in metadata
+in_briefcase = "Briefcase-Version" in metadata
 ```
 
 ## Can I use third-party Python packages in my app?

--- a/docs/en/reference/platforms/linux/system.md
+++ b/docs/en/reference/platforms/linux/system.md
@@ -115,7 +115,7 @@ The following options can be provided at the command line when producing Deb pac
 
 A Docker base image identifier for the Linux distribution you want to target. The identifier will be in the pattern `<vendor>:<codename>` (e.g., `debian:buster` or `ubuntu:jammy`). You can also use the version number in place of the code name (e.g., `debian:10`, `ubuntu:22.04`, or `fedora:37`). Whichever form you choose, you should be consistent; no normalization of code name and version is performed, so `ubuntu:jammy` and `ubuntu:22.04` will be identified as different versions (even though they the same version).
 
-You can specify any identifier you want, provided the distribution is still supported by the vendor, and system Python is Python 3.10 or later.
+You can specify any identifier you want, provided the distribution is still supported by the vendor, and system Python is Python 3.11 or later.
 
 The following Linux vendors are known to work as Docker targets:
 

--- a/docs/en/reference/platforms/linux/system.md
+++ b/docs/en/reference/platforms/linux/system.md
@@ -115,7 +115,7 @@ The following options can be provided at the command line when producing Deb pac
 
 A Docker base image identifier for the Linux distribution you want to target. The identifier will be in the pattern `<vendor>:<codename>` (e.g., `debian:buster` or `ubuntu:jammy`). You can also use the version number in place of the code name (e.g., `debian:10`, `ubuntu:22.04`, or `fedora:37`). Whichever form you choose, you should be consistent; no normalization of code name and version is performed, so `ubuntu:jammy` and `ubuntu:22.04` will be identified as different versions (even though they the same version).
 
-You can specify any identifier you want, provided the distribution is still supported by the vendor, and system Python is Python 3.11 or later.
+You can specify any identifier you want, provided the distribution is still supported by the vendor, and system Python is Python {{ min_python_version }} or later.
 
 The following Linux vendors are known to work as Docker targets:
 

--- a/docs/en/reference/platforms/macOS/index.md
+++ b/docs/en/reference/platforms/macOS/index.md
@@ -63,7 +63,7 @@ Configuration options between the [.app bundle][app-bundle] and [macOS Xcode pro
 
 ## Prerequisites  { #macos-prerequisites }
 
-Briefcase requires installing Python 3.11+. You will also need a method for managing virtual environments (such as `venv`).
+Briefcase requires installing Python {{ min_python_version }} or later. You will also need a method for managing virtual environments (such as `venv`).
 
 ## Packaging format
 

--- a/docs/en/reference/platforms/macOS/index.md
+++ b/docs/en/reference/platforms/macOS/index.md
@@ -63,7 +63,7 @@ Configuration options between the [.app bundle][app-bundle] and [macOS Xcode pro
 
 ## Prerequisites  { #macos-prerequisites }
 
-Briefcase requires installing Python 3.10+. You will also need a method for managing virtual environments (such as `venv`).
+Briefcase requires installing Python 3.11+. You will also need a method for managing virtual environments (such as `venv`).
 
 ## Packaging format
 

--- a/docs/en/reference/platforms/web/static.md
+++ b/docs/en/reference/platforms/web/static.md
@@ -58,7 +58,7 @@ Although Briefcase provides a `run` command that can be used to serve the websit
 
 [PyScript](https://pyscript.net) (which forms the base of Briefcase's web backend) is a new project; and Toga's web backend is very new. As a result this web backend should be considered experimental.
 
-Regardless of what Python version you run Briefcase with, the app will use PyScript's current Python version (as of October 2022, this is 3.10).
+Regardless of what Python version you run Briefcase with, the app will use PyScript's current Python version (as of October 2026, this is 3.14).
 
 There are also a [number of constraints](https://pyodide.org/en/stable/usage/wasm-constraints.html) on what you can do in a web environment. Some of these are fundamental constraints on the web as a platform; some are known issues with PyScript and Pyodide as runtime environments. You shouldn't expect that arbitrary third-party Python packages will "just run" in a web environment.
 

--- a/docs/en/reference/platforms/windows/index.md
+++ b/docs/en/reference/platforms/windows/index.md
@@ -61,7 +61,7 @@ Configuration options between the [Windows app folder][windows-app-folder] and [
 
 ## Prerequisites  { #windows-prerequisites }
 
-Briefcase requires installing Python 3.10+. You will also need a method for managing virtual environments (such as `venv`).
+Briefcase requires installing Python {{ min_python_version }} or later. You will also need a method for managing virtual environments (such as `venv`).
 
 ## Packaging format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 name = "briefcase"
 description = "Tools to support converting a Python project into a standalone native application."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -50,11 +50,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Utilities",
@@ -92,7 +92,6 @@ dependencies = [
     "httpx >= 0.20, < 1.0",
     "rich >= 12.6, < 16.0",
     "tenacity >= 8.0, < 10.0",
-    "tomli >= 2.0, < 3.0; python_version <= '3.10'",
     "tomli_w >= 1.0, < 2.0",
     "typing_extensions >= 4.6; python_version < '3.11'",
 ]
@@ -246,8 +245,6 @@ no-cover-if-not-windows = "'win32' != os_environ.get('COVERAGE_PLATFORM', sys_pl
 no-cover-if-gte-py312 = "sys_version_info >= (3, 12) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-is-py312 = "python_version == '3.12' and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-lt-py312 = "sys_version_info < (3, 12) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
-no-cover-if-lt-py311 = "sys_version_info < (3, 11) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
-no-cover-if-gte-py311 = "sys_version_info >= (3, 11) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/briefcase/bootstraps/pyside6.py
+++ b/src/briefcase/bootstraps/pyside6.py
@@ -47,8 +47,8 @@ def main():
     def pyproject_table_briefcase_app_extra_content(self):
         return """
 requires = [
-    "PySide6-Essentials~=6.8",
-    # "PySide6-Addons~=6.8",
+    "PySide6-Essentials~=6.11",
+    # "PySide6-Addons~=6.11",
 ]
 test_requires = [
 {% if cookiecutter.test_framework == "pytest" %}

--- a/src/briefcase/bootstraps/pyside6.py
+++ b/src/briefcase/bootstraps/pyside6.py
@@ -47,8 +47,8 @@ def main():
     def pyproject_table_briefcase_app_extra_content(self):
         return """
 requires = [
-    "PySide6-Essentials~=6.11",
-    # "PySide6-Addons~=6.11",
+    "PySide6-Essentials~=6.8",
+    # "PySide6-Addons~=6.8",
 ]
 test_requires = [
 {% if cookiecutter.test_framework == "pytest" %}

--- a/src/briefcase/commands/base.py
+++ b/src/briefcase/commands/base.py
@@ -9,6 +9,7 @@ import platform
 import re
 import subprocess
 import sys
+import tomllib
 from abc import ABC, abstractmethod
 from argparse import RawDescriptionHelpFormatter
 from collections.abc import Collection, Iterable
@@ -22,13 +23,6 @@ from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import Version
 from platformdirs import PlatformDirs
 
-from briefcase.debuggers import get_debugger, get_debuggers
-
-if sys.version_info >= (3, 11):  # pragma: no-cover-if-lt-py311
-    import tomllib
-else:  # pragma: no-cover-if-gte-py311
-    import tomli as tomllib
-
 import briefcase
 from briefcase import __version__
 from briefcase.config import (
@@ -40,6 +34,7 @@ from briefcase.config import (
     parse_config,
 )
 from briefcase.console import MAX_TEXT_WIDTH, Console
+from briefcase.debuggers import get_debugger, get_debuggers
 from briefcase.exceptions import (
     BriefcaseCommandError,
     BriefcaseConfigError,

--- a/src/briefcase/commands/convert.py
+++ b/src/briefcase/commands/convert.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-import sys
+import tomllib
 from functools import cached_property, partial
 from pathlib import Path
 from shutil import copy2, copytree
@@ -10,17 +10,12 @@ from urllib.parse import urlparse
 
 from packaging.utils import canonicalize_name
 
-from ..config import get_license_from_text, is_valid_app_name
-from .new import LICENSE_OPTIONS, NewCommand, parse_project_overrides
-
-if sys.version_info >= (3, 11):  # pragma: no-cover-if-lt-py311
-    import tomllib
-else:  # pragma: no-cover-if-gte-py311
-    import tomli as tomllib
-
 from briefcase.bootstraps import EmptyBootstrap
 from briefcase.config import APP_NAME_SPEC, make_class_name, validate_url
 from briefcase.exceptions import BriefcaseCommandError
+
+from ..config import get_license_from_text, is_valid_app_name
+from .new import LICENSE_OPTIONS, NewCommand, parse_project_overrides
 
 
 class ConvertCommand(NewCommand):

--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -5,6 +5,7 @@ import keyword
 import re
 import subprocess
 import sys
+import tomllib
 import unicodedata
 from email.utils import getaddresses
 from pathlib import Path
@@ -15,11 +16,6 @@ from build import BuildBackendException
 from build.util import project_wheel_metadata
 from packaging.licenses import InvalidLicenseExpression, canonicalize_license_expression
 from packaging.version import InvalidVersion, Version
-
-if sys.version_info >= (3, 11):  # pragma: no-cover-if-lt-py311
-    import tomllib
-else:  # pragma: no-cover-if-gte-py311
-    import tomli as tomllib
 
 from briefcase.debuggers.base import BaseDebugger
 from briefcase.platforms import get_output_formats, get_platforms

--- a/src/briefcase/debuggers/base.py
+++ b/src/briefcase/debuggers/base.py
@@ -80,7 +80,7 @@ class DebuggerConfig(TypedDict):
     app_packages_path_mappings: AppPackagesPathMappings | None
 
 
-class DebuggerConnectionMode(str, enum.Enum):
+class DebuggerConnectionMode(enum.StrEnum):
     SERVER = "server"
     CLIENT = "client"
 

--- a/src/briefcase/integrations/base.py
+++ b/src/briefcase/integrations/base.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from collections.abc import Collection, Mapping
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Self, TypeVar
 
 import httpx
 from cookiecutter.main import cookiecutter
@@ -44,10 +44,6 @@ if TYPE_CHECKING:
     from briefcase.integrations.wix import WiX
     from briefcase.integrations.xcode import Xcode, XcodeCliTools
 
-    try:
-        from typing import Self
-    except ImportError:  # pragma: no-cover-if-gte-py311
-        from typing_extensions import Self
 
 ToolT = TypeVar("ToolT", bound="Tool")
 ManagedToolT = TypeVar("ManagedToolT", bound="ManagedTool")
@@ -258,10 +254,7 @@ class ToolCache(Mapping):
 
         :returns: a character encoding (upper-cased), e.g. UTF-8. Defaults to UTF-8.
         """
-        if sys.version_info < (3, 11):  # pragma: no-cover-if-gte-py311
-            encoding = locale.getdefaultlocale()[1]  # deprecated in Python 3.11
-        else:  # pragma: no-cover-if-lt-py311
-            encoding = locale.getencoding()
+        encoding = locale.getencoding()
 
         if not encoding:
             encoding = DEFAULT_SYSTEM_ENCODING

--- a/src/briefcase/integrations/linuxdeploy.py
+++ b/src/briefcase/integrations/linuxdeploy.py
@@ -5,7 +5,7 @@ import shlex
 from abc import ABC, abstractmethod
 from collections.abc import Collection
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeVar
+from typing import Self, TypeVar
 from urllib.parse import urlparse
 
 from briefcase.exceptions import (
@@ -15,12 +15,6 @@ from briefcase.exceptions import (
     UnsupportedHostError,
 )
 from briefcase.integrations.base import ManagedTool, Tool, ToolCache
-
-if TYPE_CHECKING:
-    try:
-        from typing import Self
-    except ImportError:  # pragma: no-cover-if-gte-py311
-        from typing_extensions import Self
 
 LinuxDeployT = TypeVar("LinuxDeployT", bound="LinuxDeployBase")
 

--- a/src/briefcase/platforms/macOS/__init__.py
+++ b/src/briefcase/platforms/macOS/__init__.py
@@ -7,12 +7,14 @@ import plistlib
 import re
 import subprocess
 import time
+import tomllib
 from collections.abc import Collection
 from contextlib import suppress
 from pathlib import Path
 from signal import SIGTERM
 from typing import TYPE_CHECKING
 
+import tomli_w
 from packaging.version import Version
 
 from briefcase.config import EnvManagerT, FinalizedAppConfig
@@ -40,13 +42,6 @@ except ImportError:  # pragma: no-cover-if-is-macos
     # On non-macOS platforms, dmgbuild won't be installed.
     # Allow the plugin to be loaded; raise an error when tools are verified.
     dmgbuild = None
-
-import tomli_w
-
-try:
-    import tomllib
-except ImportError:  # pragma: no-cover-if-gte-py311
-    import tomli as tomllib  # type: ignore[no-redef]
 
 
 DEFAULT_OUTPUT_FORMAT = "app"

--- a/src/briefcase/platforms/web/static.py
+++ b/src/briefcase/platforms/web/static.py
@@ -2,24 +2,13 @@ import errno
 import re
 import subprocess
 import sys
+import tomllib
 import webbrowser
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path, PurePosixPath
 from textwrap import dedent, indent
 from typing import Any
 from zipfile import ZipFile
-
-from briefcase.console import Console
-from briefcase.exceptions import (
-    BriefcaseCommandError,
-    BriefcaseConfigError,
-    UnsupportedCommandError,
-)
-
-if sys.version_info >= (3, 11):  # pragma: no-cover-if-lt-py311
-    import tomllib
-else:  # pragma: no-cover-if-gte-py311
-    import tomli as tomllib
 
 import tomli_w
 
@@ -34,6 +23,12 @@ from briefcase.commands import (
     UpdateCommand,
 )
 from briefcase.config import FinalizedAppConfig
+from briefcase.console import Console
+from briefcase.exceptions import (
+    BriefcaseCommandError,
+    BriefcaseConfigError,
+    UnsupportedCommandError,
+)
 
 # Banner templates (Constants used in write_inserts)
 HTML_BANNER = (

--- a/tests/commands/base/test_properties.py
+++ b/tests/commands/base/test_properties.py
@@ -4,7 +4,7 @@ from .conftest import DummyCommand
 
 
 def test_briefcase_required_python_version(base_command):
-    assert base_command.briefcase_required_python_version == (3, 10)
+    assert base_command.briefcase_required_python_version == (3, 11)
 
 
 def test_bundle_path(base_command, my_app, tmp_path):

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -385,8 +385,8 @@ def main():
 """,
         "pyproject_table_briefcase_app_extra_content": """
 requires = [
-    "PySide6-Essentials~=6.8",
-    # "PySide6-Addons~=6.8",
+    "PySide6-Essentials~=6.11",
+    # "PySide6-Addons~=6.11",
 ]
 test_requires = [
 {% if cookiecutter.test_framework == "pytest" %}

--- a/tests/commands/new/test_build_gui_context.py
+++ b/tests/commands/new/test_build_gui_context.py
@@ -385,8 +385,8 @@ def main():
 """,
         "pyproject_table_briefcase_app_extra_content": """
 requires = [
-    "PySide6-Essentials~=6.11",
-    # "PySide6-Addons~=6.11",
+    "PySide6-Essentials~=6.8",
+    # "PySide6-Addons~=6.8",
 ]
 test_requires = [
 {% if cookiecutter.test_framework == "pytest" %}

--- a/tests/integrations/base/test_ToolCache.py
+++ b/tests/integrations/base/test_ToolCache.py
@@ -255,14 +255,7 @@ def test_is_32bit_python(dummy_console, maxsize, is_32bit, monkeypatch, tmp_path
 )
 def test_system_encoding(simple_tools, mock_encoding, expected_encoding, monkeypatch):
     """The expected system encoding is returned."""
-    if sys.version_info < (3, 11):
-        monkeypatch.setattr(
-            locale, "getdefaultlocale", MagicMock(return_value=("aa_BB", mock_encoding))
-        )
-    else:
-        monkeypatch.setattr(
-            locale, "getencoding", MagicMock(return_value=mock_encoding)
-        )
+    monkeypatch.setattr(locale, "getencoding", MagicMock(return_value=mock_encoding))
     monkeypatch.setattr(
         briefcase.integrations.base, "DEFAULT_SYSTEM_ENCODING", "ISO-4242"
     )

--- a/tests/platforms/linux/system/test_mixin__verify_python.py
+++ b/tests/platforms/linux/system/test_mixin__verify_python.py
@@ -99,7 +99,7 @@ def test_target_too_old(create_command, first_app_config):
     with pytest.raises(
         BriefcaseCommandError,
         match=r"The system python3 version provided by somevendor:surprising "
-        r"is 3\.7\.16; Briefcase requires a minimum Python3 version of 3\.10\.",
+        r"is 3\.7\.16; Briefcase requires a minimum Python3 version of 3\.11\.",
     ):
         create_command.verify_docker_python(first_app_config)
 

--- a/tests/platforms/web/static/test_build.py
+++ b/tests/platforms/web/static/test_build.py
@@ -1,13 +1,9 @@
 import shutil
 import subprocess
 import sys
+import tomllib
 from textwrap import dedent
 from unittest import mock
-
-if sys.version_info >= (3, 11):  # pragma: no-cover-if-lt-py311
-    import tomllib
-else:  # pragma: no-cover-if-gte-py311
-    import tomli as tomllib
 
 import pytest
 

--- a/tests/platforms/web/static/test_build_extract_pyscript_config.py
+++ b/tests/platforms/web/static/test_build_extract_pyscript_config.py
@@ -1,12 +1,5 @@
 import shutil
-import sys
 from unittest import mock
-
-if sys.version_info >= (3, 11):  # pragma: no-cover-if-lt-py311
-    pass
-else:  # pragma: no-cover-if-gte-py311
-    pass
-
 from zipfile import ZipFile
 
 import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ depends = pre-commit,py{,311,312,313,314,315}{,-cov}
 # by default, coverage should run on oldest supported Python for testing platform coverage.
 # however, coverage for a particular Python version should match the version used for pytest.
 base_python =
-    coverage: pypy311,py312,py313,py314,315
+    coverage: py311,py312,py313,py314,py315
     coverage311: py311
     coverage312: py312
     coverage313: py313

--- a/tox.ini
+++ b/tox.ini
@@ -38,12 +38,12 @@ depends = pre-commit,py{,311,312,313,314,315}{,-cov}
 # by default, coverage should run on oldest supported Python for testing platform coverage.
 # however, coverage for a particular Python version should match the version used for pytest.
 base_python =
-    coverage: py311,py312,py313,py314,py315
-    coverage311: py311
-    coverage312: py312
-    coverage313: py313
-    coverage314: py314
-    coverage315: py315
+    coverage{,-ci}{,-platform,-platform-linux,-platform-macos,-platform-windows,-project}{,-keep}{,-html}: py311
+    coverage311{,-ci}{,-platform,-platform-linux,-platform-macos,-platform-windows,-project}{,-keep}{,-html}: py311
+    coverage312{,-ci}{,-platform,-platform-linux,-platform-macos,-platform-windows,-project}{,-keep}{,-html}: py312
+    coverage313{,-ci}{,-platform,-platform-linux,-platform-macos,-platform-windows,-project}{,-keep}{,-html}: py313
+    coverage314{,-ci}{,-platform,-platform-linux,-platform-macos,-platform-windows,-project}{,-keep}{,-html}: py314
+    coverage315{,-ci}{,-platform,-platform-linux,-platform-macos,-platform-windows,-project}{,-keep}{,-html}: py315
 passenv = COVERAGE_FILE
 setenv =
     keep: COMBINE_FLAGS = --keep

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist = towncrier-check,docs-lint,pre-commit,py{310,311,312,313,314}-cov,coverage-platform,py{310,311,312,313,314}-debugger
+envlist = towncrier-check,docs-lint,pre-commit,py{311,312,313,314,315}-cov,coverage-platform,py{311,312,313,314,315}-debugger
 labels =
     test = py-cov,coverage
-    test310 = py310-cov,coverage310
     test311 = py311-cov,coverage311
     test312 = py312-cov,coverage312
     test313 = py313-cov,coverage313
     test314 = py314-cov,coverage314
-    test-fast = py{310,311,312,313,314}-fast
-    test-platform = py{310,311,312,313,314}-cov,coverage-platform
+    test315 = py315-cov,coverage315
+    test-fast = py{311,312,313,314,315}-fast
+    test-platform = py{311,312,313,314,315}-cov,coverage-platform
 skip_missing_interpreters = True
 
 [testenv:pre-commit]
@@ -17,7 +17,7 @@ wheel_build_env = .pkg
 dependency_groups = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
-[testenv:py{,310,311,312,313,314}{,-fast,-cov}]
+[testenv:py{,311,312,313,314,315}{,-fast,-cov}]
 package = wheel
 wheel_build_env = .pkg
 depends: pre-commit
@@ -31,19 +31,19 @@ commands =
     cov  : python -X warn_default_encoding -m coverage run -m pytest {posargs:-vv --color yes}
     fast : python -m pytest {posargs:-vv --color yes -n auto}
 
-[testenv:coverage{,310,311,312,313,314}{,-ci}{,-platform,-platform-linux,-platform-macos,-platform-windows,-project}{,-keep}{,-html}]
+[testenv:coverage{,311,312,313,314,315}{,-ci}{,-platform,-platform-linux,-platform-macos,-platform-windows,-project}{,-keep}{,-html}]
 package = wheel
 wheel_build_env = .pkg
-depends = pre-commit,py{,310,311,312,313,314}{,-cov}
+depends = pre-commit,py{,311,312,313,314,315}{,-cov}
 # by default, coverage should run on oldest supported Python for testing platform coverage.
 # however, coverage for a particular Python version should match the version used for pytest.
 base_python =
-    coverage: py310,py311,py312,py313,py314
-    coverage310: py310
+    coverage: pypy311,py312,py313,py314,315
     coverage311: py311
     coverage312: py312
     coverage313: py313
     coverage314: py314
+    coverage315: py315
 passenv = COVERAGE_FILE
 setenv =
     keep: COMBINE_FLAGS = --keep
@@ -67,7 +67,7 @@ commands =
     html: python -m coverage html --skip-covered --skip-empty
     python -m coverage report --fail-under=100
 
-[testenv:py{,310,311,312,313,314}-debugger]
+[testenv:py{,311,312,313,314,315}-debugger]
 changedir = debugger
 skip_install = True
 deps =


### PR DESCRIPTION
Drop support for 3.10; add support for Python 3.15

Ruff has applied code cleanup; the 3.10-specific changes were all related to tomllib and typing.Self being added to the standard library in 3.11.

Also includes an addition to the release workflow that was identified in the process of releasing support packages. This change was made as part of the zizmor changes, but wasn't tested (because release workflows can't be tested until we do a release).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
