### PR TITLE
Use the -embeddable Python download rather than -embed.

### DIFF
--- a/changes/3044.misc.md
+++ b/changes/3044.misc.md
@@ -1,0 +1,1 @@
+Windows apps now use the `-embeddable` binary rather than the `-embed` binary.

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -184,7 +184,9 @@ class WindowsCreateCommand(CreateCommand):
 
     def support_package_filename(self, support_revision):
         arch = self.tools.host_arch.lower()
-        return f"python-{self.python_version_tag}.{support_revision}-embed-{arch}.zip"
+        return (
+            f"python-{self.python_version_tag}.{support_revision}-embeddable-{arch}.zip"
+        )
 
     def support_package_url(self, support_revision):
         micro = re.match(r"\d+", str(support_revision)).group(0)

--- a/tests/platforms/windows/app/create/test_create.py
+++ b/tests/platforms/windows/app/create/test_create.py
@@ -270,7 +270,7 @@ def test_support_package_url(create_command, revision, micro):
     expected_link = (
         f"https://www.python.org/ftp/python"
         f"/{sys.version_info.major}.{sys.version_info.minor}.{micro}"
-        f"/python-{sys.version_info.major}.{sys.version_info.minor}.{revision}-embed-{create_command.tools.host_arch.lower()}.zip"
+        f"/python-{sys.version_info.major}.{sys.version_info.minor}.{revision}-embeddable-{create_command.tools.host_arch.lower()}.zip"
     )
     assert create_command.support_package_url(revision) == expected_link
 


### PR DESCRIPTION
Python.org offers 2 "embeddeable" downloads for each version/architecture:

* python-3.X.Y-embed-amd64.zip 
* python-3.X.y-embeddable-amd64.zip

The public download page uses the former; but the `windows.json` release manifest only includes the latter. The release manifest includes release hashes; hashes for the -embed variants are on the website, but nowhere else.

The contents of the files are identical, except for a single `__install__.json` file in the `-embeddable` variant that includes some useful metadata. 

Since we need to be able to easily verify hashes, we should use the version that has readily available published hashes.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
