### PR TITLE
Validate special characters in app_name config

### DIFF
--- a/src/briefcase/config.py
+++ b/src/briefcase/config.py
@@ -55,12 +55,15 @@ def get_module_name(app_name: str) -> str:
     return app_name.replace("-", "_")
 
 
+INVALID_APP_NAME_CHARS = set('!@#$%^&*()+={}[]|\\:;"\'<>,?/')
 def is_valid_app_name(app_name):
     module_name = get_module_name(app_name)
+    has_invalid_chars = any(char in INVALID_APP_NAME_CHARS for char in app_name)
     return (
         not is_reserved_keyword(app_name)
         and is_valid_pep508_name(module_name)
         and module_name.isidentifier()
+        and not has_invalid_chars
     )
 
 

--- a/tests/config/test_is_valid_app_name.py
+++ b/tests/config/test_is_valid_app_name.py
@@ -45,3 +45,16 @@ def test_is_valid_app_name(name):
 def test_is_invalid_app_name(name):
     """Test that invalid app names are rejected."""
     assert not is_valid_app_name(name)
+
+@pytest.mark.parametrize(
+    "app_name",
+    [
+        "my@app",
+        "app#name",
+        "hello$world",
+        "test!app",
+    ],
+)
+def test_invalid_app_name_special_characters(app_name):
+    """Verify that app names with special characters are considered invalid."""
+    assert not is_valid_app_name(app_name)


### PR DESCRIPTION
### Summary of Changes
Implemented additional input validation in `is_valid_app_name` to reject app names containing invalid special characters (`!@#$%^&*()` etc.). Added corresponding unit tests in `test_is_valid_app_name.py` to ensure invalid names fail as expected.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Gemini